### PR TITLE
fix(shared): break circular dependency in registry/package type schemas (phase-close reconciliation)

### DIFF
--- a/self/shared/src/types/enums.ts
+++ b/self/shared/src/types/enums.ts
@@ -105,6 +105,10 @@ export type EscalationChannel = z.infer<typeof EscalationChannelSchema>;
 export const PackageTypeSchema = z.enum(['skill', 'project', 'app', 'workflow']);
 export type PackageType = z.infer<typeof PackageTypeSchema>;
 
+// Canonical (non-legacy) package types — excludes the 'project' compatibility alias
+export const CanonicalPackageTypeSchema = z.enum(['skill', 'app', 'workflow']);
+export type CanonicalPackageType = z.infer<typeof CanonicalPackageTypeSchema>;
+
 // --- Retention Policy ---
 export const RetentionPolicySchema = z.enum(['permanent', 'session', 'ttl']);
 export type RetentionPolicy = z.infer<typeof RetentionPolicySchema>;

--- a/self/shared/src/types/package-lifecycle.ts
+++ b/self/shared/src/types/package-lifecycle.ts
@@ -3,7 +3,7 @@
  */
 import { z } from 'zod';
 import { OriginClassSchema } from './package-manifest.js';
-import { RegistryInstallEligibilitySnapshotSchema } from './registry.js';
+import { RegistryInstallEligibilitySnapshotSchema } from './registry-eligibility.js';
 
 export const PACKAGE_LIFECYCLE_EVENT_TYPES = [
   'pkg_ingest_received',

--- a/self/shared/src/types/package-manifest.ts
+++ b/self/shared/src/types/package-manifest.ts
@@ -2,14 +2,19 @@
  * Package manifest contracts for Nous package admission.
  */
 import { z } from 'zod';
-import { PackageTypeSchema, type PackageType } from './enums.js';
+import {
+  PackageTypeSchema,
+  type PackageType,
+  CanonicalPackageTypeSchema,
+  type CanonicalPackageType,
+} from './enums.js';
 import { PackageDependencySetSchema } from './package-resolution.js';
 
 export const ManifestPackageTypeSchema = PackageTypeSchema;
 export type ManifestPackageType = z.infer<typeof ManifestPackageTypeSchema>;
 
-export const CanonicalPackageTypeSchema = z.enum(['skill', 'app', 'workflow']);
-export type CanonicalPackageType = z.infer<typeof CanonicalPackageTypeSchema>;
+// Re-export from enums for consumers that import from package-manifest
+export { CanonicalPackageTypeSchema, type CanonicalPackageType };
 
 export const OriginClassSchema = z.enum([
   'nous_first_party',

--- a/self/shared/src/types/package-store.ts
+++ b/self/shared/src/types/package-store.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CanonicalPackageTypeSchema } from './package-manifest.js';
+import { CanonicalPackageTypeSchema } from './enums.js';
 
 export const CanonicalRootDirectorySchema = z.enum([
   '.apps',

--- a/self/shared/src/types/registry-eligibility.ts
+++ b/self/shared/src/types/registry-eligibility.ts
@@ -1,0 +1,59 @@
+/**
+ * Registry eligibility schemas extracted to break the circular dependency:
+ * registry.ts -> package-manifest.ts -> package-resolution.ts -> package-lifecycle.ts -> registry.ts
+ *
+ * package-lifecycle.ts imports only from this file; registry.ts re-exports from here.
+ */
+import { z } from 'zod';
+import { ProjectIdSchema } from './ids.js';
+
+export const RegistryReasonCodeSchema = z
+  .string()
+  .regex(/^MKT-00[1-9]-[A-Z0-9][A-Z0-9_-]*$/);
+export type RegistryReasonCode = z.infer<typeof RegistryReasonCodeSchema>;
+
+export const RegistryTrustTierSchema = z.enum([
+  'nous_first_party',
+  'verified_maintainer',
+  'community_unverified',
+  'unregistered_external',
+]);
+export type RegistryTrustTier = z.infer<typeof RegistryTrustTierSchema>;
+
+export const RegistryDistributionStatusSchema = z.enum([
+  'active',
+  'hold',
+  'delisted',
+  'blocked',
+]);
+export type RegistryDistributionStatus = z.infer<
+  typeof RegistryDistributionStatusSchema
+>;
+
+export const RegistryCompatibilityStateSchema = z.enum([
+  'compatible',
+  'requires_migration',
+  'blocked_incompatible',
+]);
+export type RegistryCompatibilityState = z.infer<
+  typeof RegistryCompatibilityStateSchema
+>;
+
+export const RegistryInstallEligibilitySnapshotSchema = z.object({
+  project_id: ProjectIdSchema.optional(),
+  package_id: z.string().min(1),
+  release_id: z.string().min(1),
+  package_version: z.string().min(1),
+  trust_tier: RegistryTrustTierSchema,
+  distribution_status: RegistryDistributionStatusSchema,
+  compatibility_state: RegistryCompatibilityStateSchema,
+  metadata_valid: z.boolean(),
+  signer_valid: z.boolean(),
+  requires_principal_override: z.boolean().default(false),
+  block_reason_codes: z.array(RegistryReasonCodeSchema).default([]),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+  evaluated_at: z.string().datetime(),
+});
+export type RegistryInstallEligibilitySnapshot = z.infer<
+  typeof RegistryInstallEligibilitySnapshotSchema
+>;

--- a/self/shared/src/types/registry.ts
+++ b/self/shared/src/types/registry.ts
@@ -7,37 +7,27 @@ import {
 } from './package-manifest.js';
 import { PackageDependencySetSchema } from './package-resolution.js';
 
-export const RegistryReasonCodeSchema = z
-  .string()
-  .regex(/^MKT-00[1-9]-[A-Z0-9][A-Z0-9_-]*$/);
-export type RegistryReasonCode = z.infer<typeof RegistryReasonCodeSchema>;
-
-export const RegistryTrustTierSchema = z.enum([
-  'nous_first_party',
-  'verified_maintainer',
-  'community_unverified',
-  'unregistered_external',
-]);
-export type RegistryTrustTier = z.infer<typeof RegistryTrustTierSchema>;
-
-export const RegistryDistributionStatusSchema = z.enum([
-  'active',
-  'hold',
-  'delisted',
-  'blocked',
-]);
-export type RegistryDistributionStatus = z.infer<
-  typeof RegistryDistributionStatusSchema
->;
-
-export const RegistryCompatibilityStateSchema = z.enum([
-  'compatible',
-  'requires_migration',
-  'blocked_incompatible',
-]);
-export type RegistryCompatibilityState = z.infer<
-  typeof RegistryCompatibilityStateSchema
->;
+// Re-export eligibility schemas from registry-eligibility.ts to keep backward compatibility
+// while breaking the circular dependency with package-lifecycle.ts
+export {
+  RegistryReasonCodeSchema,
+  type RegistryReasonCode,
+  RegistryTrustTierSchema,
+  type RegistryTrustTier,
+  RegistryDistributionStatusSchema,
+  type RegistryDistributionStatus,
+  RegistryCompatibilityStateSchema,
+  type RegistryCompatibilityState,
+  RegistryInstallEligibilitySnapshotSchema,
+  type RegistryInstallEligibilitySnapshot,
+} from './registry-eligibility.js';
+import {
+  RegistryReasonCodeSchema,
+  RegistryTrustTierSchema,
+  RegistryDistributionStatusSchema,
+  RegistryCompatibilityStateSchema,
+  RegistryInstallEligibilitySnapshotSchema,
+} from './registry-eligibility.js';
 
 export const RegistryModerationStateSchema = z.enum([
   'flagged_for_review',
@@ -262,25 +252,6 @@ export const RegistryEligibilityRequestSchema = z.object({
 });
 export type RegistryEligibilityRequest = z.infer<
   typeof RegistryEligibilityRequestSchema
->;
-
-export const RegistryInstallEligibilitySnapshotSchema = z.object({
-  project_id: ProjectIdSchema.optional(),
-  package_id: z.string().min(1),
-  release_id: z.string().min(1),
-  package_version: z.string().min(1),
-  trust_tier: RegistryTrustTierSchema,
-  distribution_status: RegistryDistributionStatusSchema,
-  compatibility_state: RegistryCompatibilityStateSchema,
-  metadata_valid: z.boolean(),
-  signer_valid: z.boolean(),
-  requires_principal_override: z.boolean().default(false),
-  block_reason_codes: z.array(RegistryReasonCodeSchema).default([]),
-  evidence_refs: z.array(z.string().min(1)).default([]),
-  evaluated_at: z.string().datetime(),
-});
-export type RegistryInstallEligibilitySnapshot = z.infer<
-  typeof RegistryInstallEligibilitySnapshotSchema
 >;
 
 export const RegistryReleaseSubmissionInputSchema = z.object({


### PR DESCRIPTION
## Summary

Phase 14 phase-close verification discovered 10 test failures caused by a circular module initialization dependency in `@nous/shared`. This is the phase-close reconciliation fix.

**Root cause:** `registry.ts` → `package-manifest.ts` → `package-resolution.ts` → `package-lifecycle.ts` → `registry.ts` — caused `RegistryReleaseSubmissionInputSchema` to be `undefined` when vitest loaded the module graph, failing 10 tests across 4 packages.

**Fix:**
- Extract `RegistryInstallEligibilitySnapshotSchema` and its 4 lightweight dependencies into new `registry-eligibility.ts` (no circular imports)
- `package-lifecycle.ts` now imports from `registry-eligibility.ts` instead of `registry.ts` (breaks the cycle)
- Move `CanonicalPackageTypeSchema` to `enums.ts`; `package-store.ts` imports from `enums.ts` (breaks secondary cycle)
- `registry.ts` re-exports everything for backward compatibility

**Result:** All 1828 tests pass. 0 lint errors. Only pre-existing `@nous/subcortex-mao` typecheck failure remains (outside Phase 14 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)