### PR TITLE
feat(ui/phase-1.5): MAO panel + node projection panel stubs

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react'
 import { DockviewReact } from 'dockview-react'
 import type { DockviewReadyEvent, SerializedDockview } from 'dockview-react'
-import { PlaceholderPanel } from '@nous/ui/panels'
+import { PlaceholderPanel, NodeProjectionPanel, MAOPanel } from '@nous/ui/panels'
 
 import 'dockview-react/dist/styles/dockview.css'
 
 const panelComponents = {
   placeholder: PlaceholderPanel,
+  'node-projection': NodeProjectionPanel,
+  'mao': MAOPanel,
 }
 
 // Loading state: undefined = not yet fetched; null = fetched, no saved layout
@@ -73,8 +75,14 @@ function DockviewShell({ savedLayout }: { savedLayout: SerializedDockview | null
 
 function initDefaultLayout(event: DockviewReadyEvent) {
   event.api.addPanel({
-    id: 'welcome',
-    component: 'placeholder',
-    title: 'Welcome to Nous',
+    id: 'node-projection',
+    component: 'node-projection',
+    title: 'Skill Projection',
+  })
+  event.api.addPanel({
+    id: 'mao',
+    component: 'mao',
+    title: 'MAO',
+    position: { direction: 'below', referencePanel: 'node-projection' },
   })
 }

--- a/self/ui/src/index.ts
+++ b/self/ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from './panels/index'
 export * from './components/index'
 export * from './tokens/index'
+export * from './types/skill-graph'

--- a/self/ui/src/panels/MAOPanel.tsx
+++ b/self/ui/src/panels/MAOPanel.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import type { IDockviewPanelProps } from 'dockview-react'
+
+interface AgentCycleEntry {
+  agent: string
+  role: 'orchestrator' | 'worker' | 'reviewer' | 'prompt-gen'
+  state: 'idle' | 'active' | 'complete' | 'waiting'
+  lastPacket?: string
+  cycle: number
+}
+
+const DEMO_MAO_STATE: AgentCycleEntry[] = [
+  { agent: 'nous-orchestrator', role: 'orchestrator', state: 'active', lastPacket: 'dispatch → impl-worker', cycle: 2 },
+  { agent: 'nous-prompt-gen', role: 'prompt-gen', state: 'complete', lastPacket: 'handoff → sds-worker', cycle: 1 },
+  { agent: 'nous-worker-sds', role: 'worker', state: 'complete', lastPacket: 'response_packet → orchestrator', cycle: 1 },
+  { agent: 'nous-worker-impl', role: 'worker', state: 'active', lastPacket: 'executing implementation', cycle: 2 },
+  { agent: 'nous-reviewer', role: 'reviewer', state: 'waiting', lastPacket: 'awaiting handoff', cycle: 2 },
+]
+
+const ROLE_ICON: Record<string, string> = {
+  orchestrator: '🎯', worker: '⚙️', reviewer: '🔍', 'prompt-gen': '✍️',
+}
+
+const STATE_COLOR: Record<string, string> = {
+  idle: '#52525b', active: '#3b82f6', complete: '#22c55e', waiting: '#f59e0b',
+}
+
+interface MAOPanelProps extends IDockviewPanelProps {
+  params?: { entries?: AgentCycleEntry[] }
+}
+
+export function MAOPanel({ params }: MAOPanelProps) {
+  const entries = params?.entries ?? DEMO_MAO_STATE
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#18181b', color: '#e4e4e7', fontFamily: 'system-ui, sans-serif', fontSize: '13px' }}>
+      <div style={{ padding: '10px 16px', borderBottom: '1px solid #3f3f46', fontWeight: 600, fontSize: '12px', color: '#a1a1aa', display: 'flex', justifyContent: 'space-between' }}>
+        <span>MAO — Agent Cycle</span>
+        <span style={{ color: '#52525b', fontWeight: 400 }}>Cycle {Math.max(...entries.map(e => e.cycle))}</span>
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {entries.map((entry, i) => (
+          <div key={i} style={{ padding: '10px 16px', borderBottom: '1px solid #27272a', display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <span style={{ fontSize: '16px', flexShrink: 0 }}>{ROLE_ICON[entry.role]}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={{ fontWeight: 500, color: '#d4d4d8' }}>{entry.agent}</span>
+                <span style={{ fontSize: '11px', color: STATE_COLOR[entry.state], fontWeight: 600, textTransform: 'uppercase' }}>{entry.state}</span>
+              </div>
+              {entry.lastPacket && (
+                <div style={{ fontSize: '11px', color: '#71717a', marginTop: '2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {entry.lastPacket}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ padding: '6px 16px', borderTop: '1px solid #3f3f46', fontSize: '11px', color: '#52525b' }}>
+        Stub — live adapter pending DISC-2026-02-28-001 ratification
+      </div>
+    </div>
+  )
+}

--- a/self/ui/src/panels/NodeProjectionPanel.tsx
+++ b/self/ui/src/panels/NodeProjectionPanel.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import type { IDockviewPanelProps } from 'dockview-react'
+import type { SkillGraph, NodeState } from '../types/skill-graph'
+
+const DEMO_SKILL_GRAPH: SkillGraph = {
+  skillId: 'engineer-workflow-sop::nous-core::phase-7',
+  nodes: [
+    { id: 'orchestrator', label: 'Orchestrator', type: 'orchestrator', state: 'active', cycle: 2 },
+    { id: 'prompt-gen', label: 'PromptGen', type: 'prompt-gen', state: 'complete', cycle: 1 },
+    { id: 'sds-worker', label: 'SDS Worker', type: 'worker', state: 'complete', cycle: 1 },
+    { id: 'plan-worker', label: 'Plan Worker', type: 'worker', state: 'complete', cycle: 1 },
+    { id: 'impl-worker', label: 'Impl Worker', type: 'worker', state: 'active', cycle: 2 },
+    { id: 'reviewer', label: 'Reviewer', type: 'reviewer', state: 'waiting', cycle: 2 },
+  ],
+  edges: [
+    { id: 'e1', source: 'orchestrator', target: 'prompt-gen', packetType: 'dispatch', label: 'dispatch' },
+    { id: 'e2', source: 'prompt-gen', target: 'sds-worker', packetType: 'handoff', label: 'handoff' },
+    { id: 'e3', source: 'sds-worker', target: 'orchestrator', packetType: 'response_packet', label: 'response' },
+    { id: 'e4', source: 'orchestrator', target: 'impl-worker', packetType: 'dispatch', label: 'dispatch' },
+    { id: 'e5', source: 'impl-worker', target: 'reviewer', packetType: 'handoff', label: 'handoff' },
+  ],
+  activeNodeId: 'impl-worker',
+  snapshotAt: new Date().toISOString(),
+}
+
+const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
+  orchestrator: { x: 300, y: 60 },
+  'prompt-gen': { x: 150, y: 160 },
+  'sds-worker': { x: 300, y: 160 },
+  'plan-worker': { x: 450, y: 160 },
+  'impl-worker': { x: 200, y: 260 },
+  reviewer: { x: 400, y: 260 },
+}
+
+const STATE_COLORS: Record<NodeState, string> = {
+  idle: '#3f3f46',
+  active: '#2563eb',
+  waiting: '#d97706',
+  blocked: '#dc2626',
+  complete: '#16a34a',
+  approved: '#0891b2',
+  'needs-revision': '#9333ea',
+}
+
+interface NodeProjectionPanelProps extends IDockviewPanelProps {
+  params?: { graph?: SkillGraph }
+}
+
+export function NodeProjectionPanel({ params }: NodeProjectionPanelProps) {
+  const graph = params?.graph ?? DEMO_SKILL_GRAPH
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null)
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#18181b', color: '#e4e4e7', fontFamily: 'system-ui, sans-serif' }}>
+      {/* Header */}
+      <div style={{ padding: '10px 16px', borderBottom: '1px solid #3f3f46', fontSize: '12px', color: '#a1a1aa', display: 'flex', justifyContent: 'space-between' }}>
+        <span style={{ fontWeight: 600 }}>Node Projection</span>
+        <span style={{ color: '#52525b' }}>{graph.skillId}</span>
+      </div>
+      {/* Graph */}
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '16px' }}>
+        <svg viewBox="0 0 600 340" style={{ width: '100%', maxWidth: '600px', height: 'auto' }}>
+          <defs>
+            <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+              <path d="M0,0 L0,6 L8,3 z" fill="#52525b" />
+            </marker>
+          </defs>
+          {/* Edges */}
+          {graph.edges.map(edge => {
+            const from = NODE_POSITIONS[edge.source]
+            const to = NODE_POSITIONS[edge.target]
+            if (!from || !to) return null
+            // Offset line ends to node edge (half-width=40, half-height=16)
+            const dx = to.x - from.x
+            const dy = to.y - from.y
+            const len = Math.sqrt(dx * dx + dy * dy)
+            const ux = dx / len, uy = dy / len
+            const x1 = from.x + ux * 40, y1 = from.y + uy * 16
+            const x2 = to.x - ux * 48, y2 = to.y - uy * 20
+            return (
+              <g key={edge.id}>
+                <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="#3f3f46" strokeWidth="1.5" markerEnd="url(#arrow)" />
+                {edge.label && (
+                  <text x={(x1 + x2) / 2} y={(y1 + y2) / 2 - 6} fill="#52525b" fontSize="9" textAnchor="middle">{edge.label}</text>
+                )}
+              </g>
+            )
+          })}
+          {/* Nodes */}
+          {graph.nodes.map(node => {
+            const pos = NODE_POSITIONS[node.id]
+            if (!pos) return null
+            const isActive = graph.activeNodeId === node.id
+            const isHovered = hoveredNode === node.id
+            return (
+              <g key={node.id} transform={`translate(${pos.x - 40}, ${pos.y - 16})`}
+                onMouseEnter={() => setHoveredNode(node.id)}
+                onMouseLeave={() => setHoveredNode(null)}
+                style={{ cursor: 'default' }}>
+                {isActive && <rect x="-4" y="-4" width="88" height="40" rx="10" fill="none" stroke="#60a5fa" strokeWidth="2.5" opacity="0.5" />}
+                <rect width="80" height="32" rx="7" fill={STATE_COLORS[node.state]} />
+                <text x="40" y="21" fill="white" fontSize="10" fontWeight={600} textAnchor="middle">{node.label}</text>
+                {isHovered && (
+                  <title>{`${node.id} · ${node.type} · ${node.state}${node.cycle ? ` · cycle ${node.cycle}` : ''}`}</title>
+                )}
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+      {/* Footer */}
+      <div style={{ padding: '6px 16px', borderTop: '1px solid #3f3f46', fontSize: '11px', color: '#52525b', display: 'flex', justifyContent: 'space-between' }}>
+        <span>{graph.nodes.length} nodes · {graph.edges.length} edges</span>
+        <span>{new Date(graph.snapshotAt).toLocaleTimeString()}</span>
+      </div>
+    </div>
+  )
+}

--- a/self/ui/src/panels/index.ts
+++ b/self/ui/src/panels/index.ts
@@ -1,1 +1,3 @@
 export { PlaceholderPanel } from './PlaceholderPanel'
+export { NodeProjectionPanel } from './NodeProjectionPanel'
+export { MAOPanel } from './MAOPanel'

--- a/self/ui/src/types/skill-graph.ts
+++ b/self/ui/src/types/skill-graph.ts
@@ -1,0 +1,29 @@
+export type NodeState = 'idle' | 'active' | 'waiting' | 'blocked' | 'complete' | 'approved' | 'needs-revision'
+export type NodeType = 'orchestrator' | 'worker' | 'reviewer' | 'prompt-gen'
+export type PacketType = 'dispatch' | 'handoff' | 'response_packet'
+
+export interface SkillNode {
+  id: string
+  label: string
+  type: NodeType
+  state: NodeState
+  cycle?: number
+  agent?: string
+  updatedAt?: string
+}
+
+export interface SkillEdge {
+  id: string
+  source: string
+  target: string
+  label?: string
+  packetType: PacketType
+}
+
+export interface SkillGraph {
+  skillId: string
+  nodes: SkillNode[]
+  edges: SkillEdge[]
+  activeNodeId?: string
+  snapshotAt: string
+}


### PR DESCRIPTION
## Summary

- **SkillGraph interface contract** in `@nous/ui/types/skill-graph`: `SkillNode`, `SkillEdge`, `SkillGraph`, `NodeState`, `NodeType`, `PacketType`
- **NodeProjectionPanel**: pure SVG graph — hierarchical layout, state-colored nodes, edge arrows with packet-type labels, active node glow ring, hover tooltips
- **MAOPanel**: agent cycle status list — role icons, state colors, last-packet display per agent
- Both seeded with engineer-workflow-sop phase-7 demo data (orchestrator, prompt-gen, sds/impl workers, reviewer)
- Stub footer: _"Live adapter pending DISC-2026-02-28-001 ratification"_

## Test plan

- [ ] `pnpm --filter @nous/desktop build` completes without errors
- [ ] NodeProjectionPanel renders SVG graph with 6 nodes and edges
- [ ] Active node (impl-worker) shows blue glow ring
- [ ] MAOPanel shows 5 agents with state indicators
- [ ] No external visualization library dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)