### PR TITLE
Merge Phase 15.3 — Panel Lifecycle and Persisted State into phase-15

### DIFF
--- a/docs/content/docs/architecture/interaction-surfaces.mdx
+++ b/docs/content/docs/architecture/interaction-surfaces.mdx
@@ -148,6 +148,19 @@ The advanced Projects surface is still a projection and control surface, not a s
 - **Intent projects** — objective and constraint configuration, live activity monitoring, protocol emergence proposals
 - **Hybrid projects** — both views coexist within a single project
 
+### Installable App Panels
+
+Installable app panels remain trusted-host extensions inside the web shell rather than a separate
+interaction surface.
+
+- Panels mount as sandboxed iframe projections inside the existing trusted host surfaces
+- `preserveState` keeps an inactive panel hidden for the current session when the manifest requests
+  it, instead of treating hidden browser state as durable storage
+- Cross-session panel continuity flows through the trusted host bridge and runtime-owned persisted
+  state rather than host-local or browser-local storage
+- Panel-facing activation and deactivation helpers remain wrappers over the canonical
+  `panel_mount` / `panel_unmount` lifecycle seam, not a separate panel-local lifecycle model
+
 ---
 
 ## Surface 4 — MAO Operator Surface

--- a/docs/content/docs/architecture/repo-folder-structure.mdx
+++ b/docs/content/docs/architecture/repo-folder-structure.mdx
@@ -73,10 +73,21 @@ SDK consumed by installable apps. The Phase 15.2 in-scope surface is:
 * `useTheme`
 * `useNotify`
 
+Phase 15.3 extends the same SDK surface with:
+
+* `usePersistedState`
+* `onActivate`
+* `onDeactivate`
+
 Panels use this package to speak the canonical versioned `postMessage` bridge to the trusted host.
 The SDK is a bridge client and projection helper only: it lets sandboxed panel code invoke app
 tools and read host-projected config/theme state through the host bridge, while keeping host
 internals, privileged routing, and second-source-of-truth state out of the panel surface.
+
+The lifecycle and persistence split remains explicit. `preserveState` is host-owned in-session DOM
+preservation for iframe panels; it keeps inactive panels hidden without turning the browser into a
+durable state authority. Cross-session panel state flows through `usePersistedState` over the
+trusted host bridge and the canonical `/mcp` handoff into app-scoped runtime-owned state.
 
 ### cli/
 
@@ -101,7 +112,7 @@ Web application containing integrated operator surfaces:
 
 Primary interface for most users.
 
-The same app host also owns the machine-facing `/mcp` route and the `/.well-known/oauth-protected-resource/mcp` plus `/.well-known/oauth-authorization-server/mcp` discovery documents. The host remains transport-thin: it parses HTTP, composes shared services at bootstrap, and hands admitted work into the canonical gateway runtime rather than a web-local shadow API.
+The same app host also owns the machine-facing `/mcp` route and the `/.well-known/oauth-protected-resource/mcp` plus `/.well-known/oauth-authorization-server/mcp` discovery documents. The host remains transport-thin: it parses HTTP, composes shared services at bootstrap, and hands admitted work into the canonical gateway runtime rather than a web-local shadow API. The trusted app-panel host also uses this same `/mcp` boundary adapter for lifecycle reconciliation and persisted-state bridge traffic instead of introducing a second host-local persistence or control seam.
 
 ### bridge/
 

--- a/self/apps/app-sdk/src/__tests__/panel-bridge-client.test.ts
+++ b/self/apps/app-sdk/src/__tests__/panel-bridge-client.test.ts
@@ -75,6 +75,8 @@ describe('PanelBridgeClient', () => {
         config: true,
         theme: true,
         notify: true,
+        persisted_state: true,
+        lifecycle: true,
       },
     });
 
@@ -110,6 +112,8 @@ describe('PanelBridgeClient', () => {
         config: true,
         theme: true,
         notify: true,
+        persisted_state: true,
+        lifecycle: true,
       },
     });
     await handshake;
@@ -158,6 +162,8 @@ describe('PanelBridgeClient', () => {
         config: true,
         theme: true,
         notify: true,
+        persisted_state: true,
+        lifecycle: true,
       },
     });
     await handshake;
@@ -166,5 +172,79 @@ describe('PanelBridgeClient', () => {
     client.destroy();
 
     await expect(pending).rejects.toThrow('cancelled');
+  });
+
+  it('supports persisted-state requests and lifecycle subscriptions', async () => {
+    const parentWindow = installMockParent();
+    const client = new PanelBridgeClient({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    });
+
+    const lifecycleSpy = vi.fn();
+    const unsubscribe = client.subscribeLifecycle(lifecycleSpy);
+    const handshake = client.connect();
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'host.bootstrap',
+      message_id: 'msg-1',
+      config: {},
+      theme: {
+        mode: 'dark',
+        tokens: {},
+        metadata: {},
+      },
+      capabilities: {
+        tool: true,
+        config: true,
+        theme: true,
+        notify: true,
+        persisted_state: true,
+        lifecycle: true,
+      },
+    });
+    await handshake;
+
+    const pending = client.readPersistedState('filters');
+    const request = parentWindow.postMessage.mock.calls.at(-1)?.[0] as {
+      request_id: string;
+      key: string;
+    };
+
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'persisted_state.result',
+      request_id: request.request_id,
+      key: request.key,
+      exists: true,
+      value: {
+        city: 'Seattle',
+      },
+    });
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'panel.lifecycle',
+      event: 'panel_mount',
+      reason: 'activate',
+    });
+
+    await expect(pending).resolves.toEqual(
+      expect.objectContaining({
+        exists: true,
+        value: {
+          city: 'Seattle',
+        },
+      }),
+    );
+    expect(lifecycleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'panel_mount',
+        reason: 'activate',
+      }),
+    );
+
+    unsubscribe();
   });
 });

--- a/self/apps/app-sdk/src/__tests__/panel-hooks.test.tsx
+++ b/self/apps/app-sdk/src/__tests__/panel-hooks.test.tsx
@@ -4,8 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
 import { NousPanel } from '../panel/NousPanel.js';
 import {
+  onActivate,
+  onDeactivate,
   useConfig,
   useNotify,
+  usePersistedState,
   useTheme,
   useTool,
 } from '../panel/hooks.js';
@@ -21,6 +24,8 @@ function installMockParent() {
     postMessage: vi.fn((message: {
       kind: string;
       request_id?: string;
+      key?: string;
+      value?: unknown;
     }) => {
       queueMicrotask(() => {
         switch (message.kind) {
@@ -47,6 +52,8 @@ function installMockParent() {
                 config: true,
                 theme: true,
                 notify: true,
+                persisted_state: true,
+                lifecycle: true,
               },
             });
             return;
@@ -95,6 +102,37 @@ function installMockParent() {
               accepted: true,
             });
             return;
+          case 'persisted_state.get':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'persisted_state.result',
+              request_id: message.request_id!,
+              key: message.key!,
+              exists: true,
+              value: {
+                city: 'Seattle',
+              },
+            });
+            return;
+          case 'persisted_state.set':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'persisted_state.result',
+              request_id: message.request_id!,
+              key: message.key!,
+              exists: true,
+              value: message.value,
+            });
+            return;
+          case 'persisted_state.delete':
+            dispatchFromParent({
+              protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+              kind: 'persisted_state.result',
+              request_id: message.request_id!,
+              key: message.key!,
+              exists: false,
+            });
+            return;
         }
       });
     }),
@@ -125,6 +163,7 @@ describe('@nous/app-sdk panel hooks', () => {
 
   it('exposes tool, config, theme, and notify behavior through the bridge', async () => {
     installMockParent();
+    const localStorageSpy = vi.spyOn(Storage.prototype, 'getItem');
     window.__NOUS_PANEL_BRIDGE_BOOTSTRAP__ = {
       protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
       app_id: 'app:weather',
@@ -138,14 +177,26 @@ describe('@nous/app-sdk panel hooks', () => {
           config: ReturnType<typeof useConfig>;
           theme: ReturnType<typeof useTheme>;
           notify: ReturnType<typeof useNotify>;
+          persisted: ReturnType<typeof usePersistedState<{ city: string }>>;
         }
       | undefined;
+    let activationCount = 0;
+    let deactivationCount = 0;
 
     function Harness() {
       const invokeTool = useTool('get_forecast');
       const config = useConfig();
       const theme = useTheme();
       const notify = useNotify();
+      const persisted = usePersistedState('filters', {
+        city: 'Portland',
+      });
+      onActivate(() => {
+        activationCount += 1;
+      });
+      onDeactivate(() => {
+        deactivationCount += 1;
+      });
 
       useEffect(() => {
         latest = {
@@ -153,10 +204,16 @@ describe('@nous/app-sdk panel hooks', () => {
           config,
           theme,
           notify,
+          persisted,
         };
-      }, [invokeTool, config, theme, notify]);
+      }, [invokeTool, config, theme, notify, persisted]);
 
-      return <div data-testid="units">{String(config.config.units?.value ?? '')}</div>;
+      return (
+        <div>
+          <div data-testid="units">{String(config.config.units?.value ?? '')}</div>
+          <div data-testid="persisted-city">{persisted[0].city}</div>
+        </div>
+      );
     }
 
     const screen = render(
@@ -167,6 +224,7 @@ describe('@nous/app-sdk panel hooks', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('units').textContent).toBe('metric');
+      expect(screen.getByTestId('persisted-city').textContent).toBe('Seattle');
       expect(latest).toBeDefined();
     });
 
@@ -197,5 +255,40 @@ describe('@nous/app-sdk panel hooks', () => {
       });
     });
     expect(notifyAccepted).toBe(true);
+
+    await act(async () => {
+      await latest!.persisted[1]({
+        city: 'Vancouver',
+      });
+    });
+    expect(latest!.persisted[0]).toEqual({
+      city: 'Vancouver',
+    });
+
+    await act(async () => {
+      await latest!.persisted[2].clear();
+    });
+    expect(latest!.persisted[0]).toEqual({
+      city: 'Portland',
+    });
+
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'panel.lifecycle',
+      event: 'panel_mount',
+      reason: 'activate',
+    });
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'panel.lifecycle',
+      event: 'panel_unmount',
+      reason: 'deactivate',
+    });
+
+    await waitFor(() => {
+      expect(activationCount).toBe(1);
+      expect(deactivationCount).toBe(1);
+    });
+    expect(localStorageSpy).not.toHaveBeenCalled();
   });
 });

--- a/self/apps/app-sdk/src/panel/hooks.ts
+++ b/self/apps/app-sdk/src/panel/hooks.ts
@@ -1,5 +1,6 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import type {
+  PanelLifecycleChangedMessage,
   PanelBridgeConfigSnapshot,
   PanelBridgeNotification,
   PanelBridgeThemeSnapshot,
@@ -57,4 +58,138 @@ export function useNotify() {
   return async (notification: PanelBridgeNotification): Promise<boolean> => {
     return context.client.sendNotify(notification);
   };
+}
+
+export function usePersistedState<T>(
+  key: string,
+  initialValue: T,
+): [
+  T,
+  (value: T | ((current: T) => T)) => Promise<void>,
+  {
+    hydrated: boolean;
+    error: Error | null;
+    clear: () => Promise<void>;
+  },
+] {
+  const context = usePanelSdkContext();
+  const [value, setValue] = useState<T>(initialValue);
+  const [hydrated, setHydrated] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const initialValueRef = useRef(initialValue);
+  const committedValueRef = useRef<T>(initialValue);
+
+  useEffect(() => {
+    let active = true;
+    setHydrated(false);
+    setError(null);
+
+    void context.client
+      .readPersistedState(key)
+      .then((result) => {
+        if (!active) {
+          return;
+        }
+
+        const nextValue = (
+          result.exists ? result.value : initialValueRef.current
+        ) as T;
+        committedValueRef.current = nextValue;
+        setValue(nextValue);
+        setHydrated(true);
+      })
+      .catch((nextError) => {
+        if (!active) {
+          return;
+        }
+
+        setError(
+          nextError instanceof Error
+            ? nextError
+            : new Error('Persisted state hydration failed.'),
+        );
+        setHydrated(true);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [context.client, key]);
+
+  const persistValue = async (
+    nextValueOrUpdater: T | ((current: T) => T),
+  ): Promise<void> => {
+    const previousValue = committedValueRef.current;
+    const nextValue =
+      typeof nextValueOrUpdater === 'function'
+        ? (nextValueOrUpdater as (current: T) => T)(previousValue)
+        : nextValueOrUpdater;
+
+    setValue(nextValue);
+    setError(null);
+
+    try {
+      const result = await context.client.writePersistedState(key, nextValue);
+      committedValueRef.current = (result.exists ? result.value : nextValue) as T;
+      setValue(committedValueRef.current);
+    } catch (nextError) {
+      committedValueRef.current = previousValue;
+      setValue(previousValue);
+      const normalizedError =
+        nextError instanceof Error
+          ? nextError
+          : new Error('Persisted state write failed.');
+      setError(normalizedError);
+      throw normalizedError;
+    }
+  };
+
+  const clear = async (): Promise<void> => {
+    try {
+      await context.client.deletePersistedState(key);
+      committedValueRef.current = initialValueRef.current;
+      setValue(initialValueRef.current);
+      setError(null);
+    } catch (nextError) {
+      const normalizedError =
+        nextError instanceof Error
+          ? nextError
+          : new Error('Persisted state delete failed.');
+      setError(normalizedError);
+      throw normalizedError;
+    }
+  };
+
+  return [
+    value,
+    persistValue,
+    {
+      hydrated,
+      error,
+      clear,
+    },
+  ];
+}
+
+function usePanelLifecycleSubscription(
+  targetEvent: PanelLifecycleChangedMessage['event'],
+  handler: () => void,
+): void {
+  const context = usePanelSdkContext();
+
+  useEffect(() => {
+    return context.client.subscribeLifecycle((event) => {
+      if (event.event === targetEvent) {
+        handler();
+      }
+    });
+  }, [context.client, handler, targetEvent]);
+}
+
+export function onActivate(handler: () => void): void {
+  usePanelLifecycleSubscription('panel_mount', handler);
+}
+
+export function onDeactivate(handler: () => void): void {
+  usePanelLifecycleSubscription('panel_unmount', handler);
 }

--- a/self/apps/app-sdk/src/panel/index.ts
+++ b/self/apps/app-sdk/src/panel/index.ts
@@ -1,2 +1,10 @@
 export { NousPanel } from './NousPanel.js';
-export { useTool, useConfig, useTheme, useNotify } from './hooks.js';
+export {
+  useTool,
+  useConfig,
+  useTheme,
+  useNotify,
+  usePersistedState,
+  onActivate,
+  onDeactivate,
+} from './hooks.js';

--- a/self/apps/app-sdk/src/panel/panel-bridge-client.ts
+++ b/self/apps/app-sdk/src/panel/panel-bridge-client.ts
@@ -1,10 +1,12 @@
 import {
+  type PanelLifecycleChangedMessage,
   PANEL_BRIDGE_PROTOCOL_VERSION,
   type HostBootstrapMessage,
   type PanelBridgeConfigSnapshot,
   type PanelBridgeHostMessage,
   PanelBridgeHostMessageSchema,
   type PanelBridgeNotification,
+  type PanelPersistedStateResponse,
   type PanelBridgeThemeSnapshot,
   type PanelBridgeWindowBootstrap,
 } from '@nous/shared';
@@ -38,6 +40,9 @@ export class PanelBridgeClient {
   private readonly themeListeners = new Set<
     (theme: PanelBridgeThemeSnapshot) => void
   >();
+  private readonly lifecycleListeners = new Set<
+    (event: PanelLifecycleChangedMessage) => void
+  >();
 
   private handshakeResolver?: (message: HostBootstrapMessage) => void;
   private handshakeRejector?: (error: Error) => void;
@@ -67,6 +72,13 @@ export class PanelBridgeClient {
     if (message.kind === 'theme.changed') {
       for (const listener of this.themeListeners) {
         listener(message.theme);
+      }
+      return;
+    }
+
+    if (message.kind === 'panel.lifecycle') {
+      for (const listener of this.lifecycleListeners) {
+        listener(message);
       }
       return;
     }
@@ -135,6 +147,15 @@ export class PanelBridgeClient {
     };
   }
 
+  subscribeLifecycle(
+    listener: (event: PanelLifecycleChangedMessage) => void,
+  ): () => void {
+    this.lifecycleListeners.add(listener);
+    return () => {
+      this.lifecycleListeners.delete(listener);
+    };
+  }
+
   async invokeTool(toolName: string, params?: unknown): Promise<unknown> {
     const message = await this.request({
       protocol: this.bootstrap.protocol,
@@ -196,15 +217,75 @@ export class PanelBridgeClient {
     return message.accepted;
   }
 
+  async readPersistedState(key: string): Promise<PanelPersistedStateResponse> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'persisted_state.get',
+      request_id: createRequestId(),
+      key,
+    });
+
+    if (message.kind !== 'persisted_state.result') {
+      throw new Error('Unexpected persisted-state response.');
+    }
+
+    return message;
+  }
+
+  async writePersistedState(
+    key: string,
+    value: unknown,
+  ): Promise<PanelPersistedStateResponse> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'persisted_state.set',
+      request_id: createRequestId(),
+      key,
+      value,
+    });
+
+    if (message.kind !== 'persisted_state.result') {
+      throw new Error('Unexpected persisted-state response.');
+    }
+
+    return message;
+  }
+
+  async deletePersistedState(
+    key: string,
+  ): Promise<PanelPersistedStateResponse> {
+    const message = await this.request({
+      protocol: this.bootstrap.protocol,
+      kind: 'persisted_state.delete',
+      request_id: createRequestId(),
+      key,
+    });
+
+    if (message.kind !== 'persisted_state.result') {
+      throw new Error('Unexpected persisted-state response.');
+    }
+
+    return message;
+  }
+
   private request(message: {
     protocol: number;
-    kind: 'tool.invoke' | 'config.get' | 'theme.get' | 'notify.send';
+    kind:
+      | 'tool.invoke'
+      | 'config.get'
+      | 'theme.get'
+      | 'notify.send'
+      | 'persisted_state.get'
+      | 'persisted_state.set'
+      | 'persisted_state.delete';
     request_id: string;
     app_id?: string;
     panel_id?: string;
     tool_name?: string;
     params?: unknown;
     notification?: PanelBridgeNotification;
+    key?: string;
+    value?: unknown;
   }): Promise<PanelBridgeHostMessage> {
     return new Promise((resolve, reject) => {
       const timeoutId = window.setTimeout(() => {

--- a/self/apps/web/__tests__/app-panel-bridge-host.test.tsx
+++ b/self/apps/web/__tests__/app-panel-bridge-host.test.tsx
@@ -6,13 +6,38 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
 import { AppIframePanel } from '@nous/ui/panels';
 
+function createPanelApiHarness() {
+  const activeListeners = new Set<(event: { isActive: boolean }) => void>();
+
+  return {
+    api: {
+      setRenderer: vi.fn(),
+      onDidActiveChange: (listener: (event: { isActive: boolean }) => void) => {
+        activeListeners.add(listener);
+        return {
+          dispose: () => {
+            activeListeners.delete(listener);
+          },
+        };
+      },
+    },
+    emitActive(isActive: boolean) {
+      for (const listener of activeListeners) {
+        listener({ isActive });
+      }
+    },
+  };
+}
+
 describe('AppIframePanel host bridge', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('boots the trusted host bridge and routes tool calls through the MCP endpoint', async () => {
+  it('boots the trusted host bridge, emits lifecycle, and routes tool calls through the MCP endpoint', async () => {
+    const panelHarness = createPanelApiHarness();
     const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
       json: async () => ({
         protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
         request_id: 'req-1',
@@ -27,6 +52,7 @@ describe('AppIframePanel host bridge', () => {
     const view = render(
       <AppIframePanel
         {...({
+          api: panelHarness.api,
           params: {
             appId: 'app:weather',
             panelId: 'forecast',
@@ -68,6 +94,7 @@ describe('AppIframePanel host bridge', () => {
         '*',
       );
     });
+    expect(panelHarness.api.setRenderer).toHaveBeenCalledWith('always');
 
     window.dispatchEvent(
       new MessageEvent('message', {
@@ -93,6 +120,19 @@ describe('AppIframePanel host bridge', () => {
           method: 'POST',
           headers: expect.objectContaining({
             'x-nous-panel-bridge': '1',
+          }),
+        }),
+      );
+    });
+
+    panelHarness.emitActive(false);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:3000/mcp',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-nous-panel-bridge-operation': 'panel.lifecycle',
           }),
         }),
       );
@@ -137,5 +177,147 @@ describe('AppIframePanel host bridge', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes persisted-state requests and uses non-preserved renderer semantics', async () => {
+    const panelHarness = createPanelApiHarness();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: 'req-2',
+        ok: true,
+        key: 'filters',
+        exists: true,
+        value: {
+          city: 'Seattle',
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const view = render(
+      <AppIframePanel
+        {...({
+          api: panelHarness.api,
+          params: {
+            appId: 'app:weather',
+            panelId: 'forecast',
+            src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            preserveState: false,
+            configSnapshot: {},
+          },
+        } as any)}
+      />,
+    );
+
+    const iframe = view.container.querySelector('iframe');
+    const postMessageSpy = vi.spyOn(iframe!.contentWindow!, 'postMessage');
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe!.contentWindow,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'panel.ready',
+          message_id: 'msg-2',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+        },
+      }),
+    );
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe!.contentWindow,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'persisted_state.get',
+          request_id: 'req-2',
+          key: 'filters',
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:3000/mcp',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-nous-panel-bridge-operation': 'persisted_state.get',
+          }),
+        }),
+      );
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'persisted_state.result',
+          key: 'filters',
+          exists: true,
+        }),
+        '*',
+      );
+    });
+    expect(panelHarness.api.setRenderer).toHaveBeenCalledWith('onlyWhenVisible');
+  });
+
+  it('emits canonical unmount lifecycle updates on host reload and panel close', async () => {
+    const panelHarness = createPanelApiHarness();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: 'req-3',
+        ok: true,
+        result: {},
+      }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const view = render(
+      <AppIframePanel
+        {...({
+          api: panelHarness.api,
+          params: {
+            appId: 'app:weather',
+            panelId: 'forecast',
+            src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configSnapshot: {},
+          },
+        } as any)}
+      />,
+    );
+
+    const iframe = view.container.querySelector('iframe');
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe!.contentWindow,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'panel.ready',
+          message_id: 'msg-3',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+        },
+      }),
+    );
+
+    window.dispatchEvent(new Event('beforeunload'));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:3000/mcp',
+        expect.objectContaining({
+          body: expect.stringContaining('"reason":"host_reload"'),
+        }),
+      );
+    });
+
+    view.unmount();
+
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      'http://localhost:3000/mcp',
+      expect.objectContaining({
+        body: expect.stringContaining('"reason":"close"'),
+      }),
+    );
   });
 });

--- a/self/apps/web/app/mcp/route.ts
+++ b/self/apps/web/app/mcp/route.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import {
+  AppPanelLifecycleUpdateSchema,
   PANEL_BRIDGE_PROTOCOL_VERSION,
+  PanelPersistedStateTransportDeleteRequestSchema,
+  PanelPersistedStateTransportGetRequestSchema,
+  PanelPersistedStateTransportResultSchema,
+  PanelPersistedStateTransportSetRequestSchema,
   PublicMcpExecutionRequestSchema,
   PublicMcpRpcRequestSchema,
   PanelBridgeToolTransportFailureSchema,
@@ -63,8 +68,194 @@ function extractPanelBridgeRequestId(body: unknown): string {
 }
 
 async function handlePanelBridgeRequest(
+  request: Request,
   body: unknown,
 ): Promise<Response | null> {
+  const operation = request.headers.get('x-nous-panel-bridge-operation');
+
+  if (operation === 'panel.lifecycle') {
+    const parsed = AppPanelLifecycleUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return new Response('Invalid panel lifecycle update.', { status: 400 });
+    }
+
+    const descriptor = await createNousContext().appRuntimeService.recordPanelLifecycle(
+      parsed.data,
+    );
+    return new Response(null, {
+      status: descriptor ? 204 : 404,
+    });
+  }
+
+  if (operation === 'persisted_state.get') {
+    const parsed = PanelPersistedStateTransportGetRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return Response.json(
+        PanelBridgeToolTransportFailureSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: extractPanelBridgeRequestId(body),
+          ok: false,
+          error: {
+            code: 'message_invalid',
+            message: 'Invalid persisted-state get request.',
+            retryable: false,
+          },
+        }),
+        { status: 400 },
+      );
+    }
+
+    try {
+      const result = await createNousContext().appRuntimeService.getPersistedPanelState({
+        app_id: parsed.data.app_id,
+        panel_id: parsed.data.panel_id,
+        key: parsed.data.key,
+      });
+      return Response.json(
+        PanelPersistedStateTransportResultSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: parsed.data.request_id,
+          ok: true,
+          key: parsed.data.key,
+          exists: result.exists,
+          value: result.value,
+        }),
+        { status: 200 },
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message.length > 0
+          ? error.message
+          : 'Persisted state read failed.';
+      return Response.json(
+        PanelBridgeToolTransportFailureSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: parsed.data.request_id,
+          ok: false,
+          error: {
+            code: message === 'Active app panel not found.' ? 'host_unavailable' : 'internal_error',
+            message,
+            retryable: false,
+          },
+        }),
+        { status: message === 'Active app panel not found.' ? 404 : 502 },
+      );
+    }
+  }
+
+  if (operation === 'persisted_state.set') {
+    const parsed = PanelPersistedStateTransportSetRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return Response.json(
+        PanelBridgeToolTransportFailureSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: extractPanelBridgeRequestId(body),
+          ok: false,
+          error: {
+            code: 'message_invalid',
+            message: 'Invalid persisted-state set request.',
+            retryable: false,
+          },
+        }),
+        { status: 400 },
+      );
+    }
+
+    try {
+      const result = await createNousContext().appRuntimeService.setPersistedPanelState({
+        app_id: parsed.data.app_id,
+        panel_id: parsed.data.panel_id,
+        key: parsed.data.key,
+        value: parsed.data.value,
+      });
+      return Response.json(
+        PanelPersistedStateTransportResultSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: parsed.data.request_id,
+          ok: true,
+          key: parsed.data.key,
+          exists: result.exists,
+          value: result.value,
+        }),
+        { status: 200 },
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message.length > 0
+          ? error.message
+          : 'Persisted state write failed.';
+      return Response.json(
+        PanelBridgeToolTransportFailureSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: parsed.data.request_id,
+          ok: false,
+          error: {
+            code: message === 'Active app panel not found.' ? 'host_unavailable' : 'internal_error',
+            message,
+            retryable: false,
+          },
+        }),
+        { status: message === 'Active app panel not found.' ? 404 : 502 },
+      );
+    }
+  }
+
+  if (operation === 'persisted_state.delete') {
+    const parsed = PanelPersistedStateTransportDeleteRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return Response.json(
+        PanelBridgeToolTransportFailureSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: extractPanelBridgeRequestId(body),
+          ok: false,
+          error: {
+            code: 'message_invalid',
+            message: 'Invalid persisted-state delete request.',
+            retryable: false,
+          },
+        }),
+        { status: 400 },
+      );
+    }
+
+    try {
+      const result = await createNousContext().appRuntimeService.deletePersistedPanelState({
+        app_id: parsed.data.app_id,
+        panel_id: parsed.data.panel_id,
+        key: parsed.data.key,
+      });
+      return Response.json(
+        PanelPersistedStateTransportResultSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: parsed.data.request_id,
+          ok: true,
+          key: parsed.data.key,
+          exists: result.exists,
+          value: result.value,
+        }),
+        { status: 200 },
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message.length > 0
+          ? error.message
+          : 'Persisted state delete failed.';
+      return Response.json(
+        PanelBridgeToolTransportFailureSchema.parse({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: parsed.data.request_id,
+          ok: false,
+          error: {
+            code: message === 'Active app panel not found.' ? 'host_unavailable' : 'internal_error',
+            message,
+            retryable: false,
+          },
+        }),
+        { status: message === 'Active app panel not found.' ? 404 : 502 },
+      );
+    }
+  }
+
   const parsed = PanelBridgeToolTransportRequestSchema.safeParse(body);
   if (!parsed.success) {
     return Response.json(
@@ -127,7 +318,7 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   if (request.headers.get('x-nous-panel-bridge') === '1') {
-    const panelBridgeResponse = await handlePanelBridgeRequest(body);
+    const panelBridgeResponse = await handlePanelBridgeRequest(request, body);
     if (panelBridgeResponse) {
       return panelBridgeResponse;
     }

--- a/self/apps/web/server/__tests__/public-mcp-route.test.ts
+++ b/self/apps/web/server/__tests__/public-mcp-route.test.ts
@@ -65,6 +65,55 @@ describe('public MCP route', () => {
     );
   });
 
+  it('routes trusted persisted-state bridge requests through the MCP endpoint without public bearer auth', async () => {
+    process.env.NOUS_DATA_DIR = join(tmpdir(), `nous-web-public-mcp-${randomUUID()}`);
+    clearNousContextCache();
+    const ctx = createNousContext();
+    const getPersistedPanelState = vi
+      .spyOn(ctx.appRuntimeService, 'getPersistedPanelState')
+      .mockResolvedValue({
+        app_id: 'app:weather',
+        panel_id: 'forecast',
+        key: 'filters',
+        exists: true,
+        value: {
+          city: 'Seattle',
+        },
+        updated_at: '2026-03-18T00:00:00.000Z',
+      });
+
+    const response = await POST(
+      new Request('http://localhost:3000/mcp', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-nous-panel-bridge': '1',
+          'x-nous-panel-bridge-operation': 'persisted_state.get',
+        },
+        body: JSON.stringify({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: 'req-2',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+          key: 'filters',
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.exists).toBe(true);
+    expect(body.value).toEqual({
+      city: 'Seattle',
+    });
+    expect(getPersistedPanelState).toHaveBeenCalledWith({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+    });
+  });
+
   it('rejects missing bearer before tool execution', async () => {
     process.env.NOUS_DATA_DIR = join(tmpdir(), `nous-web-public-mcp-${randomUUID()}`);
     clearNousContextCache();

--- a/self/shared/src/__tests__/types/app-runtime.test.ts
+++ b/self/shared/src/__tests__/types/app-runtime.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   AppActivationHandshakeSchema,
   AppPanelBridgeContextSchema,
+  AppPanelLifecycleUpdateSchema,
   AppPanelSafeConfigSnapshotSchema,
+  AppPanelPersistedStateResultSchema,
   AppConnectorEgressIntentSchema,
   AppConnectorIngressIntentSchema,
   AppConnectorSessionReportSchema,
@@ -96,9 +98,52 @@ describe('AppPanel bridge runtime schemas', () => {
       route_path: '/apps/app%3Aweather/panels/forecast',
       dockview_panel_id: 'app:app:weather:forecast',
       config_snapshot: snapshot,
+      lifecycle: {
+        event: 'panel_mount',
+        reason: 'open',
+        updated_at: '2026-03-18T00:00:00.000Z',
+      },
     });
 
     expect(context.config_snapshot.units?.value).toBe('metric');
+    expect(context.lifecycle?.event).toBe('panel_mount');
+  });
+});
+
+describe('App panel lifecycle and persisted-state schemas', () => {
+  it('accepts canonical lifecycle updates', () => {
+    const result = AppPanelLifecycleUpdateSchema.safeParse({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      event: 'panel_mount',
+      reason: 'activate',
+      occurred_at: '2026-03-18T00:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts persisted-state results with and without a stored value', () => {
+    const hit = AppPanelPersistedStateResultSchema.safeParse({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+      exists: true,
+      value: {
+        city: 'Seattle',
+      },
+      updated_at: '2026-03-18T00:00:00.000Z',
+    });
+    const miss = AppPanelPersistedStateResultSchema.safeParse({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+      exists: false,
+      updated_at: '2026-03-18T00:00:00.000Z',
+    });
+
+    expect(hit.success).toBe(true);
+    expect(miss.success).toBe(true);
   });
 });
 

--- a/self/shared/src/__tests__/types/panel-bridge-protocol.test.ts
+++ b/self/shared/src/__tests__/types/panel-bridge-protocol.test.ts
@@ -3,6 +3,7 @@ import {
   PANEL_BRIDGE_PROTOCOL_VERSION,
   PanelBridgeHostMessageSchema,
   PanelBridgePanelMessageSchema,
+  PanelPersistedStateTransportResultSchema,
   PanelBridgeToolTransportRequestSchema,
   PanelBridgeToolTransportResponseSchema,
   PanelBridgeWindowBootstrapSchema,
@@ -46,6 +47,8 @@ describe('panel bridge shared protocol types', () => {
         config: true,
         theme: true,
         notify: true,
+        persisted_state: true,
+        lifecycle: true,
       },
     });
 
@@ -89,5 +92,34 @@ describe('panel bridge shared protocol types', () => {
 
     expect(request.tool_name).toBe('get_forecast');
     expect(failure.ok).toBe(false);
+  });
+
+  it('parses persisted-state bridge requests, results, and lifecycle pushes', () => {
+    const getRequest = PanelBridgePanelMessageSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'persisted_state.get',
+      request_id: 'req-2',
+      key: 'filters',
+    });
+    const lifecycle = PanelBridgeHostMessageSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'panel.lifecycle',
+      event: 'panel_mount',
+      reason: 'activate',
+    });
+    const result = PanelPersistedStateTransportResultSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      request_id: 'req-2',
+      ok: true,
+      key: 'filters',
+      exists: true,
+      value: {
+        city: 'Seattle',
+      },
+    });
+
+    expect(getRequest.kind).toBe('persisted_state.get');
+    expect(lifecycle.kind).toBe('panel.lifecycle');
+    expect(result.exists).toBe(true);
   });
 });

--- a/self/shared/src/index.ts
+++ b/self/shared/src/index.ts
@@ -9,6 +9,30 @@ export * from './interfaces/index.js';
 export * from './events/index.js';
 export * from './errors/index.js';
 export * from './types/app-credentials.js';
+export {
+  AppPanelLifecycleEventSchema,
+  AppPanelLifecycleProjectionSchema,
+  AppPanelLifecycleReasonSchema,
+  AppPanelLifecycleUpdateSchema,
+  AppPanelPersistedStateDeleteInputSchema,
+  AppPanelPersistedStateGetInputSchema,
+  AppPanelPersistedStateKeySchema,
+  AppPanelPersistedStateResultSchema,
+  AppPanelPersistedStateSetInputSchema,
+  AppPanelPersistedStateValueSchema,
+} from './types/app-runtime.js';
+export type {
+  AppPanelLifecycleEvent,
+  AppPanelLifecycleProjection,
+  AppPanelLifecycleReason,
+  AppPanelLifecycleUpdate,
+  AppPanelPersistedStateDeleteInput,
+  AppPanelPersistedStateGetInput,
+  AppPanelPersistedStateKey,
+  AppPanelPersistedStateResult,
+  AppPanelPersistedStateSetInput,
+  AppPanelPersistedStateValue,
+} from './types/app-runtime.js';
 export type { GatewayExecutionContext } from './types/agent-gateway.js';
 export type {
   IAppCredentialInstallService,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -201,6 +201,11 @@ import type {
   PublicMcpTaskProjection,
   PublicMcpTaskResult,
   PublicMcpToolDefinition,
+  AppPanelLifecycleUpdate,
+  AppPanelPersistedStateDeleteInput,
+  AppPanelPersistedStateGetInput,
+  AppPanelPersistedStateResult,
+  AppPanelPersistedStateSetInput,
   PanelBridgeToolTransportRequest,
   PromoteExternalRecordCommand,
   DemotePromotedRecordCommand,
@@ -875,6 +880,24 @@ export interface IAppRuntimeService {
 
   /** Execute one panel tool request through the runtime-owned app bridge. */
   executePanelTool(input: PanelBridgeToolTransportRequest): Promise<unknown>;
+
+  /** Reconcile one canonical panel lifecycle event against the active runtime projection. */
+  recordPanelLifecycle(input: AppPanelLifecycleUpdate): Promise<AppPanelBridgeContext | null>;
+
+  /** Read one app-owned persisted panel state value through the runtime seam. */
+  getPersistedPanelState(
+    input: AppPanelPersistedStateGetInput,
+  ): Promise<AppPanelPersistedStateResult>;
+
+  /** Write one app-owned persisted panel state value through the runtime seam. */
+  setPersistedPanelState(
+    input: AppPanelPersistedStateSetInput,
+  ): Promise<AppPanelPersistedStateResult>;
+
+  /** Delete one app-owned persisted panel state value through the runtime seam. */
+  deletePersistedPanelState(
+    input: AppPanelPersistedStateDeleteInput,
+  ): Promise<AppPanelPersistedStateResult>;
 
   /** Record one heartbeat signal and return the resulting health snapshot. */
   recordHeartbeat(signal: AppHeartbeatSignal): Promise<AppHealthSnapshot>;

--- a/self/shared/src/types/app-runtime.ts
+++ b/self/shared/src/types/app-runtime.ts
@@ -102,6 +102,37 @@ export type AppPanelSafeConfigSnapshot = z.infer<
   typeof AppPanelSafeConfigSnapshotSchema
 >;
 
+export const AppPanelLifecycleEventSchema = z.enum([
+  'panel_mount',
+  'panel_unmount',
+]);
+export type AppPanelLifecycleEvent = z.infer<
+  typeof AppPanelLifecycleEventSchema
+>;
+
+export const AppPanelLifecycleReasonSchema = z.enum([
+  'open',
+  'activate',
+  'deactivate',
+  'close',
+  'remove',
+  'update',
+  'unload',
+  'host_reload',
+]);
+export type AppPanelLifecycleReason = z.infer<
+  typeof AppPanelLifecycleReasonSchema
+>;
+
+export const AppPanelLifecycleProjectionSchema = z.object({
+  event: AppPanelLifecycleEventSchema,
+  reason: AppPanelLifecycleReasonSchema,
+  updated_at: z.string().datetime(),
+});
+export type AppPanelLifecycleProjection = z.infer<
+  typeof AppPanelLifecycleProjectionSchema
+>;
+
 export const AppPanelBridgeContextSchema = z.object({
   session_id: z.string().min(1),
   app_id: z.string().min(1),
@@ -118,9 +149,66 @@ export const AppPanelBridgeContextSchema = z.object({
   route_path: z.string().min(1),
   dockview_panel_id: z.string().min(1),
   config_snapshot: AppPanelSafeConfigSnapshotSchema.default({}),
+  lifecycle: AppPanelLifecycleProjectionSchema.optional(),
 });
 export type AppPanelBridgeContext = z.infer<
   typeof AppPanelBridgeContextSchema
+>;
+
+export const AppPanelLifecycleUpdateSchema = z.object({
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  event: AppPanelLifecycleEventSchema,
+  reason: AppPanelLifecycleReasonSchema,
+  occurred_at: z.string().datetime(),
+});
+export type AppPanelLifecycleUpdate = z.infer<
+  typeof AppPanelLifecycleUpdateSchema
+>;
+
+export const AppPanelPersistedStateKeySchema = z.string().min(1);
+export type AppPanelPersistedStateKey = z.infer<
+  typeof AppPanelPersistedStateKeySchema
+>;
+
+export const AppPanelPersistedStateValueSchema = z.unknown();
+export type AppPanelPersistedStateValue = z.infer<
+  typeof AppPanelPersistedStateValueSchema
+>;
+
+export const AppPanelPersistedStateGetInputSchema = z.object({
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  key: AppPanelPersistedStateKeySchema,
+});
+export type AppPanelPersistedStateGetInput = z.infer<
+  typeof AppPanelPersistedStateGetInputSchema
+>;
+
+export const AppPanelPersistedStateSetInputSchema =
+  AppPanelPersistedStateGetInputSchema.extend({
+    value: AppPanelPersistedStateValueSchema,
+  });
+export type AppPanelPersistedStateSetInput = z.infer<
+  typeof AppPanelPersistedStateSetInputSchema
+>;
+
+export const AppPanelPersistedStateDeleteInputSchema =
+  AppPanelPersistedStateGetInputSchema;
+export type AppPanelPersistedStateDeleteInput = z.infer<
+  typeof AppPanelPersistedStateDeleteInputSchema
+>;
+
+export const AppPanelPersistedStateResultSchema = z.object({
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  key: AppPanelPersistedStateKeySchema,
+  exists: z.boolean(),
+  value: AppPanelPersistedStateValueSchema.optional(),
+  updated_at: z.string().datetime(),
+});
+export type AppPanelPersistedStateResult = z.infer<
+  typeof AppPanelPersistedStateResultSchema
 >;
 
 export const AppActivationHandshakeSchema = z.object({

--- a/self/shared/src/types/panel-bridge-protocol.ts
+++ b/self/shared/src/types/panel-bridge-protocol.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { AppHandshakeConfigSourceSchema } from './app-runtime.js';
+import {
+  AppHandshakeConfigSourceSchema,
+  AppPanelLifecycleEventSchema,
+  AppPanelLifecycleReasonSchema,
+} from './app-runtime.js';
 
 export const PANEL_BRIDGE_PROTOCOL_VERSION = 1 as const;
 export const PANEL_BRIDGE_SUPPORTED_PROTOCOL_VERSIONS = [
@@ -22,11 +26,16 @@ export const PanelBridgeMessageKindSchema = z.enum([
   'config.get',
   'theme.get',
   'notify.send',
+  'persisted_state.get',
+  'persisted_state.set',
+  'persisted_state.delete',
   'host.bootstrap',
   'tool.result',
   'config.result',
   'theme.result',
   'notify.result',
+  'persisted_state.result',
+  'panel.lifecycle',
   'theme.changed',
   'error',
 ]);
@@ -106,6 +115,8 @@ export const PanelBridgeCapabilitiesSchema = z.object({
   config: z.boolean().default(true),
   theme: z.boolean().default(true),
   notify: z.boolean().default(true),
+  persisted_state: z.boolean().default(true),
+  lifecycle: z.boolean().default(true),
 });
 export type PanelBridgeCapabilities = z.infer<
   typeof PanelBridgeCapabilitiesSchema
@@ -164,12 +175,46 @@ export const PanelNotifyRequestSchema = PanelBridgeEnvelopeSchema.extend({
 });
 export type PanelNotifyRequest = z.infer<typeof PanelNotifyRequestSchema>;
 
+export const PanelPersistedStateGetRequestSchema =
+  PanelBridgeEnvelopeSchema.extend({
+    kind: z.literal('persisted_state.get'),
+    request_id: PanelBridgeRequestIdSchema,
+    key: z.string().min(1),
+  });
+export type PanelPersistedStateGetRequest = z.infer<
+  typeof PanelPersistedStateGetRequestSchema
+>;
+
+export const PanelPersistedStateSetRequestSchema =
+  PanelBridgeEnvelopeSchema.extend({
+    kind: z.literal('persisted_state.set'),
+    request_id: PanelBridgeRequestIdSchema,
+    key: z.string().min(1),
+    value: z.unknown(),
+  });
+export type PanelPersistedStateSetRequest = z.infer<
+  typeof PanelPersistedStateSetRequestSchema
+>;
+
+export const PanelPersistedStateDeleteRequestSchema =
+  PanelBridgeEnvelopeSchema.extend({
+    kind: z.literal('persisted_state.delete'),
+    request_id: PanelBridgeRequestIdSchema,
+    key: z.string().min(1),
+  });
+export type PanelPersistedStateDeleteRequest = z.infer<
+  typeof PanelPersistedStateDeleteRequestSchema
+>;
+
 export const PanelBridgePanelMessageSchema = z.discriminatedUnion('kind', [
   PanelReadyMessageSchema,
   PanelToolInvokeRequestSchema,
   PanelConfigGetRequestSchema,
   PanelThemeGetRequestSchema,
   PanelNotifyRequestSchema,
+  PanelPersistedStateGetRequestSchema,
+  PanelPersistedStateSetRequestSchema,
+  PanelPersistedStateDeleteRequestSchema,
 ]);
 export type PanelBridgePanelMessage = z.infer<
   typeof PanelBridgePanelMessageSchema
@@ -214,6 +259,28 @@ export const PanelNotifyResponseSchema = PanelBridgeEnvelopeSchema.extend({
 });
 export type PanelNotifyResponse = z.infer<typeof PanelNotifyResponseSchema>;
 
+export const PanelPersistedStateResponseSchema =
+  PanelBridgeEnvelopeSchema.extend({
+    kind: z.literal('persisted_state.result'),
+    request_id: PanelBridgeRequestIdSchema,
+    key: z.string().min(1),
+    exists: z.boolean(),
+    value: z.unknown().optional(),
+  });
+export type PanelPersistedStateResponse = z.infer<
+  typeof PanelPersistedStateResponseSchema
+>;
+
+export const PanelLifecycleChangedMessageSchema =
+  PanelBridgeEnvelopeSchema.extend({
+    kind: z.literal('panel.lifecycle'),
+    event: AppPanelLifecycleEventSchema,
+    reason: AppPanelLifecycleReasonSchema,
+  });
+export type PanelLifecycleChangedMessage = z.infer<
+  typeof PanelLifecycleChangedMessageSchema
+>;
+
 export const PanelThemeChangedMessageSchema = PanelBridgeEnvelopeSchema.extend({
   kind: z.literal('theme.changed'),
   theme: PanelBridgeThemeSnapshotSchema,
@@ -237,6 +304,8 @@ export const PanelBridgeHostMessageSchema = z.discriminatedUnion('kind', [
   PanelConfigResponseSchema,
   PanelThemeResponseSchema,
   PanelNotifyResponseSchema,
+  PanelPersistedStateResponseSchema,
+  PanelLifecycleChangedMessageSchema,
   PanelThemeChangedMessageSchema,
   PanelBridgeErrorResponseSchema,
 ]);
@@ -250,11 +319,16 @@ export const PanelBridgeMessageSchema = z.discriminatedUnion('kind', [
   PanelConfigGetRequestSchema,
   PanelThemeGetRequestSchema,
   PanelNotifyRequestSchema,
+  PanelPersistedStateGetRequestSchema,
+  PanelPersistedStateSetRequestSchema,
+  PanelPersistedStateDeleteRequestSchema,
   HostBootstrapMessageSchema,
   PanelToolSuccessResponseSchema,
   PanelConfigResponseSchema,
   PanelThemeResponseSchema,
   PanelNotifyResponseSchema,
+  PanelPersistedStateResponseSchema,
+  PanelLifecycleChangedMessageSchema,
   PanelThemeChangedMessageSchema,
   PanelBridgeErrorResponseSchema,
 ]);
@@ -298,4 +372,41 @@ export const PanelBridgeToolTransportResponseSchema = z.union([
 ]);
 export type PanelBridgeToolTransportResponse = z.infer<
   typeof PanelBridgeToolTransportResponseSchema
+>;
+
+export const PanelPersistedStateTransportGetRequestSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+  request_id: PanelBridgeRequestIdSchema,
+  app_id: z.string().min(1),
+  panel_id: z.string().min(1),
+  key: z.string().min(1),
+});
+export type PanelPersistedStateTransportGetRequest = z.infer<
+  typeof PanelPersistedStateTransportGetRequestSchema
+>;
+
+export const PanelPersistedStateTransportSetRequestSchema =
+  PanelPersistedStateTransportGetRequestSchema.extend({
+    value: z.unknown(),
+  });
+export type PanelPersistedStateTransportSetRequest = z.infer<
+  typeof PanelPersistedStateTransportSetRequestSchema
+>;
+
+export const PanelPersistedStateTransportDeleteRequestSchema =
+  PanelPersistedStateTransportGetRequestSchema;
+export type PanelPersistedStateTransportDeleteRequest = z.infer<
+  typeof PanelPersistedStateTransportDeleteRequestSchema
+>;
+
+export const PanelPersistedStateTransportResultSchema = z.object({
+  protocol: PanelBridgeProtocolVersionSchema,
+  request_id: PanelBridgeRequestIdSchema,
+  ok: z.literal(true),
+  key: z.string().min(1),
+  exists: z.boolean(),
+  value: z.unknown().optional(),
+});
+export type PanelPersistedStateTransportResult = z.infer<
+  typeof PanelPersistedStateTransportResultSchema
 >;

--- a/self/subcortex/apps/src/__tests__/app-runtime-service.test.ts
+++ b/self/subcortex/apps/src/__tests__/app-runtime-service.test.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { PANEL_BRIDGE_PROTOCOL_VERSION } from '@nous/shared';
 import { AppRuntimeService } from '../app-runtime-service.js';
@@ -603,5 +607,115 @@ describe('AppRuntimeService', () => {
         tool_name: 'get_forecast',
       }),
     ).rejects.toThrow('Active app panel not found.');
+  });
+
+  it('records canonical panel lifecycle events against the active descriptor', async () => {
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: {
+        run: vi.fn().mockResolvedValue({}),
+        disable: vi.fn().mockResolvedValue({}),
+      } as any,
+      bridge: new McpIpcBridge(),
+      toolRegistry: createToolRegistry(),
+      spawner: new DenoSpawner({
+        sessionIdFactory: () => 'session-1',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+    });
+
+    await service.activate(activationInput as any);
+    const updated = await service.recordPanelLifecycle({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      event: 'panel_mount',
+      reason: 'open',
+      occurred_at: '2026-03-18T00:00:00.000Z',
+    });
+
+    expect(updated?.lifecycle).toEqual({
+      event: 'panel_mount',
+      reason: 'open',
+      updated_at: '2026-03-18T00:00:00.000Z',
+    });
+  });
+
+  it('persists panel state across deactivate and reactivate cycles through the runtime seam', async () => {
+    const appDataDir = await mkdtemp(join(tmpdir(), `nous-panel-runtime-${randomUUID()}-`));
+    const service = new AppRuntimeService({
+      lifecycleOrchestrator: {
+        run: vi.fn().mockResolvedValue({}),
+        disable: vi.fn().mockResolvedValue({}),
+      } as any,
+      bridge: new McpIpcBridge(),
+      toolRegistry: createToolRegistry(),
+      spawner: new DenoSpawner({
+        sessionIdFactory: () => 'session-1',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+    });
+
+    await service.activate({
+      ...(activationInput as any),
+      launch_spec: {
+        ...(activationInput.launch_spec as any),
+        app_data_dir: appDataDir,
+      },
+    });
+
+    await service.setPersistedPanelState({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+      value: {
+        city: 'Seattle',
+      },
+    });
+    await service.deactivate({
+      session_id: 'session-1',
+      reason: 'restart',
+      disable_package: false,
+    });
+
+    const reactivated = new AppRuntimeService({
+      lifecycleOrchestrator: {
+        run: vi.fn().mockResolvedValue({}),
+        disable: vi.fn().mockResolvedValue({}),
+      } as any,
+      bridge: new McpIpcBridge(),
+      toolRegistry: createToolRegistry(),
+      spawner: new DenoSpawner({
+        sessionIdFactory: () => 'session-2',
+        spawnProcess: () => ({
+          pid: 123,
+          kill: vi.fn().mockReturnValue(true),
+        }),
+      }),
+    });
+
+    await reactivated.activate({
+      ...(activationInput as any),
+      launch_spec: {
+        ...(activationInput.launch_spec as any),
+        app_data_dir: appDataDir,
+      },
+    });
+    const hydrated = await reactivated.getPersistedPanelState({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+    });
+
+    expect(hydrated.exists).toBe(true);
+    expect(hydrated.value).toEqual({
+      city: 'Seattle',
+    });
+
+    await rm(appDataDir, { recursive: true, force: true });
   });
 });

--- a/self/subcortex/apps/src/__tests__/mcp-ipc-bridge.test.ts
+++ b/self/subcortex/apps/src/__tests__/mcp-ipc-bridge.test.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { McpIpcBridge } from '../mcp-ipc-bridge.js';
 
@@ -169,5 +173,47 @@ describe('McpIpcBridge', () => {
     expect(ingress.source).toBe('telegram_poller');
     expect(egress.requested_by_tool).toBe('telegram.send_message');
     expect(report.mode).toBe('connector');
+  });
+
+  it('persists panel state to the app-scoped storage path across bridge instances', async () => {
+    const appDataDir = await mkdtemp(join(tmpdir(), `nous-panel-state-${randomUUID()}-`));
+    const firstBridge = new McpIpcBridge();
+    firstBridge.registerSessionStorage('session-1', appDataDir);
+
+    await firstBridge.setPersistedState('session-1', {
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+      value: {
+        city: 'Seattle',
+      },
+    });
+
+    const secondBridge = new McpIpcBridge();
+    secondBridge.registerSessionStorage('session-1', appDataDir);
+    const hydrated = await secondBridge.getPersistedState('session-1', {
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+    });
+
+    expect(hydrated.exists).toBe(true);
+    expect(hydrated.value).toEqual({
+      city: 'Seattle',
+    });
+
+    await secondBridge.deletePersistedState('session-1', {
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+    });
+    const cleared = await secondBridge.getPersistedState('session-1', {
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      key: 'filters',
+    });
+
+    expect(cleared.exists).toBe(false);
+    await rm(appDataDir, { recursive: true, force: true });
   });
 });

--- a/self/subcortex/apps/src/__tests__/panel-registration.test.ts
+++ b/self/subcortex/apps/src/__tests__/panel-registration.test.ts
@@ -182,4 +182,39 @@ describe('PanelRegistrationRegistry', () => {
       registry.resolvePanel('app:weather', 'forecast')?.config_snapshot.api_key,
     ).toBeUndefined();
   });
+
+  it('updates the canonical lifecycle projection for active panels', () => {
+    const registry = new PanelRegistrationRegistry();
+
+    registry.registerPanels({
+      session,
+      package_root_ref: '/repo/.apps/weather',
+      manifest_ref: '/repo/.apps/weather/manifest.json',
+      config_entries: [],
+      panels: [
+        {
+          app_id: 'app:weather',
+          session_id: 'session-1',
+          panel_id: 'forecast',
+          label: 'Forecast',
+          entry: 'panels/forecast.tsx',
+          preserve_state: true,
+        },
+      ],
+    });
+
+    const updated = registry.updateLifecycle({
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      event: 'panel_mount',
+      reason: 'activate',
+      occurred_at: '2026-03-18T00:00:00.000Z',
+    });
+
+    expect(updated?.lifecycle).toEqual({
+      event: 'panel_mount',
+      reason: 'activate',
+      updated_at: '2026-03-18T00:00:00.000Z',
+    });
+  });
 });

--- a/self/subcortex/apps/src/app-runtime-service.ts
+++ b/self/subcortex/apps/src/app-runtime-service.ts
@@ -3,6 +3,11 @@ import {
   AppConnectorIngressIntentSchema,
   AppConnectorSessionReportSchema,
   AppHealthSnapshotSchema,
+  AppPanelLifecycleUpdateSchema,
+  AppPanelPersistedStateDeleteInputSchema,
+  AppPanelPersistedStateGetInputSchema,
+  type AppPanelPersistedStateResult,
+  AppPanelPersistedStateSetInputSchema,
   AppProcessExitEventSchema,
   AppRuntimeActivationInputSchema,
   AppRuntimeDeactivationInputSchema,
@@ -94,6 +99,10 @@ export class AppRuntimeService implements IAppRuntimeService {
       this.sessions.set(session.session_id, session);
       this.receipts.set(session.session_id, receipt);
       this.healthRegistry.initializeSession(session.session_id);
+      this.bridge.registerSessionStorage(
+        session.session_id,
+        parsed.launch_spec.app_data_dir,
+      );
       await this.registerConnectorsForSession(parsed, session);
 
       const toolRecords = await this.options.toolRegistry.registerSessionTools({
@@ -125,6 +134,7 @@ export class AppRuntimeService implements IAppRuntimeService {
         this.panelRegistry.unregisterSession(session.session_id);
         await this.invalidateSessionPanelCache(session.session_id);
         this.healthRegistry.removeSession(session.session_id);
+        this.bridge.unregisterSessionStorage(session.session_id);
         await this.unregisterConnectorsForSession(session.session_id);
         this.receipts.get(session.session_id)?.handle.kill();
         this.receipts.delete(session.session_id);
@@ -156,6 +166,7 @@ export class AppRuntimeService implements IAppRuntimeService {
     this.receipts.get(parsed.session_id)?.handle.kill();
     this.receipts.delete(parsed.session_id);
     this.healthRegistry.removeSession(parsed.session_id);
+    this.bridge.unregisterSessionStorage(parsed.session_id);
     await this.unregisterConnectorsForSession(parsed.session_id);
 
     if (parsed.disable_package) {
@@ -194,6 +205,7 @@ export class AppRuntimeService implements IAppRuntimeService {
     await this.invalidateSessionPanelCache(parsed.session_id);
     this.healthRegistry.removeSession(parsed.session_id);
     this.receipts.delete(parsed.session_id);
+    this.bridge.unregisterSessionStorage(parsed.session_id);
     await this.reportConnectorStateForSession(parsed.session_id, {
       status: 'degraded',
       health: 'unhealthy',
@@ -253,6 +265,49 @@ export class AppRuntimeService implements IAppRuntimeService {
       },
       params: parsed.params,
     });
+  }
+
+  async recordPanelLifecycle(
+    input: import('@nous/shared').AppPanelLifecycleUpdate,
+  ): Promise<import('@nous/shared').AppPanelBridgeContext | null> {
+    const parsed = AppPanelLifecycleUpdateSchema.parse(input);
+    return this.panelRegistry.updateLifecycle(parsed);
+  }
+
+  async getPersistedPanelState(
+    input: import('@nous/shared').AppPanelPersistedStateGetInput,
+  ): Promise<AppPanelPersistedStateResult> {
+    const parsed = AppPanelPersistedStateGetInputSchema.parse(input);
+    const panel = this.panelRegistry.resolvePanel(parsed.app_id, parsed.panel_id);
+    if (!panel) {
+      throw new Error('Active app panel not found.');
+    }
+
+    return this.bridge.getPersistedState(panel.session_id, parsed);
+  }
+
+  async setPersistedPanelState(
+    input: import('@nous/shared').AppPanelPersistedStateSetInput,
+  ): Promise<AppPanelPersistedStateResult> {
+    const parsed = AppPanelPersistedStateSetInputSchema.parse(input);
+    const panel = this.panelRegistry.resolvePanel(parsed.app_id, parsed.panel_id);
+    if (!panel) {
+      throw new Error('Active app panel not found.');
+    }
+
+    return this.bridge.setPersistedState(panel.session_id, parsed);
+  }
+
+  async deletePersistedPanelState(
+    input: import('@nous/shared').AppPanelPersistedStateDeleteInput,
+  ): Promise<AppPanelPersistedStateResult> {
+    const parsed = AppPanelPersistedStateDeleteInputSchema.parse(input);
+    const panel = this.panelRegistry.resolvePanel(parsed.app_id, parsed.panel_id);
+    if (!panel) {
+      throw new Error('Active app panel not found.');
+    }
+
+    return this.bridge.deletePersistedState(panel.session_id, parsed);
   }
 
   async recordHeartbeat(signal: import('@nous/shared').AppHeartbeatSignal): Promise<AppHealthSnapshot> {

--- a/self/subcortex/apps/src/mcp-ipc-bridge.ts
+++ b/self/subcortex/apps/src/mcp-ipc-bridge.ts
@@ -1,3 +1,5 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import {
   AppActivationHandshakeSchema,
   AppConnectorEgressIntentSchema,
@@ -9,6 +11,11 @@ import {
   type AppConnectorIngressIntent,
   type AppConnectorSessionReport,
   type AppOutboundToolCallContext,
+  type AppPanelPersistedStateDeleteInput,
+  type AppPanelPersistedStateGetInput,
+  type AppPanelPersistedStateResult,
+  AppPanelPersistedStateResultSchema,
+  type AppPanelPersistedStateSetInput,
   type AppRuntimeActivationInput,
   type AppRuntimeSession,
 } from '@nous/shared';
@@ -28,11 +35,28 @@ export interface AppOutboundToolEnvelope {
 export interface McpIpcBridgeOptions {
   sendHandshake?: (sessionId: string, handshake: AppActivationHandshake) => Promise<void> | void;
   invokeTool?: (sessionId: string, envelope: AppOutboundToolEnvelope) => Promise<unknown> | unknown;
+  getPersistedState?: (
+    sessionId: string,
+    input: AppPanelPersistedStateGetInput,
+  ) => Promise<AppPanelPersistedStateResult> | AppPanelPersistedStateResult;
+  setPersistedState?: (
+    sessionId: string,
+    input: AppPanelPersistedStateSetInput,
+  ) => Promise<AppPanelPersistedStateResult> | AppPanelPersistedStateResult;
+  deletePersistedState?: (
+    sessionId: string,
+    input: AppPanelPersistedStateDeleteInput,
+  ) => Promise<AppPanelPersistedStateResult> | AppPanelPersistedStateResult;
   projectScopedTools?: readonly string[];
+}
+
+interface PersistedStateDocument {
+  values: Record<string, { value: unknown; updated_at: string }>;
 }
 
 export class McpIpcBridge {
   private readonly projectScopedTools: ReadonlySet<string>;
+  private readonly appDataDirs = new Map<string, string>();
 
   constructor(private readonly options: McpIpcBridgeOptions = {}) {
     this.projectScopedTools = new Set(options.projectScopedTools ?? [
@@ -45,6 +69,14 @@ export class McpIpcBridge {
       'escalation_notify',
       'scheduler_register',
     ]);
+  }
+
+  registerSessionStorage(sessionId: string, appDataDir: string): void {
+    this.appDataDirs.set(sessionId, appDataDir);
+  }
+
+  unregisterSessionStorage(sessionId: string): void {
+    this.appDataDirs.delete(sessionId);
   }
 
   createActivationHandshake(
@@ -99,6 +131,102 @@ export class McpIpcBridge {
     return this.options.invokeTool(parsed.context.session_id, parsed);
   }
 
+  async getPersistedState(
+    sessionId: string,
+    input: AppPanelPersistedStateGetInput,
+  ): Promise<AppPanelPersistedStateResult> {
+    if (this.options.getPersistedState) {
+      return AppPanelPersistedStateResultSchema.parse(
+        await this.options.getPersistedState(sessionId, input),
+      );
+    }
+
+    const document = await this.readPersistedStateDocument(
+      sessionId,
+      input.app_id,
+      input.panel_id,
+    );
+    const hit = document.values[input.key];
+    return AppPanelPersistedStateResultSchema.parse({
+      app_id: input.app_id,
+      panel_id: input.panel_id,
+      key: input.key,
+      exists: Boolean(hit),
+      value: hit?.value,
+      updated_at: hit?.updated_at ?? new Date().toISOString(),
+    });
+  }
+
+  async setPersistedState(
+    sessionId: string,
+    input: AppPanelPersistedStateSetInput,
+  ): Promise<AppPanelPersistedStateResult> {
+    if (this.options.setPersistedState) {
+      return AppPanelPersistedStateResultSchema.parse(
+        await this.options.setPersistedState(sessionId, input),
+      );
+    }
+
+    const document = await this.readPersistedStateDocument(
+      sessionId,
+      input.app_id,
+      input.panel_id,
+    );
+    const updatedAt = new Date().toISOString();
+    document.values[input.key] = {
+      value: input.value,
+      updated_at: updatedAt,
+    };
+    await this.writePersistedStateDocument(
+      sessionId,
+      input.app_id,
+      input.panel_id,
+      document,
+    );
+
+    return AppPanelPersistedStateResultSchema.parse({
+      app_id: input.app_id,
+      panel_id: input.panel_id,
+      key: input.key,
+      exists: true,
+      value: input.value,
+      updated_at: updatedAt,
+    });
+  }
+
+  async deletePersistedState(
+    sessionId: string,
+    input: AppPanelPersistedStateDeleteInput,
+  ): Promise<AppPanelPersistedStateResult> {
+    if (this.options.deletePersistedState) {
+      return AppPanelPersistedStateResultSchema.parse(
+        await this.options.deletePersistedState(sessionId, input),
+      );
+    }
+
+    const document = await this.readPersistedStateDocument(
+      sessionId,
+      input.app_id,
+      input.panel_id,
+    );
+    const current = document.values[input.key];
+    delete document.values[input.key];
+    await this.writePersistedStateDocument(
+      sessionId,
+      input.app_id,
+      input.panel_id,
+      document,
+    );
+
+    return AppPanelPersistedStateResultSchema.parse({
+      app_id: input.app_id,
+      panel_id: input.panel_id,
+      key: input.key,
+      exists: false,
+      updated_at: current?.updated_at ?? new Date().toISOString(),
+    });
+  }
+
   parseConnectorIngressIntent(payload: unknown): AppConnectorIngressIntent {
     return AppConnectorIngressIntentSchema.parse(payload);
   }
@@ -109,5 +237,76 @@ export class McpIpcBridge {
 
   parseConnectorSessionReport(payload: unknown): AppConnectorSessionReport {
     return AppConnectorSessionReportSchema.parse(payload);
+  }
+
+  private resolvePersistedStateFilePath(
+    sessionId: string,
+    appId: string,
+    panelId: string,
+  ): string {
+    const appDataDir = this.appDataDirs.get(sessionId);
+    if (!appDataDir) {
+      throw new NousError(
+        `Persisted panel state is unavailable for session ${sessionId}`,
+        'APP_PANEL_STATE_UNAVAILABLE',
+      );
+    }
+
+    return join(
+      appDataDir,
+      '.nous-panel-state',
+      encodeURIComponent(appId),
+      `${encodeURIComponent(panelId)}.json`,
+    );
+  }
+
+  private async readPersistedStateDocument(
+    sessionId: string,
+    appId: string,
+    panelId: string,
+  ): Promise<PersistedStateDocument> {
+    const filePath = this.resolvePersistedStateFilePath(sessionId, appId, panelId);
+
+    try {
+      const raw = await readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PersistedStateDocument;
+      return {
+        values:
+          parsed && typeof parsed === 'object' && parsed.values
+            ? parsed.values
+            : {},
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { values: {} };
+      }
+      throw error;
+    }
+  }
+
+  private async writePersistedStateDocument(
+    sessionId: string,
+    appId: string,
+    panelId: string,
+    document: PersistedStateDocument,
+  ): Promise<void> {
+    const filePath = this.resolvePersistedStateFilePath(sessionId, appId, panelId);
+    const hasValues = Object.keys(document.values).length > 0;
+
+    if (!hasValues) {
+      try {
+        await rm(filePath, { force: true });
+      } catch {
+        // Empty-state cleanup is best-effort; a stale file only causes a harmless cache miss.
+      }
+      return;
+    }
+
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(
+      filePath,
+      JSON.stringify(document, null, 2),
+      'utf8',
+    );
   }
 }

--- a/self/subcortex/apps/src/panel-registration.ts
+++ b/self/subcortex/apps/src/panel-registration.ts
@@ -1,10 +1,12 @@
 import {
   AppPanelBridgeContextSchema,
+  AppPanelLifecycleUpdateSchema,
   AppPanelSafeConfigSnapshotSchema,
   AppPanelRegistrationProjectionSchema,
   type AppConfig,
   type AppHandshakeConfigEntry,
   type AppPanelBridgeContext,
+  type AppPanelLifecycleUpdate,
   type AppPanelRegistrationProjection,
   type AppRuntimeSession,
 } from '@nous/shared';
@@ -90,6 +92,38 @@ export class PanelRegistrationRegistry {
 
   resolvePanel(appId: string, panelId: string): ResolvedAppPanelDescriptor | null {
     return this.panelsByKey.get(buildPanelRegistryKey(appId, panelId)) ?? null;
+  }
+
+  updateLifecycle(input: AppPanelLifecycleUpdate): ResolvedAppPanelDescriptor | null {
+    const parsed = AppPanelLifecycleUpdateSchema.parse(input);
+    const current = this.resolvePanel(parsed.app_id, parsed.panel_id);
+    if (!current) {
+      return null;
+    }
+
+    const next = AppPanelBridgeContextSchema.parse({
+      ...current,
+      lifecycle: {
+        event: parsed.event,
+        reason: parsed.reason,
+        updated_at: parsed.occurred_at,
+      },
+    });
+
+    this.panelsByKey.set(
+      buildPanelRegistryKey(next.app_id, next.panel_id),
+      next,
+    );
+    this.panelsBySession.set(
+      next.session_id,
+      (this.panelsBySession.get(next.session_id) ?? []).map((panel) =>
+        panel.app_id === next.app_id && panel.panel_id === next.panel_id
+          ? next
+          : panel,
+      ),
+    );
+
+    return next;
   }
 
   unregisterSession(sessionId: string): ResolvedAppPanelDescriptor[] {

--- a/self/ui/src/panels/AppIframePanel.tsx
+++ b/self/ui/src/panels/AppIframePanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import type { IDockviewPanelProps } from 'dockview-react'
-import type { PanelBridgeConfigSnapshot } from '@nous/shared'
+import type { AppPanelLifecycleReason, PanelBridgeConfigSnapshot } from '@nous/shared'
 import { PanelBridgeHost } from './panel-bridge-host'
 
 interface AppIframePanelParams {
@@ -17,8 +17,18 @@ interface AppIframePanelProps extends IDockviewPanelProps {
   params: AppIframePanelParams
 }
 
-export function AppIframePanel({ params }: AppIframePanelProps) {
+export function AppIframePanel({ params, api }: AppIframePanelProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  const bridgeHostRef = useRef<PanelBridgeHost | null>(null)
+  const teardownReasonRef = useRef<AppPanelLifecycleReason | null>(null)
+
+  useEffect(() => {
+    if (!api) {
+      return
+    }
+
+    api.setRenderer(params?.preserveState === false ? 'onlyWhenVisible' : 'always')
+  }, [api, params?.preserveState])
 
   useEffect(() => {
     if (!params?.src || !iframeRef.current) {
@@ -31,9 +41,33 @@ export function AppIframePanel({ params }: AppIframePanelProps) {
       iframe: iframeRef.current,
       mcpEndpoint: new URL('/mcp', params.src).toString(),
       configSnapshot: params.configSnapshot ?? {},
+      lifecycleAdapter: async (input) => {
+        const response = await fetch(new URL('/mcp', params.src).toString(), {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-nous-panel-bridge': '1',
+            'x-nous-panel-bridge-operation': 'panel.lifecycle',
+          },
+          body: JSON.stringify(input),
+        })
+
+        if (!response.ok) {
+          throw new Error('Panel lifecycle reconciliation failed.')
+        }
+      },
     })
+    bridgeHostRef.current = bridgeHost
 
     return () => {
+      if (teardownReasonRef.current !== 'host_reload') {
+        void bridgeHost.notifyLifecycle(
+          'panel_unmount',
+          teardownReasonRef.current ?? 'close',
+        )
+      }
+      bridgeHostRef.current = null
+      teardownReasonRef.current = null
       bridgeHost.destroy()
     }
   }, [
@@ -42,6 +76,35 @@ export function AppIframePanel({ params }: AppIframePanelProps) {
     params?.src,
     JSON.stringify(params?.configSnapshot ?? {}),
   ])
+
+  useEffect(() => {
+    if (!api) {
+      return
+    }
+
+    const disposable = api.onDidActiveChange(({ isActive }) => {
+      void bridgeHostRef.current?.notifyLifecycle(
+        isActive ? 'panel_mount' : 'panel_unmount',
+        isActive ? 'activate' : 'deactivate',
+      )
+    })
+
+    return () => {
+      disposable.dispose()
+    }
+  }, [api])
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      teardownReasonRef.current = 'host_reload'
+      void bridgeHostRef.current?.notifyLifecycle('panel_unmount', 'host_reload')
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [])
 
   if (!params?.src) {
     return (

--- a/self/ui/src/panels/panel-bridge-host.ts
+++ b/self/ui/src/panels/panel-bridge-host.ts
@@ -1,8 +1,12 @@
 import {
+  type AppPanelLifecycleEvent,
+  type AppPanelLifecycleReason,
   PANEL_BRIDGE_PROTOCOL_VERSION,
   type PanelBridgeConfigSnapshot,
   type PanelBridgeErrorCode,
+  PanelBridgeToolTransportFailureSchema,
   PanelBridgePanelMessageSchema,
+  PanelPersistedStateTransportResultSchema,
   type PanelBridgeThemeSnapshot,
   type PanelBridgeNotification,
   PanelBridgeToolTransportRequestSchema,
@@ -16,9 +20,19 @@ export interface PanelBridgeHostOptions {
   mcpEndpoint: string;
   configSnapshot: PanelBridgeConfigSnapshot;
   notifyAdapter?: (notification: PanelBridgeNotification) => Promise<boolean> | boolean;
+  lifecycleAdapter?: (input: {
+    app_id: string;
+    panel_id: string;
+    event: AppPanelLifecycleEvent;
+    reason: AppPanelLifecycleReason;
+    occurred_at: string;
+  }) => Promise<void> | void;
 }
 
 export class PanelBridgeHost {
+  private panelReady = false;
+  private lastLifecycleKey?: string;
+
   private readonly mediaQuery =
     typeof window.matchMedia === 'function'
       ? window.matchMedia('(prefers-color-scheme: dark)')
@@ -89,6 +103,7 @@ export class PanelBridgeHost {
   private async dispatch(message: ReturnType<typeof PanelBridgePanelMessageSchema.parse>) {
     switch (message.kind) {
       case 'panel.ready':
+        this.panelReady = true;
         this.postToPanel({
           protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
           kind: 'host.bootstrap',
@@ -100,8 +115,11 @@ export class PanelBridgeHost {
             config: true,
             theme: true,
             notify: true,
+            persisted_state: true,
+            lifecycle: true,
           },
         });
+        await this.notifyLifecycle('panel_mount', 'open');
         return;
       case 'config.get':
         this.postToPanel({
@@ -121,6 +139,11 @@ export class PanelBridgeHost {
         return;
       case 'notify.send':
         await this.handleNotify(message.request_id, message.notification);
+        return;
+      case 'persisted_state.get':
+      case 'persisted_state.set':
+      case 'persisted_state.delete':
+        await this.handlePersistedState(message);
         return;
       case 'tool.invoke':
         await this.handleToolInvoke(message);
@@ -205,6 +228,102 @@ export class PanelBridgeHost {
       this.postError({
         code: 'tool_execution_failed',
         message: 'Panel tool invocation failed.',
+        requestId: message.request_id,
+      });
+    }
+  }
+
+  async notifyLifecycle(
+    event: AppPanelLifecycleEvent,
+    reason: AppPanelLifecycleReason,
+  ): Promise<void> {
+    const nextLifecycleKey = `${event}:${reason}`;
+    if (this.lastLifecycleKey === nextLifecycleKey) {
+      return;
+    }
+
+    try {
+      await this.options.lifecycleAdapter?.({
+        app_id: this.options.appId,
+        panel_id: this.options.panelId,
+        event,
+        reason,
+        occurred_at: new Date().toISOString(),
+      });
+
+      if (this.panelReady) {
+        this.postToPanel({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'panel.lifecycle',
+          event,
+          reason,
+        });
+      }
+
+      this.lastLifecycleKey = nextLifecycleKey;
+    } catch {
+      // Lifecycle reconciliation is best-effort and must not break the host bridge.
+    }
+  }
+
+  private async handlePersistedState(
+    message: Extract<
+      ReturnType<typeof PanelBridgePanelMessageSchema.parse>,
+      | { kind: 'persisted_state.get' }
+      | { kind: 'persisted_state.set' }
+      | { kind: 'persisted_state.delete' }
+    >,
+  ): Promise<void> {
+    try {
+      const response = await fetch(this.options.mcpEndpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-nous-panel-bridge': '1',
+          'x-nous-panel-bridge-operation': message.kind,
+        },
+        body: JSON.stringify({
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          request_id: message.request_id,
+          app_id: this.options.appId,
+          panel_id: this.options.panelId,
+          key: message.key,
+          ...('value' in message ? { value: message.value } : {}),
+        }),
+      });
+
+      const body = await response.json();
+      const failure = PanelBridgeToolTransportFailureSchema.safeParse(body);
+      if (failure.success) {
+        this.postError({
+          ...failure.data.error,
+          requestId: failure.data.request_id,
+        });
+        return;
+      }
+
+      const parsed = PanelPersistedStateTransportResultSchema.safeParse(body);
+      if (!parsed.success) {
+        this.postError({
+          code: 'internal_error',
+          message: 'Invalid persisted-state bridge response.',
+          requestId: message.request_id,
+        });
+        return;
+      }
+
+      this.postToPanel({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        kind: 'persisted_state.result',
+        request_id: parsed.data.request_id,
+        key: parsed.data.key,
+        exists: parsed.data.exists,
+        value: parsed.data.value,
+      });
+    } catch {
+      this.postError({
+        code: 'host_unavailable',
+        message: 'Persisted state bridge is unavailable.',
         requestId: message.request_id,
       });
     }


### PR DESCRIPTION
## Phase 15.3 — Panel Lifecycle and Persisted State

Delivers the complete panel lifecycle event dispatch and runtime-owned persisted state as specified in the Phase 15.3 SDS.

### What was built

- **Shared contracts** — `panel_mount`/`panel_unmount` lifecycle event schemas in `panel-bridge-protocol.ts`; `AppPanelPersistedStateResultSchema`/`AppPanelPersistedStateQuerySchema` in `app-runtime.ts`; `IAppRuntimeService` extended with `getPersistedState`/`setPersistedState`/`deletePersistedState`
- **Runtime** — `AppRuntimeService` emits `panel_mount`/`panel_unmount` on open/close transitions; `preserveState` flag flows from manifest through `PanelRegistration`; `MCP IPC bridge` routes persisted-state operations to the app Deno process
- **SDK** — `usePersistedState` (bridge-routed durable state, survives deactivate/reactivate and host reload); `onActivate`/`onDeactivate` lifecycle callbacks via `PanelBridgeClient` push handling
- **Host bridge** — `PanelBridgeHost` dispatches `panel_mount`/`panel_unmount`; `AppIframePanel` applies `preserveState` → dockview renderer behavior (`always` vs `onlyWhenVisible`)
- **Web routes** — MCP route handles persisted-state dispatch from trusted panel bridge transport
- **Docs** — `repo-folder-structure.mdx` expanded with Phase 15.3 SDK surface; `interaction-surfaces.mdx` adds Installable App Panels subsection

### Verification

- 67 tests across 14 files — 100% pass
- `pnpm typecheck` — 0 errors (6 packages)
- `pnpm lint` — 0 errors (16 pre-existing warnings, untouched files)
- `pnpm build` — passes (4 packages)
- All 5 gate reviews approved on first cycle — no revision cycles

### SDS invariants

All 13 SDS invariants preserved. No new ADRs created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)