### PR TITLE
Phase 14.5 — App Runtime, Tool Registry, and Lifecycle Foundations

### DIFF
--- a/docs/content/docs/architecture/repo-folder-structure.mdx
+++ b/docs/content/docs/architecture/repo-folder-structure.mdx
@@ -323,6 +323,7 @@ self/subcortex/
 ├── tools/                            # Tool execution and capability gating
 ├── workflows/                        # Workflow graph engine
 ├── projects/                         # Project container and lifecycle
+├── apps/                             # Canonical app runtime (Deno subprocess, MCP-over-IPC)
 ├── communication-gateway/            # Human messaging ingress/egress control plane
 ├── public-mcp/                       # Public MCP discovery, admission, bootstrap, and audit runtime
 ├── endpoint-trust/                   # Peripheral pairing, trust, capability, and transport runtime
@@ -457,6 +458,21 @@ Phase 14.3 adds document-loading modules to `self/subcortex/projects/src/package
 Phase 14.4 extends the same package-store lane with canonical installed-workflow read helpers:
 
 - `document-loader.ts` / `index.ts` — add deterministic `listInstalledWorkflowPackages(...)` and `inspectInstalledWorkflowPackage(...)` helpers over `.workflows/`, keeping legacy hybrids out of canonical installed-workflow discovery while preserving compatibility-only loading paths.
+
+### apps/
+
+Canonical app runtime for installed `.apps` packages. Implemented in Phase 14.5 as `@nous/subcortex-apps`.
+
+Responsibilities:
+
+* Activate installed app packages as Deno subprocesses behind the existing `RuntimeMembrane.onAllow` seam
+* Compile manifest permissions into deterministic Deno CLI flags with ratified hard-deny posture (`--deny-env`, `--deny-run`, `--deny-ffi`)
+* Own MCP-over-IPC handshake, activation config delivery, and app-exposed tool registration through the canonical Internal MCP catalog
+* Integrate app lifecycle (activate, deactivate, enable, disable) with the package lifecycle orchestrator and witness-linked evidence
+* Track app health and heartbeat visibility through runtime-owned seams
+* Export only the contract and registration seams Phase 15 needs for panel delivery
+
+Nous core stays on Node.js; apps run as Deno subprocesses. MCP over IPC is the sole app-to-core communication path. The `IAppRuntimeService` interface lives in `@nous/shared` and is consumed by cortex-core and gateway-runtime for health projections and capability-handler integration.
 
 ### communication-gateway/
 

--- a/docs/content/docs/architecture/tech-stack.mdx
+++ b/docs/content/docs/architecture/tech-stack.mdx
@@ -16,10 +16,13 @@ The stack is chosen to support: TypeScript-first full-stack development, interfa
 | Choice | Detail |
 |---|---|
 | **Language** | TypeScript |
-| **Runtime** | Node ≥22 (LTS) |
+| **Core Runtime** | Node ≥22 (LTS) |
+| **App Sandbox Runtime** | Deno (for installed `.apps` packages) |
 | **TypeScript Version** | 5.9+ |
 
 TypeScript is the primary language across all layers — cortex, memory, subcortex, autonomic, shared, and apps. One language for the full stack. The type system maps directly to the interface-first architecture where every component sits behind a contract defined in `self/shared/interfaces/`.
+
+Phase 14.5 establishes the ratified runtime split: **Nous core runs on Node.js**; **installed app packages run as Deno subprocesses**. MCP over IPC is the sole app-to-core communication path. No shared-memory, direct TypeScript interface injection, or alternate app runtime is introduced. App permissions compile deterministically into Deno CLI flags with hard-deny posture (`--deny-env`, `--deny-run`, `--deny-ffi`).
 
 ---
 

--- a/self/cortex/core/src/__tests__/gateway-runtime/runtime-health.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/runtime-health.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { GatewayRuntimeHealthSink } from '../../gateway-runtime/runtime-health.js';
+
+describe('GatewayRuntimeHealthSink', () => {
+  it('projects active app sessions into system health and the system replica', () => {
+    const sink = new GatewayRuntimeHealthSink();
+
+    sink.upsertAppSession({
+      session_id: 'session-1',
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      project_id: '550e8400-e29b-41d4-a716-446655440000',
+      status: 'active',
+      started_at: '2026-03-17T06:00:00.000Z',
+      health_status: 'healthy',
+    });
+
+    sink.recordAppHealth({
+      session_id: 'session-1',
+      status: 'degraded',
+      reported_at: '2026-03-17T06:01:00.000Z',
+      stale: false,
+    });
+
+    const systemHealth = sink.getGatewayHealth('Cortex::System');
+    const principalHealth = sink.getGatewayHealth('Cortex::Principal');
+    const replica = sink.getSystemContextReplica();
+
+    expect(systemHealth.appSessions).toEqual([
+      expect.objectContaining({
+        sessionId: 'session-1',
+        appId: 'app:weather',
+        healthStatus: 'degraded',
+        stale: false,
+        lastHeartbeatAt: '2026-03-17T06:01:00.000Z',
+      }),
+    ]);
+    expect(principalHealth.appSessions).toEqual([]);
+    expect(replica.appSessions).toEqual(systemHealth.appSessions);
+  });
+
+  it('removes app sessions from runtime projections during teardown', () => {
+    const sink = new GatewayRuntimeHealthSink();
+
+    sink.upsertAppSession({
+      session_id: 'session-1',
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      project_id: '550e8400-e29b-41d4-a716-446655440000',
+      status: 'active',
+      started_at: '2026-03-17T06:00:00.000Z',
+      health_status: 'healthy',
+    });
+
+    sink.removeAppSession('session-1');
+
+    expect(sink.getGatewayHealth('Cortex::System').appSessions).toEqual([]);
+    expect(sink.getSystemContextReplica().appSessions).toEqual([]);
+  });
+});

--- a/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createCapabilityHandlers,
   createScopedMcpToolSurface,
+  isAppInternalMcpToolAuthorized,
 } from '../../internal-mcp/index.js';
 import {
   AGENT_ID,
@@ -518,5 +519,57 @@ describe('Internal MCP capability handlers', () => {
         traceId: TRACE_ID,
       }),
     );
+  });
+
+  it('authorizes the ratified app-only health tools and denies workflow control tools', () => {
+    expect(isAppInternalMcpToolAuthorized('health_report')).toBe(true);
+    expect(isAppInternalMcpToolAuthorized('health_heartbeat')).toBe(true);
+    expect(isAppInternalMcpToolAuthorized('workflow_start')).toBe(false);
+  });
+
+  it('routes app health tools through the app runtime service', async () => {
+    const appRuntimeService = {
+      updateHealth: vi.fn().mockResolvedValue({
+        session_id: 'session-1',
+        status: 'healthy',
+        reported_at: '2026-03-17T06:00:00.000Z',
+        stale: false,
+        details: {},
+      }),
+      recordHeartbeat: vi.fn().mockResolvedValue({
+        session_id: 'session-1',
+        status: 'healthy',
+        reported_at: '2026-03-17T06:00:05.000Z',
+        stale: false,
+        details: {},
+      }),
+    };
+    const handlers = createCapabilityHandlers({
+      agentClass: 'Worker',
+      agentId: AGENT_ID as any,
+      deps: {
+        appRuntimeService: appRuntimeService as any,
+      },
+    });
+
+    const report = await handlers.health_report({
+      session_id: 'session-1',
+      status: 'healthy',
+      reported_at: '2026-03-17T06:00:00.000Z',
+      stale: false,
+      details: {},
+    });
+    const heartbeat = await handlers.health_heartbeat({
+      session_id: 'session-1',
+      reported_at: '2026-03-17T06:00:05.000Z',
+      sequence: 1,
+    });
+
+    expect(report.success).toBe(true);
+    expect((report.output as any).health.status).toBe('healthy');
+    expect(heartbeat.success).toBe(true);
+    expect((heartbeat.output as any).heartbeat.sequence).toBe(1);
+    expect(appRuntimeService.updateHealth).toHaveBeenCalledTimes(1);
+    expect(appRuntimeService.recordHeartbeat).toHaveBeenCalledTimes(1);
   });
 });

--- a/self/cortex/core/src/__tests__/internal-mcp/scoped-tool-surface.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/scoped-tool-surface.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createScopedMcpToolSurface,
   getVisibleInternalMcpTools,
+  registerDynamicInternalMcpTool,
+  unregisterDynamicInternalMcpTool,
 } from '../../internal-mcp/index.js';
 import {
   AGENT_ID,
@@ -11,6 +13,14 @@ import {
 } from '../agent-gateway/helpers.js';
 
 describe('ScopedMcpToolSurface', () => {
+  const dynamicToolNames: string[] = [];
+
+  afterEach(() => {
+    for (const name of dynamicToolNames.splice(0)) {
+      unregisterDynamicInternalMcpTool(name);
+    }
+  });
+
   it('filters tool visibility structurally by agent class', async () => {
     const workerSurface = createScopedMcpToolSurface({
       agentClass: 'Worker',
@@ -77,5 +87,65 @@ describe('ScopedMcpToolSurface', () => {
     expect(getVisibleInternalMcpTools('Cortex::System')).toContain('promoted_memory_promote');
     expect(getVisibleInternalMcpTools('Cortex::System')).toContain('workflow_cancel');
     expect(getVisibleInternalMcpTools('Worker')).not.toContain('promoted_memory_promote');
+  });
+
+  it('surfaces runtime-registered dynamic app tools only to authorized agent classes', async () => {
+    const toolName = 'app:weather.get_forecast.dynamic';
+    dynamicToolNames.push(toolName);
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      output: { forecast: 'sunny' },
+      durationMs: 0,
+    });
+    registerDynamicInternalMcpTool({
+      name: toolName,
+      sessionId: 'session-1',
+      appId: 'app:weather',
+      visibleTo: ['Worker'],
+      definition: {
+        name: toolName,
+        version: '1.0.0',
+        description: 'Dynamic app tool',
+        inputSchema: {},
+        outputSchema: {},
+        capabilities: ['read'],
+        permissionScope: 'project',
+      },
+      execute,
+    });
+
+    const workerSurface = createScopedMcpToolSurface({
+      agentClass: 'Worker',
+      agentId: AGENT_ID,
+      deps: {
+        getProjectApi: () => createProjectApi(),
+        pfc: createPfcEngine(),
+      },
+    });
+    const principalSurface = createScopedMcpToolSurface({
+      agentClass: 'Cortex::Principal',
+      agentId: AGENT_ID,
+      deps: {
+        getProjectApi: () => createProjectApi(),
+      },
+    });
+
+    const workerTools = (await workerSurface.listTools()).map((tool) => tool.name);
+    expect(workerTools).toContain(toolName);
+    expect(getVisibleInternalMcpTools('Worker')).toContain(toolName);
+    expect(getVisibleInternalMcpTools('Cortex::Principal')).not.toContain(toolName);
+
+    const result = await workerSurface.executeTool(toolName, {
+      city: 'San Francisco',
+    });
+    expect(result.success).toBe(true);
+    expect(execute).toHaveBeenCalledWith(
+      { city: 'San Francisco' },
+      undefined,
+    );
+
+    await expect(principalSurface.executeTool(toolName, {})).rejects.toThrow(
+      'not available',
+    );
   });
 });

--- a/self/cortex/core/src/gateway-runtime/index.ts
+++ b/self/cortex/core/src/gateway-runtime/index.ts
@@ -27,6 +27,7 @@ export { SystemContextReplicaProvider } from './system-context-replica.js';
 export { GatewayRuntimeHealthSink } from './runtime-health.js';
 export { GatewayTraceRecorder } from './trace-recorder.js';
 export type {
+  GatewayAppSessionHealthProjection,
   GatewayBootSnapshot,
   GatewayBootStatus,
   GatewayBootStep,

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -462,6 +462,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       witnessService: this.deps.witnessService,
       opctlService: this.deps.opctlService,
       runtime: this.deps.runtime,
+      appRuntimeService: this.deps.appRuntimeService,
       instanceRoot: this.deps.instanceRoot,
       outputSchemaValidator: this.deps.outputSchemaValidator,
       workmodeAdmissionGuard: this.workmodeAdmissionGuard,

--- a/self/cortex/core/src/gateway-runtime/runtime-health.ts
+++ b/self/cortex/core/src/gateway-runtime/runtime-health.ts
@@ -1,14 +1,18 @@
 import type {
   AgentResult,
+  AppHealthSnapshot,
+  AppRuntimeSession,
   GatewayOutboxEvent,
 } from '@nous/shared';
 import {
+  GatewayAppSessionHealthProjectionSchema,
   GatewayBootSnapshotSchema,
   GatewayHealthSnapshotSchema,
   SystemContextReplicaSchema,
   type GatewayBootSnapshot,
   type GatewayBootStatus,
   type GatewayBootStep,
+  type GatewayAppSessionHealthProjection,
   type GatewayHealthSnapshot,
   type GatewaySubmissionSource,
   type SystemContextReplica,
@@ -43,6 +47,7 @@ export class GatewayRuntimeHealthSink {
   private readonly stepTimestamps = new Map<GatewayBootStep, string>();
   private readonly issueCodes = new Set<string>();
   private readonly gatewayHealth = new Map<TrackedAgentClass, MutableGatewayHealth>();
+  private readonly appSessions = new Map<string, GatewayAppSessionHealthProjection>();
   private pendingSystemRuns = 0;
 
   constructor() {
@@ -153,6 +158,57 @@ export class GatewayRuntimeHealthSink {
       analytics.queuedCount + analytics.activeCount + analytics.suspendedCount;
   }
 
+  upsertAppSession(
+    session: Pick<
+      AppRuntimeSession,
+      | 'session_id'
+      | 'app_id'
+      | 'package_id'
+      | 'project_id'
+      | 'status'
+      | 'health_status'
+      | 'started_at'
+      | 'last_heartbeat_at'
+    >,
+  ): GatewayAppSessionHealthProjection {
+    const current = this.appSessions.get(session.session_id);
+    const projection = GatewayAppSessionHealthProjectionSchema.parse({
+      sessionId: session.session_id,
+      appId: session.app_id,
+      packageId: session.package_id,
+      projectId: session.project_id,
+      status: session.status,
+      healthStatus: session.health_status,
+      startedAt: session.started_at,
+      lastHeartbeatAt: session.last_heartbeat_at,
+      stale:
+        current?.stale ??
+        session.health_status === 'stale',
+    });
+    this.appSessions.set(projection.sessionId, projection);
+    return projection;
+  }
+
+  recordAppHealth(snapshot: Pick<AppHealthSnapshot, 'session_id' | 'status' | 'reported_at' | 'stale'>): GatewayAppSessionHealthProjection | null {
+    const current = this.appSessions.get(snapshot.session_id);
+    if (!current) {
+      return null;
+    }
+
+    const projection = GatewayAppSessionHealthProjectionSchema.parse({
+      ...current,
+      healthStatus: snapshot.status,
+      lastHeartbeatAt: snapshot.reported_at,
+      stale: snapshot.stale,
+    });
+    this.appSessions.set(projection.sessionId, projection);
+    return projection;
+  }
+
+  removeAppSession(sessionId: string): void {
+    this.appSessions.delete(sessionId);
+  }
+
   getBootSnapshot(): GatewayBootSnapshot {
     return GatewayBootSnapshotSchema.parse({
       status: this.resolveBootStatus(),
@@ -169,6 +225,10 @@ export class GatewayRuntimeHealthSink {
       backlogAnalytics: gateway.backlogAnalytics,
       issueCodes: [...gateway.issueCodes],
       visibleTools: [...gateway.visibleTools],
+      appSessions:
+        agentClass === 'Cortex::System'
+          ? [...this.appSessions.values()]
+          : [],
     });
   }
 
@@ -184,6 +244,7 @@ export class GatewayRuntimeHealthSink {
       backlogAnalytics: gateway.backlogAnalytics,
       issueCodes: [...new Set([...this.issueCodes, ...gateway.issueCodes])],
       visibleTools: [...gateway.visibleTools],
+      appSessions: [...this.appSessions.values()],
     });
   }
 

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import type {
   AgentClass,
+  AppHealthSnapshot,
+  AppRuntimeSession,
   IDocumentStore,
   IAgentGateway,
   IAgentGatewayFactory,
@@ -17,6 +19,7 @@ import type {
   IWorkflowEngine,
   IWitnessService,
   IRuntime,
+  IAppRuntimeService,
   IOpctlService,
   IngressDispatchOutcome,
   IngressTriggerEnvelope,
@@ -72,9 +75,28 @@ export const GatewayHealthSnapshotSchema = z
       .optional(),
     backlogAnalytics: BacklogAnalyticsSchema,
     issueCodes: z.array(z.string().min(1)),
+    appSessions: z.array(
+      z.object({
+        sessionId: z.string().min(1),
+        appId: z.string().min(1),
+        packageId: z.string().min(1),
+        projectId: z.string().uuid().optional(),
+        status: z.enum(['starting', 'active', 'draining', 'stopped', 'failed']),
+        healthStatus: z.enum(['healthy', 'degraded', 'unhealthy', 'stale']),
+        startedAt: z.string().datetime(),
+        lastHeartbeatAt: z.string().datetime().optional(),
+        stale: z.boolean(),
+      }),
+    ),
   })
   .strict();
 export type GatewayHealthSnapshot = z.infer<typeof GatewayHealthSnapshotSchema>;
+
+export const GatewayAppSessionHealthProjectionSchema = GatewayHealthSnapshotSchema.shape.appSessions
+  .unwrap();
+export type GatewayAppSessionHealthProjection = z.infer<
+  typeof GatewayAppSessionHealthProjectionSchema
+>;
 
 export const GatewayBootSnapshotSchema = z
   .object({
@@ -125,6 +147,7 @@ export const SystemContextReplicaSchema = z
     backlogAnalytics: BacklogAnalyticsSchema,
     issueCodes: z.array(z.string().min(1)),
     visibleTools: z.array(z.string().min(1)),
+    appSessions: z.array(GatewayAppSessionHealthProjectionSchema),
   })
   .strict();
 export type SystemContextReplica = z.infer<typeof SystemContextReplicaSchema>;
@@ -153,6 +176,7 @@ export interface PrincipalSystemGatewayRuntimeDeps {
   witnessService?: IWitnessService;
   opctlService?: IOpctlService;
   runtime?: IRuntime;
+  appRuntimeService?: IAppRuntimeService;
   instanceRoot?: string;
   workmodeAdmissionGuard?: IWorkmodeAdmissionGuard;
   outputSchemaValidator?: InternalMcpOutputSchemaValidator;
@@ -185,4 +209,19 @@ export interface IPrincipalSystemGatewayRuntime {
   submitIngressEnvelope(envelope: IngressTriggerEnvelope): Promise<IngressDispatchOutcome>;
   notifyLeaseReleased(event: LaneLeaseReleasedEvent): Promise<void>;
   whenIdle(): Promise<void>;
+}
+
+export interface GatewayAppSessionProjectionUpdate {
+  session: Pick<
+    AppRuntimeSession,
+    | 'session_id'
+    | 'app_id'
+    | 'package_id'
+    | 'project_id'
+    | 'status'
+    | 'health_status'
+    | 'started_at'
+    | 'last_heartbeat_at'
+  >;
+  health?: Pick<AppHealthSnapshot, 'status' | 'stale'>;
 }

--- a/self/cortex/core/src/index.ts
+++ b/self/cortex/core/src/index.ts
@@ -56,17 +56,24 @@ export {
   createInternalMcpSurfaceBundle,
   createLifecycleHandlers,
   createScopedMcpToolSurface,
+  getAuthorizedAppInternalMcpTools,
   getAuthorizedInternalMcpTools,
+  getDynamicInternalMcpToolEntry,
   getInternalMcpCatalogEntry,
   getPublicToolMapping,
+  isAppInternalMcpToolAuthorized,
   resolvePublicMcpRequiredScopes,
   getVisiblePublicToolMappings,
   hasRequiredPublicMcpScopes,
   getVisibleInternalMcpTools,
   INTERNAL_MCP_CATALOG,
+  listDynamicInternalMcpToolEntries,
   PUBLIC_MCP_TOOL_MAPPINGS,
+  registerDynamicInternalMcpTool,
+  unregisterDynamicInternalMcpTool,
 } from './internal-mcp/index.js';
 export type {
+  DynamicInternalMcpToolEntry,
   InternalMcpDispatchChildArgs,
   InternalMcpDispatchRuntime,
   InternalMcpOutputSchemaValidator,
@@ -104,6 +111,7 @@ export {
   GatewayRuntimeHealthSink,
 } from './gateway-runtime/index.js';
 export type {
+  GatewayAppSessionHealthProjection,
   GatewayBootSnapshot,
   GatewayBootStatus,
   GatewayBootStep,

--- a/self/cortex/core/src/internal-mcp/authorization-matrix.ts
+++ b/self/cortex/core/src/internal-mcp/authorization-matrix.ts
@@ -69,6 +69,19 @@ const MATRIX: Record<AgentClass, readonly InternalMcpToolName[]> = {
   ],
 };
 
+const APP_MATRIX: readonly InternalMcpToolName[] = [
+  'health_report',
+  'health_heartbeat',
+  'memory_write',
+  'project_discover',
+  'artifact_store',
+  'artifact_retrieve',
+  'tool_execute',
+  'tool_list',
+  'escalation_notify',
+  'scheduler_register',
+];
+
 export function getAuthorizedInternalMcpTools(
   agentClass: AgentClass,
 ): ReadonlySet<InternalMcpToolName> {
@@ -80,4 +93,14 @@ export function isInternalMcpToolAuthorized(
   toolName: InternalMcpToolName,
 ): boolean {
   return MATRIX[agentClass].includes(toolName);
+}
+
+export function getAuthorizedAppInternalMcpTools(): ReadonlySet<InternalMcpToolName> {
+  return new Set(APP_MATRIX);
+}
+
+export function isAppInternalMcpToolAuthorized(
+  toolName: InternalMcpToolName,
+): boolean {
+  return APP_MATRIX.includes(toolName);
 }

--- a/self/cortex/core/src/internal-mcp/capability-handlers.ts
+++ b/self/cortex/core/src/internal-mcp/capability-handlers.ts
@@ -16,6 +16,8 @@ import {
   type ProjectConfig,
   type ProjectControlState,
   type ProjectId,
+  type AppHealthSnapshot,
+  type AppHeartbeatSignal,
   type ResolvedWorkflowDefinitionSource,
   type ToolResult,
   type TraceEvidenceReference,
@@ -41,6 +43,8 @@ import {
   parseExternalMemoryGetQuery,
   parseExternalMemoryPutCommand,
   parseExternalMemorySearchQuery,
+  parseHealthHeartbeatRequest,
+  parseHealthReportRequest,
   parseMemorySearchRequest,
   parseMemoryWriteRequest,
   parsePromotedMemoryDemoteCommand,
@@ -950,6 +954,44 @@ export function createCapabilityHandlers(
         {
           scheduleId: result.value,
           evidenceRef: result.evidenceRef,
+        },
+        0,
+      );
+    },
+    health_report: async (params) => {
+      const request = parseHealthReportRequest(params) as AppHealthSnapshot;
+      const appRuntimeService = context.deps.appRuntimeService;
+      if (!appRuntimeService) {
+        throw new NousError(
+          'App runtime service is unavailable',
+          'SERVICE_UNAVAILABLE',
+        );
+      }
+
+      const health = await appRuntimeService.updateHealth(request);
+      return success(
+        {
+          accepted: true,
+          health,
+        },
+        0,
+      );
+    },
+    health_heartbeat: async (params) => {
+      const request = parseHealthHeartbeatRequest(params) as AppHeartbeatSignal;
+      const appRuntimeService = context.deps.appRuntimeService;
+      if (!appRuntimeService) {
+        throw new NousError(
+          'App runtime service is unavailable',
+          'SERVICE_UNAVAILABLE',
+        );
+      }
+
+      await appRuntimeService.recordHeartbeat(request);
+      return success(
+        {
+          accepted: true,
+          heartbeat: request,
         },
         0,
       );

--- a/self/cortex/core/src/internal-mcp/catalog.ts
+++ b/self/cortex/core/src/internal-mcp/catalog.ts
@@ -1,11 +1,16 @@
-import type { ToolDefinition } from '@nous/shared';
+import type { AgentClass, ToolDefinition } from '@nous/shared';
 import {
   DISPATCH_AGENT_TOOL_NAME,
   FLAG_OBSERVATION_TOOL_NAME,
   REQUEST_ESCALATION_TOOL_NAME,
   TASK_COMPLETE_TOOL_NAME,
 } from '../agent-gateway/lifecycle-hooks.js';
-import type { InternalMcpCatalogEntry, InternalMcpToolName } from './types.js';
+import type {
+  DynamicInternalMcpToolEntry,
+  InternalMcpCatalogEntry,
+  InternalMcpCapabilityHandler,
+  InternalMcpToolName,
+} from './types.js';
 
 function defineTool(
   name: InternalMcpToolName,
@@ -388,6 +393,30 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     ),
   },
   {
+    name: 'health_report',
+    kind: 'capability',
+    definition: defineTool(
+      'health_report',
+      'Publish a canonical app-runtime health snapshot.',
+      { session_id: 'string', status: 'healthy | degraded | unhealthy | stale', reported_at: 'ISO datetime', details: 'object?' },
+      { accepted: 'boolean', health: 'AppHealthSnapshot' },
+      ['write'],
+      'runtime',
+    ),
+  },
+  {
+    name: 'health_heartbeat',
+    kind: 'capability',
+    definition: defineTool(
+      'health_heartbeat',
+      'Publish an app-runtime heartbeat signal.',
+      { session_id: 'string', reported_at: 'ISO datetime', sequence: 'number', status_hint: 'healthy | degraded | unhealthy | stale?' },
+      { accepted: 'boolean', heartbeat: 'AppHeartbeatSignal' },
+      ['write'],
+      'runtime',
+    ),
+  },
+  {
     name: DISPATCH_AGENT_TOOL_NAME,
     kind: 'lifecycle',
     definition: defineTool(
@@ -440,9 +469,54 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
 const ENTRY_BY_NAME = new Map(
   INTERNAL_MCP_CATALOG.map((entry) => [entry.name, entry] as const),
 );
+const DYNAMIC_ENTRY_BY_NAME = new Map<string, DynamicInternalMcpToolEntry>();
 
 export function getInternalMcpCatalogEntry(
   name: string,
 ): InternalMcpCatalogEntry | null {
   return ENTRY_BY_NAME.get(name as InternalMcpToolName) ?? null;
+}
+
+export function registerDynamicInternalMcpTool(input: {
+  name: string;
+  definition: ToolDefinition;
+  execute: InternalMcpCapabilityHandler;
+  sessionId: string;
+  appId: string;
+  visibleTo?: readonly AgentClass[];
+}): DynamicInternalMcpToolEntry {
+  if (ENTRY_BY_NAME.has(input.name as InternalMcpToolName) || DYNAMIC_ENTRY_BY_NAME.has(input.name)) {
+    throw new Error(`Internal MCP tool name is already registered: ${input.name}`);
+  }
+
+  const entry: DynamicInternalMcpToolEntry = {
+    name: input.name,
+    kind: 'capability',
+    definition: input.definition,
+    execute: input.execute,
+    sessionId: input.sessionId,
+    appId: input.appId,
+    visibleTo: input.visibleTo ?? ['Worker', 'Orchestrator', 'Cortex::System'],
+  };
+  DYNAMIC_ENTRY_BY_NAME.set(entry.name, entry);
+  return entry;
+}
+
+export function unregisterDynamicInternalMcpTool(name: string): void {
+  DYNAMIC_ENTRY_BY_NAME.delete(name);
+}
+
+export function getDynamicInternalMcpToolEntry(
+  name: string,
+): DynamicInternalMcpToolEntry | null {
+  return DYNAMIC_ENTRY_BY_NAME.get(name) ?? null;
+}
+
+export function listDynamicInternalMcpToolEntries(
+  agentClass?: AgentClass,
+): DynamicInternalMcpToolEntry[] {
+  const entries = [...DYNAMIC_ENTRY_BY_NAME.values()];
+  return agentClass
+    ? entries.filter((entry) => entry.visibleTo.includes(agentClass))
+    : entries;
 }

--- a/self/cortex/core/src/internal-mcp/index.ts
+++ b/self/cortex/core/src/internal-mcp/index.ts
@@ -14,11 +14,17 @@ export {
 } from './output-schema-validator.js';
 export {
   getAuthorizedInternalMcpTools,
+  getAuthorizedAppInternalMcpTools,
+  isAppInternalMcpToolAuthorized,
   isInternalMcpToolAuthorized,
 } from './authorization-matrix.js';
 export {
+  getDynamicInternalMcpToolEntry,
   getInternalMcpCatalogEntry,
   INTERNAL_MCP_CATALOG,
+  listDynamicInternalMcpToolEntries,
+  registerDynamicInternalMcpTool,
+  unregisterDynamicInternalMcpTool,
 } from './catalog.js';
 export {
   getPublicToolMapping,
@@ -40,6 +46,8 @@ export {
   parseExternalMemoryGetQuery,
   parseExternalMemoryPutCommand,
   parseExternalMemorySearchQuery,
+  parseHealthHeartbeatRequest,
+  parseHealthReportRequest,
   parsePromotedMemoryDemoteCommand,
   parsePromotedMemoryGetQuery,
   parsePromotedMemoryPromoteCommand,
@@ -64,6 +72,8 @@ export {
   type ArtifactRetrieveRequest,
   type ArtifactStoreRequest,
   type EscalationNotifyRequest,
+  type AppHeartbeatRequest,
+  type AppHealthReportRequest,
   type MemorySearchRequest,
   type ProjectDiscoverRequest,
   type PublicMcpExecutionRequest,
@@ -82,6 +92,7 @@ export {
 export type {
   InternalMcpCatalogEntry,
   InternalMcpCapabilityHandler,
+  DynamicInternalMcpToolEntry,
   InternalMcpDispatchChildArgs,
   InternalMcpDispatchRuntime,
   InternalMcpGraphResolution,

--- a/self/cortex/core/src/internal-mcp/request-normalizers.ts
+++ b/self/cortex/core/src/internal-mcp/request-normalizers.ts
@@ -56,6 +56,8 @@ import {
   WorkflowLifecycleResumeCommandSchema,
   WorkflowLifecycleStartCommandSchema,
   WorkflowLifecycleStatusQuerySchema,
+  AppHealthSnapshotSchema,
+  AppHeartbeatSignalSchema,
 } from '@nous/shared';
 import { z } from 'zod';
 
@@ -143,7 +145,12 @@ export type WorkflowStatusRequest = WorkflowLifecycleStatusQuery;
 export type WorkflowPauseRequest = WorkflowLifecyclePauseCommand;
 export type WorkflowResumeRequest = WorkflowLifecycleResumeCommand;
 export type WorkflowCancelRequest = WorkflowLifecycleCancelCommand;
+export type AppHealthReportRequest = z.infer<typeof AppHealthReportRequestSchema>;
+export type AppHeartbeatRequest = z.infer<typeof AppHeartbeatRequestSchema>;
 export type { PublicMcpAgentInvokeArguments, PublicMcpExecutionRequest };
+
+export const AppHealthReportRequestSchema = AppHealthSnapshotSchema.strict();
+export const AppHeartbeatRequestSchema = AppHeartbeatSignalSchema.strict();
 
 export function parsePromotedMemoryPromoteCommand(
   params: unknown,
@@ -328,6 +335,18 @@ export function parseWorkflowCancelRequest(
   params: unknown,
 ): WorkflowCancelRequest {
   return WorkflowLifecycleCancelCommandSchema.parse(params ?? {});
+}
+
+export function parseHealthReportRequest(
+  params: unknown,
+): AppHealthReportRequest {
+  return AppHealthReportRequestSchema.parse(params ?? {});
+}
+
+export function parseHealthHeartbeatRequest(
+  params: unknown,
+): AppHeartbeatRequest {
+  return AppHeartbeatRequestSchema.parse(params ?? {});
 }
 
 export function parseExternalMemoryPutCommand(

--- a/self/cortex/core/src/internal-mcp/scoped-tool-surface.ts
+++ b/self/cortex/core/src/internal-mcp/scoped-tool-surface.ts
@@ -2,7 +2,12 @@ import { NousError, type AgentClass, type IScopedMcpToolSurface } from '@nous/sh
 import { getLifecycleUnavailableMessage } from '../agent-gateway/lifecycle-hooks.js';
 import { getAuthorizedInternalMcpTools } from './authorization-matrix.js';
 import { createCapabilityHandlers } from './capability-handlers.js';
-import { getInternalMcpCatalogEntry, INTERNAL_MCP_CATALOG } from './catalog.js';
+import {
+  getDynamicInternalMcpToolEntry,
+  getInternalMcpCatalogEntry,
+  INTERNAL_MCP_CATALOG,
+  listDynamicInternalMcpToolEntries,
+} from './catalog.js';
 import type { InternalMcpScopedToolSurfaceOptions } from './types.js';
 
 export class ScopedMcpToolSurface implements IScopedMcpToolSurface {
@@ -19,9 +24,14 @@ export class ScopedMcpToolSurface implements IScopedMcpToolSurface {
   }
 
   async listTools() {
-    return INTERNAL_MCP_CATALOG
-      .filter((entry) => this.allowed.has(entry.name))
-      .map((entry) => entry.definition);
+    return [
+      ...INTERNAL_MCP_CATALOG
+        .filter((entry) => this.allowed.has(entry.name))
+        .map((entry) => entry.definition),
+      ...listDynamicInternalMcpToolEntries(this.options.agentClass).map(
+        (entry) => entry.definition,
+      ),
+    ];
   }
 
   async executeTool(
@@ -30,7 +40,32 @@ export class ScopedMcpToolSurface implements IScopedMcpToolSurface {
     execution?: import('@nous/shared').GatewayExecutionContext,
   ) {
     const entry = getInternalMcpCatalogEntry(name);
-    if (!entry || !this.allowed.has(entry.name)) {
+    const dynamicEntry = getDynamicInternalMcpToolEntry(name);
+    if (!entry && !dynamicEntry) {
+      throw new NousError(
+        `Tool ${name} is not available for ${this.options.agentClass}`,
+        'TOOL_NOT_AVAILABLE',
+      );
+    }
+
+    if (dynamicEntry) {
+      if (!dynamicEntry.visibleTo.includes(this.options.agentClass)) {
+        throw new NousError(
+          `Tool ${name} is not available for ${this.options.agentClass}`,
+          'TOOL_NOT_AVAILABLE',
+        );
+      }
+      return dynamicEntry.execute(params, execution);
+    }
+
+    if (!entry) {
+      throw new NousError(
+        `Tool ${name} is not available for ${this.options.agentClass}`,
+        'TOOL_NOT_AVAILABLE',
+      );
+    }
+
+    if (!this.allowed.has(entry.name)) {
       throw new NousError(
         `Tool ${name} is not available for ${this.options.agentClass}`,
         'TOOL_NOT_AVAILABLE',
@@ -58,7 +93,10 @@ export function createScopedMcpToolSurface(
 }
 
 export function getVisibleInternalMcpTools(agentClass: AgentClass) {
-  return INTERNAL_MCP_CATALOG
-    .filter((entry) => getAuthorizedInternalMcpTools(agentClass).has(entry.name))
-    .map((entry) => entry.name);
+  return [
+    ...INTERNAL_MCP_CATALOG
+      .filter((entry) => getAuthorizedInternalMcpTools(agentClass).has(entry.name))
+      .map((entry) => entry.name),
+    ...listDynamicInternalMcpToolEntries(agentClass).map((entry) => entry.name),
+  ];
 }

--- a/self/cortex/core/src/internal-mcp/types.ts
+++ b/self/cortex/core/src/internal-mcp/types.ts
@@ -12,6 +12,7 @@ import type {
   IPromotedMemoryBridgeService,
   IPublicMcpSurfaceService,
   IRuntime,
+  IAppRuntimeService,
   IOpctlService,
   IProjectApi,
   IProjectStore,
@@ -28,6 +29,8 @@ import type {
   ToolResult,
   TraceEvidenceReference,
   WorkflowNodeDefinition,
+  AppHealthSnapshot,
+  AppHeartbeatSignal,
 } from '@nous/shared';
 
 export const INTERNAL_MCP_TOOL_NAMES = [
@@ -60,6 +63,8 @@ export const INTERNAL_MCP_TOOL_NAMES = [
   'workflow_pause',
   'workflow_resume',
   'workflow_cancel',
+  'health_report',
+  'health_heartbeat',
   'dispatch_agent',
   'task_complete',
   'request_escalation',
@@ -114,6 +119,7 @@ export interface InternalMcpRuntimeDeps {
   witnessService?: IWitnessService;
   escalationService?: IEscalationService;
   scheduler?: IScheduler;
+  appRuntimeService?: IAppRuntimeService;
   outputSchemaValidator?: InternalMcpOutputSchemaValidator;
   dispatchRuntime?: InternalMcpDispatchRuntime;
   now?: () => string;
@@ -152,6 +158,26 @@ export interface InternalMcpCatalogEntry {
   kind: InternalMcpToolKind;
   definition: ToolDefinition;
 }
+
+export interface DynamicInternalMcpToolEntry {
+  name: string;
+  kind: 'capability';
+  definition: ToolDefinition;
+  execute: InternalMcpCapabilityHandler;
+  sessionId: string;
+  appId: string;
+  visibleTo: readonly AgentClass[];
+}
+
+export type AppHealthReportRequest = Pick<
+  AppHealthSnapshot,
+  'session_id' | 'status' | 'reported_at' | 'details'
+>;
+
+export type AppHeartbeatRequest = Pick<
+  AppHeartbeatSignal,
+  'session_id' | 'reported_at' | 'sequence' | 'status_hint'
+>;
 
 export interface InternalMcpGraphResolution {
   schemaRef: string;

--- a/self/shared/src/__tests__/types/app-runtime.test.ts
+++ b/self/shared/src/__tests__/types/app-runtime.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AppActivationHandshakeSchema,
+  AppHeartbeatSignalSchema,
+  AppLaunchSpecSchema,
+  AppOutboundToolCallContextSchema,
+  AppRuntimeActivationInputSchema,
+  AppRuntimeSessionSchema,
+  AppToolRegistrationRecordSchema,
+} from '../../types/app-runtime.js';
+
+describe('AppLaunchSpecSchema', () => {
+  it('accepts deterministic launch specs with deny flags enforced', () => {
+    const result = AppLaunchSpecSchema.safeParse({
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      package_version: '1.0.0',
+      manifest_version: '1',
+      entrypoint: 'main.ts',
+      working_directory: '/tmp/weather',
+      deno_args: ['run', '--deny-env', '--deny-run', '--deny-ffi', 'main.ts'],
+      compiled_permissions: {
+        allow_read: ['/tmp/weather', '/tmp/weather/data'],
+        allow_write: ['/tmp/weather/data'],
+        allow_net: ['api.example.com'],
+        deny_env: true,
+        deny_run: true,
+        deny_ffi: true,
+        cached_only: true,
+      },
+      app_data_dir: '/tmp/weather/data',
+      config_version: 'cfg-1',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('AppActivationHandshakeSchema', () => {
+  it('requires read-only config entries', () => {
+    const result = AppActivationHandshakeSchema.safeParse({
+      session_id: 'session-1',
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      package_version: '1.0.0',
+      allowed_outbound_tools: ['health_report'],
+      config: [
+        {
+          key: 'city',
+          value: 'Seattle',
+          source: 'project_config',
+          mutable: false,
+        },
+      ],
+      permissions: {
+        allow_read: ['/tmp/weather'],
+        allow_write: ['/tmp/weather/data'],
+        allow_net: ['api.example.com'],
+        deny_env: true,
+        deny_run: true,
+        deny_ffi: true,
+        cached_only: true,
+      },
+      panels: [],
+      heartbeat_interval_ms: 5000,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('AppRuntimeSessionSchema', () => {
+  it('accepts runtime sessions with health metadata', () => {
+    const result = AppRuntimeSessionSchema.safeParse({
+      session_id: 'session-1',
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      package_version: '1.0.0',
+      project_id: '550e8400-e29b-41d4-a716-446655440000',
+      pid: 1234,
+      status: 'active',
+      started_at: '2026-03-17T00:00:00.000Z',
+      registered_tool_ids: ['app:weather.get_forecast'],
+      panel_ids: ['weather.main'],
+      health_status: 'healthy',
+      last_heartbeat_at: '2026-03-17T00:00:10.000Z',
+      config_version: 'cfg-1',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('AppOutboundToolCallContextSchema', () => {
+  it('accepts app caller context with explicit project scope', () => {
+    const result = AppOutboundToolCallContextSchema.safeParse({
+      caller_type: 'app',
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      session_id: 'session-1',
+      project_id: '550e8400-e29b-41d4-a716-446655440000',
+      tool_id: 'memory_write',
+      request_id: 'req-1',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('AppToolRegistrationRecordSchema', () => {
+  it('accepts namespaced tool registration records', () => {
+    const result = AppToolRegistrationRecordSchema.safeParse({
+      app_id: 'app:weather',
+      session_id: 'session-1',
+      tool_name: 'get_forecast',
+      namespaced_tool_id: 'app:weather.get_forecast',
+      description: 'Fetch the current forecast.',
+      input_schema: {
+        type: 'object',
+      },
+      registration_witness_ref: 'evt-1',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('AppHeartbeatSignalSchema', () => {
+  it('rejects negative heartbeat sequence values', () => {
+    const result = AppHeartbeatSignalSchema.safeParse({
+      session_id: 'session-1',
+      reported_at: '2026-03-17T00:00:10.000Z',
+      sequence: -1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('AppRuntimeActivationInputSchema', () => {
+  it('accepts activation input with manifest and handshake configuration', () => {
+    const result = AppRuntimeActivationInputSchema.safeParse({
+      package_root_ref: '/tmp/.apps/weather',
+      manifest_ref: '/tmp/.apps/weather/manifest.json',
+      manifest: {
+        id: 'app:weather',
+        name: 'Weather',
+        version: '1.0.0',
+        package_type: 'app',
+        origin_class: 'nous_first_party',
+        display_name: 'Weather',
+        description: 'Weather runtime app',
+        api_contract_range: '^1.0.0',
+        capabilities: ['tool.execute'],
+        permissions: {
+          network: ['api.example.com'],
+          credentials: false,
+          witnessLevel: 'session',
+          systemNotify: true,
+          memoryContribute: false,
+        },
+        tools: [
+          {
+            name: 'get_forecast',
+            description: 'Fetch weather',
+            inputSchema: {},
+            outputSchema: {},
+            riskLevel: 'low',
+            idempotent: true,
+            sideEffects: [],
+            memoryRelevance: 'low',
+          },
+        ],
+      },
+      launch_spec: {
+        app_id: 'app:weather',
+        package_id: 'app:weather',
+        package_version: '1.0.0',
+        manifest_version: '1',
+        entrypoint: 'main.ts',
+        working_directory: '/tmp/.apps/weather',
+        deno_args: ['run', '--deny-env', 'main.ts'],
+        compiled_permissions: {
+          allow_read: ['/tmp/.apps/weather'],
+          allow_write: ['/tmp/.apps/weather/data'],
+          allow_net: ['api.example.com'],
+          deny_env: true,
+          deny_run: true,
+          deny_ffi: true,
+          cached_only: true,
+        },
+        app_data_dir: '/tmp/.apps/weather/data',
+        config_version: 'cfg-1',
+      },
+      config: [
+        {
+          key: 'units',
+          value: 'metric',
+          source: 'project_config',
+          mutable: false,
+        },
+      ],
+      allowed_outbound_tools: ['health_report'],
+      panels: [],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/self/shared/src/__tests__/types/evidence.test.ts
+++ b/self/shared/src/__tests__/types/evidence.test.ts
@@ -106,6 +106,26 @@ describe('WitnessEventSchema', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('accepts app as a witness actor', () => {
+    const result = WitnessEventSchema.safeParse({
+      id: UUID_1,
+      sequence: 2,
+      previousEventHash: HASH,
+      payloadHash: HASH,
+      eventHash: HASH,
+      stage: 'authorization',
+      actionCategory: 'tool-execute',
+      actionRef: 'app:weather.get_forecast',
+      actor: 'app',
+      status: 'approved',
+      detail: {},
+      occurredAt: NOW,
+      recordedAt: NOW,
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('WitnessCheckpointSchema', () => {

--- a/self/shared/src/__tests__/types/package-documents.test.ts
+++ b/self/shared/src/__tests__/types/package-documents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   AtomicSkillFrontmatterSchema,
   CompositeSkillFrontmatterSchema,
+  LoadedAppPackageSchema,
   LoadedWorkflowPackageSchema,
   ProjectWorkflowPackageBindingSchema,
   ResolvedWorkflowDefinitionSourceSchema,
@@ -224,5 +225,51 @@ describe('LoadedWorkflowPackageSchema', () => {
     });
 
     expect(parsed.steps[0]?.stepId).toBe('draft');
+  });
+});
+
+describe('LoadedAppPackageSchema', () => {
+  it('accepts fully loaded app packages', () => {
+    const parsed = LoadedAppPackageSchema.parse({
+      packageId: 'app.weather',
+      packageVersion: '1.2.3',
+      rootRef: '.apps/app__weather',
+      manifestRef: '.apps/app__weather/manifest.json',
+      entrypointRef: '.apps/app__weather/main.ts',
+      lockfileRef: '.apps/app__weather/deno.lock',
+      manifest: {
+        id: 'app.weather',
+        name: 'weather',
+        version: '1.2.3',
+        package_type: 'app',
+        origin_class: 'nous_first_party',
+        api_contract_range: '^1.0.0',
+        capabilities: ['tool.execute'],
+        permissions: {
+          network: ['api.example.com'],
+          credentials: false,
+          witnessLevel: 'session',
+          systemNotify: true,
+          memoryContribute: false,
+        },
+        tools: [
+          {
+            name: 'get_forecast',
+            description: 'Fetch weather',
+            inputSchema: {},
+            outputSchema: {},
+            riskLevel: 'low',
+            idempotent: true,
+            sideEffects: [],
+            memoryRelevance: 'low',
+          },
+        ],
+      },
+      references: [],
+      scripts: [],
+      assets: [],
+    });
+
+    expect(parsed.entrypointRef).toContain('main.ts');
   });
 });

--- a/self/shared/src/__tests__/types/package-lifecycle.test.ts
+++ b/self/shared/src/__tests__/types/package-lifecycle.test.ts
@@ -145,6 +145,20 @@ describe('PackageLifecycleTransitionResultSchema', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('accepts runtime reason codes in blocked transition results', () => {
+    const result = PackageLifecycleTransitionResultSchema.safeParse({
+      decision: 'blocked',
+      transition: 'run',
+      from_state: 'enabled',
+      to_state: 'enabled',
+      reason_code: 'PKG-010-HANDSHAKE_TIMEOUT',
+      witness_ref: 'evt_123',
+      evidence_refs: ['event:pkg_runtime_action_decided'],
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('PackageLifecycleStateRecordSchema', () => {

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -38,6 +38,7 @@ export type {
   IEndpointTrustService,
   IVoiceControlService,
   ISandbox,
+  IAppRuntimeService,
   IPackageLifecycleOrchestrator,
   IPackageInstallService,
   ISkillAdmissionOrchestrator,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -85,6 +85,12 @@ import type {
   GtmGateReportInput,
   GtmGateReport,
   GtmStageLabel,
+  AppProcessExitEvent,
+  AppRuntimeActivationInput,
+  AppRuntimeDeactivationInput,
+  AppRuntimeSession,
+  AppHealthSnapshot,
+  AppHeartbeatSignal,
   PackageLifecycleTransitionRequest,
   PackageLifecycleTransitionResult,
   PackageLifecycleStateRecord,
@@ -733,6 +739,11 @@ export interface IPackageLifecycleOrchestrator {
     request: PackageLifecycleTransitionRequest,
   ): Promise<PackageLifecycleTransitionResult>;
 
+  /** Record canonical transition into runtime-active state. */
+  run(
+    request: PackageLifecycleTransitionRequest,
+  ): Promise<PackageLifecycleTransitionResult>;
+
   /** Stage package update while preserving previous safe version snapshot. */
   stageUpdate(
     request: PackageLifecycleTransitionRequest,
@@ -763,11 +774,43 @@ export interface IPackageLifecycleOrchestrator {
     request: PackageLifecycleTransitionRequest,
   ): Promise<PackageLifecycleTransitionResult>;
 
+  /** Disable package runtime activity while preserving canonical lifecycle truth. */
+  disable(
+    request: PackageLifecycleTransitionRequest,
+  ): Promise<PackageLifecycleTransitionResult>;
+
   /** Retrieve canonical lifecycle state for project/package identity. */
   getState(
     projectId: ProjectId,
     packageId: string,
   ): Promise<PackageLifecycleStateRecord | null>;
+}
+
+export interface IAppRuntimeService {
+  /** Activate one installed app package and publish the runtime session. */
+  activate(input: AppRuntimeActivationInput): Promise<AppRuntimeSession>;
+
+  /** Deactivate one runtime session and clean up runtime-owned registrations. */
+  deactivate(
+    input: AppRuntimeDeactivationInput,
+  ): Promise<AppRuntimeSession | null>;
+
+  /** Reconcile runtime-owned state after a subprocess exit. */
+  handleProcessExit(
+    input: AppProcessExitEvent,
+  ): Promise<AppRuntimeSession | null>;
+
+  /** Lookup one runtime session by session ID. */
+  getSession(sessionId: string): Promise<AppRuntimeSession | null>;
+
+  /** List runtime sessions, optionally filtered by package ID. */
+  listSessions(packageId?: string): Promise<AppRuntimeSession[]>;
+
+  /** Record one heartbeat signal and return the resulting health snapshot. */
+  recordHeartbeat(signal: AppHeartbeatSignal): Promise<AppHealthSnapshot>;
+
+  /** Publish an explicit health snapshot from the runtime. */
+  updateHealth(snapshot: AppHealthSnapshot): Promise<AppHealthSnapshot>;
 }
 
 export interface IPackageInstallService {

--- a/self/shared/src/types/app-runtime.ts
+++ b/self/shared/src/types/app-runtime.ts
@@ -1,0 +1,194 @@
+import { z } from 'zod';
+import { AppPackageManifestSchema } from './app-manifest.js';
+import { ProjectIdSchema } from './ids.js';
+import { SandboxPayloadSchema } from './sandbox.js';
+
+export const AppCompiledPermissionFlagsSchema = z.object({
+  allow_read: z.array(z.string().min(1)).default([]),
+  allow_write: z.array(z.string().min(1)).default([]),
+  allow_net: z.array(z.string().min(1)).default([]),
+  deny_env: z.literal(true).default(true),
+  deny_run: z.literal(true).default(true),
+  deny_ffi: z.literal(true).default(true),
+  cached_only: z.boolean().default(true),
+});
+export type AppCompiledPermissionFlags = z.infer<
+  typeof AppCompiledPermissionFlagsSchema
+>;
+
+export const AppLaunchSpecSchema = z.object({
+  app_id: z.string().min(1),
+  package_id: z.string().min(1),
+  package_version: z.string().min(1),
+  project_id: ProjectIdSchema.optional(),
+  manifest_version: z.string().min(1).default('1'),
+  entrypoint: z.string().min(1),
+  working_directory: z.string().min(1),
+  deno_args: z.array(z.string().min(1)).min(1),
+  compiled_permissions: AppCompiledPermissionFlagsSchema,
+  lockfile_path: z.string().min(1).optional(),
+  app_data_dir: z.string().min(1),
+  config_version: z.string().min(1),
+  manifest_ref: z.string().min(1).optional(),
+});
+export type AppLaunchSpec = z.infer<typeof AppLaunchSpecSchema>;
+
+export const AppHandshakeConfigSourceSchema = z.enum([
+  'manifest_default',
+  'project_config',
+  'system',
+]);
+export type AppHandshakeConfigSource = z.infer<
+  typeof AppHandshakeConfigSourceSchema
+>;
+
+export const AppHandshakeConfigEntrySchema = z.object({
+  key: z.string().min(1),
+  value: z.unknown(),
+  source: AppHandshakeConfigSourceSchema,
+  mutable: z.literal(false).default(false),
+});
+export type AppHandshakeConfigEntry = z.infer<
+  typeof AppHandshakeConfigEntrySchema
+>;
+
+export const AppHealthStatusSchema = z.enum([
+  'healthy',
+  'degraded',
+  'unhealthy',
+  'stale',
+]);
+export type AppHealthStatus = z.infer<typeof AppHealthStatusSchema>;
+
+export const AppRuntimeStatusSchema = z.enum([
+  'starting',
+  'active',
+  'draining',
+  'stopped',
+  'failed',
+]);
+export type AppRuntimeStatus = z.infer<typeof AppRuntimeStatusSchema>;
+
+export const AppPanelRegistrationProjectionSchema = z.object({
+  app_id: z.string().min(1),
+  session_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  label: z.string().min(1),
+  entry: z.string().min(1),
+  position: z.enum(['left', 'right', 'bottom', 'main']).optional(),
+  preserve_state: z.boolean().default(true),
+});
+export type AppPanelRegistrationProjection = z.infer<
+  typeof AppPanelRegistrationProjectionSchema
+>;
+
+export const AppActivationHandshakeSchema = z.object({
+  session_id: z.string().min(1),
+  app_id: z.string().min(1),
+  package_id: z.string().min(1),
+  package_version: z.string().min(1),
+  allowed_outbound_tools: z.array(z.string().min(1)).default([]),
+  config: z.array(AppHandshakeConfigEntrySchema).default([]),
+  permissions: AppCompiledPermissionFlagsSchema,
+  panels: z.array(AppPanelRegistrationProjectionSchema).default([]),
+  heartbeat_interval_ms: z.number().int().positive().default(30_000),
+});
+export type AppActivationHandshake = z.infer<
+  typeof AppActivationHandshakeSchema
+>;
+
+export const AppRuntimeSessionSchema = z.object({
+  session_id: z.string().min(1),
+  app_id: z.string().min(1),
+  package_id: z.string().min(1),
+  package_version: z.string().min(1),
+  project_id: ProjectIdSchema.optional(),
+  pid: z.number().int().positive(),
+  status: AppRuntimeStatusSchema,
+  started_at: z.string().datetime(),
+  stopped_at: z.string().datetime().optional(),
+  registered_tool_ids: z.array(z.string().min(1)).default([]),
+  panel_ids: z.array(z.string().min(1)).default([]),
+  health_status: AppHealthStatusSchema.default('healthy'),
+  last_heartbeat_at: z.string().datetime().optional(),
+  config_version: z.string().min(1),
+});
+export type AppRuntimeSession = z.infer<typeof AppRuntimeSessionSchema>;
+
+export const AppOutboundToolCallContextSchema = z.object({
+  caller_type: z.literal('app'),
+  app_id: z.string().min(1),
+  package_id: z.string().min(1),
+  session_id: z.string().min(1),
+  project_id: ProjectIdSchema.optional(),
+  tool_id: z.string().min(1),
+  request_id: z.string().min(1),
+});
+export type AppOutboundToolCallContext = z.infer<
+  typeof AppOutboundToolCallContextSchema
+>;
+
+export const AppToolRegistrationRecordSchema = z.object({
+  app_id: z.string().min(1),
+  session_id: z.string().min(1),
+  tool_name: z.string().min(1),
+  namespaced_tool_id: z.string().min(1),
+  description: z.string().min(1),
+  input_schema: z.record(z.unknown()),
+  output_schema: z.record(z.unknown()).optional(),
+  registration_witness_ref: z.string().min(1).optional(),
+});
+export type AppToolRegistrationRecord = z.infer<
+  typeof AppToolRegistrationRecordSchema
+>;
+
+export const AppHealthSnapshotSchema = z.object({
+  session_id: z.string().min(1),
+  status: AppHealthStatusSchema,
+  reported_at: z.string().datetime(),
+  latency_ms: z.number().min(0).optional(),
+  details: z.record(z.unknown()).default({}),
+  stale: z.boolean().default(false),
+});
+export type AppHealthSnapshot = z.infer<typeof AppHealthSnapshotSchema>;
+
+export const AppHeartbeatSignalSchema = z.object({
+  session_id: z.string().min(1),
+  reported_at: z.string().datetime(),
+  sequence: z.number().int().nonnegative(),
+  status_hint: AppHealthStatusSchema.optional(),
+});
+export type AppHeartbeatSignal = z.infer<typeof AppHeartbeatSignalSchema>;
+
+export const AppRuntimeActivationInputSchema = z.object({
+  project_id: ProjectIdSchema.optional(),
+  package_root_ref: z.string().min(1),
+  manifest_ref: z.string().min(1),
+  manifest: AppPackageManifestSchema,
+  launch_spec: AppLaunchSpecSchema,
+  config: z.array(AppHandshakeConfigEntrySchema).default([]),
+  allowed_outbound_tools: z.array(z.string().min(1)).default([]),
+  panels: z.array(AppPanelRegistrationProjectionSchema).default([]),
+  sandbox_payload: SandboxPayloadSchema.optional(),
+});
+export type AppRuntimeActivationInput = z.infer<
+  typeof AppRuntimeActivationInputSchema
+>;
+
+export const AppRuntimeDeactivationInputSchema = z.object({
+  session_id: z.string().min(1),
+  reason: z.string().min(1),
+  disable_package: z.boolean().default(false),
+});
+export type AppRuntimeDeactivationInput = z.infer<
+  typeof AppRuntimeDeactivationInputSchema
+>;
+
+export const AppProcessExitEventSchema = z.object({
+  session_id: z.string().min(1),
+  code: z.number().int().optional(),
+  signal: z.string().min(1).optional(),
+  occurred_at: z.string().datetime(),
+  reason: z.string().min(1).optional(),
+});
+export type AppProcessExitEvent = z.infer<typeof AppProcessExitEventSchema>;

--- a/self/shared/src/types/evidence.ts
+++ b/self/shared/src/types/evidence.ts
@@ -72,6 +72,7 @@ export const WitnessActorSchema = z.enum([
   'core',
   'pfc',
   'subcortex',
+  'app',
   'principal',
   'system',
   'orchestration_agent',

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -61,6 +61,7 @@ export * from './phase8-export.js';
 export * from './vector-index.js';
 export * from './app-permissions.js';
 export * from './app-manifest.js';
+export * from './app-runtime.js';
 export * from './package-manifest.js';
 export * from './package-documents.js';
 export * from './package-resolution.js';

--- a/self/shared/src/types/package-documents.ts
+++ b/self/shared/src/types/package-documents.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { AppPackageManifestSchema } from './app-manifest.js';
 import {
   ExecutionModelSchema,
   GovernanceLevelSchema,
@@ -216,6 +217,20 @@ export const LoadedWorkflowPackageSchema = z.object({
   assets: z.array(z.string().min(1)).default([]),
 });
 export type LoadedWorkflowPackage = z.infer<typeof LoadedWorkflowPackageSchema>;
+
+export const LoadedAppPackageSchema = z.object({
+  packageId: z.string().min(1),
+  packageVersion: z.string().min(1).optional(),
+  rootRef: z.string().min(1),
+  manifestRef: z.string().min(1),
+  manifest: AppPackageManifestSchema,
+  entrypointRef: z.string().min(1),
+  lockfileRef: z.string().min(1).optional(),
+  references: z.array(z.string().min(1)).default([]),
+  scripts: z.array(z.string().min(1)).default([]),
+  assets: z.array(z.string().min(1)).default([]),
+});
+export type LoadedAppPackage = z.infer<typeof LoadedAppPackageSchema>;
 
 export const ProjectWorkflowPackageBindingSchema = z.object({
   workflowDefinitionId: WorkflowDefinitionIdSchema,

--- a/self/shared/src/types/package-lifecycle.ts
+++ b/self/shared/src/types/package-lifecycle.ts
@@ -14,6 +14,8 @@ export const PACKAGE_LIFECYCLE_EVENT_TYPES = [
   'pkg_capability_approved',
   'pkg_capability_blocked',
   'pkg_enabled',
+  'pkg_running',
+  'pkg_disabled',
   'pkg_enable_blocked',
   'pkg_update_staged',
   'pkg_update_committed',
@@ -84,6 +86,18 @@ export const PACKAGE_LIFECYCLE_REASON_CODES = {
     'Resolved package target crosses the protected .system boundary.',
   'PKG-009-INSTALL_WRITE_FAILED':
     'Package installation write failed and rollback was required.',
+  'PKG-010-SPAWN_FAILED':
+    'Runtime subprocess spawn failed before activation completed.',
+  'PKG-010-HANDSHAKE_TIMEOUT':
+    'Runtime activation handshake timed out before readiness was proven.',
+  'PKG-010-HANDSHAKE_INVALID':
+    'Runtime activation handshake payload was malformed or invalid.',
+  'PKG-010-TOOL_NAMESPACE_COLLISION':
+    'Runtime tool registration collided with an existing tool namespace.',
+  'PKG-010-HEARTBEAT_STALE':
+    'Runtime heartbeat freshness could no longer be proven.',
+  'PKG-010-HEALTH_PAYLOAD_INVALID':
+    'Runtime health payload was malformed or failed validation.',
   'MKT-002-UNREGISTERED_EXTERNAL':
     'Registry eligibility blocked an unregistered external package.',
   'MKT-004-PRINCIPAL_OVERRIDE_REQUIRED':
@@ -112,7 +126,7 @@ export const PACKAGE_LIFECYCLE_REASON_CODES = {
 
 export const PackageLifecycleReasonCodeSchema = z
   .string()
-  .regex(/^(PKG-00[1-9]|MKT-00[1-9]|API-003)-[A-Z0-9][A-Z0-9_-]*$/);
+  .regex(/^(PKG-0(0[1-9]|1[0-9])|MKT-00[1-9]|API-003)-[A-Z0-9][A-Z0-9_-]*$/);
 export type PackageLifecycleReasonCode = z.infer<
   typeof PackageLifecycleReasonCodeSchema
 >;

--- a/self/subcortex/apps/package.json
+++ b/self/subcortex/apps/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@nous/subcortex-apps",
+  "version": "0.0.1",
+  "private": true,
+  "description": "App runtime, IPC bridge, tool registry, and health lifecycle for Nous-OSS",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@nous/shared": "workspace:*"
+  }
+}

--- a/self/subcortex/apps/src/__tests__/app-health-registry.test.ts
+++ b/self/subcortex/apps/src/__tests__/app-health-registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { AppHealthRegistry } from '../app-health-registry.js';
+
+describe('AppHealthRegistry', () => {
+  it('marks skipped heartbeat sequences as degraded', () => {
+    const registry = new AppHealthRegistry({
+      now: () => new Date('2026-03-17T00:00:00.000Z'),
+    });
+    registry.initializeSession('session-1');
+    registry.recordHeartbeat({
+      session_id: 'session-1',
+      reported_at: '2026-03-17T00:00:01.000Z',
+      sequence: 0,
+    });
+
+    const snapshot = registry.recordHeartbeat({
+      session_id: 'session-1',
+      reported_at: '2026-03-17T00:00:03.000Z',
+      sequence: 2,
+    });
+
+    expect(snapshot.status).toBe('degraded');
+    expect(snapshot.details.reason).toBe('heartbeat_sequence_gap');
+  });
+
+  it('marks stale sessions when heartbeat freshness expires', () => {
+    const registry = new AppHealthRegistry({
+      now: () => new Date('2026-03-17T00:01:00.000Z'),
+    });
+    registry.updateSnapshot({
+      session_id: 'session-1',
+      status: 'healthy',
+      reported_at: '2026-03-17T00:00:00.000Z',
+      stale: false,
+      details: {},
+    });
+
+    const stale = registry.markStaleSessions(1000);
+    expect(stale[0]?.status).toBe('stale');
+    expect(stale[0]?.stale).toBe(true);
+  });
+});

--- a/self/subcortex/apps/src/__tests__/app-runtime-service.test.ts
+++ b/self/subcortex/apps/src/__tests__/app-runtime-service.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppRuntimeService } from '../app-runtime-service.js';
+import { AppToolRegistry } from '../app-tool-registry.js';
+import { DenoSpawner } from '../deno-spawner.js';
+import { McpIpcBridge } from '../mcp-ipc-bridge.js';
+
+const activationInput = {
+  project_id: '550e8400-e29b-41d4-a716-446655440000',
+  package_root_ref: '/repo/.apps/weather',
+  manifest_ref: '/repo/.apps/weather/manifest.json',
+  manifest: {
+    id: 'app:weather',
+    name: 'weather',
+    version: '1.0.0',
+    package_type: 'app',
+    origin_class: 'nous_first_party',
+    api_contract_range: '^1.0.0',
+    capabilities: ['tool.execute'],
+    permissions: {
+      network: ['api.example.com'],
+      credentials: false,
+      witnessLevel: 'session',
+      systemNotify: true,
+      memoryContribute: false,
+    },
+    tools: [
+      {
+        name: 'get_forecast',
+        description: 'Fetch weather',
+        inputSchema: {},
+        outputSchema: {},
+        riskLevel: 'low',
+        idempotent: true,
+        sideEffects: [],
+        memoryRelevance: 'low',
+      },
+    ],
+  },
+  launch_spec: {
+    app_id: 'app:weather',
+    package_id: 'app:weather',
+    package_version: '1.0.0',
+    project_id: '550e8400-e29b-41d4-a716-446655440000',
+    manifest_version: '1',
+    entrypoint: 'main.ts',
+    working_directory: '/repo/.apps/weather',
+    deno_args: ['run', '--deny-env', 'main.ts'],
+    compiled_permissions: {
+      allow_read: ['/repo/.apps/weather'],
+      allow_write: ['/repo/.apps/weather/data'],
+      allow_net: ['api.example.com'],
+      deny_env: true,
+      deny_run: true,
+      deny_ffi: true,
+      cached_only: true,
+    },
+    app_data_dir: '/repo/.apps/weather/data',
+    config_version: 'cfg-1',
+  },
+  config: [],
+  allowed_outbound_tools: ['health_report'],
+  panels: [],
+} as const;
+
+describe('AppRuntimeService', () => {
+  it('activates and then deactivates a runtime session', async () => {
+    const lifecycleOrchestrator = {
+      run: vi.fn().mockResolvedValue({}),
+      disable: vi.fn().mockResolvedValue({}),
+    };
+    const toolRegistry = new AppToolRegistry({
+      register: vi.fn().mockResolvedValue({ witnessRef: 'evt-1' }),
+      unregister: vi.fn().mockResolvedValue(undefined),
+    });
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: lifecycleOrchestrator as any,
+      spawner: new DenoSpawner({
+        now: () => new Date('2026-03-17T00:00:00.000Z'),
+        sessionIdFactory: () => 'session-1',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+      bridge: new McpIpcBridge({
+        sendHandshake: vi.fn(),
+      }),
+      toolRegistry,
+    });
+
+    const session = await service.activate(activationInput as any);
+    expect(session.status).toBe('active');
+    expect(session.registered_tool_ids).toEqual(['app:weather.get_forecast']);
+    expect(lifecycleOrchestrator.run).toHaveBeenCalledTimes(1);
+
+    const stopped = await service.deactivate({
+      session_id: 'session-1',
+      reason: 'test shutdown',
+      disable_package: true,
+    });
+    expect(stopped?.status).toBe('stopped');
+    expect(lifecycleOrchestrator.disable).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back tool registration when lifecycle run fails', async () => {
+    const unregister = vi.fn().mockResolvedValue(undefined);
+    const lifecycleOrchestrator = {
+      run: vi.fn().mockRejectedValue(new Error('run failed')),
+      disable: vi.fn().mockResolvedValue({}),
+    };
+    const toolRegistry = new AppToolRegistry({
+      register: vi.fn().mockResolvedValue({ witnessRef: 'evt-1' }),
+      unregister,
+    });
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: lifecycleOrchestrator as any,
+      spawner: new DenoSpawner({
+        sessionIdFactory: () => 'session-1',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+      bridge: new McpIpcBridge(),
+      toolRegistry,
+    });
+
+    await expect(service.activate(activationInput as any)).rejects.toThrow('run failed');
+    expect(unregister).toHaveBeenCalledWith('app:weather.get_forecast');
+  });
+
+  it('updates health state from heartbeats and process exits', async () => {
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: {
+        run: vi.fn().mockResolvedValue({}),
+        disable: vi.fn().mockResolvedValue({}),
+      } as any,
+      spawner: new DenoSpawner({
+        sessionIdFactory: () => 'session-1',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+      bridge: new McpIpcBridge(),
+      toolRegistry: new AppToolRegistry({
+        register: vi.fn().mockResolvedValue({ witnessRef: 'evt-1' }),
+        unregister: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    await service.activate(activationInput as any);
+    const snapshot = await service.recordHeartbeat({
+      session_id: 'session-1',
+      reported_at: '2026-03-17T00:00:05.000Z',
+      sequence: 0,
+    });
+    expect(snapshot.status).toBe('healthy');
+
+    const exited = await service.handleProcessExit({
+      session_id: 'session-1',
+      code: 1,
+      occurred_at: '2026-03-17T00:00:10.000Z',
+      reason: 'crash',
+    });
+    expect(exited?.status).toBe('failed');
+  });
+});

--- a/self/subcortex/apps/src/__tests__/app-tool-registry.test.ts
+++ b/self/subcortex/apps/src/__tests__/app-tool-registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppToolRegistry } from '../app-tool-registry.js';
+
+describe('AppToolRegistry', () => {
+  it('registers and deregisters namespaced app tools', async () => {
+    const registrar = {
+      register: vi.fn().mockResolvedValue({ witnessRef: 'evt-1' }),
+      unregister: vi.fn().mockResolvedValue(undefined),
+    };
+    const registry = new AppToolRegistry(registrar);
+
+    const records = await registry.registerSessionTools({
+      appId: 'app:weather',
+      sessionId: 'session-1',
+      definitions: [
+        {
+          tool_name: 'get_forecast',
+          description: 'Fetch weather',
+          input_schema: {},
+        },
+      ],
+    });
+
+    expect(records[0]?.namespaced_tool_id).toBe('app:weather.get_forecast');
+    expect(registrar.register).toHaveBeenCalledWith(
+      'app:weather.get_forecast',
+      expect.objectContaining({ tool_name: 'get_forecast' }),
+    );
+
+    await registry.deregisterSessionTools('session-1');
+    expect(registrar.unregister).toHaveBeenCalledWith('app:weather.get_forecast');
+  });
+});

--- a/self/subcortex/apps/src/__tests__/mcp-ipc-bridge.test.ts
+++ b/self/subcortex/apps/src/__tests__/mcp-ipc-bridge.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { McpIpcBridge } from '../mcp-ipc-bridge.js';
+
+const session = {
+  session_id: 'session-1',
+  app_id: 'app:weather',
+  package_id: 'app:weather',
+  package_version: '1.0.0',
+  pid: 123,
+  status: 'active',
+  started_at: '2026-03-17T00:00:00.000Z',
+  registered_tool_ids: [],
+  panel_ids: [],
+  health_status: 'healthy',
+  config_version: 'cfg-1',
+} as const;
+
+const activationInput = {
+  package_root_ref: '/repo/.apps/weather',
+  manifest_ref: '/repo/.apps/weather/manifest.json',
+  manifest: {
+    id: 'app:weather',
+    name: 'weather',
+    version: '1.0.0',
+    package_type: 'app',
+    origin_class: 'nous_first_party',
+    api_contract_range: '^1.0.0',
+    capabilities: ['tool.execute'],
+    permissions: {
+      network: ['api.example.com'],
+      credentials: false,
+      witnessLevel: 'session',
+      systemNotify: true,
+      memoryContribute: false,
+    },
+    tools: [
+      {
+        name: 'get_forecast',
+        description: 'Fetch weather',
+        inputSchema: {},
+        outputSchema: {},
+        riskLevel: 'low',
+        idempotent: true,
+        sideEffects: [],
+        memoryRelevance: 'low',
+      },
+    ],
+  },
+  launch_spec: {
+    app_id: 'app:weather',
+    package_id: 'app:weather',
+    package_version: '1.0.0',
+    manifest_version: '1',
+    entrypoint: 'main.ts',
+    working_directory: '/repo/.apps/weather',
+    deno_args: ['run', '--deny-env', 'main.ts'],
+    compiled_permissions: {
+      allow_read: ['/repo/.apps/weather'],
+      allow_write: ['/repo/.apps/weather/data'],
+      allow_net: ['api.example.com'],
+      deny_env: true,
+      deny_run: true,
+      deny_ffi: true,
+      cached_only: true,
+    },
+    app_data_dir: '/repo/.apps/weather/data',
+    config_version: 'cfg-1',
+  },
+  config: [
+    {
+      key: 'units',
+      value: 'metric',
+      source: 'project_config',
+      mutable: false,
+    },
+  ],
+  allowed_outbound_tools: ['health_report'],
+  panels: [],
+} as const;
+
+describe('McpIpcBridge', () => {
+  it('builds and sends an activation handshake', async () => {
+    const sendHandshake = vi.fn();
+    const bridge = new McpIpcBridge({ sendHandshake });
+
+    const handshake = await bridge.sendActivationHandshake(session as any, activationInput as any);
+
+    expect(handshake.session_id).toBe('session-1');
+    expect(sendHandshake).toHaveBeenCalledWith('session-1', handshake);
+  });
+
+  it('requires explicit project_id for project-scoped tool calls', () => {
+    const bridge = new McpIpcBridge();
+
+    expect(() =>
+      bridge.parseOutboundToolEnvelope({
+        context: {
+          caller_type: 'app',
+          app_id: 'app:weather',
+          package_id: 'app:weather',
+          session_id: 'session-1',
+          tool_id: 'memory_write',
+          request_id: 'req-1',
+        },
+      }),
+    ).toThrow('requires explicit project_id');
+  });
+});

--- a/self/subcortex/apps/src/__tests__/permission-compiler.test.ts
+++ b/self/subcortex/apps/src/__tests__/permission-compiler.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { buildAppLaunchSpec, compileAppPermissions, normalizeAppHosts } from '../permission-compiler.js';
+
+const manifest = {
+  permissions: {
+    network: ['API.EXAMPLE.COM', 'api.example.com', 'weather.example.com'],
+  },
+} as const;
+
+describe('normalizeAppHosts', () => {
+  it('lowercases, deduplicates, and sorts hosts deterministically', () => {
+    expect(normalizeAppHosts(manifest.permissions.network)).toEqual([
+      'api.example.com',
+      'weather.example.com',
+    ]);
+  });
+});
+
+describe('compileAppPermissions', () => {
+  it('adds canonical app data access and hard-deny flags', () => {
+    const compiled = compileAppPermissions({
+      manifest,
+      appDataDir: '/runtime/apps/weather',
+      readPaths: ['/repo/apps/weather'],
+      writePaths: ['/repo/apps/weather/cache'],
+    });
+
+    expect(compiled.allow_read).toEqual(['/repo/apps/weather', '/runtime/apps/weather']);
+    expect(compiled.allow_write).toEqual([
+      '/repo/apps/weather/cache',
+      '/runtime/apps/weather',
+    ]);
+    expect(compiled.allow_net).toEqual(['api.example.com', 'weather.example.com']);
+    expect(compiled.deny_env).toBe(true);
+    expect(compiled.deny_run).toBe(true);
+    expect(compiled.deny_ffi).toBe(true);
+  });
+});
+
+describe('buildAppLaunchSpec', () => {
+  it('emits stable Deno flags for equivalent input', () => {
+    const first = buildAppLaunchSpec({
+      appId: 'app:weather',
+      packageId: 'app:weather',
+      packageVersion: '1.0.0',
+      manifest,
+      entrypoint: 'main.ts',
+      workingDirectory: '/repo/apps/weather',
+      appDataDir: '/runtime/apps/weather',
+      configVersion: 'cfg-1',
+      readPaths: ['/repo/apps/weather'],
+      writePaths: ['/repo/apps/weather/cache'],
+      lockfilePath: '/repo/apps/weather/deno.lock',
+    });
+    const second = buildAppLaunchSpec({
+      appId: 'app:weather',
+      packageId: 'app:weather',
+      packageVersion: '1.0.0',
+      manifest: {
+        permissions: {
+          network: ['weather.example.com', 'api.example.com', 'API.EXAMPLE.COM'],
+        },
+      },
+      entrypoint: 'main.ts',
+      workingDirectory: '/repo/apps/weather',
+      appDataDir: '/runtime/apps/weather',
+      configVersion: 'cfg-1',
+      readPaths: ['/repo/apps/weather'],
+      writePaths: ['/repo/apps/weather/cache'],
+      lockfilePath: '/repo/apps/weather/deno.lock',
+    });
+
+    expect(first.compiled_permissions).toEqual(second.compiled_permissions);
+    expect(first.deno_args).toEqual(second.deno_args);
+    expect(first.deno_args).toContain('--deny-env');
+    expect(first.deno_args).toContain('--deny-run');
+    expect(first.deno_args).toContain('--deny-ffi');
+  });
+});

--- a/self/subcortex/apps/src/app-health-registry.ts
+++ b/self/subcortex/apps/src/app-health-registry.ts
@@ -1,0 +1,98 @@
+import {
+  AppHealthSnapshotSchema,
+  AppHeartbeatSignalSchema,
+  type AppHealthSnapshot,
+  type AppHeartbeatSignal,
+} from '@nous/shared';
+
+export interface AppHealthRegistryOptions {
+  now?: () => Date;
+}
+
+export class AppHealthRegistry {
+  private readonly now: () => Date;
+  private readonly snapshots = new Map<string, AppHealthSnapshot>();
+  private readonly heartbeatSequences = new Map<string, number>();
+
+  constructor(options: AppHealthRegistryOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  initializeSession(sessionId: string): AppHealthSnapshot {
+    const snapshot = AppHealthSnapshotSchema.parse({
+      session_id: sessionId,
+      status: 'healthy',
+      reported_at: this.now().toISOString(),
+      stale: false,
+      details: {},
+    });
+    this.snapshots.set(sessionId, snapshot);
+    this.heartbeatSequences.set(sessionId, -1);
+    return snapshot;
+  }
+
+  updateSnapshot(snapshot: AppHealthSnapshot): AppHealthSnapshot {
+    const parsed = AppHealthSnapshotSchema.parse(snapshot);
+    this.snapshots.set(parsed.session_id, parsed);
+    return parsed;
+  }
+
+  recordHeartbeat(signal: AppHeartbeatSignal): AppHealthSnapshot {
+    const parsed = AppHeartbeatSignalSchema.parse(signal);
+    const previousSequence = this.heartbeatSequences.get(parsed.session_id) ?? -1;
+    const skippedSequence = parsed.sequence > previousSequence + 1;
+    this.heartbeatSequences.set(parsed.session_id, parsed.sequence);
+
+    const nextSnapshot = AppHealthSnapshotSchema.parse({
+      session_id: parsed.session_id,
+      status: skippedSequence ? 'degraded' : parsed.status_hint ?? 'healthy',
+      reported_at: parsed.reported_at,
+      stale: false,
+      details: skippedSequence
+        ? { reason: 'heartbeat_sequence_gap', previousSequence, nextSequence: parsed.sequence }
+        : {},
+    });
+    this.snapshots.set(parsed.session_id, nextSnapshot);
+    return nextSnapshot;
+  }
+
+  markStaleSessions(maxAgeMs: number): AppHealthSnapshot[] {
+    const nowMs = this.now().getTime();
+    const updated: AppHealthSnapshot[] = [];
+
+    for (const [sessionId, snapshot] of this.snapshots.entries()) {
+      const ageMs = nowMs - new Date(snapshot.reported_at).getTime();
+      if (ageMs <= maxAgeMs) {
+        continue;
+      }
+
+      const nextSnapshot = AppHealthSnapshotSchema.parse({
+        ...snapshot,
+        status: 'stale',
+        stale: true,
+        details: {
+          ...snapshot.details,
+          staleAfterMs: maxAgeMs,
+          ageMs,
+        },
+      });
+      this.snapshots.set(sessionId, nextSnapshot);
+      updated.push(nextSnapshot);
+    }
+
+    return updated;
+  }
+
+  getSnapshot(sessionId: string): AppHealthSnapshot | null {
+    return this.snapshots.get(sessionId) ?? null;
+  }
+
+  listSnapshots(): AppHealthSnapshot[] {
+    return [...this.snapshots.values()];
+  }
+
+  removeSession(sessionId: string): void {
+    this.snapshots.delete(sessionId);
+    this.heartbeatSequences.delete(sessionId);
+  }
+}

--- a/self/subcortex/apps/src/app-runtime-service.ts
+++ b/self/subcortex/apps/src/app-runtime-service.ts
@@ -1,0 +1,237 @@
+import {
+  AppHealthSnapshotSchema,
+  AppProcessExitEventSchema,
+  AppRuntimeActivationInputSchema,
+  AppRuntimeDeactivationInputSchema,
+  AppRuntimeSessionSchema,
+  type AppHealthSnapshot,
+  type AppProcessExitEvent,
+  type AppRuntimeActivationInput,
+  type AppRuntimeDeactivationInput,
+  type AppRuntimeSession,
+  type IAppRuntimeService,
+  type IPackageLifecycleOrchestrator,
+  type PackageLifecycleTransitionRequest,
+} from '@nous/shared';
+import { AppHealthRegistry } from './app-health-registry.js';
+import { AppToolRegistry, type AppToolRegistryDefinition } from './app-tool-registry.js';
+import { DenoSpawner, type DenoSpawnReceipt } from './deno-spawner.js';
+import { McpIpcBridge } from './mcp-ipc-bridge.js';
+import { PanelRegistrationRegistry } from './panel-registration.js';
+
+export interface AppRuntimeServiceOptions {
+  lifecycleOrchestrator: IPackageLifecycleOrchestrator;
+  spawner?: DenoSpawner;
+  bridge?: McpIpcBridge;
+  toolRegistry: AppToolRegistry;
+  healthRegistry?: AppHealthRegistry;
+  panelRegistry?: PanelRegistrationRegistry;
+}
+
+export class AppRuntimeService implements IAppRuntimeService {
+  private readonly spawner: DenoSpawner;
+  private readonly bridge: McpIpcBridge;
+  private readonly healthRegistry: AppHealthRegistry;
+  private readonly panelRegistry: PanelRegistrationRegistry;
+  private readonly sessions = new Map<string, AppRuntimeSession>();
+  private readonly receipts = new Map<string, DenoSpawnReceipt>();
+
+  constructor(private readonly options: AppRuntimeServiceOptions) {
+    this.spawner = options.spawner ?? new DenoSpawner();
+    this.bridge = options.bridge ?? new McpIpcBridge();
+    this.healthRegistry = options.healthRegistry ?? new AppHealthRegistry();
+    this.panelRegistry = options.panelRegistry ?? new PanelRegistrationRegistry();
+  }
+
+  async activate(input: AppRuntimeActivationInput): Promise<AppRuntimeSession> {
+    const parsed = AppRuntimeActivationInputSchema.parse(input);
+    const receipt = this.spawner.spawn(parsed.launch_spec);
+    const toolDefinitions: AppToolRegistryDefinition[] = parsed.manifest.tools.map((tool: AppRuntimeActivationInput['manifest']['tools'][number]) => ({
+      tool_name: tool.name,
+      description: tool.description,
+      input_schema: tool.inputSchema,
+      output_schema: tool.outputSchema,
+    }));
+
+    const session = AppRuntimeSessionSchema.parse({
+      session_id: receipt.sessionId,
+      app_id: parsed.launch_spec.app_id,
+      package_id: parsed.launch_spec.package_id,
+      package_version: parsed.launch_spec.package_version,
+      project_id: parsed.project_id,
+      pid: Math.max(receipt.pid, 1),
+      status: 'starting',
+      started_at: receipt.startedAt,
+      registered_tool_ids: [],
+      panel_ids: [],
+      health_status: 'healthy',
+      config_version: parsed.launch_spec.config_version,
+    });
+
+    this.sessions.set(session.session_id, session);
+    this.receipts.set(session.session_id, receipt);
+    this.healthRegistry.initializeSession(session.session_id);
+
+    try {
+      const toolRecords = await this.options.toolRegistry.registerSessionTools({
+        appId: session.app_id,
+        sessionId: session.session_id,
+        definitions: toolDefinitions,
+      });
+      const panels = this.panelRegistry.registerPanels(session.session_id, parsed.panels);
+      const activeSession = this.updateSession({
+        ...session,
+        status: 'active',
+        registered_tool_ids: toolRecords.map((record) => record.namespaced_tool_id),
+        panel_ids: panels.map((panel) => panel.panel_id),
+      });
+
+      await this.bridge.sendActivationHandshake(activeSession, parsed);
+      await this.runLifecycleTransition(parsed, 'run');
+      return activeSession;
+    } catch (error) {
+      await this.options.toolRegistry.deregisterSessionTools(session.session_id);
+      this.panelRegistry.unregisterSession(session.session_id);
+      this.healthRegistry.removeSession(session.session_id);
+      this.receipts.get(session.session_id)?.handle.kill();
+      this.receipts.delete(session.session_id);
+      this.sessions.delete(session.session_id);
+      throw error;
+    }
+  }
+
+  async deactivate(
+    input: AppRuntimeDeactivationInput,
+  ): Promise<AppRuntimeSession | null> {
+    const parsed = AppRuntimeDeactivationInputSchema.parse(input);
+    const current = this.sessions.get(parsed.session_id);
+    if (!current) {
+      return null;
+    }
+
+    const draining = this.updateSession({
+      ...current,
+      status: 'draining',
+    });
+
+    await this.options.toolRegistry.deregisterSessionTools(parsed.session_id);
+    this.panelRegistry.unregisterSession(parsed.session_id);
+    this.receipts.get(parsed.session_id)?.handle.kill();
+    this.receipts.delete(parsed.session_id);
+    this.healthRegistry.removeSession(parsed.session_id);
+
+    if (parsed.disable_package) {
+      await this.runLifecycleTransition(
+        {
+          project_id: draining.project_id,
+          launch_spec: {
+            package_id: draining.package_id,
+            package_version: draining.package_version,
+          } as AppRuntimeActivationInput['launch_spec'],
+        } as AppRuntimeActivationInput,
+        'disable',
+      );
+    }
+
+    return this.updateSession({
+      ...draining,
+      status: 'stopped',
+      stopped_at: new Date().toISOString(),
+      registered_tool_ids: [],
+      panel_ids: [],
+    });
+  }
+
+  async handleProcessExit(
+    input: AppProcessExitEvent,
+  ): Promise<AppRuntimeSession | null> {
+    const parsed = AppProcessExitEventSchema.parse(input);
+    const current = this.sessions.get(parsed.session_id);
+    if (!current) {
+      return null;
+    }
+
+    await this.options.toolRegistry.deregisterSessionTools(parsed.session_id);
+    this.panelRegistry.unregisterSession(parsed.session_id);
+    this.healthRegistry.removeSession(parsed.session_id);
+    this.receipts.delete(parsed.session_id);
+
+    return this.updateSession({
+      ...current,
+      status: 'failed',
+      stopped_at: parsed.occurred_at,
+      registered_tool_ids: [],
+      panel_ids: [],
+    });
+  }
+
+  async getSession(sessionId: string): Promise<AppRuntimeSession | null> {
+    return this.sessions.get(sessionId) ?? null;
+  }
+
+  async listSessions(packageId?: string): Promise<AppRuntimeSession[]> {
+    const sessions = [...this.sessions.values()];
+    return packageId
+      ? sessions.filter((session) => session.package_id === packageId)
+      : sessions;
+  }
+
+  async recordHeartbeat(signal: import('@nous/shared').AppHeartbeatSignal): Promise<AppHealthSnapshot> {
+    const snapshot = this.healthRegistry.recordHeartbeat(signal);
+    const current = this.sessions.get(snapshot.session_id);
+    if (current) {
+      this.updateSession({
+        ...current,
+        health_status: snapshot.status,
+        last_heartbeat_at: snapshot.reported_at,
+      });
+    }
+    return snapshot;
+  }
+
+  async updateHealth(snapshot: AppHealthSnapshot): Promise<AppHealthSnapshot> {
+    const parsed = AppHealthSnapshotSchema.parse(snapshot);
+    this.healthRegistry.updateSnapshot(parsed);
+    const current = this.sessions.get(parsed.session_id);
+    if (current) {
+      this.updateSession({
+        ...current,
+        health_status: parsed.status,
+        last_heartbeat_at: parsed.reported_at,
+      });
+    }
+    return parsed;
+  }
+
+  private updateSession(session: AppRuntimeSession): AppRuntimeSession {
+    const parsed = AppRuntimeSessionSchema.parse(session);
+    this.sessions.set(parsed.session_id, parsed);
+    return parsed;
+  }
+
+  private async runLifecycleTransition(
+    input: Pick<AppRuntimeActivationInput, 'project_id' | 'launch_spec'>,
+    transition: 'run' | 'disable',
+  ): Promise<void> {
+    const projectId = input.project_id;
+    if (!projectId) {
+      return;
+    }
+
+    const request: PackageLifecycleTransitionRequest = {
+      project_id: projectId,
+      package_id: input.launch_spec.package_id,
+      package_version: input.launch_spec.package_version,
+      origin_class: 'nous_first_party',
+      target_transition: transition,
+      actor_id: 'app-runtime-service',
+    };
+
+    if (transition === 'run') {
+      await this.options.lifecycleOrchestrator.run(request);
+      return;
+    }
+
+    await this.options.lifecycleOrchestrator.disable(request);
+  }
+}

--- a/self/subcortex/apps/src/app-tool-registry.ts
+++ b/self/subcortex/apps/src/app-tool-registry.ts
@@ -1,0 +1,64 @@
+import {
+  AppToolRegistrationRecordSchema,
+  type AppToolRegistrationRecord,
+} from '@nous/shared';
+
+export interface AppToolRegistryDefinition {
+  tool_name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  output_schema?: Record<string, unknown>;
+}
+
+export interface AppToolRegistrar {
+  register(
+    toolId: string,
+    definition: AppToolRegistryDefinition,
+  ): Promise<{ witnessRef?: string } | void> | { witnessRef?: string } | void;
+  unregister(toolId: string): Promise<void> | void;
+}
+
+export class AppToolRegistry {
+  private readonly recordsBySession = new Map<string, AppToolRegistrationRecord[]>();
+
+  constructor(private readonly registrar: AppToolRegistrar) {}
+
+  async registerSessionTools(input: {
+    appId: string;
+    sessionId: string;
+    definitions: readonly AppToolRegistryDefinition[];
+  }): Promise<AppToolRegistrationRecord[]> {
+    const records: AppToolRegistrationRecord[] = [];
+
+    for (const definition of input.definitions) {
+      const namespacedToolId = `${input.appId}.${definition.tool_name}`;
+      const receipt = await this.registrar.register(namespacedToolId, definition);
+      const record = AppToolRegistrationRecordSchema.parse({
+        app_id: input.appId,
+        session_id: input.sessionId,
+        tool_name: definition.tool_name,
+        namespaced_tool_id: namespacedToolId,
+        description: definition.description,
+        input_schema: definition.input_schema,
+        output_schema: definition.output_schema,
+        registration_witness_ref: receipt?.witnessRef,
+      });
+      records.push(record);
+    }
+
+    this.recordsBySession.set(input.sessionId, records);
+    return records;
+  }
+
+  getSessionRecords(sessionId: string): AppToolRegistrationRecord[] {
+    return this.recordsBySession.get(sessionId) ?? [];
+  }
+
+  async deregisterSessionTools(sessionId: string): Promise<void> {
+    const records = this.recordsBySession.get(sessionId) ?? [];
+    for (const record of records) {
+      await this.registrar.unregister(record.namespaced_tool_id);
+    }
+    this.recordsBySession.delete(sessionId);
+  }
+}

--- a/self/subcortex/apps/src/deno-spawner.ts
+++ b/self/subcortex/apps/src/deno-spawner.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import type { AppLaunchSpec } from '@nous/shared';
+
+export interface DenoSpawnHandle {
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+export interface DenoSpawnReceipt {
+  sessionId: string;
+  pid: number;
+  startedAt: string;
+  command: string;
+  args: string[];
+  handle: DenoSpawnHandle;
+}
+
+export interface DenoSpawnerOptions {
+  command?: string;
+  now?: () => Date;
+  sessionIdFactory?: () => string;
+  spawnProcess?: (command: string, args: readonly string[]) => {
+    pid?: number;
+    kill(signal?: NodeJS.Signals | number): boolean;
+  };
+}
+
+export class DenoSpawner {
+  private readonly command: string;
+  private readonly now: () => Date;
+  private readonly sessionIdFactory: () => string;
+  private readonly spawnProcess: NonNullable<DenoSpawnerOptions['spawnProcess']>;
+
+  constructor(options: DenoSpawnerOptions = {}) {
+    this.command = options.command ?? 'deno';
+    this.now = options.now ?? (() => new Date());
+    this.sessionIdFactory = options.sessionIdFactory ?? randomUUID;
+    this.spawnProcess =
+      options.spawnProcess ??
+      ((command, args) => spawn(command, args, { stdio: 'pipe' }));
+  }
+
+  spawn(spec: AppLaunchSpec): DenoSpawnReceipt {
+    const child = this.spawnProcess(this.command, spec.deno_args);
+    return {
+      sessionId: this.sessionIdFactory(),
+      pid: child.pid ?? -1,
+      startedAt: this.now().toISOString(),
+      command: this.command,
+      args: [...spec.deno_args],
+      handle: {
+        kill: (signal?: NodeJS.Signals | number) => child.kill(signal),
+      },
+    };
+  }
+}

--- a/self/subcortex/apps/src/index.ts
+++ b/self/subcortex/apps/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @nous/subcortex-apps — app runtime, IPC bridge, tool registry, and health seams.
+ */
+export { compileAppPermissions, buildAppLaunchSpec, normalizeAppHosts } from './permission-compiler.js';
+export { DenoSpawner, type DenoSpawnHandle, type DenoSpawnReceipt } from './deno-spawner.js';
+export { McpIpcBridge, type AppOutboundToolEnvelope } from './mcp-ipc-bridge.js';
+export {
+  AppToolRegistry,
+  type AppToolRegistrar,
+  type AppToolRegistryDefinition,
+} from './app-tool-registry.js';
+export { AppHealthRegistry } from './app-health-registry.js';
+export { PanelRegistrationRegistry } from './panel-registration.js';
+export { AppRuntimeService, type AppRuntimeServiceOptions } from './app-runtime-service.js';

--- a/self/subcortex/apps/src/mcp-ipc-bridge.ts
+++ b/self/subcortex/apps/src/mcp-ipc-bridge.ts
@@ -1,0 +1,82 @@
+import {
+  AppActivationHandshakeSchema,
+  AppOutboundToolCallContextSchema,
+  type AppActivationHandshake,
+  type AppOutboundToolCallContext,
+  type AppRuntimeActivationInput,
+  type AppRuntimeSession,
+} from '@nous/shared';
+import { NousError } from '@nous/shared';
+import { z } from 'zod';
+
+const AppOutboundToolEnvelopeSchema = z.object({
+  context: AppOutboundToolCallContextSchema,
+  params: z.unknown().optional(),
+});
+
+export interface AppOutboundToolEnvelope {
+  context: AppOutboundToolCallContext;
+  params?: unknown;
+}
+
+export interface McpIpcBridgeOptions {
+  sendHandshake?: (sessionId: string, handshake: AppActivationHandshake) => Promise<void> | void;
+  projectScopedTools?: readonly string[];
+}
+
+export class McpIpcBridge {
+  private readonly projectScopedTools: ReadonlySet<string>;
+
+  constructor(private readonly options: McpIpcBridgeOptions = {}) {
+    this.projectScopedTools = new Set(options.projectScopedTools ?? [
+      'memory_write',
+      'project_discover',
+      'artifact_store',
+      'artifact_retrieve',
+      'tool_execute',
+      'tool_list',
+      'escalation_notify',
+      'scheduler_register',
+    ]);
+  }
+
+  createActivationHandshake(
+    session: AppRuntimeSession,
+    input: AppRuntimeActivationInput,
+  ): AppActivationHandshake {
+    return AppActivationHandshakeSchema.parse({
+      session_id: session.session_id,
+      app_id: session.app_id,
+      package_id: session.package_id,
+      package_version: session.package_version,
+      allowed_outbound_tools: input.allowed_outbound_tools,
+      config: input.config,
+      permissions: input.launch_spec.compiled_permissions,
+      panels: input.panels,
+    });
+  }
+
+  async sendActivationHandshake(
+    session: AppRuntimeSession,
+    input: AppRuntimeActivationInput,
+  ): Promise<AppActivationHandshake> {
+    const handshake = this.createActivationHandshake(session, input);
+    await this.options.sendHandshake?.(session.session_id, handshake);
+    return handshake;
+  }
+
+  parseOutboundToolEnvelope(payload: unknown): AppOutboundToolEnvelope {
+    const parsed = AppOutboundToolEnvelopeSchema.parse(payload);
+    if (
+      this.projectScopedTools.has(parsed.context.tool_id) &&
+      !parsed.context.project_id
+    ) {
+      throw new NousError(
+        `App tool ${parsed.context.tool_id} requires explicit project_id`,
+        'PROJECT_SCOPE_REQUIRED',
+      );
+    }
+
+    return parsed;
+  }
+}

--- a/self/subcortex/apps/src/panel-registration.ts
+++ b/self/subcortex/apps/src/panel-registration.ts
@@ -1,0 +1,29 @@
+import {
+  AppPanelRegistrationProjectionSchema,
+  type AppPanelRegistrationProjection,
+} from '@nous/shared';
+
+export class PanelRegistrationRegistry {
+  private readonly panelsBySession = new Map<string, AppPanelRegistrationProjection[]>();
+
+  registerPanels(
+    sessionId: string,
+    panels: readonly AppPanelRegistrationProjection[],
+  ): AppPanelRegistrationProjection[] {
+    const parsed = panels.map((panel) =>
+      AppPanelRegistrationProjectionSchema.parse(panel),
+    );
+    this.panelsBySession.set(sessionId, parsed);
+    return parsed;
+  }
+
+  listSessionPanels(sessionId: string): AppPanelRegistrationProjection[] {
+    return this.panelsBySession.get(sessionId) ?? [];
+  }
+
+  unregisterSession(sessionId: string): AppPanelRegistrationProjection[] {
+    const panels = this.panelsBySession.get(sessionId) ?? [];
+    this.panelsBySession.delete(sessionId);
+    return panels;
+  }
+}

--- a/self/subcortex/apps/src/permission-compiler.ts
+++ b/self/subcortex/apps/src/permission-compiler.ts
@@ -1,0 +1,78 @@
+import {
+  AppLaunchSpecSchema,
+  type AppCompiledPermissionFlags,
+  type AppLaunchSpec,
+  type AppPackageManifest,
+} from '@nous/shared';
+
+export interface CompileAppPermissionsInput {
+  manifest: Pick<AppPackageManifest, 'permissions'>;
+  appDataDir: string;
+  readPaths?: readonly string[];
+  writePaths?: readonly string[];
+}
+
+const sortUnique = (values: readonly string[]): string[] =>
+  [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+export const normalizeAppHosts = (hosts: readonly string[]): string[] =>
+  sortUnique(hosts.map((host) => host.toLowerCase()));
+
+export const compileAppPermissions = (
+  input: CompileAppPermissionsInput,
+): AppCompiledPermissionFlags => ({
+  allow_read: sortUnique([...(input.readPaths ?? []), input.appDataDir]),
+  allow_write: sortUnique([...(input.writePaths ?? []), input.appDataDir]),
+  allow_net: normalizeAppHosts(input.manifest.permissions.network),
+  deny_env: true,
+  deny_run: true,
+  deny_ffi: true,
+  cached_only: true,
+});
+
+export interface BuildAppLaunchSpecInput {
+  appId: string;
+  packageId: string;
+  packageVersion: string;
+  manifest: Pick<AppPackageManifest, 'permissions'>;
+  entrypoint: string;
+  workingDirectory: string;
+  appDataDir: string;
+  configVersion: string;
+  readPaths?: readonly string[];
+  writePaths?: readonly string[];
+  lockfilePath?: string;
+  manifestRef?: string;
+}
+
+export const buildAppLaunchSpec = (
+  input: BuildAppLaunchSpecInput,
+): AppLaunchSpec =>
+  AppLaunchSpecSchema.parse({
+    app_id: input.appId,
+    package_id: input.packageId,
+    package_version: input.packageVersion,
+    entrypoint: input.entrypoint,
+    working_directory: input.workingDirectory,
+    deno_args: [
+      'run',
+      '--deny-env',
+      '--deny-run',
+      '--deny-ffi',
+      '--cached-only',
+      `--allow-read=${compileAppPermissions(input).allow_read.join(',')}`,
+      `--allow-write=${compileAppPermissions(input).allow_write.join(',')}`,
+      ...(compileAppPermissions(input).allow_net.length > 0
+        ? [`--allow-net=${compileAppPermissions(input).allow_net.join(',')}`]
+        : []),
+      ...(input.lockfilePath ? ['--lock', input.lockfilePath] : []),
+      input.entrypoint,
+    ],
+    compiled_permissions: compileAppPermissions(input),
+    lockfile_path: input.lockfilePath,
+    app_data_dir: input.appDataDir,
+    config_version: input.configVersion,
+    manifest_ref: input.manifestRef,
+  });

--- a/self/subcortex/apps/tsconfig.json
+++ b/self/subcortex/apps/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@nous/shared": ["../../shared/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../shared" }]
+}

--- a/self/subcortex/apps/vitest.config.ts
+++ b/self/subcortex/apps/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  resolve: {
+    alias: {
+      '@nous/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+    exclude: ['**/dist/**', '**/node_modules/**'],
+  },
+});

--- a/self/subcortex/projects/src/__tests__/package-document-loading.test.ts
+++ b/self/subcortex/projects/src/__tests__/package-document-loading.test.ts
@@ -6,6 +6,7 @@ import { NodeRuntime } from '@nous/autonomic-runtime';
 import { ProjectConfigSchema } from '@nous/shared';
 import {
   inspectInstalledWorkflowPackage,
+  loadInstalledAppPackage,
   listInstalledWorkflowPackages,
   loadCompositeSkillDependencyGraph,
   loadInstalledSkillPackage,
@@ -100,6 +101,30 @@ async function writeInstalledWorkflow(options: {
   for (const [name, content] of Object.entries(options.steps)) {
     await writeFile(join(root, 'steps', name), content);
   }
+  if (options.packageVersion) {
+    await writeFile(
+      join(root, '.nous-package.json'),
+      JSON.stringify({ package_version: options.packageVersion }, null, 2),
+    );
+  }
+}
+
+async function writeInstalledApp(options: {
+  instanceRoot: string;
+  packageId: string;
+  manifest: Record<string, unknown>;
+  mainTs?: string;
+  packageVersion?: string;
+}) {
+  const root = join(
+    options.instanceRoot,
+    '.apps',
+    sanitizePackageId(options.packageId),
+  );
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, 'manifest.json'), JSON.stringify(options.manifest, null, 2));
+  await writeFile(join(root, 'main.ts'), options.mainTs ?? 'export default {};\n');
+  await writeFile(join(root, 'deno.lock'), '{}\n');
   if (options.packageVersion) {
     await writeFile(
       join(root, '.nous-package.json'),
@@ -351,6 +376,53 @@ config:
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
     );
     expect(resolved.source.sourceKind).toBe('installed_package');
+  });
+
+  it('loads installed app packages from the canonical app store', async () => {
+    const instanceRoot = await createInstanceRoot();
+    await writeInstalledApp({
+      instanceRoot,
+      packageId: 'app.weather',
+      packageVersion: '1.0.0',
+      manifest: {
+        id: 'app.weather',
+        name: 'weather',
+        version: '1.0.0',
+        package_type: 'app',
+        origin_class: 'nous_first_party',
+        api_contract_range: '^1.0.0',
+        capabilities: ['tool.execute'],
+        permissions: {
+          network: ['api.example.com'],
+          credentials: false,
+          witnessLevel: 'session',
+          systemNotify: true,
+          memoryContribute: false,
+        },
+        tools: [
+          {
+            name: 'get_forecast',
+            description: 'Fetch weather',
+            inputSchema: {},
+            outputSchema: {},
+            riskLevel: 'low',
+            idempotent: true,
+            sideEffects: [],
+            memoryRelevance: 'low',
+          },
+        ],
+      },
+    });
+
+    const loaded = await loadInstalledAppPackage({
+      instanceRoot,
+      runtime,
+      packageId: 'app.weather',
+    });
+
+    expect(loaded.packageVersion).toBe('1.0.0');
+    expect(loaded.entrypointRef).toContain('main.ts');
+    expect(loaded.lockfileRef).toContain('deno.lock');
   });
 
   it('lists and inspects canonical installed workflow packages from the system workflow store', async () => {

--- a/self/subcortex/projects/src/package-lifecycle/orchestrator.ts
+++ b/self/subcortex/projects/src/package-lifecycle/orchestrator.ts
@@ -55,6 +55,10 @@ const resolveAllowedEventType = (
       return 'pkg_compatibility_evaluated';
     case 'enable':
       return 'pkg_enabled';
+    case 'run':
+      return 'pkg_running';
+    case 'disable':
+      return 'pkg_disabled';
     case 'stage_update':
       return 'pkg_update_staged';
     case 'commit_update':
@@ -67,10 +71,6 @@ const resolveAllowedEventType = (
       return 'pkg_import_verified';
     case 'remove':
       return 'pkg_removed';
-    case 'run':
-      return 'pkg_runtime_action_decided';
-    case 'disable':
-      return 'pkg_enable_blocked';
     default: {
       const exhaustiveCheck: never = transition;
       throw new Error(`Unhandled transition for event mapping: ${exhaustiveCheck}`);
@@ -182,6 +182,17 @@ export class PackageLifecycleOrchestrator implements IPackageLifecycleOrchestrat
         packageVersion: context.request.package_version,
       };
     });
+  }
+
+  async run(
+    request: PackageLifecycleTransitionRequest,
+  ): Promise<PackageLifecycleTransitionResult> {
+    return this.executeTransition('run', request, async (context) => ({
+      ...handleSimpleAllowedTransition('running'),
+      packageVersion:
+        context.current?.package_version ?? context.request.package_version,
+      previousSafeVersion: context.current?.previous_safe_version,
+    }));
   }
 
   async stageUpdate(
@@ -313,6 +324,17 @@ export class PackageLifecycleOrchestrator implements IPackageLifecycleOrchestrat
         previousSafeVersion: context.current?.previous_safe_version,
       };
     });
+  }
+
+  async disable(
+    request: PackageLifecycleTransitionRequest,
+  ): Promise<PackageLifecycleTransitionResult> {
+    return this.executeTransition('disable', request, async (context) => ({
+      ...handleSimpleAllowedTransition('disabled'),
+      packageVersion:
+        context.current?.package_version ?? context.request.package_version,
+      previousSafeVersion: context.current?.previous_safe_version,
+    }));
   }
 
   async getState(

--- a/self/subcortex/projects/src/package-store/document-loader.ts
+++ b/self/subcortex/projects/src/package-store/document-loader.ts
@@ -2,7 +2,9 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { relative, resolve } from 'node:path';
 import type {
+  AppPackageManifest,
   IRuntime,
+  LoadedAppPackage,
   LoadedSkillPackage,
   LoadedWorkflowPackage,
   ProjectConfig,
@@ -15,8 +17,10 @@ import type {
   WorkflowNodeDefinition,
 } from '@nous/shared';
 import {
+  AppPackageManifestSchema,
   AtomicSkillFrontmatterSchema,
   CompositeSkillFrontmatterSchema,
+  LoadedAppPackageSchema,
   LoadedSkillPackageSchema,
   LoadedWorkflowPackageSchema,
   ProjectWorkflowPackageBindingSchema,
@@ -426,7 +430,7 @@ const classifySkillPackageKind = async (input: {
 const resolvePackagePath = async (input: {
   instanceRoot: string;
   runtime: IRuntime;
-  rootDir: '.skills' | '.workflows';
+  rootDir: '.apps' | '.skills' | '.workflows';
   packageId: string;
 }): Promise<string> => {
   const snapshot = await discoverCanonicalPackageStores({
@@ -457,7 +461,7 @@ const resolvePackagePath = async (input: {
 const listInstalledPackageRoots = async (input: {
   instanceRoot: string;
   runtime: IRuntime;
-  rootDir: '.skills' | '.workflows';
+  rootDir: '.apps' | '.skills' | '.workflows';
 }): Promise<Array<{ packageId: string; rootPath: string }>> => {
   const snapshot = await discoverCanonicalPackageStores({
     instanceRoot: input.instanceRoot,
@@ -619,6 +623,12 @@ export interface LoadInstalledWorkflowPackageOptions {
   packageId: string;
 }
 
+export interface LoadInstalledAppPackageOptions {
+  instanceRoot: string;
+  runtime: IRuntime;
+  packageId: string;
+}
+
 const normalizeWorkflowManifest = (
   rawFrontmatter: Record<string, unknown>,
 ) => {
@@ -703,6 +713,43 @@ export const loadInstalledWorkflowPackage = async (
     manifest: normalizedManifest,
     flow: parsedFlow,
     steps,
+    ...(await loadResourceRefs(options.runtime, rootPath)),
+  });
+};
+
+const parseAppManifest = (source: string): AppPackageManifest =>
+  AppPackageManifestSchema.parse(JSON.parse(source));
+
+export const loadInstalledAppPackage = async (
+  options: LoadInstalledAppPackageOptions,
+): Promise<LoadedAppPackage> => {
+  const rootPath = await resolvePackagePath({
+    instanceRoot: options.instanceRoot,
+    runtime: options.runtime,
+    rootDir: '.apps',
+    packageId: options.packageId,
+  });
+  const manifestPath = options.runtime.resolvePath(rootPath, 'manifest.json');
+  const entrypointPath = options.runtime.resolvePath(rootPath, 'main.ts');
+  const lockfilePath = options.runtime.resolvePath(rootPath, 'deno.lock');
+
+  if (!(await options.runtime.exists(manifestPath))) {
+    throw new Error(`Installed app package is missing manifest.json: ${options.packageId}`);
+  }
+  if (!(await options.runtime.exists(entrypointPath))) {
+    throw new Error(`Installed app package is missing main.ts: ${options.packageId}`);
+  }
+
+  return LoadedAppPackageSchema.parse({
+    packageId: options.packageId,
+    packageVersion: await readInstalledPackageVersion(options.runtime, rootPath),
+    rootRef: rootPath,
+    manifestRef: manifestPath,
+    manifest: parseAppManifest(await readText(manifestPath)),
+    entrypointRef: entrypointPath,
+    ...(await options.runtime.exists(lockfilePath)
+      ? { lockfileRef: lockfilePath }
+      : {}),
     ...(await loadResourceRefs(options.runtime, rootPath)),
   });
 };

--- a/self/subcortex/projects/src/package-store/index.ts
+++ b/self/subcortex/projects/src/package-store/index.ts
@@ -4,6 +4,7 @@ export {
   type PackageStoreDiscoveryOptions,
 } from './discovery.js';
 export {
+  loadInstalledAppPackage,
   loadCompositeSkillDependencyGraph,
   inspectInstalledWorkflowPackage,
   loadInstalledSkillPackage,
@@ -12,6 +13,7 @@ export {
   resolveInstalledWorkflowDefinition,
   type LoadedCompositeSkillDependencyGraph,
   type InspectInstalledWorkflowPackageOptions,
+  type LoadInstalledAppPackageOptions,
   type LoadInstalledSkillPackageOptions,
   type LoadInstalledWorkflowPackageOptions,
   type ListInstalledWorkflowPackagesOptions,

--- a/self/subcortex/sandbox/src/__tests__/runtime-membrane.test.ts
+++ b/self/subcortex/sandbox/src/__tests__/runtime-membrane.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { RuntimeMembrane } from '../runtime-membrane.js';
 import type { SandboxPayload } from '@nous/shared';
 
@@ -98,5 +98,25 @@ describe('RuntimeMembrane', () => {
 
     expect(resultA.decision.decision).toBe(resultB.decision.decision);
     expect(resultA.decision.reason_code).toBe(resultB.decision.reason_code);
+  });
+
+  it('uses onAllow as the only allow-path execution seam and does not invoke it on deny', async () => {
+    const onAllow = vi.fn().mockResolvedValue({ status: 'spawned' });
+    const membrane = new RuntimeMembrane({
+      now: () => new Date('2026-03-01T00:30:00.000Z'),
+      onAllow,
+    });
+
+    const allowed = await membrane.execute(BASE_PAYLOAD);
+    const denied = await membrane.execute({
+      ...BASE_PAYLOAD,
+      declared_capabilities: ['tool.execute'],
+    });
+
+    expect(allowed.success).toBe(true);
+    expect(allowed.output).toEqual({ status: 'spawned' });
+    expect(denied.success).toBe(false);
+    expect(onAllow).toHaveBeenCalledTimes(1);
+    expect(onAllow).toHaveBeenCalledWith(BASE_PAYLOAD);
   });
 });


### PR DESCRIPTION
## Phase 14.5 — App Runtime, Tool Registry, and Lifecycle Foundations

Delivers the Deno subprocess activation layer, namespaced app tool registration in the Internal MCP catalog, activation-handshake config delivery, app lifecycle control, health reporting, and Phase 15 panel seams.

## Gate reviews

All five gate reviews approved on Cycle 1 — no revision cycles required.

| Gate | Result |
|------|--------|
| Goals | Approved (Cycle 1) |
| SDS | Approved (Cycle 1) |
| Implementation Plan | Approved (Cycle 1) |
| Completion Report | Approved (Cycle 1) |
| User Documentation | Approved (Cycle 1) |

Sub-phase synthesis review: `.worklog/phase-14/phase-14.5/review.mdx` — **Approved**

## Verification

- `pnpm typecheck` — Pass (shared, subcortex-projects, subcortex-apps, cortex-core, subcortex-sandbox, autonomic-health)
- `pnpm lint` — Pass (14 pre-existing warnings, 0 errors)
- `pnpm test` — Pass (15 files / 90 tests, 100% pass rate)
- `pnpm build` — Pass (all 6 packages)

## SOP notes

- Phase 14.4 SOP Improvement 1 carry-forward (witness-governed test with injected mock `witnessService`) — confirmed delivered and passing; closed.
- SOP Improvement 2 authored for Phase 14.6+: each SDS activation rollback branch must have a named isolated test case.

---
Dispatch: HF-150 | Correlation: phase-14.5-subphase-review