### PR TITLE
feat(ui/phase-1.4): file browser panel with Electron IPC filesystem

### DIFF
--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'node:path'
+import { readdir, readFile } from 'node:fs/promises'
 import Store from 'electron-store'
 
 interface StoredLayout {
@@ -24,9 +25,28 @@ ipcMain.handle('layout:set', (_event, layout: unknown) => {
   } satisfies StoredLayout)
 })
 
-// Filesystem stubs — implemented in ui/phase-1.4
-ipcMain.handle('fs:readDir', () => null)
-ipcMain.handle('fs:readFile', () => null)
+// Filesystem handlers — implemented in ui/phase-1.4
+ipcMain.handle('fs:readDir', async (_event, dirPath: string) => {
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true })
+    return entries.map(e => ({
+      name: e.name,
+      isDirectory: e.isDirectory(),
+      path: dirPath.replace(/\\/g, '/') + '/' + e.name,
+    }))
+  } catch {
+    return []
+  }
+})
+
+ipcMain.handle('fs:readFile', async (_event, filePath: string) => {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    return content
+  } catch {
+    return null
+  }
+})
 
 function createWindow(): void {
   const win = new BrowserWindow({

--- a/self/apps/desktop/src/preload/index.ts
+++ b/self/apps/desktop/src/preload/index.ts
@@ -6,7 +6,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     set: (layout: unknown): Promise<void> => ipcRenderer.invoke('layout:set', layout),
   },
   fs: {
-    readDir: (path: string): Promise<null> => ipcRenderer.invoke('fs:readDir', path),
-    readFile: (path: string): Promise<null> => ipcRenderer.invoke('fs:readFile', path),
+    readDir: (path: string): Promise<{ name: string; isDirectory: boolean; path: string }[]> => ipcRenderer.invoke('fs:readDir', path),
+    readFile: (path: string): Promise<string | null> => ipcRenderer.invoke('fs:readFile', path),
   },
 })

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react'
 import { DockviewReact } from 'dockview-react'
 import type { DockviewReadyEvent, SerializedDockview } from 'dockview-react'
-import { PlaceholderPanel } from '@nous/ui/panels'
+import { PlaceholderPanel, FileBrowserPanel } from '@nous/ui/panels'
 
 import 'dockview-react/dist/styles/dockview.css'
 
 const panelComponents = {
   placeholder: PlaceholderPanel,
+  'file-browser': FileBrowserPanel,
 }
 
 // Loading state: undefined = not yet fetched; null = fetched, no saved layout
@@ -76,5 +77,15 @@ function initDefaultLayout(event: DockviewReadyEvent) {
     id: 'welcome',
     component: 'placeholder',
     title: 'Welcome to Nous',
+  })
+  event.api.addPanel({
+    id: 'files',
+    component: 'file-browser',
+    title: 'Files',
+    position: { direction: 'right', referencePanel: 'welcome' },
+    params: {
+      fsApi: (window as any).electronAPI?.fs,
+      initialPath: '/',
+    },
   })
 }

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -6,8 +6,8 @@ interface ElectronAPI {
     set: (layout: unknown) => Promise<void>
   }
   fs: {
-    readDir: (path: string) => Promise<null>
-    readFile: (path: string) => Promise<null>
+    readDir: (path: string) => Promise<{ name: string; isDirectory: boolean; path: string }[]>
+    readFile: (path: string) => Promise<string | null>
   }
 }
 

--- a/self/ui/src/panels/FileBrowserPanel.tsx
+++ b/self/ui/src/panels/FileBrowserPanel.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { IDockviewPanelProps } from 'dockview-react'
+
+interface FsEntry {
+  name: string
+  isDirectory: boolean
+  path: string
+}
+
+interface FsAPI {
+  readDir: (path: string) => Promise<FsEntry[]>
+}
+
+interface FileBrowserPanelProps extends IDockviewPanelProps {
+  params?: { fsApi?: FsAPI; initialPath?: string }
+}
+
+export function FileBrowserPanel({ params }: FileBrowserPanelProps) {
+  const fsApi = params?.fsApi
+  const [currentPath, setCurrentPath] = useState(params?.initialPath ?? '/')
+  const [entries, setEntries] = useState<FsEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!fsApi) return
+    setLoading(true)
+    fsApi.readDir(currentPath).then(result => {
+      setEntries(result.sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
+        return a.name.localeCompare(b.name)
+      }))
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [currentPath, fsApi])
+
+  const goUp = () => {
+    const parts = currentPath.replace(/\\/g, '/').split('/').filter(Boolean)
+    if (parts.length === 0) return
+    parts.pop()
+    setCurrentPath('/' + parts.join('/') || '/')
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#18181b', color: '#e4e4e7', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', fontSize: '13px' }}>
+      {/* Path bar */}
+      <div style={{ padding: '8px 12px', borderBottom: '1px solid #3f3f46', display: 'flex', alignItems: 'center', gap: '8px', background: '#1c1c1f' }}>
+        <button onClick={goUp} style={{ background: 'none', border: 'none', color: '#a1a1aa', cursor: 'pointer', padding: '2px 6px', borderRadius: '4px', fontSize: '14px' }}>↑</button>
+        <span style={{ color: '#71717a', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{currentPath}</span>
+      </div>
+      {/* File list */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
+        {!fsApi && <div style={{ padding: '16px', color: '#52525b', textAlign: 'center' }}>File system API not connected.</div>}
+        {loading && <div style={{ padding: '16px', color: '#52525b', textAlign: 'center' }}>Loading...</div>}
+        {!loading && entries.map(entry => (
+          <div
+            key={entry.path}
+            onClick={() => {
+              if (entry.isDirectory) { setCurrentPath(entry.path); setSelected(null) }
+              else setSelected(entry.path)
+            }}
+            style={{
+              padding: '5px 12px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '8px',
+              background: selected === entry.path ? '#2d2d30' : 'transparent',
+              color: entry.isDirectory ? '#93c5fd' : '#e4e4e7',
+            }}
+            onMouseEnter={e => { if (selected !== entry.path) (e.currentTarget as HTMLElement).style.background = '#27272a' }}
+            onMouseLeave={e => { if (selected !== entry.path) (e.currentTarget as HTMLElement).style.background = 'transparent' }}
+          >
+            <span style={{ fontSize: '12px', width: '16px', textAlign: 'center', flexShrink: 0 }}>
+              {entry.isDirectory ? '📁' : '📄'}
+            </span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{entry.name}</span>
+          </div>
+        ))}
+      </div>
+      {/* Status bar */}
+      {selected && (
+        <div style={{ padding: '4px 12px', borderTop: '1px solid #3f3f46', color: '#71717a', fontSize: '11px', background: '#1c1c1f', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {selected}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/self/ui/src/panels/index.ts
+++ b/self/ui/src/panels/index.ts
@@ -1,1 +1,2 @@
 export { PlaceholderPanel } from './PlaceholderPanel'
+export { FileBrowserPanel } from './FileBrowserPanel'


### PR DESCRIPTION
## Summary

- **FileBrowserPanel** in `@nous/ui/panels`: directory navigation, sorted listing (dirs first), blue dir / grey file distinction, status bar, loading + disconnected states
- **`fs:readDir` IPC handler**: Node.js `readdir` with `withFileTypes`, returns name/isDirectory/path array
- **`fs:readFile` IPC handler**: reads file as utf-8, returns null on error
- Replaces the phase-1.1 no-op stubs with full implementations
- Desktop default layout updated: welcome panel + file browser side by side

## Test plan

- [ ] `pnpm --filter @nous/desktop build` completes without errors
- [ ] File browser panel shows directory listing starting at `/`
- [ ] Click directory → navigates into it; `↑` button → goes up
- [ ] Click file → shows path in status bar
- [ ] Path with permission error → shows empty listing (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)