### PR TITLE
Phase 13.5 — Tunnel and Hosted Public Gateway Deployment

### DIFF
--- a/docs/content/docs/api/public-mcp.mdx
+++ b/docs/content/docs/api/public-mcp.mdx
@@ -5,15 +5,16 @@ description: Reference for the public machine-to-machine MCP surface
 
 # Public MCP Edge
 
-Phase 13.4 keeps the public MCP edge as a real public execution surface while the promoted-tier
-bridge remains internal-only. External clients can:
+Phase 13.5 keeps the public MCP edge as a real public execution surface while adding deployment
+parity across development, hosted, and local-tunnel backends. External clients can:
 
 - discover public-safe agent entries with `ortho.agents.v1.list`
 - invoke approved public agents with `ortho.agents.v1.invoke`
 - read public-safe runtime posture with `ortho.system.v1.info`
 - poll long-running public work with `tasks/get` and `tasks/result`
 
-The web host remains transport-thin. It authenticates, validates, and delegates into the canonical public runtime rather than acting as a second execution harness.
+The web host remains transport-thin. It authenticates, validates, and delegates into the canonical
+public runtime rather than acting as a second execution harness.
 
 ## Endpoints
 
@@ -23,6 +24,18 @@ The web host remains transport-thin. It authenticates, validates, and delegates 
 | `/.well-known/oauth-protected-resource/mcp` | `GET` | Protected Resource Metadata for the public MCP resource |
 | `/.well-known/oauth-authorization-server/mcp` | `GET` | Authorization Server Metadata for the public MCP resource |
 
+## Deployment parity
+
+Phase 13.5 preserves one public MCP contract across all supported deployment backends:
+
+- `development` uses the app-hosted runtime directly
+- `local_tunnel` forwards only already-admitted public calls into the local runtime
+- `hosted` resolves the request into a tenant-local hosted runtime
+
+Clients do not switch endpoints, tools, auth posture, or task semantics when the backend changes.
+The only public-safe deployment distinction surfaced to callers is `server.backendMode` in
+`ortho.system.v1.info`, which can be `development`, `local_tunnel`, or `hosted`.
+
 ## Admission posture
 
 - `/mcp` requires OAuth bearer posture before any tool mapping, task lookup, or runtime dispatch.
@@ -30,8 +43,10 @@ The web host remains transport-thin. It authenticates, validates, and delegates 
 - External callers are represented as `ExternalClient` subjects at the boundary.
 - Public tool names stay namespaced as `ortho.*` and map once onto the canonical flat internal capability surface.
 - Agent invoke scopes are binding-aware: `ortho.agents.v1.invoke` always requires `ortho.agents.invoke`, plus any requested memory-tier scopes derived from the binding payload.
+- The public edge remains the only authority for auth, quota, rate-limit, and audit posture even
+  when the selected backend is `local_tunnel` or `hosted`.
 
-## Phase 13.4 availability
+## Phase 13.5 availability
 
 `tools/list` returns only the intersection of caller scopes and current-phase-enabled public mappings.
 
@@ -47,6 +62,9 @@ The web host remains transport-thin. It authenticates, validates, and delegates 
 | `ortho.agents.v1.list` | Discover public-safe agent catalog entries | `ortho.system.read` | none |
 | `ortho.agents.v1.invoke` | Invoke an approved public agent | `ortho.agents.invoke` plus any binding-derived memory scopes | optional |
 | `ortho.system.v1.info` | Read public-safe runtime metadata | `ortho.system.read` | none |
+
+The tool list and request/response shapes remain the same across `development`, `local_tunnel`, and
+`hosted` backends.
 
 ## Public agents
 
@@ -328,9 +346,9 @@ Synchronous completion example for `executionMode: "sync"` when the run finishes
   "id": "rpc-system-1",
   "result": {
     "server": {
-      "name": "Nous Public MCP",
-      "phase": "phase-13.4",
-      "backendMode": "development",
+      "name": "Andre Hosted Nous",
+      "phase": "phase-13.5",
+      "backendMode": "hosted",
       "protocolVersion": "2025-11-25"
     },
     "features": {
@@ -358,6 +376,9 @@ Synchronous completion example for `executionMode: "sync"` when the run finishes
   }
 }
 ```
+
+The response shape stays the same across backends. Only public-safe deployment details such as
+`server.name`, `server.phase`, and `server.backendMode` vary.
 
 ## Carried-forward memory examples
 
@@ -412,7 +433,7 @@ Use `mode: "supersede"` when the new record replaces an existing one. The gatewa
 
 ## Error behavior
 
-Common public reject reasons in Phase 13.4:
+Common public reject reasons in Phase 13.5:
 
 | Reject reason | Meaning |
 |---|---|
@@ -426,11 +447,33 @@ Common public reject reasons in Phase 13.4:
 | `source_quarantined` | The source is quarantined or purged for durable mutation paths. |
 | `quota_exceeded` | The request exceeds the namespace + token quota window. |
 | `rate_limited` | The namespace + token has exceeded the allowed request rate for the tool. |
+| `deployment_not_resolved` | The public host did not map to a known development, hosted, or tunnel deployment target. |
+| `tunnel_envelope_invalid` | The forwarded tunnel request failed signature, binding, or expiry validation. |
+| `tunnel_replay_detected` | A tunnel nonce was already consumed and the request was rejected as a replay. |
 
 ## Operator configuration
 
-Phase 13.4 introduces no additional public-edge environment variables. `NOUS_PUBLIC_BASE_URL` remains the public MCP edge override used by the OAuth discovery documents.
+Phase 13.5 adds deployment-seeding environment variables for hosted and local-tunnel routing:
+
+| Variable | Purpose |
+|---|---|
+| `NOUS_PUBLIC_BASE_URL` | Base URL used by the OAuth discovery documents for the public MCP edge. |
+| `NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON` | Seeded hosted tenant bindings used to map a public host or user handle to a hosted backend. |
+| `NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON` | Seeded tunnel sessions used to map a public host or user handle to a local-tunnel backend. |
+
+See [Configuration Schema](/docs/configuration/config-schema) for the accepted JSON shapes.
 
 ## Runtime boundary
 
-The public MCP edge is not a public-only business-logic stack. The host accepts HTTP and JSON-RPC traffic, the public gateway owns admission and audit posture, and admitted calls flow into the canonical gateway/runtime seam. Long-running public work is projected through subject-scoped task records rather than a second status model. Phase 13.4 does not add any public promoted-tier tool or public path into internal-only promoted storage.
+The public MCP edge is not a public-only business-logic stack. The host accepts HTTP and JSON-RPC
+traffic, the public gateway owns admission and audit posture, and admitted calls flow into the
+canonical gateway/runtime seam.
+
+- `local_tunnel` does not expose a raw local MCP server; it forwards only already-admitted public
+  calls into the local runtime.
+- `hosted` resolves requests into tenant-local runtime state rather than proxying through shared
+  mutable storage.
+- Long-running public work is projected through subject-scoped task records rather than a second
+  status model.
+- Phase 13.5 still does not add any public promoted-tier tool or public path into internal-only
+  promoted storage.

--- a/docs/content/docs/architecture/entity-model.mdx
+++ b/docs/content/docs/architecture/entity-model.mdx
@@ -1,0 +1,86 @@
+---
+title: Entity Model
+description: "Apps, Skills, Projects, and Workflows — how the four entity types in Nous are organized and interconnect."
+---
+
+# Entity Model
+
+## Entity Map
+
+```
+Nous Instance
+│
+├── Apps (system-wide, always available when active)
+│   ├── com.acme.email
+│   ├── com.acme.trading
+│   └── com.acme.calendar
+│
+├── Skills (system-wide, but loadable per-context)
+│   ├── conservative-trading (atomic)
+│   ├── email-triage (atomic)
+│   ├── writing-style-formal (atomic)
+│   └── swe-project-management (composite → deps on atomic skills)
+│
+└── Projects (organizational containers)
+    ├── "Personal Finance"
+    │   ├── uses: com.acme.trading, com.acme.email
+    │   ├── loads: conservative-trading
+    │   └── workflows:
+    │       ├── morning-portfolio-review
+    │       └── monthly-tax-summary
+    │
+    └── "Startup"
+        ├── uses: com.acme.email, com.acme.calendar
+        ├── loads: email-triage, writing-style-formal
+        └── workflows:
+            ├── daily-inbox-zero
+            └── weekly-investor-update
+```
+
+## The Hierarchy
+
+| Entity | Scope | Lives Where | Owned By |
+|---|---|---|---|
+| **App** | System-wide | Installed on the Nous instance | User installs, Nous governs |
+| **Skill** | System-wide, but context-loadable | Installed on the Nous instance | User installs or agent generates |
+| **Project** | Organizational container | Memory namespace with isolation policies | User creates |
+| **Workflow** | Scoped to a Project (instance) | Definition installed system-wide; instance lives inside a Project | User or agent creates |
+
+## How They Interconnect
+
+**Apps are infrastructure.** They exist at the system level. They don't know about Projects, Skills, or Workflows. They just expose tools. Any Project can use any active App's tools.
+
+**Skills are judgment.** They exist at the system level but are **contextually loaded** — a Project can declare which Skills are active within it. A Workflow can declare which Skills guide its execution. Skills not loaded into a context aren't consulted. System-wide Skills (always active) are also possible.
+
+**Projects are containers.** They group conversations, workflows, memory, and context. They declare which Apps they use and which Skills they load. Projects are the **user's organizational unit** — "Personal Finance," "Startup," "PhD Research."
+
+**Workflows are automation within a Project.** They compose App tools + Skill guidance into executable sequences. A workflow has two levels: the **definition** (an installable package, system-wide, like a class) and the **instance** (scoped to a Project, like an object). Multiple Projects can instantiate the same workflow definition simultaneously, each with its own memory context, skill loadout, and app bindings. Workflow instances belong to a Project — they can't execute outside one.
+
+## Skills: Atomic and Composite
+
+Skills exist in two tiers:
+
+- **Atomic skills** are self-contained, single-concern judgment units. They follow the [agentskills.io](https://agentskills.io) open standard and are portable across any compatible agent.
+- **Composite skills** orchestrate multiple atomic skills into coherent domain expertise. They declare dependencies on constituent skills and guide which to load and when.
+
+**The workflow says what to do. The composite skill says what judgment to apply and how to compose it. The atomic skills are the actual judgment units.**
+
+```
+Workflow graph node (e.g., "code review step")
+  → loads composite skill (e.g., "code-review")
+    → loads atomic skills (e.g., "variable-scoping", "testing-patterns", "error-handling")
+```
+
+## The Key UX Distinctions
+
+1. **Installing an App** is like installing an app on your phone. System-wide. Available to everything. Not project-specific.
+
+2. **Installing a Skill** is like acquiring expertise. System-wide. But you choose when to apply it — some Projects load it, others don't.
+
+3. **Creating a Project** is like opening a workspace. It's where you organize your work, conversations, and automation around a purpose.
+
+4. **Creating a Workflow** is like setting up a recurring routine within a workspace. It only makes sense within the context of a Project. Installing a workflow definition is like downloading a recipe; binding it to a Project is like cooking it in your kitchen.
+
+## The One Sentence Version
+
+**Apps give Nous hands. Skills give Nous judgment. Projects give the user organization. Workflows give Projects automation.**

--- a/docs/content/docs/architecture/interaction-surfaces.mdx
+++ b/docs/content/docs/architecture/interaction-surfaces.mdx
@@ -254,11 +254,24 @@ Allowing approved external clients to discover and call the ratified public MCP 
 - Boundary-local `ExternalClient` subject posture; internal Worker, Orchestrator, Cortex:System, and Cortex:Principal classes remain unchanged
 - Public `ortho.*` tool names mapped once onto the canonical flat internal catalog
 - External-only namespace bootstrap and witness-linked audit evidence for durable admits and security-sensitive rejects
-- Phase 13.1 intentionally exposes no current-phase-enabled public tools until later public capability phases land
+- Same public contract across `development`, `local_tunnel`, and `hosted` backends
+- Public-safe system info can expose deployment mode, phase, and server name without revealing internal-only topology
+- Backend selection is internal to the edge and does not create a second public API surface
 
 ### Runtime Boundary
 
-The public MCP edge is not a second API stack. The web host parses HTTP and discovery traffic, then composes `IPublicMcpGatewayService` with the core public execution bridge. Admitted traffic still flows through the existing AgentGateway, Internal MCP, and backpressure seams, and rejected traffic records the same witness and audit posture as other authority-sensitive ingress paths.
+The public MCP edge is not a second API stack. The web host parses HTTP and discovery traffic, then
+composes `IPublicMcpGatewayService` with the core public execution bridge.
+
+- Admitted traffic still flows through the existing AgentGateway, Internal MCP, and backpressure
+  seams, and rejected traffic records the same witness and audit posture as other
+  authority-sensitive ingress paths.
+- The public edge remains the only admission authority for auth, quotas, rate limits, and audit
+  posture even when execution is routed to a tunnel or hosted backend.
+- Tunnel mode does not expose a raw local MCP server publicly; it forwards only already-admitted
+  public calls into the local runtime.
+- Hosted mode resolves requests into tenant-local runtime state rather than a shared thin proxy
+  over shared mutable storage.
 
 ---
 

--- a/docs/content/docs/architecture/meta.json
+++ b/docs/content/docs/architecture/meta.json
@@ -1,1 +1,1 @@
-{"title":"Architecture","pages":["repo-folder-structure","tech-stack","pfc-mode-capability-matrix","project-model","interaction-surfaces","security-baseline","workmode-and-authority-boundaries"]}
+{"title":"Architecture","pages":["repo-folder-structure","tech-stack","entity-model","pfc-mode-capability-matrix","project-model","interaction-surfaces","security-baseline","workmode-and-authority-boundaries"]}

--- a/docs/content/docs/configuration/config-schema.mdx
+++ b/docs/content/docs/configuration/config-schema.mdx
@@ -170,5 +170,68 @@ These apply to newly created projects.
 | `NOUS_CONFIG_PATH` | Config file path |
 | `NOUS_BASIC_AUTH` | Basic auth for tRPC (format: `user:password`) |
 | `NOUS_PUBLIC_BASE_URL` | Base URL used in OAuth discovery documents for the public MCP edge (default: `http://localhost:3000`). Set this when deploying behind a non-localhost public endpoint. |
+| `NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON` | Seeded hosted public-MCP binding records used to map a public host or user handle onto a hosted tenant runtime. Accepts a JSON object or JSON array of binding records. |
+| `NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON` | Seeded public-MCP tunnel session records used to map a public host or user handle onto a local tunnel runtime. Accepts a JSON object or JSON array of session records. |
 
-Phase 13.2 config audit result: the public memory tool rollout introduced no additional operator-facing environment variables. `NOUS_PUBLIC_BASE_URL` remains the only public MCP edge override required for OAuth metadata and discovery URLs.
+Phase 13.5 config audit result: public MCP deployment routing adds two operator-facing seed
+variables for hosted and local-tunnel routing. `NOUS_PUBLIC_BASE_URL` remains the public MCP edge
+override for OAuth metadata and discovery URLs.
+
+### `NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON`
+
+Use this variable to seed hosted tenant routing records during web bootstrap. Each record must
+match the hosted-binding schema used by the public gateway:
+
+```json
+[
+  {
+    "bindingId": "binding-1",
+    "tenantId": "tenant-1",
+    "userHandle": "andre",
+    "host": "andre.nous.run",
+    "storePrefix": "tenant-andre",
+    "serverName": "Andre Hosted Nous",
+    "phase": "phase-13.5",
+    "status": "active",
+    "createdAt": "2026-03-14T00:00:00.000Z",
+    "updatedAt": "2026-03-14T00:00:00.000Z"
+  }
+]
+```
+
+- `bindingId` — stable binding record identifier
+- `tenantId` — tenant-scoped runtime identity
+- `userHandle` — public handle used for hosted routing
+- `host` — public host that resolves to the hosted tenant runtime
+- `storePrefix` — tenant-local storage prefix used for document/vector/task/audit isolation
+- `serverName` — public-safe `ortho.system.v1.info` server name override
+- `phase` — public-safe phase label surfaced in `ortho.system.v1.info`
+- `status` — current binding state (`active` or `disabled`)
+
+### `NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON`
+
+Use this variable to seed local-tunnel routing records during web bootstrap. Each record must match
+the tunnel-session schema used by the public gateway:
+
+```json
+[
+  {
+    "sessionId": "session-1",
+    "userHandle": "casey",
+    "host": "casey.tunnel.nous.run",
+    "sharedSecret": "0123456789abcdef0123456789abcdef",
+    "status": "active",
+    "createdAt": "2026-03-14T00:00:00.000Z",
+    "updatedAt": "2026-03-14T00:00:00.000Z"
+  }
+]
+```
+
+- `sessionId` — stable tunnel session identifier
+- `userHandle` — public handle associated with the tunnel session
+- `host` — public host that resolves to the tunnel backend
+- `sharedSecret` — shared secret used to validate edge-issued tunnel envelopes
+- `status` — current session state (`active` or `disabled`)
+
+These variables affect deployment routing only. They do not change the public MCP tool catalog,
+OAuth posture, or JSON-RPC request and response shapes seen by external clients.

--- a/self/apps/web/app/mcp/route.ts
+++ b/self/apps/web/app/mcp/route.ts
@@ -110,6 +110,7 @@ export async function POST(request: Request): Promise<Response> {
             ? rpcRequest.params
             : undefined,
       subject: admission.subject!,
+      requestUrl: request.url,
       idempotencyKey: request.headers.get('idempotency-key') ?? undefined,
       requestedAt: new Date().toISOString(),
     }),

--- a/self/apps/web/server/__tests__/bootstrap-gateway-runtime.test.ts
+++ b/self/apps/web/server/__tests__/bootstrap-gateway-runtime.test.ts
@@ -3,11 +3,14 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdirSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import type { PublicMcpSubject } from '@nous/shared';
 import { ProviderRegistry } from '@nous/subcortex-providers';
 import { clearNousContextCache, createNousContext } from '../bootstrap';
 
 describe('bootstrap gateway runtime', () => {
   const originalDataDir = process.env.NOUS_DATA_DIR;
+  const originalHostedBindings = process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON;
+  const originalTunnelSessions = process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON;
   let capturedLaneRegistry: ProviderRegistry['laneRegistry'] | null = null;
   let capturedProviderId: ReturnType<ProviderRegistry['listProviders']>[number]['id'] | null =
     null;
@@ -29,6 +32,16 @@ describe('bootstrap gateway runtime', () => {
       delete process.env.NOUS_DATA_DIR;
     } else {
       process.env.NOUS_DATA_DIR = originalDataDir;
+    }
+    if (originalHostedBindings === undefined) {
+      delete process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON;
+    } else {
+      process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON = originalHostedBindings;
+    }
+    if (originalTunnelSessions === undefined) {
+      delete process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON;
+    } else {
+      process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON = originalTunnelSessions;
     }
     vi.restoreAllMocks();
     clearNousContextCache();
@@ -82,5 +95,80 @@ describe('bootstrap gateway runtime', () => {
         leaseId,
       });
     });
+  });
+
+  it('boots deployment-aware public gateway bundles for hosted and tunnel routing', async () => {
+    const dataDir = join(tmpdir(), `nous-web-gateway-runtime-${randomUUID()}`);
+    mkdirSync(dataDir, { recursive: true });
+
+    process.env.NOUS_DATA_DIR = dataDir;
+    process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON = JSON.stringify([
+      {
+        bindingId: 'binding-1',
+        tenantId: 'tenant-1',
+        userHandle: 'andre',
+        host: 'andre.nous.run',
+        storePrefix: 'tenant-andre',
+        serverName: 'Andre Hosted Nous',
+        phase: 'phase-13.5',
+        status: 'active',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+      },
+    ]);
+    process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON = JSON.stringify([
+      {
+        sessionId: 'session-1',
+        userHandle: 'casey',
+        host: 'casey.tunnel.nous.run',
+        sharedSecret: '0123456789abcdef0123456789abcdef',
+        status: 'active',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+      },
+    ]);
+    clearNousContextCache();
+
+    const ctx = createNousContext();
+    const subject: PublicMcpSubject = {
+      class: 'ExternalClient' as const,
+      clientId: 'client-1',
+      clientIdHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      namespace: 'app:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      scopes: ['ortho.system.read'],
+      audience: 'urn:nous:ortho:mcp',
+    };
+
+    const hosted = await ctx.publicMcpGatewayService.execute({
+      requestId: '550e8400-e29b-41d4-a716-446655440010',
+      jsonrpc: '2.0',
+      rpcId: 'rpc-hosted',
+      protocolVersion: '2025-11-25',
+      method: 'tools/call',
+      toolName: 'ortho.system.v1.info',
+      arguments: {},
+      subject,
+      requestUrl: 'https://andre.nous.run/mcp',
+      requestedAt: '2026-03-14T00:00:00.000Z',
+    });
+    const tunnel = await ctx.publicMcpGatewayService.execute({
+      requestId: '550e8400-e29b-41d4-a716-446655440011',
+      jsonrpc: '2.0',
+      rpcId: 'rpc-tunnel',
+      protocolVersion: '2025-11-25',
+      method: 'tools/call',
+      toolName: 'ortho.system.v1.info',
+      arguments: {},
+      subject,
+      requestUrl: 'https://casey.tunnel.nous.run/mcp',
+      requestedAt: '2026-03-14T00:00:00.000Z',
+    });
+
+    expect((hosted.result as { server: { backendMode: string } }).server.backendMode).toBe(
+      'hosted',
+    );
+    expect((tunnel.result as { server: { backendMode: string } }).server.backendMode).toBe(
+      'local_tunnel',
+    );
   });
 });

--- a/self/apps/web/server/__tests__/mao-router.test.ts
+++ b/self/apps/web/server/__tests__/mao-router.test.ts
@@ -33,6 +33,7 @@ function createWorkflow(projectId: ProjectId): WorkflowDefinition {
         type: 'model-call',
         governance: 'must',
         executionModel: 'synchronous',
+        outputSchemaRef: 'schema://mao-router/draft-output',
         config: {
           type: 'model-call',
           modelRole: 'reasoner',

--- a/self/apps/web/server/__tests__/projects-router.test.ts
+++ b/self/apps/web/server/__tests__/projects-router.test.ts
@@ -38,6 +38,7 @@ function createWorkflow(projectId: ProjectId, version = '1.0.0'): WorkflowDefini
         type: 'model-call' as const,
         governance: 'must' as const,
         executionModel: 'synchronous' as const,
+        outputSchemaRef: 'schema://projects-workflow/draft-output',
         config: {
           type: 'model-call' as const,
           modelRole: 'reasoner' as const,

--- a/self/apps/web/server/__tests__/public-mcp-route.test.ts
+++ b/self/apps/web/server/__tests__/public-mcp-route.test.ts
@@ -16,6 +16,8 @@ function wait(ms: number) {
 
 describe('public MCP route', () => {
   afterEach(() => {
+    delete process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON;
+    delete process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON;
     clearNousContextCache();
   });
 
@@ -144,5 +146,93 @@ describe('public MCP route', () => {
     expect(taskResultResponse.status).toBe(200);
     expect(taskResultBody.result.status).toBe('completed');
     expect(taskResultBody.result.result.outputs[0].type).toBe('text');
+  });
+
+  it('keeps one public route while selecting the hosted backend from the request host', async () => {
+    process.env.NOUS_DATA_DIR = join(tmpdir(), `nous-web-public-mcp-${randomUUID()}`);
+    process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON = JSON.stringify([
+      {
+        bindingId: 'binding-1',
+        tenantId: 'tenant-1',
+        userHandle: 'andre',
+        host: 'andre.nous.run',
+        storePrefix: 'tenant-andre',
+        serverName: 'Andre Hosted Nous',
+        phase: 'phase-13.5',
+        status: 'active',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+      },
+    ]);
+    clearNousContextCache();
+
+    const response = await POST(new Request('https://andre.nous.run/mcp', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${encodeClaims({
+          clientId: 'client-1',
+          audience: 'urn:nous:ortho:mcp',
+          scopes: ['ortho.system.read'],
+          expiresAt: '2030-01-01T00:00:00.000Z',
+        })}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'rpc-1',
+        method: 'tools/call',
+        params: {
+          name: 'ortho.system.v1.info',
+          arguments: {},
+        },
+      }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.result.server.backendMode).toBe('hosted');
+    expect(body.result.server.name).toBe('Andre Hosted Nous');
+  });
+
+  it('keeps one public route while selecting the tunnel backend from the request host', async () => {
+    process.env.NOUS_DATA_DIR = join(tmpdir(), `nous-web-public-mcp-${randomUUID()}`);
+    process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON = JSON.stringify([
+      {
+        sessionId: 'session-1',
+        userHandle: 'casey',
+        host: 'casey.tunnel.nous.run',
+        sharedSecret: '0123456789abcdef0123456789abcdef',
+        status: 'active',
+        createdAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+      },
+    ]);
+    clearNousContextCache();
+
+    const response = await POST(new Request('https://casey.tunnel.nous.run/mcp', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${encodeClaims({
+          clientId: 'client-1',
+          audience: 'urn:nous:ortho:mcp',
+          scopes: ['ortho.system.read'],
+          expiresAt: '2030-01-01T00:00:00.000Z',
+        })}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'rpc-1',
+        method: 'tools/call',
+        params: {
+          name: 'ortho.system.v1.info',
+          arguments: {},
+        },
+      }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.result.server.backendMode).toBe('local_tunnel');
   });
 });

--- a/self/apps/web/server/__tests__/trpc-procedures.test.ts
+++ b/self/apps/web/server/__tests__/trpc-procedures.test.ts
@@ -196,6 +196,7 @@ describe('tRPC procedures', () => {
                 type: 'model-call',
                 governance: 'must',
                 executionModel: 'synchronous',
+                outputSchemaRef: 'schema://projects-procedure/draft-output',
                 config: {
                   type: 'model-call',
                   modelRole: 'reasoner',
@@ -223,6 +224,7 @@ describe('tRPC procedures', () => {
           type: 'model-call' as const,
           governance: 'must' as const,
           executionModel: 'synchronous' as const,
+          outputSchemaRef: 'schema://projects-procedure/draft-output',
           config: {
             type: 'model-call' as const,
             modelRole: 'reasoner' as const,

--- a/self/apps/web/server/bootstrap.ts
+++ b/self/apps/web/server/bootstrap.ts
@@ -8,7 +8,9 @@ import { join, isAbsolute } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import {
   DEFAULT_STM_COMPACTION_POLICY,
+  PublicMcpHostedTenantBindingRecordSchema,
   PublicMcpScopeSchema,
+  PublicMcpTunnelSessionRecordSchema,
   StmCompactionPolicySchema,
 } from '@nous/shared';
 import type {
@@ -75,19 +77,25 @@ import { GtmGateCalculator } from '@nous/subcortex-gtm';
 import { VoiceControlService } from '@nous/subcortex-voice-control';
 import {
   AuditProjectionStore,
+  DeploymentRouterService,
   ExternalSourceMemoryService,
   ExternalSourceStorageAdapter,
+  HostedTenantBindingStore,
+  HostedTenantRuntimeFactory,
   NamespaceRegistryStore,
   PromotedMemoryBridgeService,
   PublicMcpGatewayService,
+  type PublicMcpRuntimeAgentDefinition,
   PublicMcpSurfaceService,
   PublicMcpTaskProjectionStore,
   QuotaUsageStore,
   RateLimitBucketStore,
+  TunnelForwarder,
+  TunnelSessionStore,
 } from '@nous/subcortex-public-mcp';
 import { MemoryAccessPolicyEngine } from '@nous/memory-access';
 import type { NousContext } from './context';
-import type { IIngressGateway } from '@nous/shared';
+import type { IDocumentStore, IIngressGateway, IVectorStore } from '@nous/shared';
 
 const MOCK_PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as ProviderId;
 
@@ -187,6 +195,28 @@ function createBootstrapIngressShim(): IIngressGateway {
       evidence_refs: ['web bootstrap does not wire ingress dispatch'],
     }),
   };
+}
+
+interface PublicMcpRuntimeBundle {
+  executionBridge: PublicMcpExecutionBridge;
+  surfaceService: PublicMcpSurfaceService;
+}
+
+function parseJsonArrayEnv(value: string | undefined): unknown[] {
+  if (!value) {
+    return [];
+  }
+
+  const parsed = JSON.parse(value);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function parsePublicBaseHost(baseUrl: string): string | null {
+  try {
+    return new URL(baseUrl).host.toLowerCase();
+  } catch {
+    return null;
+  }
 }
 
 let cachedContext: NousContext | null = null;
@@ -330,15 +360,6 @@ export function createNousContext(): NousContext {
     vectorStore,
     embedder,
   });
-  const externalSourceMemoryService = new ExternalSourceMemoryService({
-    documentStore,
-    namespaceStore: publicMcpNamespaceStore,
-    auditStore: publicMcpAuditStore,
-    storageAdapter: externalSourceStorageAdapter,
-    quotaStore: publicMcpQuotaUsageStore,
-    rateLimitStore: publicMcpRateLimitStore,
-    witnessService,
-  });
   const promotedMemoryBridgeService = new PromotedMemoryBridgeService({
     documentStore,
     namespaceStore: publicMcpNamespaceStore,
@@ -369,104 +390,271 @@ export function createNousContext(): NousContext {
       getProvider,
     });
 
-  const publicMcpTaskStore = new PublicMcpTaskProjectionStore(documentStore);
-  const publicMcpRuntimeAdapter = new PublicMcpRuntimeAdapter({
-    modelRouter: router,
-    getProvider,
-    getProjectApi: createRuntimeProjectApi,
-    toolExecutor,
-    pfc: Cortex,
-    workflowEngine,
-    projectStore,
-    scheduler: schedulerService,
-    escalationService,
-    witnessService,
-    outputSchemaValidator: new DefaultSchemaRefValidator(),
-    promotedMemoryBridgeService,
-  });
-  const publicMcpSurfaceService = new PublicMcpSurfaceService({
-    runtimeAdapter: publicMcpRuntimeAdapter,
-    taskStore: publicMcpTaskStore,
-    auditStore: publicMcpAuditStore,
-    publicAgents: [
-      {
-        catalog: {
-          agentId: 'engineering.workflow',
-          title: 'Engineering Workflow',
-          description:
-            'A public-safe orchestration agent for structured engineering tasks.',
-          inputModes: ['text', 'packet', 'json'],
-          memoryBinding: {
-            supported: true,
-            readTiers: ['stm', 'ltm'],
-            writeTiers: ['stm'],
-          },
-          execution: {
-            taskSupport: 'optional',
-            asyncThreshold: 'long_running_only',
+  const buildPublicAgents = (): readonly PublicMcpRuntimeAgentDefinition[] => [
+    {
+      catalog: {
+        agentId: 'engineering.workflow',
+        title: 'Engineering Workflow',
+        description:
+          'A public-safe orchestration agent for structured engineering tasks.',
+        inputModes: ['text', 'packet', 'json'],
+        memoryBinding: {
+          supported: true,
+          readTiers: ['stm', 'ltm'],
+          writeTiers: ['stm'],
+        },
+        execution: {
+          taskSupport: 'optional',
+          asyncThreshold: 'long_running_only',
+        },
+      },
+      targetClass: 'Orchestrator',
+      buildTaskInstructions: (request) =>
+        [
+          'Process the authenticated public engineering workflow request.',
+          'Preserve the canonical AgentGateway and lifecycle-tool execution posture.',
+          'Return a concise, public-safe result.',
+          `Requested agent: ${request.arguments.agentId}`,
+          request.arguments.input.type === 'json'
+            ? 'Input payload is attached as structured JSON.'
+            : `Input: ${request.arguments.input.text}`,
+        ].join('\n'),
+      buildPayload: (request) => ({
+        subject: {
+          clientId: request.subject.clientId,
+          namespace: request.subject.namespace,
+        },
+        input: request.arguments.input,
+        memory: request.arguments.memory,
+      }),
+    },
+  ];
+
+  const buildPublicMcpRuntimeBundle = (args: {
+    backendMode: 'development' | 'local_tunnel' | 'hosted';
+    serverName?: string;
+    phase?: string;
+    documentStore: IDocumentStore;
+    vectorStore?: IVectorStore;
+    namespaceStore: NamespaceRegistryStore;
+    auditStore: AuditProjectionStore;
+    taskStore: PublicMcpTaskProjectionStore;
+    quotaStore: QuotaUsageStore;
+    rateLimitStore: RateLimitBucketStore;
+    witnessService: WitnessService;
+    pfcEngine: PfcEngine;
+    publicWorkflowEngine: DeterministicWorkflowEngine;
+    runtimeContext?: {
+      deploymentMode?: 'development' | 'local_tunnel' | 'hosted';
+      tenantId?: string;
+      userHandle?: string;
+    };
+    storageAdapter?: ExternalSourceStorageAdapter;
+    promotedBridgeService?: PromotedMemoryBridgeService;
+  }): PublicMcpRuntimeBundle => {
+    const storageAdapter =
+      args.storageAdapter ??
+      new ExternalSourceStorageAdapter(args.documentStore, {
+        vectorStore: args.vectorStore,
+        embedder,
+      });
+    const publicPromotedBridgeService =
+      args.promotedBridgeService ??
+      new PromotedMemoryBridgeService({
+        documentStore: args.documentStore,
+        namespaceStore: args.namespaceStore,
+        storageAdapter,
+        pfc: args.pfcEngine,
+        witnessService: args.witnessService,
+        vectorStore: args.vectorStore,
+        embedder,
+      });
+    const externalSourceMemoryService = new ExternalSourceMemoryService({
+      documentStore: args.documentStore,
+      namespaceStore: args.namespaceStore,
+      auditStore: args.auditStore,
+      storageAdapter,
+      quotaStore: args.quotaStore,
+      rateLimitStore: args.rateLimitStore,
+      witnessService: args.witnessService,
+    });
+    const runtimeAdapter = new PublicMcpRuntimeAdapter({
+      modelRouter: router,
+      getProvider,
+      getProjectApi: createRuntimeProjectApi,
+      toolExecutor,
+      pfc: args.pfcEngine,
+      workflowEngine: args.publicWorkflowEngine,
+      projectStore,
+      scheduler: schedulerService,
+      escalationService,
+      witnessService: args.witnessService,
+      outputSchemaValidator: new DefaultSchemaRefValidator(),
+      promotedMemoryBridgeService: publicPromotedBridgeService,
+    });
+    const surfaceService = new PublicMcpSurfaceService({
+      runtimeAdapter,
+      taskStore: args.taskStore,
+      auditStore: args.auditStore,
+      publicAgents: buildPublicAgents(),
+      serverName: args.serverName ?? 'Nous Public MCP',
+      phase: args.phase ?? 'phase-13.5',
+      backendMode: args.backendMode,
+      runtimeContext: args.runtimeContext,
+    });
+    const publicCapabilityHandlers = createCapabilityHandlers({
+      agentClass: 'Worker',
+      agentId: 'public-mcp-runtime' as any,
+      deps: {
+        externalSourceMemoryService,
+        publicMcpSurfaceService: surfaceService,
+      },
+    });
+
+    return {
+      surfaceService,
+      executionBridge: new PublicMcpExecutionBridge({
+        executor: {
+          execute: async (internalName, request) => {
+            const handler =
+              publicCapabilityHandlers[internalName as keyof typeof publicCapabilityHandlers];
+            if (!handler) {
+              throw new Error(`Public MCP handler ${internalName} is unavailable`);
+            }
+            return handler(request);
           },
         },
-        targetClass: 'Orchestrator',
-        buildTaskInstructions: (request) =>
-          [
-            'Process the authenticated public engineering workflow request.',
-            'Preserve the canonical AgentGateway and lifecycle-tool execution posture.',
-            'Return a concise, public-safe result.',
-            `Requested agent: ${request.arguments.agentId}`,
-            request.arguments.input.type === 'json'
-              ? 'Input payload is attached as structured JSON.'
-              : `Input: ${
-                  request.arguments.input.text
-                }`,
-          ].join('\n'),
-        buildPayload: (request) => ({
-          subject: {
-            clientId: request.subject.clientId,
-            namespace: request.subject.namespace,
-          },
-          input: request.arguments.input,
-          memory: request.arguments.memory,
-        }),
-      },
+      }),
+    };
+  };
+
+  const publicBaseUrl = process.env.NOUS_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+  const publicMcpTaskStore = new PublicMcpTaskProjectionStore(documentStore);
+  const hostedBindingSeeds = parseJsonArrayEnv(
+    process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON,
+  ).map((record) => PublicMcpHostedTenantBindingRecordSchema.parse(record));
+  const tunnelSessionSeeds = parseJsonArrayEnv(
+    process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON,
+  ).map((record) => PublicMcpTunnelSessionRecordSchema.parse(record));
+  const publicMcpHostedBindingStore = new HostedTenantBindingStore(documentStore, {
+    seedRecords: hostedBindingSeeds,
+  });
+  const publicMcpTunnelSessionStore = new TunnelSessionStore(documentStore, {
+    seedRecords: tunnelSessionSeeds,
+  });
+  const publicMcpDeploymentRouter = new DeploymentRouterService({
+    hostedTenantBindingStore: publicMcpHostedBindingStore,
+    tunnelSessionStore: publicMcpTunnelSessionStore,
+    developmentHosts: [
+      'localhost:3000',
+      '127.0.0.1:3000',
+      ...(parsePublicBaseHost(publicBaseUrl) ? [parsePublicBaseHost(publicBaseUrl)!] : []),
     ],
-    serverName: 'Nous Public MCP',
-    phase: 'phase-13.4',
+  });
+  const publicMcpTunnelForwarder = new TunnelForwarder({
+    sessionStore: publicMcpTunnelSessionStore,
+  });
+  const developmentPublicMcpBundle = buildPublicMcpRuntimeBundle({
     backendMode: 'development',
+    documentStore,
+    vectorStore,
+    namespaceStore: publicMcpNamespaceStore,
+    auditStore: publicMcpAuditStore,
+    taskStore: publicMcpTaskStore,
+    quotaStore: publicMcpQuotaUsageStore,
+    rateLimitStore: publicMcpRateLimitStore,
+    witnessService,
+    pfcEngine: Cortex,
+    publicWorkflowEngine: workflowEngine,
+    storageAdapter: externalSourceStorageAdapter,
+    promotedBridgeService: promotedMemoryBridgeService,
   });
-  const publicCapabilityHandlers = createCapabilityHandlers({
-    agentClass: 'Worker',
-    agentId: 'public-mcp-runtime' as any,
-    deps: {
-      externalSourceMemoryService,
-      publicMcpSurfaceService,
+  const tunnelPublicMcpBundle = buildPublicMcpRuntimeBundle({
+    backendMode: 'local_tunnel',
+    documentStore,
+    vectorStore,
+    namespaceStore: publicMcpNamespaceStore,
+    auditStore: publicMcpAuditStore,
+    taskStore: publicMcpTaskStore,
+    quotaStore: publicMcpQuotaUsageStore,
+    rateLimitStore: publicMcpRateLimitStore,
+    witnessService,
+    pfcEngine: Cortex,
+    publicWorkflowEngine: workflowEngine,
+    runtimeContext: {
+      deploymentMode: 'local_tunnel',
+    },
+    storageAdapter: externalSourceStorageAdapter,
+    promotedBridgeService: promotedMemoryBridgeService,
+  });
+  const hostedTenantRuntimeFactory = new HostedTenantRuntimeFactory<PublicMcpRuntimeBundle>({
+    documentStore,
+    vectorStore,
+    build: ({ binding, documentStore: tenantDocumentStore, vectorStore: tenantVectorStore }) => {
+      const tenantPfc = new PfcEngine(config, toolExecutor);
+      const tenantWorkflowEngine = new DeterministicWorkflowEngine({
+        pfcEngine: tenantPfc,
+        modelRouter: router,
+        toolExecutor,
+      });
+      const tenantWitnessService = new WitnessService(tenantDocumentStore);
+
+      return buildPublicMcpRuntimeBundle({
+        backendMode: 'hosted',
+        serverName: binding.serverName,
+        phase: binding.phase,
+        documentStore: tenantDocumentStore,
+        vectorStore: tenantVectorStore,
+        namespaceStore: new NamespaceRegistryStore(tenantDocumentStore),
+        auditStore: new AuditProjectionStore(tenantDocumentStore),
+        taskStore: new PublicMcpTaskProjectionStore(tenantDocumentStore),
+        quotaStore: new QuotaUsageStore(tenantDocumentStore),
+        rateLimitStore: new RateLimitBucketStore(tenantDocumentStore),
+        witnessService: tenantWitnessService,
+        pfcEngine: tenantPfc,
+        publicWorkflowEngine: tenantWorkflowEngine,
+        runtimeContext: {
+          deploymentMode: 'hosted',
+          tenantId: binding.tenantId,
+          userHandle: binding.userHandle,
+        },
+      });
     },
   });
-  const publicMcpExecutionBridge = new PublicMcpExecutionBridge({
-    executor: {
-      execute: async (internalName, request) => {
-        const handler =
-          publicCapabilityHandlers[internalName as keyof typeof publicCapabilityHandlers];
-        if (!handler) {
-          throw new Error(`Public MCP handler ${internalName} is unavailable`);
-        }
-        return handler(request);
-      },
-    },
-  });
+  const publicMcpExecutionBridge = developmentPublicMcpBundle.executionBridge;
   const publicMcpGatewayService = new PublicMcpGatewayService({
     documentStore,
     namespaceStore: publicMcpNamespaceStore,
     auditStore: publicMcpAuditStore,
     witnessService,
     executionBridge: publicMcpExecutionBridge,
-    baseUrl: process.env.NOUS_PUBLIC_BASE_URL ?? 'http://localhost:3000',
+    baseUrl: publicBaseUrl,
     supportedScopes: PublicMcpScopeSchema.options,
     toolMappingLookup: getPublicToolMapping,
     requiredScopeResolver: (toolName, args) => {
       const mapping = getPublicToolMapping(toolName);
       return mapping ? resolvePublicMcpRequiredScopes(mapping, args) : [];
     },
-    surfaceService: publicMcpSurfaceService,
+    surfaceService: developmentPublicMcpBundle.surfaceService,
+    deploymentRouter: publicMcpDeploymentRouter,
+    deploymentBundleResolver: async (resolution) => {
+      if (resolution.mode === 'local_tunnel') {
+        return tunnelPublicMcpBundle;
+      }
+      if (resolution.mode === 'hosted') {
+        const binding = resolution.bindingId
+          ? await publicMcpHostedBindingStore.get(resolution.bindingId)
+          : resolution.userHandle
+            ? await publicMcpHostedBindingStore.getByUserHandle(resolution.userHandle)
+            : null;
+        if (!binding) {
+          throw new Error(`Hosted public MCP binding is unavailable for ${resolution.requestHost}`);
+        }
+        return hostedTenantRuntimeFactory.getOrCreate(binding);
+      }
+      return developmentPublicMcpBundle;
+    },
+    tunnelForwarder: publicMcpTunnelForwarder,
   });
 
   const coreExecutor = new GatewayBackedTurnExecutor({

--- a/self/cortex/core/src/__tests__/public-mcp/public-mcp-execution-bridge.test.ts
+++ b/self/cortex/core/src/__tests__/public-mcp/public-mcp-execution-bridge.test.ts
@@ -18,6 +18,7 @@ function createRequest(toolName: string) {
       scopes: ['ortho.system.read'],
       audience: 'urn:nous:ortho:mcp',
     },
+    requestUrl: 'https://andre.nous.run/mcp',
     requestedAt: '2026-03-14T00:00:00.000Z',
   };
 }
@@ -74,7 +75,10 @@ describe('PublicMcpExecutionBridge executeMappedTool', () => {
     expect(result.result).toEqual({ ok: true });
     expect(executor.execute).toHaveBeenCalledWith(
       'public_system_info',
-      expect.objectContaining({ toolName: 'ortho.system.v1.info' }),
+      expect.objectContaining({
+        toolName: 'ortho.system.v1.info',
+        requestUrl: 'https://andre.nous.run/mcp',
+      }),
     );
   });
 

--- a/self/cortex/core/src/gateway-runtime/public-mcp-runtime-adapter.ts
+++ b/self/cortex/core/src/gateway-runtime/public-mcp-runtime-adapter.ts
@@ -6,6 +6,7 @@ import type {
   IAgentGatewayFactory,
   IModelProvider,
   IModelRouter,
+  PublicMcpDeploymentMode,
   ModelRequirements,
   ProjectId,
   ProviderId,
@@ -41,6 +42,11 @@ export interface PublicMcpRuntimeInvocation {
     role: 'system' | 'user';
     content: string;
   }>;
+  runtimeContext?: {
+    deploymentMode?: PublicMcpDeploymentMode;
+    tenantId?: string;
+    userHandle?: string;
+  };
   modelRequirements?: ModelRequirements;
 }
 
@@ -111,12 +117,15 @@ export class PublicMcpRuntimeAdapter {
     const result = await gateway.run({
       taskInstructions: request.taskInstructions,
       payload: request.payload,
-      context: (request.context ?? []).map((frame) => ({
-        role: frame.role,
-        source: 'initial_context' as const,
-        content: frame.content,
-        createdAt: this.now(),
-      })),
+      context: [
+        ...buildRuntimeContextPrelude(request.runtimeContext),
+        ...(request.context ?? []).map((frame) => ({
+          role: frame.role,
+          source: 'initial_context' as const,
+          content: frame.content,
+          createdAt: this.now(),
+        })),
+      ],
       budget: DEFAULT_PUBLIC_AGENT_BUDGET,
       spawnBudgetCeiling: request.targetClass === 'Orchestrator' ? 8 : 0,
       correlation: {
@@ -201,4 +210,37 @@ export class PublicMcpRuntimeAdapter {
       evidenceRefs: result.evidenceRefs,
     };
   }
+}
+
+function buildRuntimeContextPrelude(
+  runtimeContext?: PublicMcpRuntimeInvocation['runtimeContext'],
+) {
+  if (!runtimeContext) {
+    return [];
+  }
+
+  const lines = [
+    runtimeContext.deploymentMode
+      ? `Public deployment mode: ${runtimeContext.deploymentMode}`
+      : undefined,
+    runtimeContext.tenantId
+      ? `Hosted tenant: ${runtimeContext.tenantId}`
+      : undefined,
+    runtimeContext.userHandle
+      ? `Resolved user handle: ${runtimeContext.userHandle}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+
+  if (lines.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      role: 'system' as const,
+      source: 'initial_context' as const,
+      content: lines.join('\n'),
+      createdAt: new Date().toISOString(),
+    },
+  ];
 }

--- a/self/shared/src/__tests__/types/public-mcp.test.ts
+++ b/self/shared/src/__tests__/types/public-mcp.test.ts
@@ -3,13 +3,18 @@ import {
   PublicMcpAgentCatalogEntrySchema,
   PublicMcpAgentInvokeResultSchema,
   PublicMcpAuditRecordSchema,
+  PublicMcpDeploymentModeSchema,
+  PublicMcpDeploymentResolutionSchema,
   PublicMcpDiscoveryBundleSchema,
   PublicMcpExecutionRequestSchema,
+  PublicMcpHostedTenantBindingRecordSchema,
   PublicMcpNamespaceRecordSchema,
   PublicMcpRpcRequestSchema,
   PublicMcpSystemInfoSchema,
   PublicMcpTaskProjectionSchema,
   PublicMcpTaskResultSchema,
+  PublicMcpTunnelForwardEnvelopeSchema,
+  PublicMcpTunnelSessionRecordSchema,
   PublicMcpToolMappingEntrySchema,
   PromoteExternalRecordCommandSchema,
   PromotedMemoryAuditRecordSchema,
@@ -86,6 +91,7 @@ describe('public MCP shared types', () => {
         scopes: ['ortho.agents.invoke', 'ortho.memory.ltm.read'],
         audience: 'urn:nous:ortho:mcp',
       },
+      requestUrl: 'https://andre.nous.run/mcp',
       requestedAt: '2026-03-14T00:00:00.000Z',
     });
 
@@ -168,6 +174,77 @@ describe('public MCP shared types', () => {
     expect(task.status).toBe('running');
     expect(taskResult.status).toBe('completed');
     expect(systemInfo.tasks.supportedMethods).toContain('tasks/result');
+  });
+
+  it('parses deployment mode, hosted binding, tunnel session, and tunnel envelope payloads', () => {
+    const mode = PublicMcpDeploymentModeSchema.parse('hosted');
+    const binding = PublicMcpHostedTenantBindingRecordSchema.parse({
+      bindingId: 'binding-1',
+      tenantId: 'tenant-1',
+      userHandle: 'andre',
+      host: 'andre.nous.run',
+      storePrefix: 'tenant-andre',
+      serverName: 'Andre Hosted Nous',
+      phase: 'phase-13.5',
+      status: 'active',
+      createdAt: '2026-03-14T00:00:00.000Z',
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    });
+    const session = PublicMcpTunnelSessionRecordSchema.parse({
+      sessionId: 'session-1',
+      userHandle: 'andre',
+      host: 'andre.tunnel.nous.run',
+      sharedSecret: '0123456789abcdef0123456789abcdef',
+      status: 'active',
+      createdAt: '2026-03-14T00:00:00.000Z',
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    });
+    const resolution = PublicMcpDeploymentResolutionSchema.parse({
+      mode,
+      requestHost: binding.host,
+      userHandle: binding.userHandle,
+      bindingId: binding.bindingId,
+      tenantId: binding.tenantId,
+      storePrefix: binding.storePrefix,
+      serverName: binding.serverName,
+      phase: binding.phase,
+    });
+    const envelope = PublicMcpTunnelForwardEnvelopeSchema.parse({
+      envelopeId: 'envelope-1',
+      requestId: '550e8400-e29b-41d4-a716-446655440000',
+      sessionId: session.sessionId,
+      userHandle: session.userHandle,
+      nonce: 'nonce-1',
+      issuedAt: '2026-03-14T00:00:00.000Z',
+      expiresAt: '2026-03-14T00:01:00.000Z',
+      request: {
+        requestId: '550e8400-e29b-41d4-a716-446655440000',
+        jsonrpc: '2.0',
+        rpcId: 'rpc-1',
+        protocolVersion: '2025-11-25',
+        method: 'tools/call',
+        toolName: 'ortho.system.v1.info',
+        arguments: {},
+        subject: {
+          class: 'ExternalClient',
+          clientId: 'client-1',
+          clientIdHash:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          namespace:
+            'app:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          scopes: ['ortho.system.read'],
+          audience: 'urn:nous:ortho:mcp',
+        },
+        requestUrl: 'https://andre.tunnel.nous.run/mcp',
+        requestedAt: '2026-03-14T00:00:00.000Z',
+      },
+      signature: 'signature-1',
+    });
+
+    expect(binding.host).toBe('andre.nous.run');
+    expect(session.userHandle).toBe('andre');
+    expect(resolution.tenantId).toBe('tenant-1');
+    expect(envelope.request.requestUrl).toBe('https://andre.tunnel.nous.run/mcp');
   });
 
   it('requires external-only namespace records and audit fields', () => {

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -32,6 +32,7 @@ export type {
   ExternalSourceSearchQuery,
   IExternalSourceMemoryService,
   IPromotedMemoryBridgeService,
+  IPublicMcpDeploymentRouterService,
   IPublicMcpGatewayService,
   IPublicMcpSurfaceService,
   IEndpointTrustService,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -165,6 +165,7 @@ import type {
   PublicMcpCompactArguments,
   PublicMcpDiscoveryBundle,
   PublicMcpDeleteArguments,
+  PublicMcpDeploymentResolution,
   ExternalSourceCompactionResult,
   ExternalSourceMemoryEntry,
   ExternalSourceMutationResult,
@@ -502,6 +503,11 @@ export interface IPublicMcpGatewayService {
 
   /** Execute an authorized public MCP request over the canonical bridge surface. */
   execute(request: PublicMcpExecutionRequest): Promise<PublicMcpExecutionResult>;
+}
+
+export interface IPublicMcpDeploymentRouterService {
+  /** Resolve the active backend mode and deployment binding for a public MCP request. */
+  resolve(request: PublicMcpExecutionRequest): Promise<PublicMcpDeploymentResolution>;
 }
 
 export interface PublicMcpAgentListQuery {

--- a/self/shared/src/types/public-mcp.ts
+++ b/self/shared/src/types/public-mcp.ts
@@ -44,6 +44,9 @@ export const PublicMcpRejectReasonSchema = z.enum([
   'task_not_found',
   'task_not_ready',
   'task_not_owned',
+  'deployment_not_resolved',
+  'tunnel_envelope_invalid',
+  'tunnel_replay_detected',
 ]);
 export type PublicMcpRejectReason = z.infer<typeof PublicMcpRejectReasonSchema>;
 
@@ -323,6 +326,70 @@ export const PublicMcpSystemInfoSchema = z.object({
   }).strict(),
 }).strict();
 export type PublicMcpSystemInfo = z.infer<typeof PublicMcpSystemInfoSchema>;
+
+export const PublicMcpDeploymentModeSchema = z.enum([
+  'local_tunnel',
+  'hosted',
+  'development',
+]);
+export type PublicMcpDeploymentMode = z.infer<typeof PublicMcpDeploymentModeSchema>;
+
+export const PublicMcpUserHandleSchema = z
+  .string()
+  .regex(/^[a-z0-9](?:[a-z0-9_-]{1,30}[a-z0-9])?$/);
+export type PublicMcpUserHandle = z.infer<typeof PublicMcpUserHandleSchema>;
+
+export const PublicMcpTunnelSessionRecordSchema = z.object({
+  sessionId: z.string().min(1),
+  userHandle: PublicMcpUserHandleSchema,
+  host: z.string().min(1),
+  sharedSecret: z.string().min(32),
+  status: z.enum(['active', 'revoked']).default('active'),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  expiresAt: z.string().datetime().optional(),
+  lastSeenAt: z.string().datetime().optional(),
+}).strict();
+export type PublicMcpTunnelSessionRecord = z.infer<
+  typeof PublicMcpTunnelSessionRecordSchema
+>;
+
+export const PublicMcpHostedTenantBindingRecordSchema = z.object({
+  bindingId: z.string().min(1),
+  tenantId: z.string().min(1),
+  userHandle: PublicMcpUserHandleSchema,
+  host: z.string().min(1),
+  storePrefix: z.string().min(1),
+  serverName: z.string().min(1).default('Nous Public MCP'),
+  phase: z.string().min(1).default('phase-13.5'),
+  status: z.enum(['active', 'disabled']).default('active'),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).strict();
+export type PublicMcpHostedTenantBindingRecord = z.infer<
+  typeof PublicMcpHostedTenantBindingRecordSchema
+>;
+
+export const PublicMcpDeploymentAuditDetailSchema = z.object({
+  mode: PublicMcpDeploymentModeSchema,
+  requestHost: z.string().min(1),
+  userHandle: PublicMcpUserHandleSchema.optional(),
+  sessionId: z.string().min(1).optional(),
+  bindingId: z.string().min(1).optional(),
+  tenantId: z.string().min(1).optional(),
+  storePrefix: z.string().min(1).optional(),
+}).strict();
+export type PublicMcpDeploymentAuditDetail = z.infer<
+  typeof PublicMcpDeploymentAuditDetailSchema
+>;
+
+export const PublicMcpDeploymentResolutionSchema = PublicMcpDeploymentAuditDetailSchema.extend({
+  serverName: z.string().min(1).optional(),
+  phase: z.string().min(1).optional(),
+}).strict();
+export type PublicMcpDeploymentResolution = z.infer<
+  typeof PublicMcpDeploymentResolutionSchema
+>;
 
 export const ExternalMemoryEntryIdSchema = z.string().min(1).max(128);
 export type ExternalMemoryEntryId = z.infer<typeof ExternalMemoryEntryIdSchema>;
@@ -794,6 +861,7 @@ export const PublicMcpExecutionRequestSchema = z.object({
   toolName: z.string().regex(/^ortho\.[a-z0-9.]+$/).optional(),
   arguments: z.record(z.unknown()).optional(),
   subject: PublicMcpSubjectSchema,
+  requestUrl: z.string().url().optional(),
   idempotencyKey: z.string().min(1).optional(),
   requestedAt: z.string().datetime(),
 }).strict();
@@ -819,3 +887,18 @@ export const PublicMcpExecutionResultSchema = z.object({
   auditRecordId: z.string().min(1).optional(),
 }).strict();
 export type PublicMcpExecutionResult = z.infer<typeof PublicMcpExecutionResultSchema>;
+
+export const PublicMcpTunnelForwardEnvelopeSchema = z.object({
+  envelopeId: z.string().min(1),
+  requestId: z.string().uuid(),
+  sessionId: z.string().min(1),
+  userHandle: PublicMcpUserHandleSchema,
+  nonce: z.string().min(1),
+  issuedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  request: PublicMcpExecutionRequestSchema,
+  signature: z.string().min(1),
+}).strict();
+export type PublicMcpTunnelForwardEnvelope = z.infer<
+  typeof PublicMcpTunnelForwardEnvelopeSchema
+>;

--- a/self/subcortex/public-mcp/src/__tests__/deployment-router-service.test.ts
+++ b/self/subcortex/public-mcp/src/__tests__/deployment-router-service.test.ts
@@ -1,0 +1,88 @@
+import type { PublicMcpExecutionRequest } from '@nous/shared';
+import { describe, expect, it } from 'vitest';
+import { DeploymentRouterService } from '../deployment-router-service.js';
+import { HostedTenantBindingStore } from '../hosted-tenant-binding-store.js';
+import { TunnelSessionStore } from '../tunnel-session-store.js';
+import { createMemoryDocumentStore } from './test-store.js';
+
+function createRequest(requestUrl: string): PublicMcpExecutionRequest {
+  return {
+    requestId: '550e8400-e29b-41d4-a716-446655440000',
+    jsonrpc: '2.0' as const,
+    rpcId: 'rpc-1',
+    protocolVersion: '2025-11-25' as const,
+    method: 'tools/call' as const,
+    toolName: 'ortho.system.v1.info',
+    arguments: {},
+    subject: {
+      class: 'ExternalClient' as const,
+      clientId: 'client-1',
+      clientIdHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      namespace: 'app:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      scopes: ['ortho.system.read'],
+      audience: 'urn:nous:ortho:mcp',
+    },
+    requestUrl,
+    requestedAt: '2026-03-14T00:00:00.000Z',
+  };
+}
+
+describe('DeploymentRouterService', () => {
+  it('resolves hosted, tunnel, and development backends from request host', async () => {
+    const documentStore = createMemoryDocumentStore();
+    const router = new DeploymentRouterService({
+      hostedTenantBindingStore: new HostedTenantBindingStore(documentStore, {
+        seedRecords: [
+          {
+            bindingId: 'binding-1',
+            tenantId: 'tenant-1',
+            userHandle: 'andre',
+            host: 'andre.nous.run',
+            storePrefix: 'tenant-andre',
+            serverName: 'Andre Hosted Nous',
+            phase: 'phase-13.5',
+            status: 'active',
+            createdAt: '2026-03-14T00:00:00.000Z',
+            updatedAt: '2026-03-14T00:00:00.000Z',
+          },
+        ],
+      }),
+      tunnelSessionStore: new TunnelSessionStore(documentStore, {
+        seedRecords: [
+          {
+            sessionId: 'session-1',
+            userHandle: 'casey',
+            host: 'casey.tunnel.nous.run',
+            sharedSecret: '0123456789abcdef0123456789abcdef',
+            status: 'active',
+            createdAt: '2026-03-14T00:00:00.000Z',
+            updatedAt: '2026-03-14T00:00:00.000Z',
+          },
+        ],
+      }),
+      developmentHosts: ['localhost:3000'],
+    });
+
+    expect((await router.resolve(createRequest('https://andre.nous.run/mcp'))).mode).toBe(
+      'hosted',
+    );
+    expect(
+      (await router.resolve(createRequest('https://casey.tunnel.nous.run/mcp'))).mode,
+    ).toBe('local_tunnel');
+    expect((await router.resolve(createRequest('http://localhost:3000/mcp'))).mode).toBe(
+      'development',
+    );
+  });
+
+  it('fails closed for an unknown public host', async () => {
+    const router = new DeploymentRouterService({
+      hostedTenantBindingStore: new HostedTenantBindingStore(createMemoryDocumentStore()),
+      tunnelSessionStore: new TunnelSessionStore(createMemoryDocumentStore()),
+      developmentHosts: ['localhost:3000'],
+    });
+
+    await expect(router.resolve(createRequest('https://unknown.nous.run/mcp'))).rejects.toThrow(
+      'No public MCP deployment resolved',
+    );
+  });
+});

--- a/self/subcortex/public-mcp/src/__tests__/hosted-tenant-binding-store.test.ts
+++ b/self/subcortex/public-mcp/src/__tests__/hosted-tenant-binding-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { HostedTenantBindingStore } from '../hosted-tenant-binding-store.js';
+import { createMemoryDocumentStore } from './test-store.js';
+
+describe('HostedTenantBindingStore', () => {
+  it('stores and resolves hosted tenant bindings by id, host, and user handle', async () => {
+    const store = new HostedTenantBindingStore(createMemoryDocumentStore());
+
+    await store.save({
+      bindingId: 'binding-1',
+      tenantId: 'tenant-1',
+      userHandle: 'andre',
+      host: 'Andre.Nous.Run',
+      storePrefix: 'tenant-andre',
+      serverName: 'Andre Hosted Nous',
+      phase: 'phase-13.5',
+      status: 'active',
+      createdAt: '2026-03-14T00:00:00.000Z',
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    });
+
+    expect((await store.get('binding-1'))?.tenantId).toBe('tenant-1');
+    expect((await store.getByHost('andre.nous.run'))?.userHandle).toBe('andre');
+    expect((await store.getByUserHandle('andre'))?.storePrefix).toBe('tenant-andre');
+  });
+
+  it('resolves seeded hosted bindings before document-store reads', async () => {
+    const store = new HostedTenantBindingStore(createMemoryDocumentStore(), {
+      seedRecords: [
+        {
+          bindingId: 'seed-1',
+          tenantId: 'tenant-seed',
+          userHandle: 'seeded',
+          host: 'seeded.nous.run',
+          storePrefix: 'tenant-seeded',
+          serverName: 'Seeded Hosted Nous',
+          phase: 'phase-13.5',
+          status: 'active',
+          createdAt: '2026-03-14T00:00:00.000Z',
+          updatedAt: '2026-03-14T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect((await store.getByHost('seeded.nous.run'))?.bindingId).toBe('seed-1');
+  });
+});

--- a/self/subcortex/public-mcp/src/__tests__/public-mcp-gateway-service.test.ts
+++ b/self/subcortex/public-mcp/src/__tests__/public-mcp-gateway-service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { WitnessService } from '@nous/subcortex-witnessd';
+import { DeploymentRouterService } from '../deployment-router-service.js';
+import { HostedTenantBindingStore } from '../hosted-tenant-binding-store.js';
 import { PublicMcpGatewayService } from '../public-mcp-gateway-service.js';
 import { createMemoryDocumentStore } from './test-store.js';
 
@@ -65,12 +67,104 @@ describe('PublicMcpGatewayService', () => {
       protocolVersion: '2025-11-25',
       method: 'tools/list',
       subject: decision.subject!,
+      requestUrl: 'http://localhost:3000/mcp',
       requestedAt: '2026-03-14T00:00:00.000Z',
     });
 
     expect((result.result as { tools: Array<{ name: string }> }).tools).toEqual([
       expect.objectContaining({ name: 'ortho.system.v1.info' }),
     ]);
+    expect(result.authorizationEventId).toBeTruthy();
+    expect(result.auditRecordId).toBe(decision.requestId);
+  });
+
+  it('resolves hosted deployment bundles before execution while preserving edge audit linkage', async () => {
+    const documentStore = createMemoryDocumentStore();
+    const witnessService = new WitnessService(documentStore);
+    const hostedBindings = new HostedTenantBindingStore(documentStore, {
+      seedRecords: [
+        {
+          bindingId: 'binding-1',
+          tenantId: 'tenant-1',
+          userHandle: 'andre',
+          host: 'andre.nous.run',
+          storePrefix: 'tenant-andre',
+          serverName: 'Andre Hosted Nous',
+          phase: 'phase-13.5',
+          status: 'active',
+          createdAt: '2026-03-14T00:00:00.000Z',
+          updatedAt: '2026-03-14T00:00:00.000Z',
+        },
+      ],
+    });
+    const service = new PublicMcpGatewayService({
+      documentStore,
+      witnessService,
+      supportedScopes: ['ortho.system.read'],
+      executionBridge: {
+        listTools: async () => [],
+        executeMappedTool: async () => ({
+          requestId: '550e8400-e29b-41d4-a716-446655440000',
+          httpStatus: 500,
+          rpcId: 'rpc-1',
+          rejectReason: 'tool_not_available',
+          error: { code: -32601, message: 'default bundle should not run' },
+        }),
+      },
+      deploymentRouter: new DeploymentRouterService({
+        hostedTenantBindingStore: hostedBindings,
+        developmentHosts: ['localhost:3000'],
+      }),
+      deploymentBundleResolver: async () => ({
+        executionBridge: {
+          listTools: async () => [],
+          executeMappedTool: async () => ({
+            requestId: '550e8400-e29b-41d4-a716-446655440000',
+            httpStatus: 200,
+            rpcId: 'rpc-1',
+            result: { backendMode: 'hosted' },
+            internalToolName: 'public_system_info',
+          }),
+        },
+      }),
+    });
+
+    const decision = await service.authorize({
+      requestId: '550e8400-e29b-41d4-a716-446655440000',
+      method: 'POST',
+      url: 'https://andre.nous.run/mcp',
+      headers: {
+        authorization: `Bearer ${encodeClaims({
+          clientId: 'client-1',
+          audience: 'urn:nous:ortho:mcp',
+          scopes: ['ortho.system.read'],
+          expiresAt: '2030-01-01T00:00:00.000Z',
+        })}`,
+      },
+      body: {
+        jsonrpc: '2.0',
+        id: 'rpc-1',
+        method: 'tools/call',
+        params: {
+          name: 'ortho.system.v1.info',
+          arguments: {},
+        },
+      },
+    });
+    const result = await service.execute({
+      requestId: decision.requestId,
+      jsonrpc: '2.0',
+      rpcId: 'rpc-1',
+      protocolVersion: '2025-11-25',
+      method: 'tools/call',
+      toolName: 'ortho.system.v1.info',
+      arguments: {},
+      subject: decision.subject!,
+      requestUrl: 'https://andre.nous.run/mcp',
+      requestedAt: '2026-03-14T00:00:00.000Z',
+    });
+
+    expect(result.result).toEqual({ backendMode: 'hosted' });
     expect(result.authorizationEventId).toBeTruthy();
     expect(result.auditRecordId).toBe(decision.requestId);
   });

--- a/self/subcortex/public-mcp/src/__tests__/public-mcp-surface-service.test.ts
+++ b/self/subcortex/public-mcp/src/__tests__/public-mcp-surface-service.test.ts
@@ -62,6 +62,35 @@ describe('PublicMcpSurfaceService', () => {
     expect(systemInfo.tasks.supportedMethods).toEqual(['tasks/get', 'tasks/result']);
   });
 
+  it('projects backend-aware system info from deployment-specific options', async () => {
+    const documentStore = createMemoryDocumentStore();
+    const service = new PublicMcpSurfaceService({
+      runtimeAdapter: {
+        runAgent: vi.fn(),
+      },
+      taskStore: new PublicMcpTaskProjectionStore(documentStore),
+      auditStore: new AuditProjectionStore(documentStore),
+      publicAgents: [],
+      backendMode: 'hosted',
+      featureOverrides: {
+        publicCompactAsync: false,
+      },
+      taskToolSupport: {
+        'ortho.agents.v1.invoke': 'required',
+      },
+    });
+
+    const systemInfo = await service.getSystemInfo({
+      requestId: '550e8400-e29b-41d4-a716-446655440010',
+      subject: SUBJECT,
+      requestedAt: '2026-03-14T00:00:00.000Z',
+    });
+
+    expect(systemInfo.server.backendMode).toBe('hosted');
+    expect(systemInfo.features.publicCompactAsync).toBe(false);
+    expect(systemInfo.tasks.toolSupport['ortho.agents.v1.invoke']).toBe('required');
+  });
+
   it('creates async public invoke tasks and serves the completed result', async () => {
     const documentStore = createMemoryDocumentStore();
     const service = new PublicMcpSurfaceService({

--- a/self/subcortex/public-mcp/src/__tests__/tunnel-forwarder.test.ts
+++ b/self/subcortex/public-mcp/src/__tests__/tunnel-forwarder.test.ts
@@ -1,0 +1,136 @@
+import type { PublicMcpExecutionRequest } from '@nous/shared';
+import { describe, expect, it } from 'vitest';
+import { TunnelForwarder } from '../tunnel-forwarder.js';
+import { TunnelSessionStore } from '../tunnel-session-store.js';
+import { createMemoryDocumentStore } from './test-store.js';
+
+function createRequest(): PublicMcpExecutionRequest {
+  return {
+    requestId: '550e8400-e29b-41d4-a716-446655440000',
+    jsonrpc: '2.0' as const,
+    rpcId: 'rpc-1',
+    protocolVersion: '2025-11-25' as const,
+    method: 'tools/call' as const,
+    toolName: 'ortho.system.v1.info',
+    arguments: {},
+    subject: {
+      class: 'ExternalClient' as const,
+      clientId: 'client-1',
+      clientIdHash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      namespace: 'app:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      scopes: ['ortho.system.read'],
+      audience: 'urn:nous:ortho:mcp',
+    },
+    requestUrl: 'https://andre.tunnel.nous.run/mcp',
+    requestedAt: '2026-03-14T00:00:00.000Z',
+  };
+}
+
+describe('TunnelForwarder', () => {
+  it('forwards a valid signed envelope exactly once', async () => {
+    const sessionStore = new TunnelSessionStore(createMemoryDocumentStore(), {
+      seedRecords: [
+        {
+          sessionId: 'session-1',
+          userHandle: 'andre',
+          host: 'andre.tunnel.nous.run',
+          sharedSecret: '0123456789abcdef0123456789abcdef',
+          status: 'active',
+          createdAt: '2026-03-14T00:00:00.000Z',
+          updatedAt: '2026-03-14T00:00:00.000Z',
+        },
+      ],
+    });
+    const forwarder = new TunnelForwarder({
+      sessionStore,
+      now: () => '2026-03-14T00:00:00.000Z',
+      idFactory: (() => {
+        const values = ['envelope-1', 'nonce-1'];
+        return () => values.shift() ?? 'extra-id';
+      })(),
+    });
+    const request = createRequest();
+    const resolution = {
+      mode: 'local_tunnel' as const,
+      requestHost: 'andre.tunnel.nous.run',
+      userHandle: 'andre',
+      sessionId: 'session-1',
+    };
+    const envelope = await forwarder.issueEnvelope(request, resolution);
+    const result = await forwarder.forwardEnvelope(envelope, {
+      executionBridge: {
+        listTools: async () => [],
+        executeMappedTool: async () => ({
+          requestId: request.requestId,
+          httpStatus: 200,
+          rpcId: request.rpcId,
+          result: { backendMode: 'local_tunnel' },
+        }),
+      },
+    });
+    const replay = await forwarder.forwardEnvelope(envelope, {
+      executionBridge: {
+        listTools: async () => [],
+        executeMappedTool: async () => ({
+          requestId: request.requestId,
+          httpStatus: 200,
+          rpcId: request.rpcId,
+          result: { ok: true },
+        }),
+      },
+    });
+
+    expect(result.result).toEqual({ backendMode: 'local_tunnel' });
+    expect(replay.rejectReason).toBe('tunnel_replay_detected');
+  });
+
+  it('rejects tampered or mismatched envelopes', async () => {
+    const sessionStore = new TunnelSessionStore(createMemoryDocumentStore(), {
+      seedRecords: [
+        {
+          sessionId: 'session-1',
+          userHandle: 'andre',
+          host: 'andre.tunnel.nous.run',
+          sharedSecret: '0123456789abcdef0123456789abcdef',
+          status: 'active',
+          createdAt: '2026-03-14T00:00:00.000Z',
+          updatedAt: '2026-03-14T00:00:00.000Z',
+        },
+      ],
+    });
+    const forwarder = new TunnelForwarder({
+      sessionStore,
+      now: () => '2026-03-14T00:00:00.000Z',
+    });
+    const request = createRequest();
+    const envelope = await forwarder.issueEnvelope(request, {
+      mode: 'local_tunnel',
+      requestHost: 'andre.tunnel.nous.run',
+      userHandle: 'andre',
+      sessionId: 'session-1',
+    });
+
+    const result = await forwarder.forwardEnvelope(
+      {
+        ...envelope,
+        request: {
+          ...envelope.request,
+          requestUrl: 'https://mallory.tunnel.nous.run/mcp',
+        },
+      },
+      {
+        executionBridge: {
+          listTools: async () => [],
+          executeMappedTool: async () => ({
+            requestId: request.requestId,
+            httpStatus: 200,
+            rpcId: request.rpcId,
+            result: { ok: true },
+          }),
+        },
+      },
+    );
+
+    expect(result.rejectReason).toBe('tunnel_envelope_invalid');
+  });
+});

--- a/self/subcortex/public-mcp/src/deployment-router-service.ts
+++ b/self/subcortex/public-mcp/src/deployment-router-service.ts
@@ -1,0 +1,117 @@
+import type {
+  IPublicMcpDeploymentRouterService,
+  PublicMcpDeploymentMode,
+  PublicMcpDeploymentResolution,
+  PublicMcpExecutionRequest,
+  PublicMcpUserHandle,
+} from '@nous/shared';
+import { PublicMcpUserHandleSchema } from '@nous/shared';
+import { HostedTenantBindingStore } from './hosted-tenant-binding-store.js';
+import { TunnelSessionStore } from './tunnel-session-store.js';
+
+export interface DeploymentRouterServiceOptions {
+  hostedTenantBindingStore?: HostedTenantBindingStore;
+  tunnelSessionStore?: TunnelSessionStore;
+  defaultMode?: PublicMcpDeploymentMode;
+  developmentHosts?: readonly string[];
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
+function safeParseHost(requestUrl?: string): string | null {
+  if (!requestUrl) {
+    return null;
+  }
+
+  try {
+    return normalizeHost(new URL(requestUrl).host);
+  } catch {
+    return null;
+  }
+}
+
+function extractUserHandle(host: string): PublicMcpUserHandle | undefined {
+  const [firstLabel] = normalizeHost(host).split('.');
+  const parsed = PublicMcpUserHandleSchema.safeParse(firstLabel);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export class DeploymentRouterService implements IPublicMcpDeploymentRouterService {
+  private readonly developmentHosts: Set<string>;
+
+  constructor(private readonly options: DeploymentRouterServiceOptions = {}) {
+    this.developmentHosts = new Set(
+      (options.developmentHosts ?? ['localhost:3000', '127.0.0.1:3000']).map(normalizeHost),
+    );
+  }
+
+  async resolve(
+    request: PublicMcpExecutionRequest,
+  ): Promise<PublicMcpDeploymentResolution> {
+    const requestHost = safeParseHost(request.requestUrl) ?? 'localhost:3000';
+
+    const hostedByHost = await this.options.hostedTenantBindingStore?.getByHost(requestHost);
+    if (hostedByHost?.status === 'active') {
+      return {
+        mode: 'hosted',
+        requestHost,
+        userHandle: hostedByHost.userHandle,
+        bindingId: hostedByHost.bindingId,
+        tenantId: hostedByHost.tenantId,
+        storePrefix: hostedByHost.storePrefix,
+        serverName: hostedByHost.serverName,
+        phase: hostedByHost.phase,
+      };
+    }
+
+    const tunnelByHost = await this.options.tunnelSessionStore?.getByHost(requestHost);
+    if (tunnelByHost?.status === 'active') {
+      return {
+        mode: 'local_tunnel',
+        requestHost,
+        userHandle: tunnelByHost.userHandle,
+        sessionId: tunnelByHost.sessionId,
+      };
+    }
+
+    const userHandle = extractUserHandle(requestHost);
+    if (userHandle) {
+      const hostedByHandle =
+        await this.options.hostedTenantBindingStore?.getByUserHandle(userHandle);
+      if (hostedByHandle?.status === 'active') {
+        return {
+          mode: 'hosted',
+          requestHost,
+          userHandle: hostedByHandle.userHandle,
+          bindingId: hostedByHandle.bindingId,
+          tenantId: hostedByHandle.tenantId,
+          storePrefix: hostedByHandle.storePrefix,
+          serverName: hostedByHandle.serverName,
+          phase: hostedByHandle.phase,
+        };
+      }
+
+      const tunnelByHandle =
+        await this.options.tunnelSessionStore?.getByUserHandle(userHandle);
+      if (tunnelByHandle?.status === 'active') {
+        return {
+          mode: 'local_tunnel',
+          requestHost,
+          userHandle: tunnelByHandle.userHandle,
+          sessionId: tunnelByHandle.sessionId,
+        };
+      }
+    }
+
+    if (this.developmentHosts.has(requestHost) || !request.requestUrl) {
+      return {
+        mode: this.options.defaultMode ?? 'development',
+        requestHost,
+      };
+    }
+
+    throw new Error(`No public MCP deployment resolved for host ${requestHost}`);
+  }
+}

--- a/self/subcortex/public-mcp/src/hosted-tenant-binding-store.ts
+++ b/self/subcortex/public-mcp/src/hosted-tenant-binding-store.ts
@@ -1,0 +1,97 @@
+import type {
+  IDocumentStore,
+  PublicMcpHostedTenantBindingRecord,
+  PublicMcpUserHandle,
+} from '@nous/shared';
+import { PublicMcpHostedTenantBindingRecordSchema } from '@nous/shared';
+
+export const PUBLIC_MCP_HOSTED_TENANT_BINDING_COLLECTION =
+  'public_mcp_hosted_tenant_binding';
+
+export interface HostedTenantBindingStoreOptions {
+  seedRecords?: readonly PublicMcpHostedTenantBindingRecord[];
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
+export class HostedTenantBindingStore {
+  private readonly seeded = new Map<string, PublicMcpHostedTenantBindingRecord>();
+
+  constructor(
+    private readonly documentStore: IDocumentStore,
+    options: HostedTenantBindingStoreOptions = {},
+  ) {
+    for (const record of options.seedRecords ?? []) {
+      const parsed = PublicMcpHostedTenantBindingRecordSchema.parse({
+        ...record,
+        host: normalizeHost(record.host),
+      });
+      this.seeded.set(parsed.bindingId, parsed);
+    }
+  }
+
+  async save(
+    record: PublicMcpHostedTenantBindingRecord,
+  ): Promise<PublicMcpHostedTenantBindingRecord> {
+    const parsed = PublicMcpHostedTenantBindingRecordSchema.parse({
+      ...record,
+      host: normalizeHost(record.host),
+    });
+    await this.documentStore.put(
+      PUBLIC_MCP_HOSTED_TENANT_BINDING_COLLECTION,
+      parsed.bindingId,
+      parsed,
+    );
+    this.seeded.set(parsed.bindingId, parsed);
+    return parsed;
+  }
+
+  async get(bindingId: string): Promise<PublicMcpHostedTenantBindingRecord | null> {
+    const seeded = this.seeded.get(bindingId);
+    if (seeded) {
+      return seeded;
+    }
+    const raw = await this.documentStore.get<unknown>(
+      PUBLIC_MCP_HOSTED_TENANT_BINDING_COLLECTION,
+      bindingId,
+    );
+    return raw ? PublicMcpHostedTenantBindingRecordSchema.parse(raw) : null;
+  }
+
+  async getByHost(host: string): Promise<PublicMcpHostedTenantBindingRecord | null> {
+    const normalized = normalizeHost(host);
+    for (const record of this.seeded.values()) {
+      if (record.host === normalized) {
+        return record;
+      }
+    }
+    const rows = await this.documentStore.query<unknown>(
+      PUBLIC_MCP_HOSTED_TENANT_BINDING_COLLECTION,
+      {
+        where: { host: normalized },
+        limit: 1,
+      },
+    );
+    return rows[0] ? PublicMcpHostedTenantBindingRecordSchema.parse(rows[0]) : null;
+  }
+
+  async getByUserHandle(
+    userHandle: PublicMcpUserHandle,
+  ): Promise<PublicMcpHostedTenantBindingRecord | null> {
+    for (const record of this.seeded.values()) {
+      if (record.userHandle === userHandle) {
+        return record;
+      }
+    }
+    const rows = await this.documentStore.query<unknown>(
+      PUBLIC_MCP_HOSTED_TENANT_BINDING_COLLECTION,
+      {
+        where: { userHandle },
+        limit: 1,
+      },
+    );
+    return rows[0] ? PublicMcpHostedTenantBindingRecordSchema.parse(rows[0]) : null;
+  }
+}

--- a/self/subcortex/public-mcp/src/hosted-tenant-runtime-factory.ts
+++ b/self/subcortex/public-mcp/src/hosted-tenant-runtime-factory.ts
@@ -1,0 +1,79 @@
+import type {
+  IDocumentStore,
+  IVectorStore,
+  PublicMcpHostedTenantBindingRecord,
+} from '@nous/shared';
+
+export interface HostedTenantRuntimeFactoryContext {
+  binding: PublicMcpHostedTenantBindingRecord;
+  documentStore: IDocumentStore;
+  vectorStore?: IVectorStore;
+}
+
+export interface HostedTenantRuntimeFactoryOptions<TBundle> {
+  documentStore: IDocumentStore;
+  vectorStore?: IVectorStore;
+  build: (context: HostedTenantRuntimeFactoryContext) => Promise<TBundle> | TBundle;
+}
+
+function qualifyCollection(prefix: string, collection: string): string {
+  return `${prefix}:${collection}`;
+}
+
+export function createPrefixedDocumentStore(
+  documentStore: IDocumentStore,
+  prefix: string,
+): IDocumentStore {
+  return {
+    put: async (collection, id, document) =>
+      documentStore.put(qualifyCollection(prefix, collection), id, document),
+    get: async (collection, id) =>
+      documentStore.get(qualifyCollection(prefix, collection), id),
+    query: async (collection, filter) =>
+      documentStore.query(qualifyCollection(prefix, collection), filter),
+    delete: async (collection, id) =>
+      documentStore.delete(qualifyCollection(prefix, collection), id),
+  };
+}
+
+export function createPrefixedVectorStore(
+  vectorStore: IVectorStore,
+  prefix: string,
+): IVectorStore {
+  return {
+    upsert: async (collection, id, vector, metadata) =>
+      vectorStore.upsert(qualifyCollection(prefix, collection), id, vector, metadata),
+    search: async (collection, query, limit, filter) =>
+      vectorStore.search(qualifyCollection(prefix, collection), query, limit, filter),
+    delete: async (collection, id) =>
+      vectorStore.delete(qualifyCollection(prefix, collection), id),
+  };
+}
+
+export class HostedTenantRuntimeFactory<TBundle> {
+  private readonly cache = new Map<string, Promise<TBundle>>();
+
+  constructor(private readonly options: HostedTenantRuntimeFactoryOptions<TBundle>) {}
+
+  async getOrCreate(binding: PublicMcpHostedTenantBindingRecord): Promise<TBundle> {
+    const existing = this.cache.get(binding.bindingId);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = Promise.resolve(
+      this.options.build({
+        binding,
+        documentStore: createPrefixedDocumentStore(
+          this.options.documentStore,
+          binding.storePrefix,
+        ),
+        vectorStore: this.options.vectorStore
+          ? createPrefixedVectorStore(this.options.vectorStore, binding.storePrefix)
+          : undefined,
+      }),
+    );
+    this.cache.set(binding.bindingId, promise);
+    return promise;
+  }
+}

--- a/self/subcortex/public-mcp/src/index.ts
+++ b/self/subcortex/public-mcp/src/index.ts
@@ -14,6 +14,10 @@ export {
   PUBLIC_MCP_AUDIT_COLLECTION,
 } from './audit-projection-store.js';
 export {
+  DeploymentRouterService,
+  type DeploymentRouterServiceOptions,
+} from './deployment-router-service.js';
+export {
   ExternalSourceMemoryService,
   type ExternalSourceMemoryServiceOptions,
 } from './external-source-memory-service.js';
@@ -29,6 +33,17 @@ export {
   ExternalSourceStorageAdapter,
   type ExternalSourceStorageAdapterOptions,
 } from './external-source-storage-adapter.js';
+export {
+  HostedTenantBindingStore,
+  PUBLIC_MCP_HOSTED_TENANT_BINDING_COLLECTION,
+} from './hosted-tenant-binding-store.js';
+export {
+  HostedTenantRuntimeFactory,
+  createPrefixedDocumentStore,
+  createPrefixedVectorStore,
+  type HostedTenantRuntimeFactoryContext,
+  type HostedTenantRuntimeFactoryOptions,
+} from './hosted-tenant-runtime-factory.js';
 export {
   DefaultPublicMcpTokenVerifier,
   PublicMcpAuthAdmission,
@@ -67,3 +82,13 @@ export {
   type ConsumeRateLimitInput,
   type RateLimitConsumptionResult,
 } from './rate-limit-bucket-store.js';
+export {
+  TunnelForwarder,
+  type TunnelForwardTargetBundle,
+  type TunnelForwarderOptions,
+} from './tunnel-forwarder.js';
+export {
+  PUBLIC_MCP_TUNNEL_NONCE_COLLECTION,
+  PUBLIC_MCP_TUNNEL_SESSION_COLLECTION,
+  TunnelSessionStore,
+} from './tunnel-session-store.js';

--- a/self/subcortex/public-mcp/src/public-mcp-gateway-service.ts
+++ b/self/subcortex/public-mcp/src/public-mcp-gateway-service.ts
@@ -1,10 +1,12 @@
 import type {
   IDocumentStore,
+  IPublicMcpDeploymentRouterService,
   IPublicMcpSurfaceService,
   IPublicMcpGatewayService,
   IWitnessService,
   PublicMcpAdmissionDecision,
   PublicMcpClientMetadata,
+  PublicMcpDeploymentResolution,
   PublicMcpDiscoveryBundle,
   PublicMcpExecutionRequest,
   PublicMcpExecutionResult,
@@ -29,6 +31,19 @@ export interface PublicMcpExecutionBridgeLike {
   executeMappedTool(request: PublicMcpExecutionRequest): Promise<PublicMcpExecutionResult>;
 }
 
+export interface PublicMcpDeploymentBundle {
+  executionBridge?: PublicMcpExecutionBridgeLike;
+  surfaceService?: IPublicMcpSurfaceService;
+}
+
+export interface PublicMcpTunnelForwarderLike {
+  forward(
+    request: PublicMcpExecutionRequest,
+    resolution: PublicMcpDeploymentResolution,
+    targets: PublicMcpDeploymentBundle,
+  ): Promise<PublicMcpExecutionResult>;
+}
+
 export interface PublicMcpGatewayServiceOptions {
   documentStore?: IDocumentStore;
   namespaceStore?: NamespaceRegistryStore;
@@ -49,6 +64,11 @@ export interface PublicMcpGatewayServiceOptions {
     toolName: string,
     args?: Record<string, unknown>,
   ) => PublicMcpScope[];
+  deploymentRouter?: IPublicMcpDeploymentRouterService;
+  deploymentBundleResolver?: (
+    resolution: PublicMcpDeploymentResolution,
+  ) => Promise<PublicMcpDeploymentBundle> | PublicMcpDeploymentBundle;
+  tunnelForwarder?: PublicMcpTunnelForwarderLike;
   surfaceService?: IPublicMcpSurfaceService;
   now?: () => string;
 }
@@ -146,6 +166,33 @@ export class PublicMcpGatewayService implements IPublicMcpGatewayService {
     request: PublicMcpExecutionRequest,
   ): Promise<PublicMcpExecutionResult> {
     const startedAt = Date.now();
+    let resolution: PublicMcpDeploymentResolution | undefined;
+    if (request.method !== 'initialize' && request.method !== 'tools/list') {
+      try {
+        resolution = await this.resolveDeployment(request);
+      } catch (error) {
+        return this.finalizeExecution(
+          request,
+          PublicMcpExecutionResultSchema.parse({
+            requestId: request.requestId,
+            httpStatus: 404,
+            rpcId: request.rpcId,
+            rejectReason: 'deployment_not_resolved',
+            error: {
+              code: -32012,
+              message: error instanceof Error ? error.message : 'Public MCP deployment could not be resolved.',
+            },
+          }),
+          startedAt,
+        );
+      }
+    }
+    const bundle = resolution
+      ? await this.resolveDeploymentBundle(resolution)
+      : {
+          executionBridge: this.options.executionBridge,
+          surfaceService: this.options.surfaceService,
+        };
 
     if (request.method === 'initialize') {
       return this.finalizeExecution(
@@ -187,71 +234,44 @@ export class PublicMcpGatewayService implements IPublicMcpGatewayService {
     }
 
     if (request.method === 'tasks/get') {
-      const task = await this.options.surfaceService?.getTask({
-        requestId: request.requestId,
-        subject: request.subject,
-        taskId: String(request.arguments?.taskId ?? ''),
-        requestedAt: request.requestedAt,
-      });
       return this.finalizeExecution(
         request,
-        {
-          requestId: request.requestId,
-          httpStatus: task ? 200 : 404,
-          rpcId: request.rpcId,
-          result: task ?? undefined,
-          rejectReason: task ? undefined : 'task_not_found',
-          error: task
-            ? undefined
-            : {
-                code: -32010,
-                message: 'Task not found.',
-              },
-        },
+        resolution?.mode === 'local_tunnel' && this.options.tunnelForwarder
+          ? await this.options.tunnelForwarder.forward(request, resolution, bundle)
+          : await this.executeTaskGet(request, bundle.surfaceService),
         startedAt,
+        resolution,
       );
     }
 
     if (request.method === 'tasks/result') {
-      const taskResult = await this.options.surfaceService?.getTaskResult({
-        requestId: request.requestId,
-        subject: request.subject,
-        taskId: String(request.arguments?.taskId ?? ''),
-        requestedAt: request.requestedAt,
-      });
       return this.finalizeExecution(
         request,
-        {
-          requestId: request.requestId,
-          httpStatus: taskResult ? 200 : 404,
-          rpcId: request.rpcId,
-          result: taskResult ?? undefined,
-          rejectReason: taskResult ? undefined : 'task_not_ready',
-          error: taskResult
-            ? undefined
-            : {
-                code: -32011,
-                message: 'Task result is not available.',
-              },
-        },
+        resolution?.mode === 'local_tunnel' && this.options.tunnelForwarder
+          ? await this.options.tunnelForwarder.forward(request, resolution, bundle)
+          : await this.executeTaskResult(request, bundle.surfaceService),
         startedAt,
+        resolution,
       );
     }
 
-    const bridgeResult = this.options.executionBridge
-      ? await this.options.executionBridge.executeMappedTool(request)
-      : PublicMcpExecutionResultSchema.parse({
-          requestId: request.requestId,
-          httpStatus: 404,
-          rpcId: request.rpcId,
-          rejectReason: 'tool_not_available',
-          error: {
-            code: -32601,
-            message: 'Tool not available.',
-          },
-        });
+    const bridgeResult =
+      resolution?.mode === 'local_tunnel' && this.options.tunnelForwarder
+        ? await this.options.tunnelForwarder.forward(request, resolution, bundle)
+        : bundle.executionBridge
+          ? await bundle.executionBridge.executeMappedTool(request)
+          : PublicMcpExecutionResultSchema.parse({
+              requestId: request.requestId,
+              httpStatus: 404,
+              rpcId: request.rpcId,
+              rejectReason: 'tool_not_available',
+              error: {
+                code: -32601,
+                message: 'Tool not available.',
+              },
+            });
 
-    return this.finalizeExecution(request, bridgeResult, startedAt);
+    return this.finalizeExecution(request, bridgeResult, startedAt, resolution);
   }
 
   getNamespaceStore(): NamespaceRegistryStore {
@@ -266,9 +286,10 @@ export class PublicMcpGatewayService implements IPublicMcpGatewayService {
     request: PublicMcpExecutionRequest,
     result: PublicMcpExecutionResult,
     startedAtMs: number,
+    resolution?: PublicMcpDeploymentResolution,
   ): Promise<PublicMcpExecutionResult> {
     const outcome = result.error ? 'blocked' : 'completed';
-    const auditDetail = buildAuditDetail(request, result);
+    const auditDetail = buildAuditDetail(request, result, resolution);
     const detail = {
       ...this.buildWitnessDetail(
         request.requestId,
@@ -421,11 +442,84 @@ export class PublicMcpGatewayService implements IPublicMcpGatewayService {
     });
     return event.id;
   }
+
+  private async resolveDeployment(
+    request: PublicMcpExecutionRequest,
+  ): Promise<PublicMcpDeploymentResolution | undefined> {
+    if (!this.options.deploymentRouter) {
+      return undefined;
+    }
+
+    return this.options.deploymentRouter.resolve(request);
+  }
+
+  private async resolveDeploymentBundle(
+    resolution: PublicMcpDeploymentResolution,
+  ): Promise<PublicMcpDeploymentBundle> {
+    const resolved = this.options.deploymentBundleResolver
+      ? await this.options.deploymentBundleResolver(resolution)
+      : {};
+    return {
+      executionBridge: resolved.executionBridge ?? this.options.executionBridge,
+      surfaceService: resolved.surfaceService ?? this.options.surfaceService,
+    };
+  }
+
+  private async executeTaskGet(
+    request: PublicMcpExecutionRequest,
+    surfaceService?: IPublicMcpSurfaceService,
+  ): Promise<PublicMcpExecutionResult> {
+    const task = await surfaceService?.getTask({
+      requestId: request.requestId,
+      subject: request.subject,
+      taskId: String(request.arguments?.taskId ?? ''),
+      requestedAt: request.requestedAt,
+    });
+    return PublicMcpExecutionResultSchema.parse({
+      requestId: request.requestId,
+      httpStatus: task ? 200 : 404,
+      rpcId: request.rpcId,
+      result: task ?? undefined,
+      rejectReason: task ? undefined : 'task_not_found',
+      error: task
+        ? undefined
+        : {
+            code: -32010,
+            message: 'Task not found.',
+          },
+    });
+  }
+
+  private async executeTaskResult(
+    request: PublicMcpExecutionRequest,
+    surfaceService?: IPublicMcpSurfaceService,
+  ): Promise<PublicMcpExecutionResult> {
+    const taskResult = await surfaceService?.getTaskResult({
+      requestId: request.requestId,
+      subject: request.subject,
+      taskId: String(request.arguments?.taskId ?? ''),
+      requestedAt: request.requestedAt,
+    });
+    return PublicMcpExecutionResultSchema.parse({
+      requestId: request.requestId,
+      httpStatus: taskResult ? 200 : 404,
+      rpcId: request.rpcId,
+      result: taskResult ?? undefined,
+      rejectReason: taskResult ? undefined : 'task_not_ready',
+      error: taskResult
+        ? undefined
+        : {
+            code: -32011,
+            message: 'Task result is not available.',
+          },
+    });
+  }
 }
 
 function buildAuditDetail(
   request: PublicMcpExecutionRequest,
   result: PublicMcpExecutionResult,
+  resolution?: PublicMcpDeploymentResolution,
 ): {
   tier?: 'stm' | 'ltm';
   entryId?: string;
@@ -433,6 +527,7 @@ function buildAuditDetail(
   lifecycleState?: 'active' | 'quarantined' | 'purging' | 'purged';
   quotaDecision?: 'allow' | 'reject';
   rateLimitDecision?: 'allow' | 'reject';
+  deployment?: PublicMcpDeploymentResolution;
 } {
   const args =
     request.method === 'tools/call' && request.arguments
@@ -468,6 +563,7 @@ function buildAuditDetail(
         : request.method === 'tools/call'
           ? 'allow'
           : undefined,
+    deployment: resolution,
   };
 }
 

--- a/self/subcortex/public-mcp/src/public-mcp-surface-service.ts
+++ b/self/subcortex/public-mcp/src/public-mcp-surface-service.ts
@@ -27,6 +27,11 @@ export interface PublicMcpRuntimeInvocationLike {
   targetClass: 'Worker' | 'Orchestrator';
   taskInstructions: string;
   payload?: unknown;
+  runtimeContext?: {
+    deploymentMode?: 'local_tunnel' | 'hosted' | 'development';
+    tenantId?: string;
+    userHandle?: string;
+  };
   context?: Array<{
     role: 'system' | 'user';
     content: string;
@@ -64,6 +69,9 @@ export interface PublicMcpSurfaceServiceOptions {
   serverName?: string;
   phase?: string;
   backendMode?: 'local_tunnel' | 'hosted' | 'development';
+  featureOverrides?: Partial<PublicMcpSystemInfo['features']>;
+  taskToolSupport?: PublicMcpSystemInfo['tasks']['toolSupport'];
+  runtimeContext?: PublicMcpRuntimeInvocationLike['runtimeContext'];
   maxInvokeInputBytes?: number;
   maxSearchTopK?: number;
   maxTaskPollWindowSeconds?: number;
@@ -108,6 +116,7 @@ export class PublicMcpSurfaceService implements IPublicMcpSurfaceService {
       targetClass: agent.targetClass,
       taskInstructions: agent.buildTaskInstructions(request),
       payload: agent.buildPayload?.(request),
+      runtimeContext: this.options.runtimeContext,
       context: buildRuntimeContext(request),
     });
 
@@ -142,15 +151,15 @@ export class PublicMcpSurfaceService implements IPublicMcpSurfaceService {
     return PublicMcpSystemInfoSchema.parse({
       server: {
         name: this.options.serverName ?? 'Nous Public MCP',
-        phase: this.options.phase ?? 'phase-13.4',
+        phase: this.options.phase ?? 'phase-13.5',
         backendMode: this.options.backendMode ?? 'development',
         protocolVersion: '2025-11-25',
       },
       features: {
-        publicAgents: true,
-        publicSystemInfo: true,
-        publicTasks: true,
-        publicCompactAsync: true,
+        publicAgents: this.options.featureOverrides?.publicAgents ?? true,
+        publicSystemInfo: this.options.featureOverrides?.publicSystemInfo ?? true,
+        publicTasks: this.options.featureOverrides?.publicTasks ?? true,
+        publicCompactAsync: this.options.featureOverrides?.publicCompactAsync ?? true,
       },
       limits: {
         maxInvokeInputBytes: this.options.maxInvokeInputBytes ?? 8192,
@@ -163,7 +172,7 @@ export class PublicMcpSurfaceService implements IPublicMcpSurfaceService {
       },
       tasks: {
         supportedMethods: ['tasks/get', 'tasks/result'],
-        toolSupport: {
+        toolSupport: this.options.taskToolSupport ?? {
           'ortho.agents.v1.invoke': 'optional',
           'ortho.memory.v1.compact': 'optional',
         },
@@ -225,6 +234,7 @@ export class PublicMcpSurfaceService implements IPublicMcpSurfaceService {
       targetClass: agent.targetClass,
       taskInstructions: agent.buildTaskInstructions(request),
       payload: agent.buildPayload?.(request),
+      runtimeContext: this.options.runtimeContext,
       context: buildRuntimeContext(request),
     });
 

--- a/self/subcortex/public-mcp/src/tunnel-forwarder.ts
+++ b/self/subcortex/public-mcp/src/tunnel-forwarder.ts
@@ -1,0 +1,284 @@
+import { createHmac, randomUUID } from 'node:crypto';
+import type {
+  IPublicMcpSurfaceService,
+  PublicMcpDeploymentResolution,
+  PublicMcpExecutionRequest,
+  PublicMcpExecutionResult,
+  PublicMcpTunnelForwardEnvelope,
+  PublicMcpTunnelSessionRecord,
+} from '@nous/shared';
+import {
+  PublicMcpExecutionResultSchema,
+  PublicMcpTunnelForwardEnvelopeSchema,
+} from '@nous/shared';
+import type { PublicMcpExecutionBridgeLike } from './public-mcp-gateway-service.js';
+import { TunnelSessionStore } from './tunnel-session-store.js';
+
+export interface TunnelForwarderOptions {
+  sessionStore: TunnelSessionStore;
+  now?: () => string;
+  idFactory?: () => string;
+  ttlMs?: number;
+}
+
+export interface TunnelForwardTargetBundle {
+  executionBridge?: PublicMcpExecutionBridgeLike;
+  surfaceService?: IPublicMcpSurfaceService;
+}
+
+function buildSignaturePayload(
+  envelope: Omit<PublicMcpTunnelForwardEnvelope, 'signature'>,
+): string {
+  return JSON.stringify({
+    envelopeId: envelope.envelopeId,
+    requestId: envelope.requestId,
+    sessionId: envelope.sessionId,
+    userHandle: envelope.userHandle,
+    nonce: envelope.nonce,
+    issuedAt: envelope.issuedAt,
+    expiresAt: envelope.expiresAt,
+    request: envelope.request,
+  });
+}
+
+function signEnvelope(
+  envelope: Omit<PublicMcpTunnelForwardEnvelope, 'signature'>,
+  sharedSecret: string,
+): string {
+  return createHmac('sha256', sharedSecret)
+    .update(buildSignaturePayload(envelope))
+    .digest('hex');
+}
+
+function reject(
+  request: PublicMcpExecutionRequest,
+  rejectReason: PublicMcpExecutionResult['rejectReason'],
+  code: number,
+  message: string,
+): PublicMcpExecutionResult {
+  return PublicMcpExecutionResultSchema.parse({
+    requestId: request.requestId,
+    httpStatus: 403,
+    rpcId: request.rpcId,
+    rejectReason,
+    error: {
+      code,
+      message,
+      data: { rejectReason },
+    },
+  });
+}
+
+export class TunnelForwarder {
+  private readonly now: () => string;
+  private readonly idFactory: () => string;
+  private readonly ttlMs: number;
+
+  constructor(private readonly options: TunnelForwarderOptions) {
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.idFactory = options.idFactory ?? randomUUID;
+    this.ttlMs = options.ttlMs ?? 60_000;
+  }
+
+  async issueEnvelope(
+    request: PublicMcpExecutionRequest,
+    resolution: PublicMcpDeploymentResolution,
+  ): Promise<PublicMcpTunnelForwardEnvelope> {
+    const session = await this.requireSession(resolution);
+    const issuedAt = this.now();
+    const expiresAt = new Date(Date.parse(issuedAt) + this.ttlMs).toISOString();
+    const unsigned = {
+      envelopeId: this.idFactory(),
+      requestId: request.requestId,
+      sessionId: session.sessionId,
+      userHandle: session.userHandle,
+      nonce: this.idFactory(),
+      issuedAt,
+      expiresAt,
+      request,
+    };
+    return PublicMcpTunnelForwardEnvelopeSchema.parse({
+      ...unsigned,
+      signature: signEnvelope(unsigned, session.sharedSecret),
+    });
+  }
+
+  async forward(
+    request: PublicMcpExecutionRequest,
+    resolution: PublicMcpDeploymentResolution,
+    targets: TunnelForwardTargetBundle,
+  ): Promise<PublicMcpExecutionResult> {
+    const envelope = await this.issueEnvelope(request, resolution);
+    return this.forwardEnvelope(envelope, targets);
+  }
+
+  async forwardEnvelope(
+    envelope: PublicMcpTunnelForwardEnvelope,
+    targets: TunnelForwardTargetBundle,
+  ): Promise<PublicMcpExecutionResult> {
+    const parsed = PublicMcpTunnelForwardEnvelopeSchema.parse(envelope);
+    const session = await this.options.sessionStore.get(parsed.sessionId);
+    if (!session || session.status !== 'active') {
+      return reject(
+        parsed.request,
+        'tunnel_envelope_invalid',
+        -32012,
+        'Tunnel session is unavailable.',
+      );
+    }
+
+    if (!this.isEnvelopeValidForSession(parsed, session)) {
+      return reject(
+        parsed.request,
+        'tunnel_envelope_invalid',
+        -32012,
+        'Tunnel forward envelope validation failed.',
+      );
+    }
+
+    const nonceAccepted = await this.options.sessionStore.consumeNonce(
+      session.sessionId,
+      parsed.nonce,
+      this.now(),
+      parsed.expiresAt,
+    );
+    if (!nonceAccepted) {
+      return reject(
+        parsed.request,
+        'tunnel_replay_detected',
+        -32013,
+        'Tunnel forward envelope replay detected.',
+      );
+    }
+
+    await this.options.sessionStore.touch(session.sessionId, this.now());
+
+    if (parsed.request.method === 'tasks/get') {
+      const task = await targets.surfaceService?.getTask({
+        requestId: parsed.request.requestId,
+        subject: parsed.request.subject,
+        taskId: String(parsed.request.arguments?.taskId ?? ''),
+        requestedAt: parsed.request.requestedAt,
+      });
+      return PublicMcpExecutionResultSchema.parse({
+        requestId: parsed.request.requestId,
+        httpStatus: task ? 200 : 404,
+        rpcId: parsed.request.rpcId,
+        result: task ?? undefined,
+        rejectReason: task ? undefined : 'task_not_found',
+        error: task
+          ? undefined
+          : {
+              code: -32010,
+              message: 'Task not found.',
+            },
+      });
+    }
+
+    if (parsed.request.method === 'tasks/result') {
+      const taskResult = await targets.surfaceService?.getTaskResult({
+        requestId: parsed.request.requestId,
+        subject: parsed.request.subject,
+        taskId: String(parsed.request.arguments?.taskId ?? ''),
+        requestedAt: parsed.request.requestedAt,
+      });
+      return PublicMcpExecutionResultSchema.parse({
+        requestId: parsed.request.requestId,
+        httpStatus: taskResult ? 200 : 404,
+        rpcId: parsed.request.rpcId,
+        result: taskResult ?? undefined,
+        rejectReason: taskResult ? undefined : 'task_not_ready',
+        error: taskResult
+          ? undefined
+          : {
+              code: -32011,
+              message: 'Task result is not available.',
+            },
+      });
+    }
+
+    if (parsed.request.method === 'tools/list') {
+      return PublicMcpExecutionResultSchema.parse({
+        requestId: parsed.request.requestId,
+        httpStatus: 200,
+        rpcId: parsed.request.rpcId,
+        result: {
+          tools: await targets.executionBridge?.listTools(parsed.request.subject),
+        },
+      });
+    }
+
+    if (parsed.request.method === 'initialize') {
+      return PublicMcpExecutionResultSchema.parse({
+        requestId: parsed.request.requestId,
+        httpStatus: 200,
+        rpcId: parsed.request.rpcId,
+        result: {
+          protocolVersion: parsed.request.protocolVersion,
+          serverInfo: {
+            name: 'Nous Public MCP',
+            version: '0.0.1',
+          },
+          capabilities: {
+            tools: {
+              listChanged: false,
+            },
+            tasks: {},
+          },
+        },
+      });
+    }
+
+    return (
+      (await targets.executionBridge?.executeMappedTool(parsed.request)) ??
+      reject(parsed.request, 'tool_not_available', -32601, 'Tool not available.')
+    );
+  }
+
+  private async requireSession(
+    resolution: PublicMcpDeploymentResolution,
+  ): Promise<PublicMcpTunnelSessionRecord> {
+    if (!resolution.sessionId) {
+      throw new Error('Tunnel resolution is missing sessionId');
+    }
+    const session = await this.options.sessionStore.get(resolution.sessionId);
+    if (!session || session.status !== 'active') {
+      throw new Error(`Tunnel session ${resolution.sessionId} is unavailable`);
+    }
+    return session;
+  }
+
+  private isEnvelopeValidForSession(
+    envelope: PublicMcpTunnelForwardEnvelope,
+    session: PublicMcpTunnelSessionRecord,
+  ): boolean {
+    const requestHost = envelope.request.requestUrl
+      ? new URL(envelope.request.requestUrl).host.toLowerCase()
+      : session.host.toLowerCase();
+    if (requestHost !== session.host.toLowerCase()) {
+      return false;
+    }
+    if (envelope.userHandle !== session.userHandle) {
+      return false;
+    }
+    if (session.expiresAt && session.expiresAt < this.now()) {
+      return false;
+    }
+    if (envelope.expiresAt < this.now()) {
+      return false;
+    }
+    return signEnvelope(
+      {
+        envelopeId: envelope.envelopeId,
+        requestId: envelope.requestId,
+        sessionId: envelope.sessionId,
+        userHandle: envelope.userHandle,
+        nonce: envelope.nonce,
+        issuedAt: envelope.issuedAt,
+        expiresAt: envelope.expiresAt,
+        request: envelope.request,
+      },
+      session.sharedSecret,
+    ) === envelope.signature;
+  }
+}

--- a/self/subcortex/public-mcp/src/tunnel-session-store.ts
+++ b/self/subcortex/public-mcp/src/tunnel-session-store.ts
@@ -1,0 +1,139 @@
+import type {
+  IDocumentStore,
+  PublicMcpTunnelSessionRecord,
+  PublicMcpUserHandle,
+} from '@nous/shared';
+import { PublicMcpTunnelSessionRecordSchema } from '@nous/shared';
+
+export const PUBLIC_MCP_TUNNEL_SESSION_COLLECTION = 'public_mcp_tunnel_session';
+export const PUBLIC_MCP_TUNNEL_NONCE_COLLECTION = 'public_mcp_tunnel_nonce';
+
+export interface TunnelSessionStoreOptions {
+  seedRecords?: readonly PublicMcpTunnelSessionRecord[];
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
+export class TunnelSessionStore {
+  private readonly seeded = new Map<string, PublicMcpTunnelSessionRecord>();
+  private readonly consumedNonces = new Set<string>();
+
+  constructor(
+    private readonly documentStore: IDocumentStore,
+    options: TunnelSessionStoreOptions = {},
+  ) {
+    for (const record of options.seedRecords ?? []) {
+      const parsed = PublicMcpTunnelSessionRecordSchema.parse({
+        ...record,
+        host: normalizeHost(record.host),
+      });
+      this.seeded.set(parsed.sessionId, parsed);
+    }
+  }
+
+  async save(
+    record: PublicMcpTunnelSessionRecord,
+  ): Promise<PublicMcpTunnelSessionRecord> {
+    const parsed = PublicMcpTunnelSessionRecordSchema.parse({
+      ...record,
+      host: normalizeHost(record.host),
+    });
+    await this.documentStore.put(
+      PUBLIC_MCP_TUNNEL_SESSION_COLLECTION,
+      parsed.sessionId,
+      parsed,
+    );
+    this.seeded.set(parsed.sessionId, parsed);
+    return parsed;
+  }
+
+  async get(sessionId: string): Promise<PublicMcpTunnelSessionRecord | null> {
+    const seeded = this.seeded.get(sessionId);
+    if (seeded) {
+      return seeded;
+    }
+    const raw = await this.documentStore.get<unknown>(
+      PUBLIC_MCP_TUNNEL_SESSION_COLLECTION,
+      sessionId,
+    );
+    return raw ? PublicMcpTunnelSessionRecordSchema.parse(raw) : null;
+  }
+
+  async getByHost(host: string): Promise<PublicMcpTunnelSessionRecord | null> {
+    const normalized = normalizeHost(host);
+    for (const record of this.seeded.values()) {
+      if (record.host === normalized) {
+        return record;
+      }
+    }
+    const rows = await this.documentStore.query<unknown>(
+      PUBLIC_MCP_TUNNEL_SESSION_COLLECTION,
+      {
+        where: { host: normalized },
+        limit: 1,
+      },
+    );
+    return rows[0] ? PublicMcpTunnelSessionRecordSchema.parse(rows[0]) : null;
+  }
+
+  async getByUserHandle(
+    userHandle: PublicMcpUserHandle,
+  ): Promise<PublicMcpTunnelSessionRecord | null> {
+    for (const record of this.seeded.values()) {
+      if (record.userHandle === userHandle) {
+        return record;
+      }
+    }
+    const rows = await this.documentStore.query<unknown>(
+      PUBLIC_MCP_TUNNEL_SESSION_COLLECTION,
+      {
+        where: { userHandle },
+        limit: 1,
+      },
+    );
+    return rows[0] ? PublicMcpTunnelSessionRecordSchema.parse(rows[0]) : null;
+  }
+
+  async touch(sessionId: string, now: string): Promise<void> {
+    const record = await this.get(sessionId);
+    if (!record) {
+      return;
+    }
+    await this.save({
+      ...record,
+      updatedAt: now,
+      lastSeenAt: now,
+    });
+  }
+
+  async consumeNonce(
+    sessionId: string,
+    nonce: string,
+    consumedAt: string,
+    expiresAt: string,
+  ): Promise<boolean> {
+    const nonceId = `${sessionId}:${nonce}`;
+    if (this.consumedNonces.has(nonceId)) {
+      return false;
+    }
+    const existing = await this.documentStore.get(
+      PUBLIC_MCP_TUNNEL_NONCE_COLLECTION,
+      nonceId,
+    );
+    if (existing) {
+      return false;
+    }
+
+    await this.documentStore.put(PUBLIC_MCP_TUNNEL_NONCE_COLLECTION, nonceId, {
+      id: nonceId,
+      sessionId,
+      nonce,
+      consumedAt,
+      expiresAt,
+    });
+    this.consumedNonces.add(nonceId);
+    return true;
+  }
+}


### PR DESCRIPTION
## Phase 13.5 — Tunnel and Hosted Public Gateway Deployment

Delivers one public MCP contract served across `local_tunnel` and `hosted` backends through HMAC-signed, session-bound, nonce-protected tunnel forwarding and per-tenant hosted runtime isolation, without weakening the public-edge admission posture from Phases 13.1–13.4.

### What's in this PR

- **`@nous/shared`** — `PublicMcpDeploymentResolutionSchema`, `PublicMcpHostedTenantBindingRecordSchema`, `PublicMcpTunnelForwardEnvelopeSchema`, `IPublicMcpDeploymentRouterService`
- **`@nous/subcortex-public-mcp`** — `DeploymentRouterService`, `TunnelForwarder` (HMAC-SHA256 envelopes + nonce replay protection), `HostedTenantRuntimeFactory`, `TunnelSessionStore`, `HostedTenantBindingStore`; updated `PublicMcpGatewayService` and `PublicMcpSurfaceService`
- **`@nous/cortex-core`** — `PublicMcpRuntimeAdapter` updated for multi-backend routing
- **`@nous/web`** — `bootstrap.ts` seeds hosted bindings and tunnel sessions from env vars; `mcp/route.ts` updated
- **Docs** — `public-mcp.mdx` (deployment parity, tunnel/hosted modes, new reject reasons, operator config, sync invoke carry-forward), `config-schema.mdx` (`NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON`, `NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON`), `interaction-surfaces.mdx` (Surface 7 runtime boundary)
- **Worklog** — Goals, SDS, Implementation Plan, Completion Report (Cycle 2), User Documentation, synthesis review, and all gate review artifacts

### Gate Review Results

| Gate | Verdict | Notes |
|---|---|---|
| Goals | Approved (Cycle 1) | All 9 criteria passed |
| SDS | Approved (Cycle 1) | 9 criteria passed |
| Implementation Plan | Approved (Cycle 1) | 12 criteria passed |
| Completion Report | Approved (Cycle 2) | One revision cycle — five SDS/plan deviations documented |
| User Documentation | Approved With Notes (Cycle 1) | Two non-blocking editorial carry-forward items |
| Synthesis Review | Approved | Phase 13.5 is the final Phase 13 sub-phase |

### Verification

299 test files / 1680 tests pass. Typecheck, lint (14 pre-existing warnings, 0 new), and build all pass across `@nous/shared`, `@nous/cortex-core`, `@nous/subcortex-public-mcp`, `@nous/web`.

Closes Phase 13.5. Phase 13 may now proceed to phase-close.