### PR TITLE
feat(ui/phase-1.2): design system tokens, shared components, @nous/ui Tailwind wiring

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,7 +628,26 @@ importers:
         version: link:../../shared
 
   self/ui:
+    dependencies:
+      clsx:
+        specifier: ^2.1.0
+        version: 2.1.1
+      tailwind-merge:
+        specifier: ^2.5.0
+        version: 2.6.1
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19
     devDependencies:
+      '@radix-ui/react-collapsible':
+        specifier: '*'
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-scroll-area':
+        specifier: '*'
+        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-select':
+        specifier: '*'
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -1830,6 +1849,19 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5435,6 +5467,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
@@ -6908,6 +6943,35 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -8686,7 +8750,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -8709,7 +8773,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8724,14 +8788,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8746,7 +8810,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11191,6 +11255,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@2.6.1: {}
 
   tailwind-merge@3.4.0: {}
 

--- a/self/apps/desktop/src/renderer/src/index.css
+++ b/self/apps/desktop/src/renderer/src/index.css
@@ -6,6 +6,16 @@
   padding: 0;
 }
 
+:root {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --border: 240 3.7% 15.9%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+}
+
 html,
 body,
 #root {

--- a/self/apps/web/next.config.ts
+++ b/self/apps/web/next.config.ts
@@ -5,6 +5,7 @@ const configuredDistDir = process.env.NOUS_NEXT_DIST_DIR?.trim();
 const nextConfig: NextConfig = {
   distDir: configuredDistDir || '.next',
   transpilePackages: [
+    '@nous/ui',
     '@nous/shared',
     '@nous/cortex-core',
     '@nous/cortex-pfc',

--- a/self/ui/package.json
+++ b/self/ui/package.json
@@ -8,20 +8,34 @@
     ".": "./src/index.ts",
     "./panels": "./src/panels/index.ts",
     "./components": "./src/components/index.ts",
-    "./tokens": "./src/tokens/index.ts"
+    "./tokens": "./src/tokens/index.ts",
+    "./lib/cn": "./src/lib/cn.ts"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.5.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "dockview-react": "^4.0.0"
+    "dockview-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "@radix-ui/react-select": "*",
+    "@radix-ui/react-scroll-area": "*",
+    "@radix-ui/react-collapsible": "*"
   },
   "devDependencies": {
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "clsx": "^2.1.0",
     "dockview-react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "typescript": "^5"
+    "tailwind-merge": "^2.5.0",
+    "typescript": "^5",
+    "@radix-ui/react-select": "*",
+    "@radix-ui/react-scroll-area": "*",
+    "@radix-ui/react-collapsible": "*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/self/ui/src/components/badge.tsx
+++ b/self/ui/src/components/badge.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../lib/cn'
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: 'default' | 'secondary' | 'outline'
+}
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    const base = 'inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-medium'
+    const variants = {
+      default: 'bg-primary text-primary-foreground',
+      secondary: 'bg-muted text-muted-foreground',
+      outline: 'border border-border',
+    }
+    return (
+      <span
+        ref={ref}
+        className={cn(base, variants[variant], className)}
+        {...props}
+      />
+    )
+  },
+)
+Badge.displayName = 'Badge'
+
+export { Badge }

--- a/self/ui/src/components/button.tsx
+++ b/self/ui/src/components/button.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../lib/cn'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline' | 'ghost'
+  size?: 'default' | 'sm'
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', type = 'button', ...props }, ref) => {
+    const base =
+      'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'
+    const sizes = {
+      default: 'px-4 py-2',
+      sm: 'px-2 py-1',
+    }
+    const variants = {
+      default: 'bg-primary text-primary-foreground hover:opacity-90',
+      outline: 'border border-border bg-transparent hover:bg-muted',
+      ghost: 'hover:bg-muted',
+    }
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(base, sizes[size], variants[variant], className)}
+        {...props}
+      />
+    )
+  },
+)
+Button.displayName = 'Button'
+
+export { Button }

--- a/self/ui/src/components/card.tsx
+++ b/self/ui/src/components/card.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../lib/cn'
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('rounded-lg border border-border bg-background', className)}
+    {...props}
+  />
+))
+Card.displayName = 'Card'
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
+))
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+CardTitle.displayName = 'CardTitle'
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-4 pt-0', className)} {...props} />
+))
+CardContent.displayName = 'CardContent'
+
+export { Card, CardHeader, CardTitle, CardContent }

--- a/self/ui/src/components/collapsible.tsx
+++ b/self/ui/src/components/collapsible.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import * as React from 'react'
+
+interface CollapsibleContextValue {
+  open: boolean
+  onToggle: () => void
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null)
+
+export function Collapsible({
+  children,
+  defaultOpen = false,
+}: {
+  children: React.ReactNode
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = React.useState(defaultOpen)
+  const value = React.useMemo(
+    () => ({ open, onToggle: () => setOpen((o) => !o) }),
+    [open],
+  )
+  return (
+    <CollapsibleContext.Provider value={value}>
+      {children}
+    </CollapsibleContext.Provider>
+  )
+}
+
+export function CollapsibleTrigger({
+  children,
+  className = '',
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const ctx = React.useContext(CollapsibleContext)
+  if (!ctx) return null
+  return (
+    <button
+      type="button"
+      onClick={ctx.onToggle}
+      className={className}
+      {...props}
+    >
+      {children}
+      <span className="ml-1">{ctx.open ? '▼' : '▶'}</span>
+    </button>
+  )
+}
+
+export function CollapsibleContent({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  const ctx = React.useContext(CollapsibleContext)
+  if (!ctx) return null
+  if (!ctx.open) return null
+  return <div className={className}>{children}</div>
+}

--- a/self/ui/src/components/index.ts
+++ b/self/ui/src/components/index.ts
@@ -1,4 +1,7 @@
-// Shared component library — populated in ui/phase-1.2 (design system and component library)
-// This file is a scaffold placeholder.
-
-export {}
+export * from './badge'
+export * from './button'
+export * from './card'
+export * from './collapsible'
+export * from './input'
+export * from './scroll-area'
+export * from './select'

--- a/self/ui/src/components/input.tsx
+++ b/self/ui/src/components/input.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../lib/cn'
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/self/ui/src/components/scroll-area.tsx
+++ b/self/ui/src/components/scroll-area.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../lib/cn'
+
+const ScrollArea = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, children, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('overflow-auto', className)}
+    {...props}
+  >
+    {children}
+  </div>
+))
+ScrollArea.displayName = 'ScrollArea'
+
+export { ScrollArea }

--- a/self/ui/src/components/select.tsx
+++ b/self/ui/src/components/select.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../lib/cn'
+
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-border bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  ),
+)
+Select.displayName = 'Select'
+
+export { Select }

--- a/self/ui/src/index.ts
+++ b/self/ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from './panels/index'
 export * from './components/index'
 export * from './tokens/index'
+export { cn } from './lib/cn'

--- a/self/ui/src/lib/cn.ts
+++ b/self/ui/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/self/ui/src/tokens/index.ts
+++ b/self/ui/src/tokens/index.ts
@@ -1,4 +1,17 @@
-// Design tokens — populated in ui/phase-1.2 (design system and component library)
-// This file is a scaffold placeholder.
-
-export {}
+export const tokens = {
+  colors: {
+    background: 'hsl(var(--background))',
+    foreground: 'hsl(var(--foreground))',
+    border: 'hsl(var(--border))',
+    muted: 'hsl(var(--muted))',
+    mutedForeground: 'hsl(var(--muted-foreground))',
+    primary: 'hsl(var(--primary))',
+    primaryForeground: 'hsl(var(--primary-foreground))',
+    // dark defaults (zinc palette)
+    bgDefault: '#18181b',    // zinc-900
+    fgDefault: '#e4e4e7',    // zinc-200
+    fgMuted: '#71717a',      // zinc-500
+    fgSubtle: '#a1a1aa',     // zinc-400
+    borderDefault: '#3f3f46', // zinc-700
+  },
+} as const


### PR DESCRIPTION
## Summary

- **Design tokens** — `@nous/ui/tokens`: CSS variable references + zinc-palette dark defaults
- **`cn()` utility** — `@nous/ui/lib/cn` via clsx + tailwind-merge
- **7 components migrated** from `apps/web/components/ui/` to `@nous/ui/components`: button, input, badge, card, scroll-area, select, collapsible — all with `'use client'`
- **CSS custom properties** added to desktop renderer `index.css` (dark theme vars)
- **`transpilePackages: ['@nous/ui']`** added to `apps/web/next.config.ts`
- **peerDependencies** updated: tailwindcss, radix-ui packages

## Test plan

- [ ] `pnpm --filter @nous/desktop build` completes without errors
- [ ] `pnpm --filter @nous/web build` compiles `@nous/ui` components without errors
- [ ] Design tokens resolve correctly (CSS variables) in dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)