### PR TITLE
Phase 15.2 — Panel Bridge and SDK Core

### DIFF
--- a/docs/content/docs/api/procedures.mdx
+++ b/docs/content/docs/api/procedures.mdx
@@ -153,11 +153,11 @@ description: Reference for all tRPC procedures
 
 | Procedure | Type | Input | Output |
 |----------|------|-------|--------|
-| `packages.listAppPanels` | query | — | `{ app_id, panel_id, label, route_path, dockview_panel_id, preserve_state, position? }[]` |
+| `packages.listAppPanels` | query | — | `{ app_id, panel_id, label, route_path, dockview_panel_id, preserve_state, position?, config_snapshot }[]` |
 | `packages.install` | mutation | `PackageInstallRequest` | `PackageInstallResult` |
 
 - `packages.listAppPanels` — Returns the runtime-owned projection of active manifest-declared app panels for trusted first-party hosts.
-  - Each item includes the canonical `route_path`, host-safe `dockview_panel_id`, panel label, `preserve_state`, and optional dock position.
+  - Each item includes the canonical `route_path`, host-safe `dockview_panel_id`, panel label, `preserve_state`, optional dock position, and the sanitized `config_snapshot` used by trusted hosts during panel bridge bootstrap.
   - Panels appear here only while an app session is active; manifest declarations alone do not make a panel serveable.
 - `packages.install` — Runs the canonical package install pipeline for one project-scoped package request.
   - Input fields: `project_id`, `package_id`, optional `requested_version_range`, optional `release_id`, `actor_id`, optional `instance_root`, and optional `evidence_refs`.

--- a/docs/content/docs/architecture/repo-folder-structure.mdx
+++ b/docs/content/docs/architecture/repo-folder-structure.mdx
@@ -54,10 +54,29 @@ How Nous perceives the world and communicates with the user. These are part of t
 
 ```
 self/apps/
+├── app-sdk/                         # Browser-runtime SDK for installable app panels
 ├── cli/                              # Terminal interface
 ├── web/                              # Chat UI + Projects UI + Dashboard + MAO + mobile operations + public MCP edge
 └── bridge/                           # Approved messaging bridge app and connector adapters
 ```
+
+### app-sdk/
+
+Browser-runtime SDK for installable app panels.
+
+Phase 15.2 adds `self/apps/app-sdk/` as the canonical workspace package for the browser-side panel
+SDK consumed by installable apps. The Phase 15.2 in-scope surface is:
+
+* `NousPanel`
+* `useTool`
+* `useConfig`
+* `useTheme`
+* `useNotify`
+
+Panels use this package to speak the canonical versioned `postMessage` bridge to the trusted host.
+The SDK is a bridge client and projection helper only: it lets sandboxed panel code invoke app
+tools and read host-projected config/theme state through the host bridge, while keeping host
+internals, privileged routing, and second-source-of-truth state out of the panel surface.
 
 ### cli/
 

--- a/self/apps/app-sdk/package.json
+++ b/self/apps/app-sdk/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@nous/app-sdk",
+  "version": "0.0.1",
+  "private": false,
+  "description": "Nous app panel SDK",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./panel": "./src/panel/index.ts"
+  },
+  "dependencies": {
+    "@nous/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "jsdom": "^26.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5",
+    "vitest": "^4.0.18"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
+  }
+}

--- a/self/apps/app-sdk/src/__tests__/panel-bridge-client.test.ts
+++ b/self/apps/app-sdk/src/__tests__/panel-bridge-client.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  PANEL_BRIDGE_PROTOCOL_VERSION,
+  type PanelBridgeHostMessage,
+} from '@nous/shared';
+import { PanelBridgeClient } from '../panel/panel-bridge-client.js';
+
+function installMockParent() {
+  const parentWindow = {
+    postMessage: vi.fn(),
+  };
+
+  Object.defineProperty(window, 'parent', {
+    value: parentWindow,
+    configurable: true,
+  });
+
+  return parentWindow;
+}
+
+function dispatchFromParent(message: PanelBridgeHostMessage) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window.parent,
+      data: message,
+    }),
+  );
+}
+
+describe('PanelBridgeClient', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends panel.ready and resolves the host bootstrap handshake', async () => {
+    const parentWindow = installMockParent();
+    const client = new PanelBridgeClient({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    });
+
+    const handshake = client.connect();
+
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'panel.ready',
+        app_id: 'app:weather',
+        panel_id: 'forecast',
+      }),
+      '*',
+    );
+
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'host.bootstrap',
+      message_id: 'msg-1',
+      config: {
+        units: {
+          value: 'metric',
+          source: 'project_config',
+        },
+      },
+      theme: {
+        mode: 'dark',
+        tokens: {
+          background: '#000',
+          foreground: '#fff',
+        },
+        metadata: {},
+      },
+      capabilities: {
+        tool: true,
+        config: true,
+        theme: true,
+        notify: true,
+      },
+    });
+
+    await expect(handshake).resolves.toEqual(
+      expect.objectContaining({
+        kind: 'host.bootstrap',
+      }),
+    );
+  });
+
+  it('correlates tool requests to tool results', async () => {
+    const parentWindow = installMockParent();
+    const client = new PanelBridgeClient({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    });
+
+    const handshake = client.connect();
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'host.bootstrap',
+      message_id: 'msg-1',
+      config: {},
+      theme: {
+        mode: 'dark',
+        tokens: {},
+        metadata: {},
+      },
+      capabilities: {
+        tool: true,
+        config: true,
+        theme: true,
+        notify: true,
+      },
+    });
+    await handshake;
+
+    const invokePromise = client.invokeTool('get_forecast', { city: 'Seattle' });
+    const toolCall = parentWindow.postMessage.mock.calls.at(-1)?.[0] as {
+      request_id: string;
+    };
+
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'tool.result',
+      request_id: toolCall.request_id,
+      result: {
+        forecast: 'rain',
+      },
+    });
+
+    await expect(invokePromise).resolves.toEqual({
+      forecast: 'rain',
+    });
+  });
+
+  it('rejects pending requests on teardown cleanup', async () => {
+    installMockParent();
+    const client = new PanelBridgeClient({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    });
+
+    const handshake = client.connect();
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'host.bootstrap',
+      message_id: 'msg-1',
+      config: {},
+      theme: {
+        mode: 'dark',
+        tokens: {},
+        metadata: {},
+      },
+      capabilities: {
+        tool: true,
+        config: true,
+        theme: true,
+        notify: true,
+      },
+    });
+    await handshake;
+
+    const pending = client.readConfig();
+    client.destroy();
+
+    await expect(pending).rejects.toThrow('cancelled');
+  });
+});

--- a/self/apps/app-sdk/src/__tests__/panel-hooks.test.tsx
+++ b/self/apps/app-sdk/src/__tests__/panel-hooks.test.tsx
@@ -1,0 +1,201 @@
+import { useEffect } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
+import { NousPanel } from '../panel/NousPanel.js';
+import {
+  useConfig,
+  useNotify,
+  useTheme,
+  useTool,
+} from '../panel/hooks.js';
+
+declare global {
+  interface Window {
+    __NOUS_PANEL_BRIDGE_BOOTSTRAP__?: unknown;
+  }
+}
+
+function installMockParent() {
+  const parentWindow = {
+    postMessage: vi.fn((message: {
+      kind: string;
+      request_id?: string;
+    }) => {
+      queueMicrotask(() => {
+        switch (message.kind) {
+          case 'panel.ready':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'host.bootstrap',
+              message_id: 'msg-1',
+              config: {
+                units: {
+                  value: 'metric',
+                  source: 'project_config',
+                },
+              },
+              theme: {
+                mode: 'dark',
+                tokens: {
+                  background: '#000',
+                },
+                metadata: {},
+              },
+              capabilities: {
+                tool: true,
+                config: true,
+                theme: true,
+                notify: true,
+              },
+            });
+            return;
+          case 'tool.invoke':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'tool.result',
+              request_id: message.request_id!,
+              result: {
+                forecast: 'sunny',
+              },
+            });
+            return;
+          case 'config.get':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'config.result',
+              request_id: message.request_id!,
+              config: {
+                units: {
+                  value: 'imperial',
+                  source: 'project_config',
+                },
+              },
+            });
+            return;
+          case 'theme.get':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'theme.result',
+              request_id: message.request_id!,
+              theme: {
+                mode: 'light',
+                tokens: {
+                  background: '#fff',
+                },
+                metadata: {},
+              },
+            });
+            return;
+          case 'notify.send':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'notify.result',
+              request_id: message.request_id!,
+              accepted: true,
+            });
+            return;
+        }
+      });
+    }),
+  };
+
+  Object.defineProperty(window, 'parent', {
+    value: parentWindow,
+    configurable: true,
+  });
+
+  return parentWindow;
+}
+
+function dispatchFromParent(message: unknown) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      source: window.parent,
+      data: message,
+    }),
+  );
+}
+
+describe('@nous/app-sdk panel hooks', () => {
+  afterEach(() => {
+    delete window.__NOUS_PANEL_BRIDGE_BOOTSTRAP__;
+    vi.restoreAllMocks();
+  });
+
+  it('exposes tool, config, theme, and notify behavior through the bridge', async () => {
+    installMockParent();
+    window.__NOUS_PANEL_BRIDGE_BOOTSTRAP__ = {
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    };
+
+    let latest:
+      | {
+          invokeTool: ReturnType<typeof useTool>;
+          config: ReturnType<typeof useConfig>;
+          theme: ReturnType<typeof useTheme>;
+          notify: ReturnType<typeof useNotify>;
+        }
+      | undefined;
+
+    function Harness() {
+      const invokeTool = useTool('get_forecast');
+      const config = useConfig();
+      const theme = useTheme();
+      const notify = useNotify();
+
+      useEffect(() => {
+        latest = {
+          invokeTool,
+          config,
+          theme,
+          notify,
+        };
+      }, [invokeTool, config, theme, notify]);
+
+      return <div data-testid="units">{String(config.config.units?.value ?? '')}</div>;
+    }
+
+    const screen = render(
+      <NousPanel>
+        <Harness />
+      </NousPanel>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('units').textContent).toBe('metric');
+      expect(latest).toBeDefined();
+    });
+
+    const toolResult = await act(async () => {
+      return latest!.invokeTool({
+        city: 'Seattle',
+      });
+    });
+    expect(toolResult).toEqual({
+      forecast: 'sunny',
+    });
+
+    const refreshedConfig = await act(async () => {
+      return latest!.config.refresh();
+    });
+    expect(refreshedConfig.units?.value).toBe('imperial');
+
+    const refreshedTheme = await act(async () => {
+      return latest!.theme.refresh();
+    });
+    expect(refreshedTheme.mode).toBe('light');
+
+    const notifyAccepted = await act(async () => {
+      return latest!.notify({
+        title: 'Weather updated',
+        message: 'Forecast ready',
+        level: 'info',
+      });
+    });
+    expect(notifyAccepted).toBe(true);
+  });
+});

--- a/self/apps/app-sdk/src/index.ts
+++ b/self/apps/app-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from './panel/index.js';

--- a/self/apps/app-sdk/src/panel/NousPanel.tsx
+++ b/self/apps/app-sdk/src/panel/NousPanel.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  PanelBridgeWindowBootstrapSchema,
+  type HostBootstrapMessage,
+  type PanelBridgeConfigSnapshot,
+} from '@nous/shared';
+import { PanelSdkContext } from './panel-context.js';
+import { PanelBridgeClient } from './panel-bridge-client.js';
+
+declare global {
+  interface Window {
+    __NOUS_PANEL_BRIDGE_BOOTSTRAP__?: unknown;
+  }
+}
+
+function readBootstrap() {
+  return PanelBridgeWindowBootstrapSchema.parse(
+    window.__NOUS_PANEL_BRIDGE_BOOTSTRAP__,
+  );
+}
+
+export function NousPanel({ children }: { children: ReactNode }) {
+  const [bridgeState, setBridgeState] = useState<{
+    client: PanelBridgeClient;
+    bootstrap: HostBootstrapMessage;
+  } | null>(null);
+  const [config, setConfig] = useState<PanelBridgeConfigSnapshot>({});
+  const [theme, setTheme] = useState<HostBootstrapMessage['theme']>({
+    mode: 'dark',
+    tokens: {},
+    metadata: {},
+  });
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribeTheme: (() => void) | undefined;
+
+    try {
+      const client = new PanelBridgeClient(readBootstrap());
+      void client
+        .connect()
+        .then((bootstrap) => {
+          if (!active) {
+            client.destroy();
+            return;
+          }
+
+          setBridgeState({
+            client,
+            bootstrap,
+          });
+          setConfig(bootstrap.config);
+          setTheme(bootstrap.theme);
+          unsubscribeTheme = client.subscribeTheme((nextTheme) => {
+            setTheme(nextTheme);
+          });
+        })
+        .catch((nextError) => {
+          if (active) {
+            setError(nextError instanceof Error ? nextError : new Error('Panel bridge setup failed.'));
+          }
+        });
+
+      return () => {
+        active = false;
+        unsubscribeTheme?.();
+        client.destroy();
+      };
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError : new Error('Invalid panel bridge bootstrap.'));
+      return;
+    }
+  }, []);
+
+  if (error) {
+    throw error;
+  }
+
+  if (!bridgeState) {
+    return null;
+  }
+
+  return (
+    <PanelSdkContext.Provider
+      value={{
+        client: bridgeState.client,
+        capabilities: bridgeState.bootstrap.capabilities,
+        config,
+        theme,
+        setConfig,
+        setTheme,
+      }}
+    >
+      {children}
+    </PanelSdkContext.Provider>
+  );
+}

--- a/self/apps/app-sdk/src/panel/hooks.ts
+++ b/self/apps/app-sdk/src/panel/hooks.ts
@@ -1,0 +1,60 @@
+import { useContext } from 'react';
+import type {
+  PanelBridgeConfigSnapshot,
+  PanelBridgeNotification,
+  PanelBridgeThemeSnapshot,
+} from '@nous/shared';
+import { PanelSdkContext } from './panel-context.js';
+
+function usePanelSdkContext() {
+  const context = useContext(PanelSdkContext);
+  if (!context) {
+    throw new Error('Panel SDK hooks must be used inside <NousPanel>.');
+  }
+
+  return context;
+}
+
+export function useTool(toolName: string) {
+  const context = usePanelSdkContext();
+  return async (params?: unknown): Promise<unknown> => {
+    return context.client.invokeTool(toolName, params);
+  };
+}
+
+export function useConfig(): {
+  config: PanelBridgeConfigSnapshot;
+  refresh: () => Promise<PanelBridgeConfigSnapshot>;
+} {
+  const context = usePanelSdkContext();
+  return {
+    config: context.config,
+    refresh: async () => {
+      const nextConfig = await context.client.readConfig();
+      context.setConfig(nextConfig);
+      return nextConfig;
+    },
+  };
+}
+
+export function useTheme(): {
+  theme: PanelBridgeThemeSnapshot;
+  refresh: () => Promise<PanelBridgeThemeSnapshot>;
+} {
+  const context = usePanelSdkContext();
+  return {
+    theme: context.theme,
+    refresh: async () => {
+      const nextTheme = await context.client.readTheme();
+      context.setTheme(nextTheme);
+      return nextTheme;
+    },
+  };
+}
+
+export function useNotify() {
+  const context = usePanelSdkContext();
+  return async (notification: PanelBridgeNotification): Promise<boolean> => {
+    return context.client.sendNotify(notification);
+  };
+}

--- a/self/apps/app-sdk/src/panel/index.ts
+++ b/self/apps/app-sdk/src/panel/index.ts
@@ -1,0 +1,2 @@
+export { NousPanel } from './NousPanel.js';
+export { useTool, useConfig, useTheme, useNotify } from './hooks.js';

--- a/self/apps/app-sdk/src/panel/panel-bridge-client.ts
+++ b/self/apps/app-sdk/src/panel/panel-bridge-client.ts
@@ -1,0 +1,224 @@
+import {
+  PANEL_BRIDGE_PROTOCOL_VERSION,
+  type HostBootstrapMessage,
+  type PanelBridgeConfigSnapshot,
+  type PanelBridgeHostMessage,
+  PanelBridgeHostMessageSchema,
+  type PanelBridgeNotification,
+  type PanelBridgeThemeSnapshot,
+  type PanelBridgeWindowBootstrap,
+} from '@nous/shared';
+
+function createRequestId(): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `panel-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function toBridgeError(message: PanelBridgeHostMessage): Error {
+  if (message.kind !== 'error') {
+    return new Error('Unexpected panel bridge response.');
+  }
+
+  const error = new Error(message.error.message);
+  error.name = message.error.code;
+  return error;
+}
+
+export class PanelBridgeClient {
+  private readonly pendingRequests = new Map<
+    string,
+    {
+      resolve: (value: PanelBridgeHostMessage) => void;
+      reject: (error: Error) => void;
+      timeoutId: number;
+    }
+  >();
+
+  private readonly themeListeners = new Set<
+    (theme: PanelBridgeThemeSnapshot) => void
+  >();
+
+  private handshakeResolver?: (message: HostBootstrapMessage) => void;
+  private handshakeRejector?: (error: Error) => void;
+
+  private readonly handleMessage = (event: MessageEvent) => {
+    if (event.source !== window.parent) {
+      return;
+    }
+
+    const parsed = PanelBridgeHostMessageSchema.safeParse(event.data);
+    if (!parsed.success) {
+      return;
+    }
+
+    const message = parsed.data;
+    if (message.protocol !== PANEL_BRIDGE_PROTOCOL_VERSION) {
+      return;
+    }
+
+    if (message.kind === 'host.bootstrap') {
+      this.handshakeResolver?.(message);
+      this.handshakeResolver = undefined;
+      this.handshakeRejector = undefined;
+      return;
+    }
+
+    if (message.kind === 'theme.changed') {
+      for (const listener of this.themeListeners) {
+        listener(message.theme);
+      }
+      return;
+    }
+
+    if ('request_id' in message && message.request_id) {
+      const pending = this.pendingRequests.get(message.request_id);
+      if (!pending) {
+        return;
+      }
+
+      window.clearTimeout(pending.timeoutId);
+      this.pendingRequests.delete(message.request_id);
+
+      if (message.kind === 'error') {
+        pending.reject(toBridgeError(message));
+        return;
+      }
+
+      pending.resolve(message);
+    }
+  };
+
+  constructor(private readonly bootstrap: PanelBridgeWindowBootstrap) {}
+
+  async connect(): Promise<HostBootstrapMessage> {
+    window.addEventListener('message', this.handleMessage);
+
+    const handshake = new Promise<HostBootstrapMessage>((resolve, reject) => {
+      this.handshakeResolver = resolve;
+      this.handshakeRejector = reject;
+    });
+
+    window.parent.postMessage(
+      {
+        protocol: this.bootstrap.protocol,
+        kind: 'panel.ready',
+        message_id: createRequestId(),
+        app_id: this.bootstrap.app_id,
+        panel_id: this.bootstrap.panel_id,
+      },
+      '*',
+    );
+
+    return handshake;
+  }
+
+  destroy(): void {
+    window.removeEventListener('message', this.handleMessage);
+    this.handshakeRejector?.(new Error('Panel bridge host is unavailable.'));
+    this.handshakeResolver = undefined;
+    this.handshakeRejector = undefined;
+
+    for (const [requestId, pending] of this.pendingRequests.entries()) {
+      window.clearTimeout(pending.timeoutId);
+      pending.reject(new Error(`Panel bridge request ${requestId} was cancelled.`));
+      this.pendingRequests.delete(requestId);
+    }
+  }
+
+  subscribeTheme(
+    listener: (theme: PanelBridgeThemeSnapshot) => void,
+  ): () => void {
+    this.themeListeners.add(listener);
+    return () => {
+      this.themeListeners.delete(listener);
+    };
+  }
+
+  async invokeTool(toolName: string, params?: unknown): Promise<unknown> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'tool.invoke',
+      request_id: createRequestId(),
+      app_id: this.bootstrap.app_id,
+      panel_id: this.bootstrap.panel_id,
+      tool_name: toolName,
+      params,
+    });
+
+    if (message.kind !== 'tool.result') {
+      throw new Error('Unexpected tool response.');
+    }
+
+    return message.result;
+  }
+
+  async readConfig(): Promise<PanelBridgeConfigSnapshot> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'config.get',
+      request_id: createRequestId(),
+    });
+
+    if (message.kind !== 'config.result') {
+      throw new Error('Unexpected config response.');
+    }
+
+    return message.config;
+  }
+
+  async readTheme(): Promise<PanelBridgeThemeSnapshot> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'theme.get',
+      request_id: createRequestId(),
+    });
+
+    if (message.kind !== 'theme.result') {
+      throw new Error('Unexpected theme response.');
+    }
+
+    return message.theme;
+  }
+
+  async sendNotify(notification: PanelBridgeNotification): Promise<boolean> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'notify.send',
+      request_id: createRequestId(),
+      notification,
+    });
+
+    if (message.kind !== 'notify.result') {
+      throw new Error('Unexpected notify response.');
+    }
+
+    return message.accepted;
+  }
+
+  private request(message: {
+    protocol: number;
+    kind: 'tool.invoke' | 'config.get' | 'theme.get' | 'notify.send';
+    request_id: string;
+    app_id?: string;
+    panel_id?: string;
+    tool_name?: string;
+    params?: unknown;
+    notification?: PanelBridgeNotification;
+  }): Promise<PanelBridgeHostMessage> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = window.setTimeout(() => {
+        this.pendingRequests.delete(message.request_id);
+        reject(new Error('Panel bridge request timed out.'));
+      }, 5_000);
+
+      this.pendingRequests.set(message.request_id, {
+        resolve,
+        reject,
+        timeoutId,
+      });
+
+      window.parent.postMessage(message, '*');
+    });
+  }
+}

--- a/self/apps/app-sdk/src/panel/panel-context.ts
+++ b/self/apps/app-sdk/src/panel/panel-context.ts
@@ -1,0 +1,19 @@
+import { createContext } from 'react';
+import type {
+  PanelBridgeCapabilities,
+  PanelBridgeConfigSnapshot,
+  PanelBridgeThemeSnapshot,
+} from '@nous/shared';
+import type { Dispatch, SetStateAction } from 'react';
+import type { PanelBridgeClient } from './panel-bridge-client.js';
+
+export interface PanelSdkContextValue {
+  client: PanelBridgeClient;
+  config: PanelBridgeConfigSnapshot;
+  theme: PanelBridgeThemeSnapshot;
+  capabilities: PanelBridgeCapabilities;
+  setConfig: Dispatch<SetStateAction<PanelBridgeConfigSnapshot>>;
+  setTheme: Dispatch<SetStateAction<PanelBridgeThemeSnapshot>>;
+}
+
+export const PanelSdkContext = createContext<PanelSdkContextValue | null>(null);

--- a/self/apps/app-sdk/tsconfig.json
+++ b/self/apps/app-sdk/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@nous/shared": ["../../shared/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/self/apps/app-sdk/vitest.config.ts
+++ b/self/apps/app-sdk/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  resolve: {
+    alias: {
+      '@nous/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/__tests__/**/*.test.tsx'],
+    exclude: ['**/dist/**', '**/node_modules/**'],
+  },
+});

--- a/self/apps/desktop/electron.vite.config.ts
+++ b/self/apps/desktop/electron.vite.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 
@@ -10,5 +11,10 @@ export default defineConfig({
   },
   renderer: {
     plugins: [react()],
+    resolve: {
+      alias: {
+        '@nous/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+      },
+    },
   },
 })

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -75,6 +75,10 @@ interface WebHostAppPanel {
   dockview_panel_id: string
   preserve_state: boolean
   position?: 'left' | 'right' | 'bottom' | 'main'
+  config_snapshot: Record<string, {
+    value: unknown
+    source: 'manifest_default' | 'project_config' | 'system'
+  }>
 }
 
 interface DesktopAppPanel extends WebHostAppPanel {

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -53,6 +53,10 @@ interface AppPanelSnapshot {
   dockview_panel_id: string
   preserve_state: boolean
   position?: 'left' | 'right' | 'bottom' | 'main'
+  config_snapshot: Record<string, {
+    value: unknown
+    source: 'manifest_default' | 'project_config' | 'system'
+  }>
   src: string
 }
 
@@ -97,6 +101,7 @@ function toAppPanelDef(panel: AppPanelSnapshot): PanelDef {
       panelId: panel.panel_id,
       src: panel.src,
       preserveState: panel.preserve_state,
+      configSnapshot: panel.config_snapshot,
     }),
     position: panel.position ? APP_PANEL_POSITIONS[panel.position] : undefined,
   }

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -38,6 +38,10 @@ interface ElectronAPI {
       dockview_panel_id: string
       preserve_state: boolean
       position?: 'left' | 'right' | 'bottom' | 'main'
+      config_snapshot: Record<string, {
+        value: unknown
+        source: 'manifest_default' | 'project_config' | 'system'
+      }>
       src: string
     }[]>
   }

--- a/self/apps/desktop/tsconfig.web.json
+++ b/self/apps/desktop/tsconfig.web.json
@@ -11,7 +11,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@nous/shared": ["../../shared/src/index.ts"]
+    }
   },
   "include": ["src/renderer/src/**/*.ts", "src/renderer/src/**/*.tsx"],
   "exclude": ["node_modules", "out"]

--- a/self/apps/web/__tests__/app-panel-bridge-host.test.tsx
+++ b/self/apps/web/__tests__/app-panel-bridge-host.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
+import { AppIframePanel } from '@nous/ui/panels';
+
+describe('AppIframePanel host bridge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('boots the trusted host bridge and routes tool calls through the MCP endpoint', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      json: async () => ({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: 'req-1',
+        ok: true,
+        result: {
+          forecast: 'rain',
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const view = render(
+      <AppIframePanel
+        {...({
+          params: {
+            appId: 'app:weather',
+            panelId: 'forecast',
+            src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configSnapshot: {
+              units: {
+                value: 'metric',
+                source: 'project_config',
+              },
+            },
+          },
+        } as any)}
+      />,
+    );
+
+    const iframe = view.container.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+
+    const postMessageSpy = vi.spyOn(iframe!.contentWindow!, 'postMessage');
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe!.contentWindow,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'panel.ready',
+          message_id: 'msg-1',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'host.bootstrap',
+        }),
+        '*',
+      );
+    });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe!.contentWindow,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'tool.invoke',
+          request_id: 'req-1',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+          tool_name: 'get_forecast',
+          params: {
+            city: 'Seattle',
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:3000/mcp',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'x-nous-panel-bridge': '1',
+          }),
+        }),
+      );
+    });
+  });
+
+  it('ignores unexpected message sources', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const view = render(
+      <AppIframePanel
+        {...({
+          params: {
+            appId: 'app:weather',
+            panelId: 'forecast',
+            src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configSnapshot: {},
+          },
+        } as any)}
+      />,
+    );
+
+    const iframe = view.container.querySelector('iframe');
+    const postMessageSpy = vi.spyOn(iframe!.contentWindow!, 'postMessage');
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: window,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'tool.invoke',
+          request_id: 'req-1',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+          tool_name: 'get_forecast',
+        },
+      }),
+    );
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+});

--- a/self/apps/web/__tests__/apps-cortex-integration.test.ts
+++ b/self/apps/web/__tests__/apps-cortex-integration.test.ts
@@ -64,6 +64,12 @@ describe('apps → cortex integration', () => {
         manifest_ref: '/repo/.apps/weather/manifest.json',
         route_path: '/apps/app%3Aweather/panels/forecast',
         dockview_panel_id: 'app:app:weather:forecast',
+        config_snapshot: {
+          units: {
+            value: 'metric',
+            source: 'project_config',
+          },
+        },
       },
     ] as any);
 
@@ -76,6 +82,12 @@ describe('apps → cortex integration', () => {
         route_path: '/apps/app%3Aweather/panels/forecast',
         dockview_panel_id: 'app:app:weather:forecast',
         preserve_state: true,
+        config_snapshot: {
+          units: {
+            value: 'metric',
+            source: 'project_config',
+          },
+        },
       },
     ]);
   });

--- a/self/apps/web/app/apps/[appId]/panels/[panelId]/route.ts
+++ b/self/apps/web/app/apps/[appId]/panels/[panelId]/route.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
 import { createNousContext } from '@/server/bootstrap';
 
 const AppPanelRouteParamsSchema = z.object({
@@ -20,9 +21,18 @@ async function resolveParams(
 }
 
 function buildPanelHtml(input: {
+  appId: string;
+  panelId: string;
   mcpEndpoint: string;
   bundleJs: string;
 }): string {
+  const bootstrap = {
+    protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+    app_id: input.appId,
+    panel_id: input.panelId,
+    mcp_endpoint: input.mcpEndpoint,
+  };
+
   return [
     '<!DOCTYPE html>',
     '<html lang="en">',
@@ -30,7 +40,7 @@ function buildPanelHtml(input: {
     '  <meta charset="utf-8">',
     '  <meta name="viewport" content="width=device-width, initial-scale=1">',
     '  <style>html,body,#root{height:100%;margin:0;}body{overflow:hidden;}</style>',
-    `  <script>window.__NOUS_MCP_ENDPOINT__=${JSON.stringify(input.mcpEndpoint)};</script>`,
+    `  <script>window.__NOUS_MCP_ENDPOINT__=${JSON.stringify(input.mcpEndpoint)};window.__NOUS_PANEL_BRIDGE_BOOTSTRAP__=${JSON.stringify(bootstrap)};</script>`,
     '</head>',
     '<body>',
     '  <div id="root"></div>',
@@ -77,6 +87,8 @@ export async function GET(
     const transpiled = await ctx.panelTranspiler.getTranspiledPanel(panel);
     const response = new Response(
       buildPanelHtml({
+        appId: panel.app_id,
+        panelId: panel.panel_id,
         mcpEndpoint: new URL('/mcp', request.url).toString(),
         bundleJs: transpiled.entry.bundle_js,
       }),

--- a/self/apps/web/app/mcp/route.ts
+++ b/self/apps/web/app/mcp/route.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import {
+  PANEL_BRIDGE_PROTOCOL_VERSION,
   PublicMcpExecutionRequestSchema,
   PublicMcpRpcRequestSchema,
+  PanelBridgeToolTransportFailureSchema,
+  PanelBridgeToolTransportRequestSchema,
+  PanelBridgeToolTransportSuccessSchema,
   type PublicMcpRejectReason,
 } from '@nous/shared';
 import { createNousContext } from '@/server/bootstrap';
@@ -47,6 +51,70 @@ function mapRejectCode(reason?: PublicMcpRejectReason): number {
   }
 }
 
+function extractPanelBridgeRequestId(body: unknown): string {
+  if (typeof body !== 'object' || body == null) {
+    return randomUUID();
+  }
+
+  const requestId = (body as { request_id?: unknown }).request_id;
+  return typeof requestId === 'string' && requestId.length > 0
+    ? requestId
+    : randomUUID();
+}
+
+async function handlePanelBridgeRequest(
+  body: unknown,
+): Promise<Response | null> {
+  const parsed = PanelBridgeToolTransportRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      PanelBridgeToolTransportFailureSchema.parse({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: extractPanelBridgeRequestId(body),
+        ok: false,
+        error: {
+          code: 'message_invalid',
+          message: 'Invalid panel bridge tool request.',
+          retryable: false,
+        },
+      }),
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await createNousContext().appRuntimeService.executePanelTool(parsed.data);
+    return Response.json(
+      PanelBridgeToolTransportSuccessSchema.parse({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: parsed.data.request_id,
+        ok: true,
+        result,
+      }),
+      { status: 200 },
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message.length > 0
+        ? error.message
+        : 'Panel tool execution failed.';
+    const status = message === 'Active app panel not found.' ? 404 : 502;
+    return Response.json(
+      PanelBridgeToolTransportFailureSchema.parse({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: parsed.data.request_id,
+        ok: false,
+        error: {
+          code: status === 404 ? 'host_unavailable' : 'tool_execution_failed',
+          message,
+          retryable: false,
+        },
+      }),
+      { status },
+    );
+  }
+}
+
 export async function POST(request: Request): Promise<Response> {
   const ctx = createNousContext();
   const requestId = request.headers.get('x-request-id') ?? randomUUID();
@@ -56,6 +124,13 @@ export async function POST(request: Request): Promise<Response> {
     body = await request.json();
   } catch {
     body = null;
+  }
+
+  if (request.headers.get('x-nous-panel-bridge') === '1') {
+    const panelBridgeResponse = await handlePanelBridgeRequest(body);
+    if (panelBridgeResponse) {
+      return panelBridgeResponse;
+    }
   }
 
   const admission = await ctx.publicMcpGatewayService.authorize({

--- a/self/apps/web/server/__tests__/app-panel-route.test.ts
+++ b/self/apps/web/server/__tests__/app-panel-route.test.ts
@@ -65,6 +65,7 @@ describe('app panel route', () => {
     );
     expect(response.headers.get('x-nous-panel-cache')).toBe('miss');
     expect(body).toContain('window.__NOUS_MCP_ENDPOINT__="http://localhost:3000/mcp"');
+    expect(body).toContain('window.__NOUS_PANEL_BRIDGE_BOOTSTRAP__=');
     expect(body).toContain('console.log("forecast");');
   });
 

--- a/self/apps/web/server/__tests__/public-mcp-route.test.ts
+++ b/self/apps/web/server/__tests__/public-mcp-route.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
 import { PUBLIC_MCP_AUDIT_COLLECTION } from '@nous/subcortex-public-mcp';
 import { clearNousContextCache, createNousContext } from '../bootstrap';
 import { POST } from '../../app/mcp/route';
@@ -19,6 +20,49 @@ describe('public MCP route', () => {
     delete process.env.NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON;
     delete process.env.NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON;
     clearNousContextCache();
+  });
+
+  it('routes trusted panel bridge requests through the MCP endpoint without public bearer auth', async () => {
+    process.env.NOUS_DATA_DIR = join(tmpdir(), `nous-web-public-mcp-${randomUUID()}`);
+    clearNousContextCache();
+    const ctx = createNousContext();
+    const executePanelTool = vi
+      .spyOn(ctx.appRuntimeService, 'executePanelTool')
+      .mockResolvedValue({
+        forecast: 'rain',
+      });
+
+    const response = await POST(
+      new Request('http://localhost:3000/mcp', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-nous-panel-bridge': '1',
+        },
+        body: JSON.stringify({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: 'req-1',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+          tool_name: 'get_forecast',
+          params: {
+            city: 'Seattle',
+          },
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.result).toEqual({
+      forecast: 'rain',
+    });
+    expect(executePanelTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool_name: 'get_forecast',
+      }),
+    );
   });
 
   it('rejects missing bearer before tool execution', async () => {

--- a/self/apps/web/server/context.ts
+++ b/self/apps/web/server/context.ts
@@ -22,8 +22,9 @@ import type {
   IPackageInstallService,
   IVoiceControlService,
   IPublicMcpGatewayService,
+  IAppRuntimeService,
 } from '@nous/shared';
-import type { AppRuntimeService, PanelTranspiler } from '@nous/subcortex-apps';
+import type { PanelTranspiler } from '@nous/subcortex-apps';
 import type {
   IPrincipalSystemGatewayRuntime,
   IPublicMcpExecutionBridge,
@@ -61,7 +62,7 @@ export interface NousContext {
   voiceControlService: IVoiceControlService;
   publicMcpGatewayService: IPublicMcpGatewayService;
   publicMcpExecutionBridge: IPublicMcpExecutionBridge;
-  appRuntimeService: AppRuntimeService;
+  appRuntimeService: IAppRuntimeService;
   panelTranspiler: PanelTranspiler;
   dataDir: string;
 }

--- a/self/apps/web/server/trpc/routers/packages.ts
+++ b/self/apps/web/server/trpc/routers/packages.ts
@@ -1,4 +1,5 @@
 import {
+  AppPanelSafeConfigSnapshotSchema,
   PackageInstallRequestSchema,
   PackageInstallResultSchema,
 } from '@nous/shared';
@@ -14,6 +15,7 @@ const AppHostPanelSchema = z.object({
   dockview_panel_id: z.string().min(1),
   preserve_state: z.boolean(),
   position: z.enum(['left', 'right', 'bottom', 'main']).optional(),
+  config_snapshot: AppPanelSafeConfigSnapshotSchema,
 });
 
 export const packagesRouter = router({
@@ -35,6 +37,7 @@ export const packagesRouter = router({
         dockview_panel_id: panel.dockview_panel_id,
         preserve_state: panel.preserve_state,
         position: panel.position,
+        config_snapshot: panel.config_snapshot,
       }));
     }),
 });

--- a/self/apps/web/vitest.config.ts
+++ b/self/apps/web/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname),
       '@nous/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+      '@nous/ui/panels': path.resolve(__dirname, '../../ui/src/panels/index.ts'),
+      '@nous/ui': path.resolve(__dirname, '../../ui/src/index.ts'),
       '@nous/subcortex-apps': path.resolve(
         __dirname,
         '../../subcortex/apps/src/index.ts',

--- a/self/shared/src/__tests__/types/app-runtime.test.ts
+++ b/self/shared/src/__tests__/types/app-runtime.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   AppActivationHandshakeSchema,
+  AppPanelBridgeContextSchema,
+  AppPanelSafeConfigSnapshotSchema,
   AppConnectorEgressIntentSchema,
   AppConnectorIngressIntentSchema,
   AppConnectorSessionReportSchema,
@@ -69,6 +71,34 @@ describe('AppActivationHandshakeSchema', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe('AppPanel bridge runtime schemas', () => {
+  it('accepts panel-safe config snapshots and bridge contexts', () => {
+    const snapshot = AppPanelSafeConfigSnapshotSchema.parse({
+      units: {
+        value: 'metric',
+        source: 'project_config',
+      },
+    });
+    const context = AppPanelBridgeContextSchema.parse({
+      session_id: 'session-1',
+      app_id: 'app:weather',
+      package_id: 'app:weather',
+      package_version: '1.0.0',
+      panel_id: 'forecast',
+      label: 'Forecast',
+      entry: 'panels/forecast.tsx',
+      preserve_state: true,
+      package_root_ref: '/tmp/.apps/weather',
+      manifest_ref: '/tmp/.apps/weather/manifest.json',
+      route_path: '/apps/app%3Aweather/panels/forecast',
+      dockview_panel_id: 'app:app:weather:forecast',
+      config_snapshot: snapshot,
+    });
+
+    expect(context.config_snapshot.units?.value).toBe('metric');
   });
 });
 

--- a/self/shared/src/__tests__/types/panel-bridge-protocol.test.ts
+++ b/self/shared/src/__tests__/types/panel-bridge-protocol.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PANEL_BRIDGE_PROTOCOL_VERSION,
+  PanelBridgeHostMessageSchema,
+  PanelBridgePanelMessageSchema,
+  PanelBridgeToolTransportRequestSchema,
+  PanelBridgeToolTransportResponseSchema,
+  PanelBridgeWindowBootstrapSchema,
+} from '../../types/panel-bridge-protocol.js';
+
+describe('panel bridge shared protocol types', () => {
+  it('parses panel bootstrap, ready, and host bootstrap messages', () => {
+    const bootstrap = PanelBridgeWindowBootstrapSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    });
+    const ready = PanelBridgePanelMessageSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'panel.ready',
+      message_id: 'msg-1',
+      app_id: bootstrap.app_id,
+      panel_id: bootstrap.panel_id,
+    });
+    const hostBootstrap = PanelBridgeHostMessageSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'host.bootstrap',
+      message_id: 'msg-1',
+      config: {
+        units: {
+          value: 'metric',
+          source: 'project_config',
+        },
+      },
+      theme: {
+        mode: 'dark',
+        tokens: {
+          background: '#000',
+          foreground: '#fff',
+        },
+        metadata: {},
+      },
+      capabilities: {
+        tool: true,
+        config: true,
+        theme: true,
+        notify: true,
+      },
+    });
+
+    expect(ready.kind).toBe('panel.ready');
+    expect(hostBootstrap.kind).toBe('host.bootstrap');
+  });
+
+  it('rejects unsupported protocol versions', () => {
+    const result = PanelBridgePanelMessageSchema.safeParse({
+      protocol: 2,
+      kind: 'panel.ready',
+      message_id: 'msg-1',
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('parses internal MCP transport requests and typed failures', () => {
+    const request = PanelBridgeToolTransportRequestSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      request_id: 'req-1',
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      tool_name: 'get_forecast',
+      params: {
+        city: 'Seattle',
+      },
+    });
+    const failure = PanelBridgeToolTransportResponseSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      request_id: request.request_id,
+      ok: false,
+      error: {
+        code: 'tool_execution_failed',
+        message: 'Panel tool invocation failed.',
+        retryable: false,
+      },
+    });
+
+    expect(request.tool_name).toBe('get_forecast');
+    expect(failure.ok).toBe(false);
+  });
+});

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -189,6 +189,7 @@ import type {
   ExternalSourceMemoryEntry,
   ExternalSourceMutationResult,
   ExternalSourceSearchResult,
+  AppPanelBridgeContext,
   PublicMcpExecutionRequest,
   PublicMcpExecutionResult,
   PublicMcpGetArguments,
@@ -200,6 +201,7 @@ import type {
   PublicMcpTaskProjection,
   PublicMcpTaskResult,
   PublicMcpToolDefinition,
+  PanelBridgeToolTransportRequest,
   PromoteExternalRecordCommand,
   DemotePromotedRecordCommand,
   PromotedMemoryGetQuery,
@@ -864,6 +866,15 @@ export interface IAppRuntimeService {
 
   /** List runtime sessions, optionally filtered by package ID. */
   listSessions(packageId?: string): Promise<AppRuntimeSession[]>;
+
+  /** List active app-panel bridge contexts for trusted host surfaces. */
+  listPanels(): Promise<AppPanelBridgeContext[]>;
+
+  /** Resolve one active app-panel bridge context by app and panel identity. */
+  resolvePanel(appId: string, panelId: string): Promise<AppPanelBridgeContext | null>;
+
+  /** Execute one panel tool request through the runtime-owned app bridge. */
+  executePanelTool(input: PanelBridgeToolTransportRequest): Promise<unknown>;
 
   /** Record one heartbeat signal and return the resulting health snapshot. */
   recordHeartbeat(signal: AppHeartbeatSignal): Promise<AppHealthSnapshot>;

--- a/self/shared/src/types/app-runtime.ts
+++ b/self/shared/src/types/app-runtime.ts
@@ -86,6 +86,43 @@ export type AppPanelRegistrationProjection = z.infer<
   typeof AppPanelRegistrationProjectionSchema
 >;
 
+export const AppPanelSafeConfigEntrySchema = z.object({
+  value: z.unknown(),
+  source: AppHandshakeConfigSourceSchema,
+});
+export type AppPanelSafeConfigEntry = z.infer<
+  typeof AppPanelSafeConfigEntrySchema
+>;
+
+export const AppPanelSafeConfigSnapshotSchema = z.record(
+  z.string().min(1),
+  AppPanelSafeConfigEntrySchema,
+);
+export type AppPanelSafeConfigSnapshot = z.infer<
+  typeof AppPanelSafeConfigSnapshotSchema
+>;
+
+export const AppPanelBridgeContextSchema = z.object({
+  session_id: z.string().min(1),
+  app_id: z.string().min(1),
+  package_id: z.string().min(1),
+  package_version: z.string().min(1),
+  project_id: ProjectIdSchema.optional(),
+  panel_id: z.string().min(1),
+  label: z.string().min(1),
+  entry: z.string().min(1),
+  position: z.enum(['left', 'right', 'bottom', 'main']).optional(),
+  preserve_state: z.boolean().default(true),
+  package_root_ref: z.string().min(1),
+  manifest_ref: z.string().min(1),
+  route_path: z.string().min(1),
+  dockview_panel_id: z.string().min(1),
+  config_snapshot: AppPanelSafeConfigSnapshotSchema.default({}),
+});
+export type AppPanelBridgeContext = z.infer<
+  typeof AppPanelBridgeContextSchema
+>;
+
 export const AppActivationHandshakeSchema = z.object({
   session_id: z.string().min(1),
   app_id: z.string().min(1),

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -63,6 +63,7 @@ export * from './app-permissions.js';
 export * from './app-manifest.js';
 export * from './app-credentials.js';
 export * from './app-runtime.js';
+export * from './panel-bridge-protocol.js';
 export * from './package-manifest.js';
 export * from './package-documents.js';
 export * from './package-resolution.js';

--- a/self/shared/src/types/panel-bridge-protocol.ts
+++ b/self/shared/src/types/panel-bridge-protocol.ts
@@ -1,0 +1,301 @@
+import { z } from 'zod';
+import { AppHandshakeConfigSourceSchema } from './app-runtime.js';
+
+export const PANEL_BRIDGE_PROTOCOL_VERSION = 1 as const;
+export const PANEL_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS = [
+  PANEL_BRIDGE_PROTOCOL_VERSION,
+] as const;
+
+export const PanelBridgeProtocolVersionSchema = z.literal(
+  PANEL_BRIDGE_PROTOCOL_VERSION,
+);
+export type PanelBridgeProtocolVersion = z.infer<
+  typeof PanelBridgeProtocolVersionSchema
+>;
+
+export const PanelBridgeRequestIdSchema = z.string().min(1);
+export type PanelBridgeRequestId = z.infer<typeof PanelBridgeRequestIdSchema>;
+
+export const PanelBridgeMessageKindSchema = z.enum([
+  'panel.ready',
+  'tool.invoke',
+  'config.get',
+  'theme.get',
+  'notify.send',
+  'host.bootstrap',
+  'tool.result',
+  'config.result',
+  'theme.result',
+  'notify.result',
+  'theme.changed',
+  'error',
+]);
+export type PanelBridgeMessageKind = z.infer<
+  typeof PanelBridgeMessageKindSchema
+>;
+
+export const PanelBridgeErrorCodeSchema = z.enum([
+  'protocol_unsupported',
+  'message_invalid',
+  'unexpected_source',
+  'tool_execution_failed',
+  'request_timeout',
+  'config_unavailable',
+  'notify_unavailable',
+  'host_unavailable',
+  'internal_error',
+]);
+export type PanelBridgeErrorCode = z.infer<typeof PanelBridgeErrorCodeSchema>;
+
+export const PanelBridgeErrorSchema = z.object({
+  code: PanelBridgeErrorCodeSchema,
+  message: z.string().min(1),
+  retryable: z.boolean().default(false),
+  details: z.record(z.unknown()).optional(),
+});
+export type PanelBridgeError = z.infer<typeof PanelBridgeErrorSchema>;
+
+export const PanelBridgeConfigEntrySchema = z.object({
+  value: z.unknown(),
+  source: AppHandshakeConfigSourceSchema,
+});
+export type PanelBridgeConfigEntry = z.infer<typeof PanelBridgeConfigEntrySchema>;
+
+export const PanelBridgeConfigSnapshotSchema = z.record(
+  z.string().min(1),
+  PanelBridgeConfigEntrySchema,
+);
+export type PanelBridgeConfigSnapshot = z.infer<
+  typeof PanelBridgeConfigSnapshotSchema
+>;
+
+export const PanelBridgeThemeModeSchema = z.enum(['light', 'dark']);
+export type PanelBridgeThemeMode = z.infer<typeof PanelBridgeThemeModeSchema>;
+
+export const PanelBridgeThemeSnapshotSchema = z.object({
+  mode: PanelBridgeThemeModeSchema,
+  tokens: z.record(z.string().min(1), z.string()),
+  metadata: z.record(z.unknown()).default({}),
+});
+export type PanelBridgeThemeSnapshot = z.infer<
+  typeof PanelBridgeThemeSnapshotSchema
+>;
+
+export const PanelBridgeNotificationLevelSchema = z.enum([
+  'info',
+  'success',
+  'warning',
+  'error',
+]);
+export type PanelBridgeNotificationLevel = z.infer<
+  typeof PanelBridgeNotificationLevelSchema
+>;
+
+export const PanelBridgeNotificationSchema = z.object({
+  title: z.string().min(1),
+  message: z.string().min(1),
+  level: PanelBridgeNotificationLevelSchema.default('info'),
+  context: z.record(z.unknown()).optional(),
+});
+export type PanelBridgeNotification = z.infer<
+  typeof PanelBridgeNotificationSchema
+>;
+
+export const PanelBridgeCapabilitiesSchema = z.object({
+  tool: z.boolean().default(true),
+  config: z.boolean().default(true),
+  theme: z.boolean().default(true),
+  notify: z.boolean().default(true),
+});
+export type PanelBridgeCapabilities = z.infer<
+  typeof PanelBridgeCapabilitiesSchema
+>;
+
+const PanelBridgeEnvelopeSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+});
+
+export const PanelBridgeWindowBootstrapSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  mcp_endpoint: z.string().url(),
+});
+export type PanelBridgeWindowBootstrap = z.infer<
+  typeof PanelBridgeWindowBootstrapSchema
+>;
+
+export const PanelReadyMessageSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('panel.ready'),
+  message_id: PanelBridgeRequestIdSchema,
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+});
+export type PanelReadyMessage = z.infer<typeof PanelReadyMessageSchema>;
+
+export const PanelToolInvokeRequestSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('tool.invoke'),
+  request_id: PanelBridgeRequestIdSchema,
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  tool_name: z.string().min(1),
+  params: z.unknown().optional(),
+});
+export type PanelToolInvokeRequest = z.infer<
+  typeof PanelToolInvokeRequestSchema
+>;
+
+export const PanelConfigGetRequestSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('config.get'),
+  request_id: PanelBridgeRequestIdSchema,
+});
+export type PanelConfigGetRequest = z.infer<typeof PanelConfigGetRequestSchema>;
+
+export const PanelThemeGetRequestSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('theme.get'),
+  request_id: PanelBridgeRequestIdSchema,
+});
+export type PanelThemeGetRequest = z.infer<typeof PanelThemeGetRequestSchema>;
+
+export const PanelNotifyRequestSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('notify.send'),
+  request_id: PanelBridgeRequestIdSchema,
+  notification: PanelBridgeNotificationSchema,
+});
+export type PanelNotifyRequest = z.infer<typeof PanelNotifyRequestSchema>;
+
+export const PanelBridgePanelMessageSchema = z.discriminatedUnion('kind', [
+  PanelReadyMessageSchema,
+  PanelToolInvokeRequestSchema,
+  PanelConfigGetRequestSchema,
+  PanelThemeGetRequestSchema,
+  PanelNotifyRequestSchema,
+]);
+export type PanelBridgePanelMessage = z.infer<
+  typeof PanelBridgePanelMessageSchema
+>;
+
+export const HostBootstrapMessageSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('host.bootstrap'),
+  message_id: PanelBridgeRequestIdSchema,
+  config: PanelBridgeConfigSnapshotSchema,
+  theme: PanelBridgeThemeSnapshotSchema,
+  capabilities: PanelBridgeCapabilitiesSchema,
+});
+export type HostBootstrapMessage = z.infer<typeof HostBootstrapMessageSchema>;
+
+export const PanelToolSuccessResponseSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('tool.result'),
+  request_id: PanelBridgeRequestIdSchema,
+  result: z.unknown(),
+});
+export type PanelToolSuccessResponse = z.infer<
+  typeof PanelToolSuccessResponseSchema
+>;
+
+export const PanelConfigResponseSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('config.result'),
+  request_id: PanelBridgeRequestIdSchema,
+  config: PanelBridgeConfigSnapshotSchema,
+});
+export type PanelConfigResponse = z.infer<typeof PanelConfigResponseSchema>;
+
+export const PanelThemeResponseSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('theme.result'),
+  request_id: PanelBridgeRequestIdSchema,
+  theme: PanelBridgeThemeSnapshotSchema,
+});
+export type PanelThemeResponse = z.infer<typeof PanelThemeResponseSchema>;
+
+export const PanelNotifyResponseSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('notify.result'),
+  request_id: PanelBridgeRequestIdSchema,
+  accepted: z.boolean(),
+});
+export type PanelNotifyResponse = z.infer<typeof PanelNotifyResponseSchema>;
+
+export const PanelThemeChangedMessageSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('theme.changed'),
+  theme: PanelBridgeThemeSnapshotSchema,
+});
+export type PanelThemeChangedMessage = z.infer<
+  typeof PanelThemeChangedMessageSchema
+>;
+
+export const PanelBridgeErrorResponseSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('error'),
+  request_id: PanelBridgeRequestIdSchema.optional(),
+  error: PanelBridgeErrorSchema,
+});
+export type PanelBridgeErrorResponse = z.infer<
+  typeof PanelBridgeErrorResponseSchema
+>;
+
+export const PanelBridgeHostMessageSchema = z.discriminatedUnion('kind', [
+  HostBootstrapMessageSchema,
+  PanelToolSuccessResponseSchema,
+  PanelConfigResponseSchema,
+  PanelThemeResponseSchema,
+  PanelNotifyResponseSchema,
+  PanelThemeChangedMessageSchema,
+  PanelBridgeErrorResponseSchema,
+]);
+export type PanelBridgeHostMessage = z.infer<
+  typeof PanelBridgeHostMessageSchema
+>;
+
+export const PanelBridgeMessageSchema = z.discriminatedUnion('kind', [
+  PanelReadyMessageSchema,
+  PanelToolInvokeRequestSchema,
+  PanelConfigGetRequestSchema,
+  PanelThemeGetRequestSchema,
+  PanelNotifyRequestSchema,
+  HostBootstrapMessageSchema,
+  PanelToolSuccessResponseSchema,
+  PanelConfigResponseSchema,
+  PanelThemeResponseSchema,
+  PanelNotifyResponseSchema,
+  PanelThemeChangedMessageSchema,
+  PanelBridgeErrorResponseSchema,
+]);
+export type PanelBridgeMessage = z.infer<typeof PanelBridgeMessageSchema>;
+
+export const PanelBridgeToolTransportRequestSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+  request_id: PanelBridgeRequestIdSchema,
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  tool_name: z.string().min(1),
+  params: z.unknown().optional(),
+});
+export type PanelBridgeToolTransportRequest = z.infer<
+  typeof PanelBridgeToolTransportRequestSchema
+>;
+
+export const PanelBridgeToolTransportSuccessSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+  request_id: PanelBridgeRequestIdSchema,
+  ok: z.literal(true),
+  result: z.unknown(),
+});
+export type PanelBridgeToolTransportSuccess = z.infer<
+  typeof PanelBridgeToolTransportSuccessSchema
+>;
+
+export const PanelBridgeToolTransportFailureSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+  request_id: PanelBridgeRequestIdSchema,
+  ok: z.literal(false),
+  error: PanelBridgeErrorSchema,
+});
+export type PanelBridgeToolTransportFailure = z.infer<
+  typeof PanelBridgeToolTransportFailureSchema
+>;
+
+export const PanelBridgeToolTransportResponseSchema = z.union([
+  PanelBridgeToolTransportSuccessSchema,
+  PanelBridgeToolTransportFailureSchema,
+]);
+export type PanelBridgeToolTransportResponse = z.infer<
+  typeof PanelBridgeToolTransportResponseSchema
+>;

--- a/self/subcortex/apps/src/__tests__/app-runtime-service.test.ts
+++ b/self/subcortex/apps/src/__tests__/app-runtime-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
 import { AppRuntimeService } from '../app-runtime-service.js';
 import { AppToolRegistry, type AppToolRegistrar } from '../app-tool-registry.js';
 import { DenoSpawner } from '../deno-spawner.js';
@@ -506,5 +507,101 @@ describe('AppRuntimeService', () => {
     expect(stopped?.status).toBe('stopped');
     expect(await service.resolvePanel('app:weather', 'forecast')).toBeNull();
     expect(invalidateSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('executes active panel tool requests through the runtime bridge with namespaced tool ids', async () => {
+    const invokeTool = vi.fn().mockResolvedValue({
+      forecast: 'rain',
+    });
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: {
+        run: vi.fn().mockResolvedValue({}),
+        disable: vi.fn().mockResolvedValue({}),
+      } as any,
+      spawner: new DenoSpawner({
+        sessionIdFactory: () => 'session-1',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+      bridge: new McpIpcBridge({
+        invokeTool,
+      }),
+      toolRegistry: createToolRegistry(),
+    });
+
+    await service.activate({
+      ...(activationInput as any),
+      manifest: {
+        ...(activationInput.manifest as any),
+        config: {
+          units: {
+            type: 'string',
+          },
+          api_key: {
+            type: 'secret',
+          },
+        },
+      },
+      config: [
+        {
+          key: 'units',
+          value: 'metric',
+          source: 'project_config',
+          mutable: false,
+        },
+      ],
+    });
+
+    const result = await service.executePanelTool({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      request_id: 'req-1',
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      tool_name: 'get_forecast',
+      params: {
+        city: 'Seattle',
+      },
+    });
+
+    expect(result).toEqual({
+      forecast: 'rain',
+    });
+    expect(invokeTool).toHaveBeenCalledWith('session-1', {
+      context: {
+        caller_type: 'app',
+        app_id: 'app:weather',
+        package_id: 'app:weather',
+        session_id: 'session-1',
+        project_id: activationInput.project_id,
+        tool_id: 'app:weather.get_forecast',
+        request_id: 'req-1',
+      },
+      params: {
+        city: 'Seattle',
+      },
+    });
+  });
+
+  it('fails panel tool execution when the target panel is not active', async () => {
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: {
+        run: vi.fn().mockResolvedValue({}),
+        disable: vi.fn().mockResolvedValue({}),
+      } as any,
+      bridge: new McpIpcBridge(),
+      toolRegistry: createToolRegistry(),
+    });
+
+    await expect(
+      service.executePanelTool({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: 'req-1',
+        app_id: 'app:weather',
+        panel_id: 'forecast',
+        tool_name: 'get_forecast',
+      }),
+    ).rejects.toThrow('Active app panel not found.');
   });
 });

--- a/self/subcortex/apps/src/__tests__/panel-registration.test.ts
+++ b/self/subcortex/apps/src/__tests__/panel-registration.test.ts
@@ -17,6 +17,7 @@ describe('PanelRegistrationRegistry', () => {
       session,
       package_root_ref: '/repo/.apps/weather',
       manifest_ref: '/repo/.apps/weather/manifest.json',
+      config_entries: [],
       panels: [
         {
           app_id: 'app:weather',
@@ -48,6 +49,7 @@ describe('PanelRegistrationRegistry', () => {
       session,
       package_root_ref: '/repo/.apps/weather',
       manifest_ref: '/repo/.apps/weather/manifest.json',
+      config_entries: [],
       panels: [
         {
           app_id: 'app:weather',
@@ -67,6 +69,7 @@ describe('PanelRegistrationRegistry', () => {
       },
       package_root_ref: '/repo/.apps/weather-v2',
       manifest_ref: '/repo/.apps/weather-v2/manifest.json',
+      config_entries: [],
       panels: [
         {
           app_id: 'app:weather',
@@ -102,6 +105,7 @@ describe('PanelRegistrationRegistry', () => {
       session,
       package_root_ref: '/repo/.apps/weather',
       manifest_ref: '/repo/.apps/weather/manifest.json',
+      config_entries: [],
       panels: [
         {
           app_id: 'app:weather',
@@ -119,5 +123,63 @@ describe('PanelRegistrationRegistry', () => {
     expect(removed).toHaveLength(1);
     expect(registry.resolvePanel('app:weather', 'forecast')).toBeNull();
     expect(registry.listPanels()).toEqual([]);
+  });
+
+  it('omits secret config fields from the bridge snapshot', () => {
+    const registry = new PanelRegistrationRegistry();
+
+    registry.registerPanels({
+      session,
+      package_root_ref: '/repo/.apps/weather',
+      manifest_ref: '/repo/.apps/weather/manifest.json',
+      manifest_config: {
+        units: {
+          type: 'string',
+          required: false,
+        },
+        api_key: {
+          type: 'secret',
+          required: false,
+        },
+      },
+      config_entries: [
+        {
+          key: 'units',
+          value: 'metric',
+          source: 'project_config',
+          mutable: false,
+        },
+        {
+          key: 'api_key',
+          value: 'secret-token',
+          source: 'project_config',
+          mutable: false,
+        },
+      ],
+      panels: [
+        {
+          app_id: 'app:weather',
+          session_id: 'session-1',
+          panel_id: 'forecast',
+          label: 'Forecast',
+          entry: 'panels/forecast.tsx',
+          preserve_state: true,
+        },
+      ],
+    });
+
+    expect(registry.resolvePanel('app:weather', 'forecast')).toEqual(
+      expect.objectContaining({
+        config_snapshot: {
+          units: {
+            value: 'metric',
+            source: 'project_config',
+          },
+        },
+      }),
+    );
+    expect(
+      registry.resolvePanel('app:weather', 'forecast')?.config_snapshot.api_key,
+    ).toBeUndefined();
   });
 });

--- a/self/subcortex/apps/src/__tests__/panel-transpiler.test.ts
+++ b/self/subcortex/apps/src/__tests__/panel-transpiler.test.ts
@@ -26,6 +26,7 @@ async function createPanelDescriptor(
     manifest_ref: join(packageRoot, 'manifest.json'),
     route_path: '/apps/app%3Aweather/panels/forecast',
     dockview_panel_id: 'app:app:weather:forecast',
+    config_snapshot: {},
     ...overrides,
   };
 }

--- a/self/subcortex/apps/src/app-runtime-service.ts
+++ b/self/subcortex/apps/src/app-runtime-service.ts
@@ -22,6 +22,8 @@ import {
   type IAppRuntimeService,
   type ICommunicationGatewayService,
   type IPackageLifecycleOrchestrator,
+  type PanelBridgeToolTransportRequest,
+  PanelBridgeToolTransportRequestSchema,
   type PackageLifecycleTransitionRequest,
 } from '@nous/shared';
 import { AppHealthRegistry } from './app-health-registry.js';
@@ -103,6 +105,8 @@ export class AppRuntimeService implements IAppRuntimeService {
         session,
         package_root_ref: parsed.package_root_ref,
         manifest_ref: parsed.manifest_ref,
+        manifest_config: parsed.manifest.config,
+        config_entries: parsed.config,
         panels: parsed.panels,
       });
       const activeSession = this.updateSession({
@@ -228,6 +232,27 @@ export class AppRuntimeService implements IAppRuntimeService {
 
   async resolvePanel(appId: string, panelId: string) {
     return this.panelRegistry.resolvePanel(appId, panelId);
+  }
+
+  async executePanelTool(input: PanelBridgeToolTransportRequest): Promise<unknown> {
+    const parsed = PanelBridgeToolTransportRequestSchema.parse(input);
+    const panel = this.panelRegistry.resolvePanel(parsed.app_id, parsed.panel_id);
+    if (!panel) {
+      throw new Error('Active app panel not found.');
+    }
+
+    return this.bridge.invokeTool({
+      context: {
+        caller_type: 'app',
+        app_id: panel.app_id,
+        package_id: panel.package_id,
+        session_id: panel.session_id,
+        project_id: panel.project_id,
+        tool_id: `${panel.app_id}.${parsed.tool_name}`,
+        request_id: parsed.request_id,
+      },
+      params: parsed.params,
+    });
   }
 
   async recordHeartbeat(signal: import('@nous/shared').AppHeartbeatSignal): Promise<AppHealthSnapshot> {

--- a/self/subcortex/apps/src/mcp-ipc-bridge.ts
+++ b/self/subcortex/apps/src/mcp-ipc-bridge.ts
@@ -27,6 +27,7 @@ export interface AppOutboundToolEnvelope {
 
 export interface McpIpcBridgeOptions {
   sendHandshake?: (sessionId: string, handshake: AppActivationHandshake) => Promise<void> | void;
+  invokeTool?: (sessionId: string, envelope: AppOutboundToolEnvelope) => Promise<unknown> | unknown;
   projectScopedTools?: readonly string[];
 }
 
@@ -84,6 +85,18 @@ export class McpIpcBridge {
     }
 
     return parsed;
+  }
+
+  async invokeTool(payload: unknown): Promise<unknown> {
+    const parsed = this.parseOutboundToolEnvelope(payload);
+    if (!this.options.invokeTool) {
+      throw new NousError(
+        'App tool invocation bridge is unavailable',
+        'APP_TOOL_BRIDGE_UNAVAILABLE',
+      );
+    }
+
+    return this.options.invokeTool(parsed.context.session_id, parsed);
   }
 
   parseConnectorIngressIntent(payload: unknown): AppConnectorIngressIntent {

--- a/self/subcortex/apps/src/panel-registration.ts
+++ b/self/subcortex/apps/src/panel-registration.ts
@@ -1,25 +1,15 @@
 import {
+  AppPanelBridgeContextSchema,
+  AppPanelSafeConfigSnapshotSchema,
   AppPanelRegistrationProjectionSchema,
+  type AppConfig,
+  type AppHandshakeConfigEntry,
+  type AppPanelBridgeContext,
   type AppPanelRegistrationProjection,
   type AppRuntimeSession,
 } from '@nous/shared';
 
-export interface ResolvedAppPanelDescriptor {
-  session_id: string;
-  app_id: string;
-  package_id: string;
-  package_version: string;
-  project_id?: string;
-  panel_id: string;
-  label: string;
-  entry: string;
-  position?: AppPanelRegistrationProjection['position'];
-  preserve_state: boolean;
-  package_root_ref: string;
-  manifest_ref: string;
-  route_path: string;
-  dockview_panel_id: string;
-}
+export type ResolvedAppPanelDescriptor = AppPanelBridgeContext;
 
 function buildPanelRegistryKey(appId: string, panelId: string): string {
   return `${appId}::${panelId}`;
@@ -45,6 +35,8 @@ export class PanelRegistrationRegistry {
       >;
       package_root_ref: string;
       manifest_ref: string;
+      manifest_config?: AppConfig;
+      config_entries: readonly AppHandshakeConfigEntry[];
       panels: readonly AppPanelRegistrationProjection[];
     },
   ): ResolvedAppPanelDescriptor[] {
@@ -52,6 +44,10 @@ export class PanelRegistrationRegistry {
 
     const parsed = input.panels.map((panel) =>
       AppPanelRegistrationProjectionSchema.parse(panel),
+    );
+    const configSnapshot = buildPanelSafeConfigSnapshot(
+      input.manifest_config,
+      input.config_entries,
     );
     const descriptors = parsed.map((panel) => ({
       session_id: input.session.session_id,
@@ -68,7 +64,8 @@ export class PanelRegistrationRegistry {
       manifest_ref: input.manifest_ref,
       route_path: buildRoutePath(panel.app_id, panel.panel_id),
       dockview_panel_id: buildDockviewPanelId(panel.app_id, panel.panel_id),
-    }));
+      config_snapshot: configSnapshot,
+    })).map((descriptor) => AppPanelBridgeContextSchema.parse(descriptor));
 
     for (const descriptor of descriptors) {
       this.panelsByKey.set(
@@ -106,4 +103,25 @@ export class PanelRegistrationRegistry {
     this.panelsBySession.delete(sessionId);
     return panels;
   }
+}
+
+function buildPanelSafeConfigSnapshot(
+  manifestConfig: AppConfig | undefined,
+  configEntries: readonly AppHandshakeConfigEntry[],
+) {
+  const snapshot: Record<string, { value: unknown; source: AppHandshakeConfigEntry['source'] }> =
+    {};
+
+  for (const entry of configEntries) {
+    if (manifestConfig?.[entry.key]?.type === 'secret') {
+      continue;
+    }
+
+    snapshot[entry.key] = {
+      value: entry.value,
+      source: entry.source,
+    };
+  }
+
+  return AppPanelSafeConfigSnapshotSchema.parse(snapshot);
 }

--- a/self/subcortex/apps/src/panel-transpiler.ts
+++ b/self/subcortex/apps/src/panel-transpiler.ts
@@ -231,7 +231,7 @@ export class PanelTranspiler {
         return null;
       }
 
-      return {
+      const record: PersistedPanelTranspileCacheRecord = {
         cache_key: metadata.cache_key,
         app_id: metadata.app_id,
         panel_id: metadata.panel_id,
@@ -241,6 +241,10 @@ export class PanelTranspiler {
         descriptor_fingerprint: metadata.descriptor_fingerprint,
         source_fingerprint: metadata.source_fingerprint,
         generated_at: metadata.generated_at,
+      };
+
+      return {
+        ...record,
         bundle_js: bundleJs,
         bundle_path: cachePaths.bundlePath,
         metadata_path: cachePaths.metadataPath,

--- a/self/ui/package.json
+++ b/self/ui/package.json
@@ -16,6 +16,7 @@
     "./lib/cn": "./src/lib/cn.ts"
   },
   "dependencies": {
+    "@nous/shared": "workspace:*",
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.5.0"
   },

--- a/self/ui/src/panels/AppIframePanel.tsx
+++ b/self/ui/src/panels/AppIframePanel.tsx
@@ -1,12 +1,16 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import type { IDockviewPanelProps } from 'dockview-react'
+import type { PanelBridgeConfigSnapshot } from '@nous/shared'
+import { PanelBridgeHost } from './panel-bridge-host'
 
 interface AppIframePanelParams {
   appId: string
   panelId: string
   src: string
   preserveState?: boolean
+  configSnapshot?: PanelBridgeConfigSnapshot
 }
 
 interface AppIframePanelProps extends IDockviewPanelProps {
@@ -14,6 +18,31 @@ interface AppIframePanelProps extends IDockviewPanelProps {
 }
 
 export function AppIframePanel({ params }: AppIframePanelProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+
+  useEffect(() => {
+    if (!params?.src || !iframeRef.current) {
+      return
+    }
+
+    const bridgeHost = new PanelBridgeHost({
+      appId: params.appId,
+      panelId: params.panelId,
+      iframe: iframeRef.current,
+      mcpEndpoint: new URL('/mcp', params.src).toString(),
+      configSnapshot: params.configSnapshot ?? {},
+    })
+
+    return () => {
+      bridgeHost.destroy()
+    }
+  }, [
+    params?.appId,
+    params?.panelId,
+    params?.src,
+    JSON.stringify(params?.configSnapshot ?? {}),
+  ])
+
   if (!params?.src) {
     return (
       <div
@@ -43,6 +72,7 @@ export function AppIframePanel({ params }: AppIframePanelProps) {
       }}
     >
       <iframe
+        ref={iframeRef}
         title={`${params.appId}:${params.panelId}`}
         src={params.src}
         sandbox="allow-scripts"

--- a/self/ui/src/panels/panel-bridge-host.ts
+++ b/self/ui/src/panels/panel-bridge-host.ts
@@ -1,0 +1,262 @@
+import {
+  PANEL_BRIDGE_PROTOCOL_VERSION,
+  type PanelBridgeConfigSnapshot,
+  type PanelBridgeErrorCode,
+  PanelBridgePanelMessageSchema,
+  type PanelBridgeThemeSnapshot,
+  type PanelBridgeNotification,
+  PanelBridgeToolTransportRequestSchema,
+  PanelBridgeToolTransportResponseSchema,
+} from '@nous/shared';
+
+export interface PanelBridgeHostOptions {
+  appId: string;
+  panelId: string;
+  iframe: HTMLIFrameElement;
+  mcpEndpoint: string;
+  configSnapshot: PanelBridgeConfigSnapshot;
+  notifyAdapter?: (notification: PanelBridgeNotification) => Promise<boolean> | boolean;
+}
+
+export class PanelBridgeHost {
+  private readonly mediaQuery =
+    typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: dark)')
+      : null;
+
+  private readonly handleMessage = (event: MessageEvent) => {
+    if (event.source !== this.options.iframe.contentWindow) {
+      return;
+    }
+
+    const parsed = PanelBridgePanelMessageSchema.safeParse(event.data);
+    if (!parsed.success) {
+      this.postError({
+        code: 'message_invalid',
+        message: 'Invalid panel bridge message.',
+      });
+      return;
+    }
+
+    const message = parsed.data;
+    if (message.protocol !== PANEL_BRIDGE_PROTOCOL_VERSION) {
+      this.postError({
+        code: 'protocol_unsupported',
+        message: 'Unsupported panel bridge protocol version.',
+      });
+      return;
+    }
+
+    if ('app_id' in message && message.app_id !== this.options.appId) {
+      this.postError({
+        code: 'message_invalid',
+        message: 'Panel bridge app identity mismatch.',
+        requestId: 'request_id' in message ? message.request_id : undefined,
+      });
+      return;
+    }
+
+    if ('panel_id' in message && message.panel_id !== this.options.panelId) {
+      this.postError({
+        code: 'message_invalid',
+        message: 'Panel bridge panel identity mismatch.',
+        requestId: 'request_id' in message ? message.request_id : undefined,
+      });
+      return;
+    }
+
+    void this.dispatch(message);
+  };
+
+  private readonly handleThemeChange = () => {
+    this.postToPanel({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'theme.changed',
+      theme: this.buildThemeSnapshot(),
+    });
+  };
+
+  constructor(private readonly options: PanelBridgeHostOptions) {
+    window.addEventListener('message', this.handleMessage);
+    this.mediaQuery?.addEventListener?.('change', this.handleThemeChange);
+  }
+
+  destroy(): void {
+    window.removeEventListener('message', this.handleMessage);
+    this.mediaQuery?.removeEventListener?.('change', this.handleThemeChange);
+  }
+
+  private async dispatch(message: ReturnType<typeof PanelBridgePanelMessageSchema.parse>) {
+    switch (message.kind) {
+      case 'panel.ready':
+        this.postToPanel({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'host.bootstrap',
+          message_id: message.message_id,
+          config: this.options.configSnapshot,
+          theme: this.buildThemeSnapshot(),
+          capabilities: {
+            tool: true,
+            config: true,
+            theme: true,
+            notify: true,
+          },
+        });
+        return;
+      case 'config.get':
+        this.postToPanel({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'config.result',
+          request_id: message.request_id,
+          config: this.options.configSnapshot,
+        });
+        return;
+      case 'theme.get':
+        this.postToPanel({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'theme.result',
+          request_id: message.request_id,
+          theme: this.buildThemeSnapshot(),
+        });
+        return;
+      case 'notify.send':
+        await this.handleNotify(message.request_id, message.notification);
+        return;
+      case 'tool.invoke':
+        await this.handleToolInvoke(message);
+        return;
+    }
+  }
+
+  private async handleNotify(
+    requestId: string,
+    notification: PanelBridgeNotification,
+  ): Promise<void> {
+    try {
+      const accepted =
+        (await this.options.notifyAdapter?.(notification)) ??
+        this.dispatchLocalNotification(notification);
+      this.postToPanel({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        kind: 'notify.result',
+        request_id: requestId,
+        accepted,
+      });
+    } catch {
+      this.postError({
+        code: 'notify_unavailable',
+        message: 'Host notification adapter is unavailable.',
+        requestId,
+      });
+    }
+  }
+
+  private async handleToolInvoke(
+    message: Extract<
+      ReturnType<typeof PanelBridgePanelMessageSchema.parse>,
+      { kind: 'tool.invoke' }
+    >,
+  ): Promise<void> {
+    try {
+      const response = await fetch(this.options.mcpEndpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-nous-panel-bridge': '1',
+        },
+        body: JSON.stringify(
+          PanelBridgeToolTransportRequestSchema.parse({
+            protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+            request_id: message.request_id,
+            app_id: message.app_id,
+            panel_id: message.panel_id,
+            tool_name: message.tool_name,
+            params: message.params,
+          }),
+        ),
+      });
+
+      const body = await response.json();
+      const parsed = PanelBridgeToolTransportResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        this.postError({
+          code: 'internal_error',
+          message: 'Invalid MCP bridge response.',
+          requestId: message.request_id,
+        });
+        return;
+      }
+
+      if (parsed.data.ok) {
+        this.postToPanel({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'tool.result',
+          request_id: parsed.data.request_id,
+          result: parsed.data.result,
+        });
+        return;
+      }
+
+      this.postError({
+        ...parsed.data.error,
+        requestId: parsed.data.request_id,
+      });
+    } catch {
+      this.postError({
+        code: 'tool_execution_failed',
+        message: 'Panel tool invocation failed.',
+        requestId: message.request_id,
+      });
+    }
+  }
+
+  private buildThemeSnapshot(): PanelBridgeThemeSnapshot {
+    const styles = window.getComputedStyle(document.documentElement);
+    const mode =
+      document.documentElement.dataset['theme'] === 'light' ||
+      document.documentElement.classList.contains('theme-light')
+        ? 'light'
+        : 'dark';
+
+    return {
+      mode,
+      tokens: {
+        background: styles.getPropertyValue('--nous-bg').trim(),
+        surface: styles.getPropertyValue('--nous-surface').trim(),
+        foreground: styles.getPropertyValue('--nous-fg').trim(),
+        subtle: styles.getPropertyValue('--nous-fg-subtle').trim(),
+      },
+      metadata: {},
+    };
+  }
+
+  private dispatchLocalNotification(notification: PanelBridgeNotification): boolean {
+    window.dispatchEvent(
+      new CustomEvent('nous:panel-notify', {
+        detail: notification,
+      }),
+    );
+    return true;
+  }
+
+  private postError(input: {
+    code: PanelBridgeErrorCode;
+    message: string;
+    requestId?: string;
+  }): void {
+    this.postToPanel({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'error',
+      request_id: input.requestId,
+      error: {
+        code: input.code,
+        message: input.message,
+        retryable: false,
+      },
+    });
+  }
+
+  private postToPanel(message: unknown): void {
+    this.options.iframe.contentWindow?.postMessage(message, '*');
+  }
+}

--- a/self/ui/tsconfig.json
+++ b/self/ui/tsconfig.json
@@ -11,7 +11,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@nous/shared": ["../shared/src/index.ts"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

- Implements the canonical postMessage bridge seam (`PanelBridgeHost`) with host-side source validation, versioned protocol schemas, and MCP HTTP endpoint routing
- Adds the browser-runtime SDK (`@nous/app-sdk`) with `NousPanel`, `useTool`, `useConfig`, `useTheme`, `useNotify` — bridge client only, no host internal access
- Closes the `IAppRuntimeService` interface gap from Phase 15.1 with `listPanels()`, `resolvePanel()`, `executePanelTool()` signatures
- Adds `/apps/[appId]/panels/[panelId]` panel route with bridge bootstrap globals and trusted MCP transport bypass

## Verification

- 130 tests passing across 4 packages: shared (13), subcortex/apps (28), app-sdk (4), web (85)
- All 15 SDS invariants preserved; no new ADRs required
- Review verdict: **Approved** (`.worklog/phase-15/phase-15.2/review.mdx`)

## Follow-ups

- FU-7: Desktop smoke evidence for `AppIframePanel` + `PanelBridgeHost` (deferred to Phase 15.5)
- FU-8: Complete `self/apps/` tree listing in `repo-folder-structure.mdx` (documentation maintenance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)