### PR TITLE
feat(ui/phase-1.3): Principal↔Cortex chat panel with voice input

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@nous/ui':
         specifier: workspace:*
         version: link:../../ui
+      '@trpc/client':
+        specifier: ^11.0.0
+        version: 11.10.0(@trpc/server@11.10.0(typescript@5.9.3))(typescript@5.9.3)
       dockview-react:
         specifier: ^4.2.0
         version: 4.13.1(react@19.2.3)
@@ -8686,7 +8689,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -8709,7 +8712,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8724,14 +8727,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8746,7 +8749,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/self/apps/desktop/package.json
+++ b/self/apps/desktop/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@nous/ui": "workspace:*",
+    "@trpc/client": "^11.0.0",
     "dockview-react": "^4.2.0",
     "electron-store": "^8.2.0",
     "react": "^19.0.0",

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'node:path'
 import Store from 'electron-store'
+import { createTRPCClient, httpBatchLink } from '@trpc/client'
 
 interface StoredLayout {
   version: 1
@@ -27,6 +28,38 @@ ipcMain.handle('layout:set', (_event, layout: unknown) => {
 // Filesystem stubs — implemented in ui/phase-1.4
 ipcMain.handle('fs:readDir', () => null)
 ipcMain.handle('fs:readFile', () => null)
+
+// Chat handlers — tRPC proxy to localhost:3000 with mock fallback
+// Lazy tRPC client — created on first use
+let trpcClient: ReturnType<typeof createTRPCClient> | null = null
+
+function getTrpcClient() {
+  if (!trpcClient) {
+    trpcClient = createTRPCClient({
+      links: [httpBatchLink({ url: 'http://localhost:3000/api/trpc' })],
+    })
+  }
+  return trpcClient
+}
+
+const chatHistory: { role: string; content: string; timestamp: string }[] = []
+
+ipcMain.handle('chat:send', async (_event, message: string) => {
+  chatHistory.push({ role: 'user', content: message, timestamp: new Date().toISOString() })
+  try {
+    const client = getTrpcClient() as any
+    const result = await client.chat.sendMessage.mutate({ message })
+    chatHistory.push({ role: 'assistant', content: result.response, timestamp: new Date().toISOString() })
+    return { response: result.response, traceId: result.traceId }
+  } catch {
+    // Fallback mock response for demo
+    const mockResponse = `[Demo mode] Nous received: "${message}". The tRPC server is not running — start the web app with \`pnpm dev:web\` to enable live responses.`
+    chatHistory.push({ role: 'assistant', content: mockResponse, timestamp: new Date().toISOString() })
+    return { response: mockResponse, traceId: 'demo-' + Date.now() }
+  }
+})
+
+ipcMain.handle('chat:getHistory', () => chatHistory)
 
 function createWindow(): void {
   const win = new BrowserWindow({

--- a/self/apps/desktop/src/preload/index.ts
+++ b/self/apps/desktop/src/preload/index.ts
@@ -9,4 +9,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     readDir: (path: string): Promise<null> => ipcRenderer.invoke('fs:readDir', path),
     readFile: (path: string): Promise<null> => ipcRenderer.invoke('fs:readFile', path),
   },
+  chat: {
+    send: (message: string): Promise<{ response: string; traceId: string }> =>
+      ipcRenderer.invoke('chat:send', message),
+    getHistory: (): Promise<{ role: string; content: string; timestamp: string }[]> =>
+      ipcRenderer.invoke('chat:getHistory'),
+  },
 })

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react'
 import { DockviewReact } from 'dockview-react'
 import type { DockviewReadyEvent, SerializedDockview } from 'dockview-react'
-import { PlaceholderPanel } from '@nous/ui/panels'
+import { PlaceholderPanel, ChatPanel } from '@nous/ui/panels'
 
 import 'dockview-react/dist/styles/dockview.css'
 
 const panelComponents = {
   placeholder: PlaceholderPanel,
+  chat: ChatPanel,
 }
 
 // Loading state: undefined = not yet fetched; null = fetched, no saved layout
@@ -73,8 +74,11 @@ function DockviewShell({ savedLayout }: { savedLayout: SerializedDockview | null
 
 function initDefaultLayout(event: DockviewReadyEvent) {
   event.api.addPanel({
-    id: 'welcome',
-    component: 'placeholder',
-    title: 'Welcome to Nous',
+    id: 'chat',
+    component: 'chat',
+    title: 'Principal ↔ Cortex',
+    params: {
+      chatApi: (window as any).electronAPI?.chat,
+    },
   })
 }

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -9,6 +9,10 @@ interface ElectronAPI {
     readDir: (path: string) => Promise<null>
     readFile: (path: string) => Promise<null>
   }
+  chat: {
+    send: (message: string) => Promise<{ response: string; traceId: string }>
+    getHistory: () => Promise<{ role: string; content: string; timestamp: string }[]>
+  }
 }
 
 interface Window {

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import type { IDockviewPanelProps } from 'dockview-react'
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: string
+}
+
+interface ChatAPI {
+  send: (message: string) => Promise<{ response: string; traceId: string }>
+  getHistory: () => Promise<ChatMessage[]>
+}
+
+interface ChatPanelProps extends IDockviewPanelProps {
+  params?: { chatApi?: ChatAPI }
+}
+
+export function ChatPanel({ params }: ChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [isListening, setIsListening] = useState(false)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+
+  const chatApi = params?.chatApi
+
+  useEffect(() => {
+    if (chatApi) {
+      chatApi.getHistory().then(setMessages)
+    }
+  }, [chatApi])
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const send = async () => {
+    if (!input.trim() || sending || !chatApi) return
+    const userMsg = input.trim()
+    setInput('')
+    setSending(true)
+    const userEntry: ChatMessage = { role: 'user', content: userMsg, timestamp: new Date().toISOString() }
+    setMessages(prev => [...prev, userEntry])
+    try {
+      const result = await chatApi.send(userMsg)
+      setMessages(prev => [...prev, { role: 'assistant', content: result.response, timestamp: new Date().toISOString() }])
+    } catch (e) {
+      setMessages(prev => [...prev, { role: 'assistant', content: 'Error: could not reach Nous.', timestamp: new Date().toISOString() }])
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      send()
+    }
+  }
+
+  const toggleVoice = () => {
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!SpeechRecognition) return
+    if (isListening && recognitionRef.current) {
+      recognitionRef.current.stop()
+      setIsListening(false)
+      return
+    }
+    const recognition: SpeechRecognition = new SpeechRecognition()
+    recognition.continuous = false
+    recognition.interimResults = false
+    recognition.onresult = (event) => {
+      const transcript = event.results[0]?.[0]?.transcript ?? ''
+      setInput(prev => prev + transcript)
+    }
+    recognition.onend = () => setIsListening(false)
+    recognitionRef.current = recognition
+    recognition.start()
+    setIsListening(true)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#18181b', color: '#e4e4e7', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' }}>
+      {/* Header */}
+      <div style={{ padding: '12px 16px', borderBottom: '1px solid #3f3f46', fontSize: '13px', fontWeight: 600, color: '#a1a1aa' }}>
+        Principal ↔ Cortex
+      </div>
+      {/* Messages */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        {messages.length === 0 && (
+          <div style={{ textAlign: 'center', color: '#52525b', fontSize: '13px', marginTop: '40px' }}>
+            {chatApi ? 'Start a conversation with Nous.' : 'Chat API not connected.'}
+          </div>
+        )}
+        {messages.map((msg, i) => (
+          <div key={i} style={{ display: 'flex', justifyContent: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
+            <div style={{
+              maxWidth: '80%', padding: '8px 12px', borderRadius: '8px', fontSize: '13px', lineHeight: '1.5',
+              background: msg.role === 'user' ? '#3b82f6' : '#27272a',
+              color: msg.role === 'user' ? '#fff' : '#e4e4e7',
+            }}>
+              {msg.content}
+            </div>
+          </div>
+        ))}
+        {sending && (
+          <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+            <div style={{ padding: '8px 12px', borderRadius: '8px', background: '#27272a', color: '#71717a', fontSize: '13px' }}>
+              Thinking...
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+      {/* Input */}
+      <div style={{ padding: '12px 16px', borderTop: '1px solid #3f3f46', display: 'flex', gap: '8px', alignItems: 'flex-end' }}>
+        <textarea
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Message Nous... (Enter to send, Shift+Enter for newline)"
+          disabled={sending}
+          style={{
+            flex: 1, resize: 'none', background: '#27272a', border: '1px solid #3f3f46',
+            borderRadius: '6px', padding: '8px 10px', color: '#e4e4e7', fontSize: '13px',
+            outline: 'none', lineHeight: '1.5', minHeight: '40px', maxHeight: '120px',
+            fontFamily: 'inherit',
+          }}
+          rows={1}
+        />
+        <button
+          onClick={toggleVoice}
+          title={isListening ? 'Stop listening' : 'Voice input'}
+          style={{
+            background: isListening ? '#ef4444' : '#27272a', border: '1px solid #3f3f46',
+            borderRadius: '6px', padding: '8px 10px', color: isListening ? '#fff' : '#a1a1aa',
+            cursor: 'pointer', fontSize: '16px', lineHeight: 1,
+          }}
+        >
+          🎤
+        </button>
+        <button
+          onClick={send}
+          disabled={sending || !input.trim() || !chatApi}
+          style={{
+            background: '#3b82f6', border: 'none', borderRadius: '6px',
+            padding: '8px 14px', color: '#fff', cursor: sending ? 'not-allowed' : 'pointer',
+            fontSize: '13px', fontWeight: 500, opacity: (sending || !input.trim() || !chatApi) ? 0.5 : 1,
+          }}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/self/ui/src/panels/index.ts
+++ b/self/ui/src/panels/index.ts
@@ -1,1 +1,2 @@
 export { PlaceholderPanel } from './PlaceholderPanel'
+export { ChatPanel } from './ChatPanel'


### PR DESCRIPTION
## Summary

- **ChatPanel** in `@nous/ui/panels`: message history, user/assistant bubbles, Enter-to-send, voice input toggle
- **Web Speech API** voice input: browser-native, works in Electron renderer, toggles mic on/off
- **tRPC client** in Electron main: connects to `localhost:3000/api/trpc` with graceful mock fallback for demo when web server not running
- **chat:send** / **chat:getHistory** IPC handlers with in-memory session history
- `@trpc/client` added to `@nous/desktop` dependencies

## Test plan

- [ ] `pnpm --filter @nous/desktop build` completes without errors
- [ ] Chat panel renders in dockview; messages send and receive
- [ ] Voice input: click mic → speak → transcript appears in input field
- [ ] Without web server: mock response shown with instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)