### PR TITLE
Phase 15.5 — App Settings Convergence and Track Closure

### DIFF
--- a/docs/content/docs/api/overview.mdx
+++ b/docs/content/docs/api/overview.mdx
@@ -36,7 +36,7 @@ When `NOUS_BASIC_AUTH` is set, include the `Authorization: Basic` header. The tR
 | `chat` | Send messages, get history |
 | `traces` | Execution traces |
 | `memory` | Memory entries, export, delete |
-| `packages` | Canonical app-install preparation, governed package installation, and active app-panel projection |
+| `packages` | Canonical app-install/settings preparation, governed app install/settings save, and active app-panel projection |
 | `config` | Configuration get/update |
 | `health` | System health check |
 | `firstRun` | First-run flow status and completion |

--- a/docs/content/docs/api/procedures.mdx
+++ b/docs/content/docs/api/procedures.mdx
@@ -154,26 +154,114 @@ description: Reference for all tRPC procedures
 | Procedure | Type | Input | Output |
 |----------|------|-------|--------|
 | `packages.prepareAppInstall` | query | `AppInstallPrepareRequest` | `AppInstallPreparation` |
+| `packages.prepareAppSettings` | query | `AppSettingsPrepareRequest` | `AppSettingsPreparation` |
 | `packages.installApp` | mutation | `AppInstallRequest` | `AppInstallResult` |
-| `packages.listAppPanels` | query | — | `{ app_id, panel_id, label, route_path, dockview_panel_id, preserve_state, position?, config_snapshot }[]` |
+| `packages.saveAppSettings` | mutation | `AppSettingsSaveRequest` | `AppSettingsSaveResult` |
+| `packages.listAppPanels` | query | — | `{ app_id, panel_id, label, route_path, dockview_panel_id, config_version, preserve_state, position?, config_snapshot }[]` |
 | `packages.install` | mutation | `PackageInstallRequest` | `PackageInstallResult` |
 
 - `packages.prepareAppInstall` — Resolves the canonical install contract for an installable app package in one project context.
   - Input fields: `project_id`, `package_id`, and optional `release_id`.
   - Output shape includes package/release identity, declared permissions, grouped config descriptors, supported install stages, and whether an install hook is present.
   - The response is preparation truth only. It does not persist config, store secrets, or materialize a package.
+- `packages.prepareAppSettings` — Resolves the canonical settings contract for one already-installed app package in one project context.
+  - Input fields: `project_id` and `package_id`.
+  - Output shape includes grouped settings descriptors, the current `config_version`, runtime summary, current secret-state metadata, and the host-safe panel config snapshot used for live convergence.
 - `packages.installApp` — Runs the canonical app-install orchestration for one project-scoped installable app.
   - Input fields: `project_id`, `package_id`, optional `release_id`, `actor_id`, `permissions_approved`, `config`, `secrets`, `oauth`, and optional `evidence_refs`.
   - Output shape includes the preparation snapshot, install `status` (`success`, `partial`, or `failed`), phase markers, validation results, optional runtime session/config version metadata, stored-secret metadata, rollback posture, and witness references.
   - Secret and OAuth values stay on the vault / credential-install path; non-secret config remains host/runtime truth.
+- `packages.saveAppSettings` — Runs the canonical app-settings orchestration for one installed app package.
+  - Input fields: `project_id`, `package_id`, `actor_id`, `expected_config_version`, non-secret `config`, secret mutation intents in `secrets`, and optional `evidence_refs`.
+  - Output shape includes save `status` (`success`, `partial`, or `failed`), `apply_status` (`applied`, `reverted`, or `blocked`), phase markers, validation results, the effective runtime/config version, stored-secret metadata, rollback posture, and optional activation failure details.
+  - The backend owns the governed `deactivate -> update config -> reactivate -> recover` flow; hosts stay transport-thin and never become a second config authority.
 - `packages.listAppPanels` — Returns the runtime-owned projection of active manifest-declared app panels for trusted first-party hosts.
-  - Each item includes the canonical `route_path`, host-safe `dockview_panel_id`, panel label, `preserve_state`, optional dock position, and the sanitized `config_snapshot` used by trusted hosts during panel bridge bootstrap.
+  - Each item includes the canonical `route_path`, host-safe `dockview_panel_id`, effective `config_version`, panel label, `preserve_state`, optional dock position, and the sanitized `config_snapshot` used by trusted hosts during panel bridge bootstrap.
   - Panels appear here only while an app session is active; manifest declarations alone do not make a panel serveable.
 - `packages.install` — Runs the canonical package install pipeline for one project-scoped package request.
   - Input fields: `project_id`, `package_id`, optional `requested_version_range`, optional `release_id`, `actor_id`, optional `instance_root`, and optional `evidence_refs`.
   - `release_id` and `requested_version_range` are mutually exclusive.
   - Output shape includes the shared resolution result, install journal writes, lifecycle transition results, final `status` (`installed`, `blocked`, or `rolled_back`), and optional failure details.
   - Canonical installs materialize only into governed package-store roots and fail closed with explicit reason-coded output when dependency resolution, lifecycle gating, or write/rollback handling blocks completion.
+
+### Settings procedure examples
+
+`packages.prepareAppSettings` request:
+
+```json
+{
+  "project_id": "550e8400-e29b-41d4-a716-446655440802",
+  "package_id": "telegram-connector"
+}
+```
+
+Response excerpt:
+
+```json
+{
+  "package_id": "telegram-connector",
+  "config_version": "cfg-1",
+  "runtime": {
+    "status": "active",
+    "config_version": "cfg-1"
+  },
+  "config_groups": [
+    {
+      "id": "connector",
+      "label": "Connector",
+      "fields": [
+        {
+          "key": "bot_token",
+          "type": "secret",
+          "secret": true,
+          "secret_state": {
+            "key": "bot_token",
+            "configured": true,
+            "source": "secret_field"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+`packages.saveAppSettings` request:
+
+```json
+{
+  "project_id": "550e8400-e29b-41d4-a716-446655440802",
+  "package_id": "telegram-connector",
+  "actor_id": "web-marketplace",
+  "expected_config_version": "cfg-1",
+  "config": {
+    "region": "eu"
+  },
+  "secrets": {
+    "bot_token": {
+      "operation": "replace",
+      "value": "new-token"
+    }
+  },
+  "evidence_refs": []
+}
+```
+
+Response excerpt:
+
+```json
+{
+  "status": "success",
+  "apply_status": "applied",
+  "phase": "completed",
+  "effective_config_version": "cfg-2",
+  "runtime": {
+    "status": "active",
+    "config_version": "cfg-2"
+  },
+  "rollback_applied": false
+}
+```
 
 ## config
 

--- a/docs/content/docs/architecture/interaction-surfaces.mdx
+++ b/docs/content/docs/architecture/interaction-surfaces.mdx
@@ -207,13 +207,15 @@ Browsing registry packages, inspecting provenance and moderation posture, review
 - Canonical projection over registry governance truth and discovery runtime truth
 - Trust tier, distribution status, compatibility posture, provenance, and release history surfaced directly from registry state
 - Project-scoped package detail views can launch the canonical app install wizard for installable app packages
+- Project-scoped package detail views can reopen installed app packages into the canonical shared settings surface
 - The install wizard uses the same host-owned three-stage sequence on touched hosts: permission review, configuration, then validation/activation
+- The settings surface shows runtime/config-version posture, vault-backed secret state, and explicit save outcomes on the same host-owned contract family
 - Moderation dashboard for holds, delistings, appeals, and escalation continuity
 - Advisory-only discovery feed with mandatory suppression controls
 - Deep links into Projects and MAO preserve project, package, release, candidate, and evidence continuity
 - No surface-owned governance, moderation, suppression, or config-authority state
 
-### Install Boundary
+### Install and Settings Boundary
 
 Marketplace can initiate app installation, but it does not become a second lifecycle engine or a
 second configuration authority.
@@ -222,10 +224,14 @@ second configuration authority.
   wizard renders
 - The shared wizard requires explicit permission approval, renders manifest-defined configuration
   groups, and reports `success`, `partial`, or `failed` validation / activation outcomes
+- Installed apps reopen through the same package detail surface as the shared settings surface,
+  using canonical `prepareAppSettings` / `saveAppSettings` transport rather than a package-local UI
 - Desktop host tooling reuses the same preparation and execution contract plus the same visible
   stage model
 - Secrets and OAuth artifacts go directly to the credential vault, while non-secret config persists
   through the project-scoped install service
+- Successful settings saves refetch canonical settings truth and push additive `config.changed`
+  panel updates without iframe remounts or panel-local config stores
 - Rollback remains service-owned when validation or activation fails
 
 ### Companion CLI Seam

--- a/docs/content/docs/architecture/repo-folder-structure.mdx
+++ b/docs/content/docs/architecture/repo-folder-structure.mdx
@@ -79,6 +79,12 @@ Phase 15.3 extends the same SDK surface with:
 * `onActivate`
 * `onDeactivate`
 
+Phase 15.5 extends the same SDK surface with live config convergence:
+
+* `PanelBridgeClient.subscribeConfig()` for additive host-owned config refreshes
+* `NousPanel` / `useConfig()` subscription-driven updates when trusted hosts push `config.changed`
+* No iframe-local or browser-local settings authority beyond the canonical host bridge snapshot
+
 Panels use this package to speak the canonical versioned `postMessage` bridge to the trusted host.
 The SDK is a bridge client and projection helper only: it lets sandboxed panel code invoke app
 tools and read host-projected config/theme state through the host bridge, while keeping host
@@ -119,6 +125,11 @@ Phase 15.4 extends the same host with canonical app-install preparation and exec
 package-detail surfaces. The host can launch the shared three-stage install wizard, but secret and
 OAuth handling plus persisted config truth remain in the backend install service instead of
 browser-owned state.
+
+Phase 15.5 extends the same host with canonical app-settings preparation and save transport for
+installed app package-detail surfaces. The web package detail view can reuse the shared
+`AppSettingsSurface`, refetch canonical settings truth after save, and push additive config refresh
+events to active app panels without introducing browser-owned settings state.
 
 ### bridge/
 
@@ -502,6 +513,11 @@ Phase 15.4 adds `self/subcortex/projects/src/app-install/` as the project-scoped
 - `service.ts` — prepares install contracts from registry releases, validates required config, delegates vault/OAuth setup, runs install hooks, activates apps, and owns rollback cleanup
 - `index.ts` — exports the install seam for host bootstrap and test consumers
 
+Phase 15.5 adds `self/subcortex/projects/src/app-settings/` as the project-scoped app-settings lane:
+
+- `service.ts` — prepares canonical settings contracts, validates candidate config, stages secret mutation, enforces config-version compare-and-swap, owns `deactivate -> update -> reactivate`, and performs rollback/recovery
+- `index.ts` — exports the settings seam for host bootstrap and test consumers
+
 ### apps/
 
 Canonical app runtime for installed `.apps` packages. Implemented in Phase 14.5 as `@nous/subcortex-apps`.
@@ -791,6 +807,11 @@ Phase 15.4 extends installable apps with a canonical host-owned install flow. Ap
 declare permissions, config fields, and optional lifecycle hooks in the manifest, but hosts now
 prepare a shared install contract and render the same staged install wizard instead of accepting
 package-authored install UIs or storing secrets locally.
+
+Phase 15.5 extends the same posture with a canonical host-owned settings flow after install.
+Installed app packages still declare config in the manifest, but hosts now reuse a shared settings
+surface, save through the project-scoped settings service, and push additive config refreshes to
+active panels without exposing secret values or inventing an app-owned settings UI runtime.
 
 This keeps the distinction clear: `self/apps/` contains first-party senses that are part of the being, while `.apps/` stores installable packages that can extend the operator experience.
 

--- a/docs/content/docs/guides/marketplace.mdx
+++ b/docs/content/docs/guides/marketplace.mdx
@@ -78,7 +78,7 @@ Accepting a marketplace package suggestion does not install the package directly
 
 Marketplace-package acceptance currently routes to `runtime_authorization_required`, which records lifecycle authorization intent and then stops at the existing runtime membrane. Install and enable flows still belong to the governed lifecycle path.
 
-## From Discovery to Install
+## From Discovery to Install and Settings
 
 Discovery stays advisory until you choose a governed install path for a specific project.
 
@@ -96,6 +96,18 @@ the flow:
 
 Secrets and OAuth setup stay vault-mediated during this flow. Non-secret configuration remains
 project-scoped runtime truth rather than browser-owned state.
+
+If the package is already installed for that project, the same package detail view swaps from the
+install wizard into the shared settings surface instead of inventing a second UI path. That
+settings surface:
+
+- Reuses the same manifest-derived grouped fields, required/optional semantics, and vault-backed
+  secret controls
+- Shows the active runtime/config-version summary before save
+- Runs the governed `deactivate -> update config -> reactivate` flow and reports explicit
+  `applied`, `reverted`, or `blocked` outcomes
+- Pushes host-owned config refreshes to active app panels after a successful save instead of
+  remounting the iframe or storing panel-local settings truth
 
 You can still use the CLI when you want to move from a reviewed suggestion into an actual
 project-scoped install:

--- a/self/apps/app-sdk/src/__tests__/panel-bridge-client.test.ts
+++ b/self/apps/app-sdk/src/__tests__/panel-bridge-client.test.ts
@@ -56,6 +56,7 @@ describe('PanelBridgeClient', () => {
       protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
       kind: 'host.bootstrap',
       message_id: 'msg-1',
+      config_version: 'cfg-1',
       config: {
         units: {
           value: 'metric',
@@ -101,6 +102,7 @@ describe('PanelBridgeClient', () => {
       protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
       kind: 'host.bootstrap',
       message_id: 'msg-1',
+      config_version: 'cfg-1',
       config: {},
       theme: {
         mode: 'dark',
@@ -151,6 +153,7 @@ describe('PanelBridgeClient', () => {
       protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
       kind: 'host.bootstrap',
       message_id: 'msg-1',
+      config_version: 'cfg-1',
       config: {},
       theme: {
         mode: 'dark',
@@ -190,6 +193,7 @@ describe('PanelBridgeClient', () => {
       protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
       kind: 'host.bootstrap',
       message_id: 'msg-1',
+      config_version: 'cfg-1',
       config: {},
       theme: {
         mode: 'dark',
@@ -244,6 +248,67 @@ describe('PanelBridgeClient', () => {
         reason: 'activate',
       }),
     );
+
+    unsubscribe();
+  });
+
+  it('notifies config subscribers when the host pushes canonical config updates', async () => {
+    installMockParent();
+    const client = new PanelBridgeClient({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      app_id: 'app:weather',
+      panel_id: 'forecast',
+      mcp_endpoint: 'http://localhost:3000/mcp',
+    });
+
+    const configSpy = vi.fn();
+    const unsubscribe = client.subscribeConfig(configSpy);
+    const handshake = client.connect();
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'host.bootstrap',
+      message_id: 'msg-1',
+      config_version: 'cfg-1',
+      config: {
+        units: {
+          value: 'metric',
+          source: 'project_config',
+        },
+      },
+      theme: {
+        mode: 'dark',
+        tokens: {},
+        metadata: {},
+      },
+      capabilities: {
+        tool: true,
+        config: true,
+        theme: true,
+        notify: true,
+        persisted_state: true,
+        lifecycle: true,
+      },
+    });
+    await handshake;
+
+    dispatchFromParent({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'config.changed',
+      config_version: 'cfg-2',
+      config: {
+        units: {
+          value: 'imperial',
+          source: 'project_config',
+        },
+      },
+    });
+
+    expect(configSpy).toHaveBeenCalledWith({
+      units: {
+        value: 'imperial',
+        source: 'project_config',
+      },
+    });
 
     unsubscribe();
   });

--- a/self/apps/app-sdk/src/__tests__/panel-hooks.test.tsx
+++ b/self/apps/app-sdk/src/__tests__/panel-hooks.test.tsx
@@ -34,6 +34,7 @@ function installMockParent() {
               protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
               kind: 'host.bootstrap',
               message_id: 'msg-1',
+              config_version: 'cfg-1',
               config: {
                 units: {
                   value: 'metric',
@@ -72,6 +73,7 @@ function installMockParent() {
               protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
               kind: 'config.result',
               request_id: message.request_id!,
+              config_version: 'cfg-2',
               config: {
                 units: {
                   value: 'imperial',
@@ -226,6 +228,24 @@ describe('@nous/app-sdk panel hooks', () => {
       expect(screen.getByTestId('units').textContent).toBe('metric');
       expect(screen.getByTestId('persisted-city').textContent).toBe('Seattle');
       expect(latest).toBeDefined();
+    });
+
+    await act(async () => {
+      dispatchFromParent({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        kind: 'config.changed',
+        config_version: 'cfg-live',
+        config: {
+          units: {
+            value: 'scientific',
+            source: 'project_config',
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('units').textContent).toBe('scientific');
     });
 
     const toolResult = await act(async () => {

--- a/self/apps/app-sdk/src/panel/NousPanel.tsx
+++ b/self/apps/app-sdk/src/panel/NousPanel.tsx
@@ -36,6 +36,7 @@ export function NousPanel({ children }: { children: ReactNode }) {
   useEffect(() => {
     let active = true;
     let unsubscribeTheme: (() => void) | undefined;
+    let unsubscribeConfig: (() => void) | undefined;
 
     try {
       const client = new PanelBridgeClient(readBootstrap());
@@ -56,6 +57,9 @@ export function NousPanel({ children }: { children: ReactNode }) {
           unsubscribeTheme = client.subscribeTheme((nextTheme) => {
             setTheme(nextTheme);
           });
+          unsubscribeConfig = client.subscribeConfig((nextConfig) => {
+            setConfig(nextConfig);
+          });
         })
         .catch((nextError) => {
           if (active) {
@@ -66,6 +70,7 @@ export function NousPanel({ children }: { children: ReactNode }) {
       return () => {
         active = false;
         unsubscribeTheme?.();
+        unsubscribeConfig?.();
         client.destroy();
       };
     } catch (nextError) {

--- a/self/apps/app-sdk/src/panel/panel-bridge-client.ts
+++ b/self/apps/app-sdk/src/panel/panel-bridge-client.ts
@@ -40,6 +40,9 @@ export class PanelBridgeClient {
   private readonly themeListeners = new Set<
     (theme: PanelBridgeThemeSnapshot) => void
   >();
+  private readonly configListeners = new Set<
+    (config: PanelBridgeConfigSnapshot) => void
+  >();
   private readonly lifecycleListeners = new Set<
     (event: PanelLifecycleChangedMessage) => void
   >();
@@ -72,6 +75,13 @@ export class PanelBridgeClient {
     if (message.kind === 'theme.changed') {
       for (const listener of this.themeListeners) {
         listener(message.theme);
+      }
+      return;
+    }
+
+    if (message.kind === 'config.changed') {
+      for (const listener of this.configListeners) {
+        listener(message.config);
       }
       return;
     }
@@ -144,6 +154,15 @@ export class PanelBridgeClient {
     this.themeListeners.add(listener);
     return () => {
       this.themeListeners.delete(listener);
+    };
+  }
+
+  subscribeConfig(
+    listener: (config: PanelBridgeConfigSnapshot) => void,
+  ): () => void {
+    this.configListeners.add(listener);
+    return () => {
+      this.configListeners.delete(listener);
     };
   }
 

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -73,6 +73,7 @@ interface WebHostAppPanel {
   label: string
   route_path: string
   dockview_panel_id: string
+  config_version: string
   preserve_state: boolean
   position?: 'left' | 'right' | 'bottom' | 'main'
   config_snapshot: Record<string, {
@@ -516,6 +517,14 @@ ipcMain.handle('app-install:prepare', async (_event, input: unknown) => {
 ipcMain.handle('app-install:install', async (_event, input: unknown) => {
   const client = getTrpcClient() as any
   return client.packages.installApp.mutate(input)
+})
+ipcMain.handle('app-settings:prepare', async (_event, input: unknown) => {
+  const client = getTrpcClient() as any
+  return client.packages.prepareAppSettings.query(input)
+})
+ipcMain.handle('app-settings:save', async (_event, input: unknown) => {
+  const client = getTrpcClient() as any
+  return client.packages.saveAppSettings.mutate(input)
 })
 ipcMain.handle('app-panels:list', async (): Promise<DesktopAppPanel[]> => {
   try {

--- a/self/apps/desktop/src/preload/index.ts
+++ b/self/apps/desktop/src/preload/index.ts
@@ -35,6 +35,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     prepare: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-install:prepare', input),
     install: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-install:install', input),
   },
+  appSettings: {
+    prepare: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-settings:prepare', input),
+    save: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-settings:save', input),
+  },
   appPanels: {
     list: (): Promise<unknown[]> => ipcRenderer.invoke('app-panels:list'),
   },

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -53,6 +53,7 @@ interface AppPanelSnapshot {
   label: string
   route_path: string
   dockview_panel_id: string
+  config_version: string
   preserve_state: boolean
   position?: 'left' | 'right' | 'bottom' | 'main'
   config_snapshot: Record<string, {
@@ -74,7 +75,10 @@ export const NATIVE_PANEL_DEFS: PanelDef[] = [
     id: 'app-installer',
     component: 'app-installer',
     title: 'App Installer',
-    params: () => ({ appInstallApi: (window as any).electronAPI?.appInstall }),
+    params: () => ({
+      appInstallApi: (window as any).electronAPI?.appInstall,
+      appSettingsApi: (window as any).electronAPI?.appSettings,
+    }),
   },
   {
     id: 'chat',
@@ -109,6 +113,7 @@ function toAppPanelDef(panel: AppPanelSnapshot): PanelDef {
       panelId: panel.panel_id,
       src: panel.src,
       preserveState: panel.preserve_state,
+      configVersion: panel.config_version,
       configSnapshot: panel.config_snapshot,
     }),
     position: panel.position ? APP_PANEL_POSITIONS[panel.position] : undefined,

--- a/self/apps/desktop/src/renderer/src/components/AppInstallWizard.tsx
+++ b/self/apps/desktop/src/renderer/src/components/AppInstallWizard.tsx
@@ -6,8 +6,11 @@ import type {
   AppInstallPreparation,
   AppInstallRequest,
   AppInstallResult,
+  AppSettingsPreparation,
+  AppSettingsSaveRequest,
+  AppSettingsSaveResult,
 } from '@nous/shared'
-import { Button, Input, InstallWizard } from '@nous/ui'
+import { AppSettingsSurface, Button, Input, InstallWizard } from '@nous/ui'
 
 interface DesktopInstallApi {
   prepare: (request: {
@@ -18,17 +21,28 @@ interface DesktopInstallApi {
   install: (request: AppInstallRequest) => Promise<AppInstallResult>
 }
 
+interface DesktopSettingsApi {
+  prepare: (request: {
+    project_id: string
+    package_id: string
+  }) => Promise<AppSettingsPreparation>
+  save: (request: AppSettingsSaveRequest) => Promise<AppSettingsSaveResult>
+}
+
 interface AppInstallWizardPanelProps extends IDockviewPanelProps {
   params: {
     appInstallApi?: DesktopInstallApi
+    appSettingsApi?: DesktopSettingsApi
   }
 }
 
 export function AppInstallWizardPanel({ params }: AppInstallWizardPanelProps) {
   const appInstallApi = params.appInstallApi
+  const appSettingsApi = params.appSettingsApi
   const [projectId, setProjectId] = useState('')
   const [packageId, setPackageId] = useState('telegram-connector')
   const [preparation, setPreparation] = useState<AppInstallPreparation | null>(null)
+  const [settingsPreparation, setSettingsPreparation] = useState<AppSettingsPreparation | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -42,6 +56,18 @@ export function AppInstallWizardPanel({ params }: AppInstallWizardPanelProps) {
         package_id: packageId.trim(),
       })
       setPreparation(next)
+      try {
+        if (appSettingsApi) {
+          setSettingsPreparation(
+            await appSettingsApi.prepare({
+              project_id: projectId.trim(),
+              package_id: packageId.trim(),
+            }),
+          )
+        }
+      } catch {
+        setSettingsPreparation(null)
+      }
     } catch (prepareError) {
       setPreparation(null)
       setError(
@@ -60,8 +86,9 @@ export function AppInstallWizardPanel({ params }: AppInstallWizardPanelProps) {
         <div>
           <h3 className="text-base font-semibold">Desktop App Installer</h3>
           <p className="text-sm text-muted-foreground">
-            Load the canonical install contract from the web backend, then run
-            the shared approval-gated wizard inside the desktop host.
+            Load the canonical install or settings contract from the web
+            backend, then run the shared host-owned surface inside the desktop
+            shell.
           </p>
         </div>
         <div className="grid gap-3 md:grid-cols-2">
@@ -96,14 +123,60 @@ export function AppInstallWizardPanel({ params }: AppInstallWizardPanelProps) {
       ) : null}
 
       {preparation ? (
-        <InstallWizard
-          preparation={preparation}
-          projectId={projectId}
-          actorId="desktop-installer"
-          onInstall={(request) => appInstallApi!.install(request)}
-          disabled={!appInstallApi}
-          disabledReason="Desktop install proxy is unavailable."
-        />
+        settingsPreparation ? (
+          <AppSettingsSurface
+            preparation={settingsPreparation}
+            actorId="desktop-installer"
+            onSave={(request) => appSettingsApi!.save(request)}
+            disabled={!appSettingsApi}
+            disabledReason="Desktop settings proxy is unavailable."
+            onSaved={async () => {
+              if (!appSettingsApi) return
+              const refreshed = await appSettingsApi.prepare({
+                project_id: projectId,
+                package_id: packageId,
+              })
+              setSettingsPreparation(refreshed)
+              window.dispatchEvent(
+                new CustomEvent('nous:app-settings-changed', {
+                  detail: {
+                    appId: refreshed.app_id,
+                    configVersion: refreshed.config_version,
+                    configSnapshot: refreshed.panel_config_snapshot,
+                  },
+                }),
+              )
+            }}
+          />
+        ) : (
+          <InstallWizard
+            preparation={preparation}
+            projectId={projectId}
+            actorId="desktop-installer"
+            onInstall={(request) => appInstallApi!.install(request)}
+            onResult={async (result) => {
+              if (!appSettingsApi || result.status === 'failed') {
+                return
+              }
+              const refreshed = await appSettingsApi.prepare({
+                project_id: projectId,
+                package_id: packageId,
+              })
+              setSettingsPreparation(refreshed)
+              window.dispatchEvent(
+                new CustomEvent('nous:app-settings-changed', {
+                  detail: {
+                    appId: refreshed.app_id,
+                    configVersion: refreshed.config_version,
+                    configSnapshot: refreshed.panel_config_snapshot,
+                  },
+                }),
+              )
+            }}
+            disabled={!appInstallApi}
+            disabledReason="Desktop install proxy is unavailable."
+          />
+        )
       ) : null}
     </div>
   )

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -4,6 +4,9 @@ import type {
   AppInstallPreparation,
   AppInstallRequest,
   AppInstallResult,
+  AppSettingsPreparation,
+  AppSettingsSaveRequest,
+  AppSettingsSaveResult,
 } from '@nous/shared'
 
 interface ElectronAPI {
@@ -43,6 +46,13 @@ interface ElectronAPI {
     }) => Promise<AppInstallPreparation>
     install: (input: AppInstallRequest) => Promise<AppInstallResult>
   }
+  appSettings: {
+    prepare: (input: {
+      project_id: string
+      package_id: string
+    }) => Promise<AppSettingsPreparation>
+    save: (input: AppSettingsSaveRequest) => Promise<AppSettingsSaveResult>
+  }
   appPanels: {
     list: () => Promise<{
       app_id: string
@@ -50,6 +60,7 @@ interface ElectronAPI {
       label: string
       route_path: string
       dockview_panel_id: string
+      config_version: string
       preserve_state: boolean
       position?: 'left' | 'right' | 'bottom' | 'main'
       config_snapshot: Record<string, {

--- a/self/apps/web/__tests__/app-panel-bridge-host.test.tsx
+++ b/self/apps/web/__tests__/app-panel-bridge-host.test.tsx
@@ -57,6 +57,7 @@ describe('AppIframePanel host bridge', () => {
             appId: 'app:weather',
             panelId: 'forecast',
             src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configVersion: 'cfg-1',
             configSnapshot: {
               units: {
                 value: 'metric',
@@ -150,6 +151,7 @@ describe('AppIframePanel host bridge', () => {
             appId: 'app:weather',
             panelId: 'forecast',
             src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configVersion: 'cfg-1',
             configSnapshot: {},
           },
         } as any)}
@@ -205,6 +207,7 @@ describe('AppIframePanel host bridge', () => {
             panelId: 'forecast',
             src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
             preserveState: false,
+            configVersion: 'cfg-1',
             configSnapshot: {},
           },
         } as any)}
@@ -281,6 +284,7 @@ describe('AppIframePanel host bridge', () => {
             appId: 'app:weather',
             panelId: 'forecast',
             src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configVersion: 'cfg-1',
             configSnapshot: {},
           },
         } as any)}
@@ -319,5 +323,97 @@ describe('AppIframePanel host bridge', () => {
         body: expect.stringContaining('"reason":"close"'),
       }),
     );
+  });
+
+  it('pushes config updates to the live iframe without remounting it', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+        request_id: 'req-4',
+        ok: true,
+        result: {},
+      }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const view = render(
+      <AppIframePanel
+        {...({
+          params: {
+            appId: 'app:weather',
+            panelId: 'forecast',
+            src: 'http://localhost:3000/apps/app%3Aweather/panels/forecast',
+            configVersion: 'cfg-1',
+            configSnapshot: {
+              units: {
+                value: 'metric',
+                source: 'project_config',
+              },
+            },
+          },
+        } as any)}
+      />,
+    );
+
+    const iframe = view.container.querySelector('iframe');
+    const postMessageSpy = vi.spyOn(iframe!.contentWindow!, 'postMessage');
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe!.contentWindow,
+        data: {
+          protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+          kind: 'panel.ready',
+          message_id: 'msg-4',
+          app_id: 'app:weather',
+          panel_id: 'forecast',
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'host.bootstrap',
+        }),
+        '*',
+      );
+    });
+
+    postMessageSpy.mockClear();
+
+    window.dispatchEvent(
+      new CustomEvent('nous:app-settings-changed', {
+        detail: {
+          appId: 'app:weather',
+          configVersion: 'cfg-2',
+          configSnapshot: {
+            units: {
+              value: 'imperial',
+              source: 'project_config',
+            },
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'config.changed',
+          config_version: 'cfg-2',
+          config: {
+            units: {
+              value: 'imperial',
+              source: 'project_config',
+            },
+          },
+        }),
+        '*',
+      );
+    });
+
+    expect(view.container.querySelector('iframe')).toBe(iframe);
   });
 });

--- a/self/apps/web/__tests__/marketplace-package-detail.test.tsx
+++ b/self/apps/web/__tests__/marketplace-package-detail.test.tsx
@@ -4,6 +4,21 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+vi.mock('@nous/ui', () => ({
+  InstallWizard: () => (
+    <div>
+      <div>Install Wizard</div>
+      <button type="button">Approve And Continue</button>
+    </div>
+  ),
+  AppSettingsSurface: () => (
+    <div>
+      <div>Settings Surface</div>
+      <button type="button">Save Settings</button>
+    </div>
+  ),
+}));
+
 vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: any) => (
     <a href={href} {...props}>
@@ -15,6 +30,8 @@ vi.mock('next/link', () => ({
 const mocks = vi.hoisted(() => ({
   prepareAppInstallUseQuery: vi.fn(),
   installAppUseMutation: vi.fn(),
+  prepareAppSettingsUseQuery: vi.fn(),
+  saveAppSettingsUseMutation: vi.fn(),
 }));
 
 vi.mock('@/lib/trpc', () => ({
@@ -22,6 +39,8 @@ vi.mock('@/lib/trpc', () => ({
     packages: {
       prepareAppInstall: { useQuery: mocks.prepareAppInstallUseQuery },
       installApp: { useMutation: mocks.installAppUseMutation },
+      prepareAppSettings: { useQuery: mocks.prepareAppSettingsUseQuery },
+      saveAppSettings: { useMutation: mocks.saveAppSettingsUseMutation },
     },
   },
 }));
@@ -51,6 +70,12 @@ const snapshot = {
 
 describe('MarketplacePackageDetail', () => {
   it('renders the shared install wizard when project context is available', () => {
+    mocks.prepareAppSettingsUseQuery.mockReturnValue({
+      data: null,
+      error: new Error('settings unavailable'),
+      isLoading: false,
+      refetch: vi.fn(),
+    });
     mocks.prepareAppInstallUseQuery.mockReturnValue({
       data: {
         package_id: 'telegram-connector',
@@ -74,6 +99,10 @@ describe('MarketplacePackageDetail', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     });
+    mocks.saveAppSettingsUseMutation.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
 
     render(
       <MarketplacePackageDetail
@@ -82,16 +111,71 @@ describe('MarketplacePackageDetail', () => {
       />,
     );
 
-    expect(screen.getByText('Install Wizard')).toBeTruthy();
+    expect(screen.getAllByText('Install Wizard')).toHaveLength(2);
     expect(screen.getByRole('button', { name: 'Approve And Continue' })).toBeTruthy();
   });
 
-  it('shows the project-context requirement when no project id is available', () => {
+  it('renders the shared settings surface when the app is already installed', () => {
+    mocks.prepareAppSettingsUseQuery.mockReturnValue({
+      data: {
+        project_id: '550e8400-e29b-41d4-a716-446655440802',
+        package_id: 'telegram-connector',
+        release_id: 'release-1',
+        package_version: '1.0.0',
+        app_id: 'telegram',
+        display_name: 'Telegram Connector',
+        config_version: 'cfg-1',
+        runtime: {
+          status: 'active',
+          config_version: 'cfg-1',
+        },
+        config_groups: [],
+        panel_config_snapshot: {},
+      },
+      error: null,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
     mocks.prepareAppInstallUseQuery.mockReturnValue({
       data: null,
       isLoading: false,
     });
     mocks.installAppUseMutation.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    mocks.saveAppSettingsUseMutation.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+
+    render(
+      <MarketplacePackageDetail
+        snapshot={snapshot}
+        projectId="550e8400-e29b-41d4-a716-446655440802"
+      />,
+    );
+
+    expect(screen.getByText('Settings Surface')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save Settings' })).toBeTruthy();
+  });
+
+  it('shows the project-context requirement when no project id is available', () => {
+    mocks.prepareAppSettingsUseQuery.mockReturnValue({
+      data: null,
+      error: null,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    mocks.prepareAppInstallUseQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+    mocks.installAppUseMutation.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    mocks.saveAppSettingsUseMutation.mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
     });

--- a/self/apps/web/components/marketplace/marketplace-package-detail.tsx
+++ b/self/apps/web/components/marketplace/marketplace-package-detail.tsx
@@ -2,8 +2,11 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import type { RegistryPackageDetailSnapshot } from '@nous/shared';
-import { InstallWizard } from '@nous/ui';
+import type {
+  AppSettingsPreparation,
+  RegistryPackageDetailSnapshot,
+} from '@nous/shared';
+import { AppSettingsSurface, InstallWizard } from '@nous/ui';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { trpc } from '@/lib/trpc';
@@ -29,7 +32,34 @@ export function MarketplacePackageDetail({
       enabled: Boolean(projectId && snapshot.latestRelease?.release_id),
     },
   );
+  const settingsPreparationQuery = trpc.packages.prepareAppSettings.useQuery(
+    {
+      project_id: projectId as any,
+      package_id: snapshot.package.package_id,
+    },
+    {
+      enabled: Boolean(projectId),
+      retry: false,
+    },
+  );
   const installAppMutation = trpc.packages.installApp.useMutation();
+  const saveAppSettingsMutation = trpc.packages.saveAppSettings.useMutation();
+
+  const syncPanels = React.useCallback((preparation?: AppSettingsPreparation | null) => {
+    if (!preparation || typeof window === 'undefined') {
+      return
+    }
+
+    window.dispatchEvent(
+      new CustomEvent('nous:app-settings-changed', {
+        detail: {
+          appId: preparation.app_id,
+          configVersion: preparation.config_version,
+          configSnapshot: preparation.panel_config_snapshot,
+        },
+      }),
+    )
+  }, [])
 
   return (
     <div className="space-y-6">
@@ -38,18 +68,38 @@ export function MarketplacePackageDetail({
           <CardTitle className="text-base">Install Wizard</CardTitle>
         </CardHeader>
         <CardContent className="pt-4">
-          {projectId && installPreparationQuery.data ? (
+          {projectId && settingsPreparationQuery.data ? (
+            <AppSettingsSurface
+              preparation={settingsPreparationQuery.data}
+              actorId="web-marketplace"
+              onSave={(request) => saveAppSettingsMutation.mutateAsync(request)}
+              disabled={settingsPreparationQuery.isLoading || saveAppSettingsMutation.isPending}
+              onSaved={async () => {
+                const refreshed = await settingsPreparationQuery.refetch()
+                syncPanels(refreshed.data)
+              }}
+            />
+          ) : projectId && installPreparationQuery.data ? (
             <InstallWizard
               preparation={installPreparationQuery.data}
               projectId={projectId}
               actorId="web-marketplace"
               onInstall={(request) => installAppMutation.mutateAsync(request)}
+              onResult={async (result) => {
+                if (result.status === 'failed') {
+                  return
+                }
+                const refreshed = await settingsPreparationQuery.refetch()
+                syncPanels(refreshed.data)
+              }}
               disabled={installPreparationQuery.isLoading || installAppMutation.isPending}
             />
           ) : (
             <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
               {projectId
-                ? 'Preparing the canonical install contract...'
+                ? settingsPreparationQuery.error
+                  ? 'Preparing the canonical settings or install contract...'
+                  : 'Preparing the canonical install contract...'
                 : 'Open this package with a project context to run the approval-gated install wizard.'}
             </div>
           )}

--- a/self/apps/web/server/__tests__/packages-router.test.ts
+++ b/self/apps/web/server/__tests__/packages-router.test.ts
@@ -2,8 +2,9 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { appRouter } from '../trpc/root';
+import { packagesRouter } from '../trpc/routers/packages';
 import { clearNousContextCache, createNousContext } from '../bootstrap';
 import { createProjectConfig } from '../../test-support/project-fixtures';
 
@@ -130,6 +131,97 @@ describe('packages router', () => {
     expect(installResult.status).toBe('failed');
     expect(installResult.phase).toBe('configuration');
     expect(installResult.validation.results[0]?.field).toBe('bot_token');
+  });
+
+  it('routes canonical app-settings prepare/save calls and panel listings through the shared context seams', async () => {
+    const prepareSettings = vi.fn().mockResolvedValue({
+      project_id: '550e8400-e29b-41d4-a716-446655440803',
+      package_id: 'telegram-connector',
+      release_id: 'release-1',
+      package_version: '1.0.0',
+      app_id: 'telegram',
+      display_name: 'Telegram Connector',
+      config_version: 'cfg-1',
+      runtime: {
+        status: 'active',
+        config_version: 'cfg-1',
+      },
+      config_groups: [],
+      panel_config_snapshot: {},
+    });
+    const saveSettings = vi.fn().mockResolvedValue({
+      status: 'success',
+      apply_status: 'applied',
+      phase: 'completed',
+      validation: {
+        status: 'success',
+        results: [],
+      },
+      effective_config_version: 'cfg-2',
+      runtime: {
+        status: 'active',
+        config_version: 'cfg-2',
+      },
+      stored_secrets: [],
+      rollback_applied: false,
+      recoverable: true,
+      metadata: {},
+    });
+    const listPanels = vi.fn().mockResolvedValue([
+      {
+        session_id: 'session-1',
+        app_id: 'telegram',
+        package_id: 'telegram-connector',
+        package_version: '1.0.0',
+        config_version: 'cfg-2',
+        panel_id: 'main',
+        label: 'Main',
+        entry: 'panels/main.tsx',
+        preserve_state: true,
+        package_root_ref: '/tmp/.apps/telegram-connector',
+        manifest_ref: '/tmp/.apps/telegram-connector/manifest.json',
+        route_path: '/apps/telegram/panels/main',
+        dockview_panel_id: 'app:telegram:main',
+        config_snapshot: {
+          units: {
+            value: 'metric',
+            source: 'project_config',
+          },
+        },
+      },
+    ]);
+
+    const caller = packagesRouter.createCaller({
+      appSettingsService: {
+        prepareSettings,
+        saveSettings,
+      },
+      appRuntimeService: {
+        listPanels,
+      },
+    } as any);
+
+    const preparation = await caller.prepareAppSettings({
+      project_id: '550e8400-e29b-41d4-a716-446655440803' as any,
+      package_id: 'telegram-connector',
+    });
+    const result = await caller.saveAppSettings({
+      project_id: '550e8400-e29b-41d4-a716-446655440803' as any,
+      package_id: 'telegram-connector',
+      actor_id: 'web-test',
+      expected_config_version: 'cfg-1',
+      config: {},
+      secrets: {},
+      evidence_refs: [],
+    });
+    const panels = await caller.listAppPanels();
+
+    expect(preparation.config_version).toBe('cfg-1');
+    expect(result.effective_config_version).toBe('cfg-2');
+    expect(panels[0]?.config_version).toBe('cfg-2');
+    expect(prepareSettings).toHaveBeenCalledTimes(1);
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+    expect(listPanels).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/self/apps/web/server/bootstrap.ts
+++ b/self/apps/web/server/bootstrap.ts
@@ -57,6 +57,7 @@ import {
 } from '@nous/cortex-core';
 import {
   AppInstallService,
+  AppSettingsService,
   DocumentAppConfigStore,
   DocumentProjectStore,
   PackageInstallService,
@@ -437,6 +438,13 @@ export function createNousContext(): NousContext {
     configStore: appConfigStore,
     runtime,
     witnessService,
+    instanceRoot,
+  });
+  const appSettingsService = new AppSettingsService({
+    appCredentialInstallService,
+    appRuntimeService,
+    configStore: appConfigStore,
+    runtime,
     instanceRoot,
   });
   const maoProjectionService = new MaoProjectionService({
@@ -824,6 +832,7 @@ export function createNousContext(): NousContext {
     endpointTrustService,
     registryService,
     appInstallService,
+    appSettingsService,
     packageInstallService,
     nudgeDiscoveryService,
     voiceControlService,

--- a/self/apps/web/server/context.ts
+++ b/self/apps/web/server/context.ts
@@ -20,6 +20,7 @@ import type {
   IRegistryService,
   INudgeDiscoveryService,
   IAppInstallService,
+  IAppSettingsService,
   IPackageInstallService,
   IVoiceControlService,
   IPublicMcpGatewayService,
@@ -59,6 +60,7 @@ export interface NousContext {
   endpointTrustService: IEndpointTrustService;
   registryService: IRegistryService;
   appInstallService: IAppInstallService;
+  appSettingsService: IAppSettingsService;
   packageInstallService: IPackageInstallService;
   nudgeDiscoveryService: INudgeDiscoveryService;
   voiceControlService: IVoiceControlService;

--- a/self/apps/web/server/trpc/routers/packages.ts
+++ b/self/apps/web/server/trpc/routers/packages.ts
@@ -3,6 +3,10 @@ import {
   AppInstallPrepareRequestSchema,
   AppInstallRequestSchema,
   AppInstallResultSchema,
+  AppSettingsPreparationSchema,
+  AppSettingsPrepareRequestSchema,
+  AppSettingsSaveRequestSchema,
+  AppSettingsSaveResultSchema,
   AppPanelSafeConfigSnapshotSchema,
   PackageInstallRequestSchema,
   PackageInstallResultSchema,
@@ -17,6 +21,7 @@ const AppHostPanelSchema = z.object({
   label: z.string().min(1),
   route_path: z.string().min(1),
   dockview_panel_id: z.string().min(1),
+  config_version: z.string().min(1),
   preserve_state: z.boolean(),
   position: z.enum(['left', 'right', 'bottom', 'main']).optional(),
   config_snapshot: AppPanelSafeConfigSnapshotSchema,
@@ -35,6 +40,18 @@ export const packagesRouter = router({
     .mutation(async ({ ctx, input }) => {
       return ctx.appInstallService.installApp(input);
     }),
+  prepareAppSettings: publicProcedure
+    .input(AppSettingsPrepareRequestSchema)
+    .output(AppSettingsPreparationSchema)
+    .query(async ({ ctx, input }) => {
+      return ctx.appSettingsService.prepareSettings(input);
+    }),
+  saveAppSettings: publicProcedure
+    .input(AppSettingsSaveRequestSchema)
+    .output(AppSettingsSaveResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      return ctx.appSettingsService.saveSettings(input);
+    }),
   install: publicProcedure
     .input(PackageInstallRequestSchema)
     .output(PackageInstallResultSchema)
@@ -51,6 +68,7 @@ export const packagesRouter = router({
         label: panel.label,
         route_path: panel.route_path,
         dockview_panel_id: panel.dockview_panel_id,
+        config_version: panel.config_version,
         preserve_state: panel.preserve_state,
         position: panel.position,
         config_snapshot: panel.config_snapshot,

--- a/self/autonomic/credentials/src/__tests__/credential-vault-service.test.ts
+++ b/self/autonomic/credentials/src/__tests__/credential-vault-service.test.ts
@@ -63,4 +63,66 @@ describe('CredentialVaultService', () => {
     expect(purged.purged_count).toBe(1);
     expect(await service.getMetadata('app:weather', 'weather_backup')).toBeNull();
   });
+
+  it('backs up, restores, and discards credential snapshots for secret rotation', async () => {
+    const service = new CredentialVaultService({
+      keyResolverOptions: {
+        masterKey: 'test-key',
+      },
+      now: () => '2026-03-19T00:00:00.000Z',
+    });
+
+    await service.store('app:weather', {
+      key: 'weather_api',
+      value: 'secret-token',
+      credential_type: 'bearer_token',
+      target_host: 'api.weather.example',
+      injection_location: 'header',
+      injection_key: 'Authorization',
+    });
+
+    const backup = await service.backup('app:weather', 'weather_api');
+    await service.store('app:weather', {
+      key: 'weather_api',
+      value: 'rotated-token',
+      credential_type: 'bearer_token',
+      target_host: 'api.weather.example',
+      injection_location: 'header',
+      injection_key: 'Authorization',
+    });
+
+    const restored = await service.restore('app:weather', backup.backup_ref);
+    const resolved = await service.resolveForInjection('app:weather', 'weather_api');
+    const discarded = await service.discardBackup('app:weather', backup.backup_ref);
+
+    expect(backup.existed).toBe(true);
+    expect(restored.restored).toBe(true);
+    expect(resolved?.secretValue).toBe('secret-token');
+    expect(discarded.discarded).toBe(true);
+  });
+
+  it('restores empty backups by removing credentials created after the snapshot', async () => {
+    const service = new CredentialVaultService({
+      keyResolverOptions: {
+        masterKey: 'test-key',
+      },
+    });
+
+    const backup = await service.backup('app:weather', 'weather_api');
+    await service.store('app:weather', {
+      key: 'weather_api',
+      value: 'secret-token',
+      credential_type: 'bearer_token',
+      target_host: 'api.weather.example',
+      injection_location: 'header',
+      injection_key: 'Authorization',
+    });
+
+    const restored = await service.restore('app:weather', backup.backup_ref);
+    const metadata = await service.getMetadata('app:weather', 'weather_api');
+
+    expect(backup.existed).toBe(false);
+    expect(restored.restored).toBe(true);
+    expect(metadata).toBeNull();
+  });
 });

--- a/self/autonomic/credentials/src/app-credential-install-service.ts
+++ b/self/autonomic/credentials/src/app-credential-install-service.ts
@@ -26,4 +26,16 @@ export class AppCredentialInstallService implements IAppCredentialInstallService
   async revokeCredential(appId: string, request: CredentialRevokeRequest) {
     return this.options.vaultService.revoke(appId, request);
   }
+
+  async backupCredential(appId: string, key: string) {
+    return this.options.vaultService.backup(appId, key);
+  }
+
+  async restoreCredential(appId: string, backupRef: string) {
+    return this.options.vaultService.restore(appId, backupRef);
+  }
+
+  async discardCredentialBackup(appId: string, backupRef: string) {
+    return this.options.vaultService.discardBackup(appId, backupRef);
+  }
 }

--- a/self/autonomic/credentials/src/credential-vault-service.ts
+++ b/self/autonomic/credentials/src/credential-vault-service.ts
@@ -1,10 +1,16 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
 import {
+  type CredentialBackupResult,
+  CredentialBackupResultSchema,
+  type CredentialDiscardBackupResult,
+  CredentialDiscardBackupResultSchema,
   type CredentialMetadata,
   type CredentialNamespacePurgeResult,
   CredentialMetadataSchema,
   type CredentialRevokeRequest,
   CredentialRevokeResultSchema,
+  type CredentialRestoreResult,
+  CredentialRestoreResultSchema,
   type CredentialStoreRequest,
   CredentialStoreResultSchema,
   type CredentialVaultEntry,
@@ -16,10 +22,19 @@ import { CredentialKeyResolver, type CredentialKeyResolverOptions } from './cred
 
 export const CREDENTIAL_VAULT_COLLECTION = 'credential_vault_entries';
 export const CREDENTIAL_NAMESPACE_COLLECTION = 'credential_vault_namespaces';
+export const CREDENTIAL_BACKUP_COLLECTION = 'credential_vault_backups';
 
 interface CredentialNamespaceRecord {
   app_id: string;
   keys: string[];
+}
+
+interface CredentialBackupRecord {
+  backup_ref: string;
+  app_id: string;
+  user_key: string;
+  entry: CredentialVaultEntry | null;
+  created_at: string;
 }
 
 export interface CredentialVaultServiceOptions {
@@ -34,6 +49,7 @@ export class CredentialVaultService implements ICredentialVaultService {
   private readonly keyResolver: CredentialKeyResolver;
   private readonly inMemoryEntries = new Map<string, CredentialVaultEntry>();
   private readonly inMemoryNamespaces = new Map<string, CredentialNamespaceRecord>();
+  private readonly inMemoryBackups = new Map<string, CredentialBackupRecord>();
 
   constructor(private readonly options: CredentialVaultServiceOptions = {}) {
     this.now = options.now ?? (() => new Date().toISOString());
@@ -97,6 +113,67 @@ export class CredentialVaultService implements ICredentialVaultService {
       revoked: true,
       credential_ref: entry.credential_ref,
       reason: request.reason,
+    });
+  }
+
+  async backup(appId: string, key: string): Promise<CredentialBackupResult> {
+    const backupRef = `backup:${appId}:${key}:${this.now()}:${randomBytes(4).toString('hex')}`;
+    const entry = await this.getEntry(this.buildVaultKey(appId, key));
+    const record: CredentialBackupRecord = {
+      backup_ref: backupRef,
+      app_id: appId,
+      user_key: key,
+      entry,
+      created_at: this.now(),
+    };
+
+    await this.putBackup(record);
+
+    return CredentialBackupResultSchema.parse({
+      backup_ref: backupRef,
+      existed: Boolean(entry),
+      metadata: entry ? this.toMetadata(entry) : undefined,
+    });
+  }
+
+  async restore(appId: string, backupRef: string): Promise<CredentialRestoreResult> {
+    const backup = await this.getBackup(backupRef);
+    if (!backup || backup.app_id !== appId) {
+      return CredentialRestoreResultSchema.parse({
+        restored: false,
+      });
+    }
+
+    if (backup.entry) {
+      await this.putEntry(backup.entry);
+      await this.addNamespaceKey(appId, backup.entry.user_key);
+      return CredentialRestoreResultSchema.parse({
+        restored: true,
+        metadata: this.toMetadata(backup.entry),
+      });
+    }
+
+    await this.deleteEntry(this.buildVaultKey(appId, backup.user_key));
+    await this.removeNamespaceKey(appId, backup.user_key);
+    return CredentialRestoreResultSchema.parse({
+      restored: true,
+    });
+  }
+
+  async discardBackup(
+    appId: string,
+    backupRef: string,
+  ): Promise<CredentialDiscardBackupResult> {
+    const backup = await this.getBackup(backupRef);
+    if (!backup || backup.app_id !== appId) {
+      return CredentialDiscardBackupResultSchema.parse({
+        discarded: false,
+      });
+    }
+
+    await this.deleteBackup(backupRef);
+    return CredentialDiscardBackupResultSchema.parse({
+      discarded: true,
     });
   }
 
@@ -260,5 +337,38 @@ export class CredentialVaultService implements ICredentialVaultService {
       app_id: appId,
       keys: record.keys.filter((candidate) => candidate !== key),
     });
+  }
+
+  private async putBackup(record: CredentialBackupRecord): Promise<void> {
+    if (this.options.documentStore) {
+      await this.options.documentStore.put(
+        CREDENTIAL_BACKUP_COLLECTION,
+        record.backup_ref,
+        record,
+      );
+      return;
+    }
+    this.inMemoryBackups.set(record.backup_ref, record);
+  }
+
+  private async getBackup(backupRef: string): Promise<CredentialBackupRecord | null> {
+    if (this.options.documentStore) {
+      return (
+        await this.options.documentStore.get<CredentialBackupRecord>(
+          CREDENTIAL_BACKUP_COLLECTION,
+          backupRef,
+        )
+      ) ?? null;
+    }
+
+    return this.inMemoryBackups.get(backupRef) ?? null;
+  }
+
+  private async deleteBackup(backupRef: string): Promise<void> {
+    if (this.options.documentStore) {
+      await this.options.documentStore.delete(CREDENTIAL_BACKUP_COLLECTION, backupRef);
+      return;
+    }
+    this.inMemoryBackups.delete(backupRef);
   }
 }

--- a/self/shared/src/__tests__/types/app-runtime.test.ts
+++ b/self/shared/src/__tests__/types/app-runtime.test.ts
@@ -89,6 +89,7 @@ describe('AppPanel bridge runtime schemas', () => {
       app_id: 'app:weather',
       package_id: 'app:weather',
       package_version: '1.0.0',
+      config_version: 'cfg-1',
       panel_id: 'forecast',
       label: 'Forecast',
       entry: 'panels/forecast.tsx',

--- a/self/shared/src/__tests__/types/app-settings.test.ts
+++ b/self/shared/src/__tests__/types/app-settings.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AppSettingsPreparationSchema,
+  AppSettingsSaveRequestSchema,
+  AppSettingsSaveResultSchema,
+  AppSettingsSecretMutationSchema,
+} from '../../types/app-settings.js';
+
+describe('AppSettingsPreparationSchema', () => {
+  it('accepts grouped settings preparation contracts with runtime state', () => {
+    const parsed = AppSettingsPreparationSchema.parse({
+      project_id: '550e8400-e29b-41d4-a716-446655440901',
+      package_id: 'telegram-connector',
+      release_id: 'release-1',
+      package_version: '1.0.0',
+      app_id: 'telegram',
+      display_name: 'Telegram Connector',
+      description: 'Reference connector app',
+      config_version: 'cfg-1',
+      runtime: {
+        session_id: 'session-1',
+        status: 'active',
+        health_status: 'healthy',
+        config_version: 'cfg-1',
+      },
+      config_groups: [
+        {
+          id: 'connector',
+          label: 'Connector',
+          fields: [
+            {
+              key: 'bot_token',
+              type: 'secret',
+              required: true,
+              label: 'Bot Token',
+              group: 'connector',
+              secret: true,
+              value_source: 'secret_state',
+              secret_state: {
+                key: 'bot_token',
+                configured: true,
+                credential_ref: 'credential:telegram:bot_token',
+                source: 'secret_field',
+              },
+            },
+            {
+              key: 'region',
+              type: 'string',
+              required: true,
+              label: 'Region',
+              group: 'connector',
+              secret: false,
+              value: 'us',
+              value_source: 'project_config',
+            },
+          ],
+        },
+      ],
+      panel_config_snapshot: {
+        region: {
+          value: 'us',
+          source: 'project_config',
+        },
+      },
+    });
+
+    expect(parsed.runtime.status).toBe('active');
+    expect(parsed.config_groups[0]?.fields[0]?.secret_state?.configured).toBe(true);
+  });
+});
+
+describe('AppSettingsSecretMutationSchema', () => {
+  it('requires a value for replace and rejects stray values for retain', () => {
+    const replace = AppSettingsSecretMutationSchema.safeParse({
+      operation: 'replace',
+      value: 'next-secret',
+    });
+    const invalidRetain = AppSettingsSecretMutationSchema.safeParse({
+      operation: 'retain',
+      value: 'should-not-be-here',
+    });
+
+    expect(replace.success).toBe(true);
+    expect(invalidRetain.success).toBe(false);
+  });
+});
+
+describe('AppSettingsSaveRequestSchema', () => {
+  it('defaults optional config, secrets, and evidence collections', () => {
+    const parsed = AppSettingsSaveRequestSchema.parse({
+      project_id: '550e8400-e29b-41d4-a716-446655440902',
+      package_id: 'telegram-connector',
+      actor_id: 'web-test',
+      expected_config_version: 'cfg-1',
+    });
+
+    expect(parsed.config).toEqual({});
+    expect(parsed.secrets).toEqual({});
+    expect(parsed.evidence_refs).toEqual([]);
+  });
+});
+
+describe('AppSettingsSaveResultSchema', () => {
+  it('accepts recoverable partial save outcomes with rollback evidence', () => {
+    const parsed = AppSettingsSaveResultSchema.parse({
+      status: 'partial',
+      apply_status: 'reverted',
+      phase: 'recovery',
+      validation: {
+        status: 'success',
+        results: [],
+      },
+      requested_config_version: 'cfg-2',
+      effective_config_version: 'cfg-1',
+      runtime: {
+        status: 'active',
+        session_id: 'session-1',
+        config_version: 'cfg-1',
+      },
+      stored_secrets: [
+        {
+          key: 'bot_token',
+          configured: true,
+          credential_ref: 'credential:telegram:bot_token',
+          source: 'secret_field',
+        },
+      ],
+      activation_failure: {
+        code: 'APP-SETTINGS-ACTIVATION-FAILED',
+        message: 'Activation failed.',
+        retryable: true,
+      },
+      rollback_applied: true,
+      recoverable: true,
+      metadata: {
+        restored_config_version: 'cfg-1',
+      },
+    });
+
+    expect(parsed.apply_status).toBe('reverted');
+    expect(parsed.rollback_applied).toBe(true);
+  });
+});

--- a/self/shared/src/__tests__/types/panel-bridge-protocol.test.ts
+++ b/self/shared/src/__tests__/types/panel-bridge-protocol.test.ts
@@ -28,6 +28,7 @@ describe('panel bridge shared protocol types', () => {
       protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
       kind: 'host.bootstrap',
       message_id: 'msg-1',
+      config_version: 'cfg-1',
       config: {
         units: {
           value: 'metric',
@@ -121,5 +122,21 @@ describe('panel bridge shared protocol types', () => {
     expect(getRequest.kind).toBe('persisted_state.get');
     expect(lifecycle.kind).toBe('panel.lifecycle');
     expect(result.exists).toBe(true);
+  });
+
+  it('parses config push messages with the effective config version', () => {
+    const changed = PanelBridgeHostMessageSchema.parse({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'config.changed',
+      config_version: 'cfg-2',
+      config: {
+        units: {
+          value: 'imperial',
+          source: 'project_config',
+        },
+      },
+    });
+
+    expect(changed.kind).toBe('config.changed');
   });
 });

--- a/self/shared/src/interfaces/autonomic.ts
+++ b/self/shared/src/interfaces/autonomic.ts
@@ -15,9 +15,12 @@ import type {
   CredentialInjectRequest,
   CredentialInjectedResponse,
   CredentialMetadata,
+  CredentialBackupResult,
+  CredentialDiscardBackupResult,
   CredentialNamespacePurgeResult,
   CredentialRevokeRequest,
   CredentialRevokeResult,
+  CredentialRestoreResult,
   CredentialStoreRequest,
   CredentialStoreResult,
 } from '../types/index.js';
@@ -165,6 +168,18 @@ export interface ICredentialVaultService {
 
   /** Revoke one app-scoped credential. */
   revoke(appId: string, request: CredentialRevokeRequest): Promise<CredentialRevokeResult>;
+
+  /** Create an opaque backup handle for one app-scoped credential. */
+  backup(appId: string, key: string): Promise<CredentialBackupResult>;
+
+  /** Restore a previously created opaque backup handle. */
+  restore(appId: string, backupRef: string): Promise<CredentialRestoreResult>;
+
+  /** Discard an unused opaque backup handle. */
+  discardBackup(
+    appId: string,
+    backupRef: string,
+  ): Promise<CredentialDiscardBackupResult>;
 
   /** Purge every credential in one app namespace. */
   purgeNamespace(appId: string): Promise<CredentialNamespacePurgeResult>;

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -40,6 +40,7 @@ export type {
   ISandbox,
   IAppCredentialInstallService,
   IAppInstallService,
+  IAppSettingsService,
   IAppRuntimeService,
   IPackageLifecycleOrchestrator,
   IPackageInstallService,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -96,12 +96,19 @@ import type {
   AppInstallPreparation,
   AppInstallRequest,
   AppInstallResult,
+  AppSettingsPreparation,
+  AppSettingsPrepareRequest,
+  AppSettingsSaveRequest,
+  AppSettingsSaveResult,
   AppHealthSnapshot,
   AppHeartbeatSignal,
+  CredentialBackupResult,
+  CredentialDiscardBackupResult,
   CredentialOAuthFlowRequest,
   CredentialOAuthFlowResult,
   CredentialRevokeRequest,
   CredentialRevokeResult,
+  CredentialRestoreResult,
   CredentialStoreRequest,
   CredentialStoreResult,
   PackageLifecycleTransitionRequest,
@@ -580,6 +587,24 @@ export interface IAppCredentialInstallService {
     appId: string,
     request: CredentialRevokeRequest,
   ): Promise<CredentialRevokeResult>;
+
+  /** Create an opaque backup handle before a destructive settings mutation. */
+  backupCredential(
+    appId: string,
+    key: string,
+  ): Promise<CredentialBackupResult>;
+
+  /** Restore a previously created opaque backup handle. */
+  restoreCredential(
+    appId: string,
+    backupRef: string,
+  ): Promise<CredentialRestoreResult>;
+
+  /** Discard an unused opaque backup handle. */
+  discardCredentialBackup(
+    appId: string,
+    backupRef: string,
+  ): Promise<CredentialDiscardBackupResult>;
 }
 
 export interface IPublicMcpGatewayService {
@@ -933,6 +958,16 @@ export interface IAppInstallService {
 
   /** Execute approval-gated install, validation, vault storage, and activation. */
   installApp(request: AppInstallRequest): Promise<AppInstallResult>;
+}
+
+export interface IAppSettingsService {
+  /** Resolve the canonical settings contract for one installed app package. */
+  prepareSettings(
+    request: AppSettingsPrepareRequest,
+  ): Promise<AppSettingsPreparation>;
+
+  /** Validate and apply one governed settings save. */
+  saveSettings(request: AppSettingsSaveRequest): Promise<AppSettingsSaveResult>;
 }
 
 export interface IPackageInstallService {

--- a/self/shared/src/types/app-credentials.ts
+++ b/self/shared/src/types/app-credentials.ts
@@ -112,6 +112,30 @@ export const CredentialRevokeResultSchema = z.object({
 });
 export type CredentialRevokeResult = z.infer<typeof CredentialRevokeResultSchema>;
 
+export const CredentialBackupResultSchema = z.object({
+  backup_ref: z.string().min(1),
+  existed: z.boolean(),
+  metadata: CredentialMetadataSchema.optional(),
+});
+export type CredentialBackupResult = z.infer<
+  typeof CredentialBackupResultSchema
+>;
+
+export const CredentialRestoreResultSchema = z.object({
+  restored: z.boolean(),
+  metadata: CredentialMetadataSchema.optional(),
+});
+export type CredentialRestoreResult = z.infer<
+  typeof CredentialRestoreResultSchema
+>;
+
+export const CredentialDiscardBackupResultSchema = z.object({
+  discarded: z.boolean(),
+});
+export type CredentialDiscardBackupResult = z.infer<
+  typeof CredentialDiscardBackupResultSchema
+>;
+
 export const CredentialNamespacePurgeResultSchema = z.object({
   app_id: z.string().min(1),
   purged_count: z.number().int().nonnegative(),

--- a/self/shared/src/types/app-runtime.ts
+++ b/self/shared/src/types/app-runtime.ts
@@ -139,6 +139,7 @@ export const AppPanelBridgeContextSchema = z.object({
   app_id: z.string().min(1),
   package_id: z.string().min(1),
   package_version: z.string().min(1),
+  config_version: z.string().min(1),
   project_id: ProjectIdSchema.optional(),
   panel_id: z.string().min(1),
   label: z.string().min(1),

--- a/self/shared/src/types/app-settings.ts
+++ b/self/shared/src/types/app-settings.ts
@@ -1,0 +1,168 @@
+import { z } from 'zod';
+import {
+  AppInstallActivationFailureSchema,
+  AppInstallConfigFieldDescriptorSchema,
+  AppInstallConfigGroupSchema,
+  AppSecretConfigStateSchema,
+} from './app-install.js';
+import {
+  AppHealthStatusSchema,
+  AppPanelSafeConfigSnapshotSchema,
+} from './app-runtime.js';
+import { InstallValidationResultSchema } from './app-manifest.js';
+import { ProjectIdSchema } from './ids.js';
+
+export const AppSettingsRuntimeStatusSchema = z.enum([
+  'active',
+  'inactive',
+  'failed',
+]);
+export type AppSettingsRuntimeStatus = z.infer<
+  typeof AppSettingsRuntimeStatusSchema
+>;
+
+export const AppSettingsRuntimeSummarySchema = z.object({
+  session_id: z.string().min(1).optional(),
+  status: AppSettingsRuntimeStatusSchema,
+  health_status: AppHealthStatusSchema.optional(),
+  config_version: z.string().min(1),
+});
+export type AppSettingsRuntimeSummary = z.infer<
+  typeof AppSettingsRuntimeSummarySchema
+>;
+
+export const AppSettingsValueSourceSchema = z.enum([
+  'manifest_default',
+  'project_config',
+  'secret_state',
+]);
+export type AppSettingsValueSource = z.infer<
+  typeof AppSettingsValueSourceSchema
+>;
+
+export const AppSettingsFieldStateSchema =
+  AppInstallConfigFieldDescriptorSchema.extend({
+    value: z.unknown().optional(),
+    value_source: AppSettingsValueSourceSchema.optional(),
+    secret_state: AppSecretConfigStateSchema.optional(),
+  });
+export type AppSettingsFieldState = z.infer<typeof AppSettingsFieldStateSchema>;
+
+export const AppSettingsConfigGroupSchema = AppInstallConfigGroupSchema.extend({
+  fields: z.array(AppSettingsFieldStateSchema).min(1),
+});
+export type AppSettingsConfigGroup = z.infer<
+  typeof AppSettingsConfigGroupSchema
+>;
+
+export const AppSettingsPreparationSchema = z.object({
+  project_id: ProjectIdSchema,
+  package_id: z.string().min(1),
+  release_id: z.string().min(1),
+  package_version: z.string().min(1),
+  app_id: z.string().min(1),
+  display_name: z.string().min(1),
+  description: z.string().min(1).optional(),
+  config_version: z.string().min(1),
+  runtime: AppSettingsRuntimeSummarySchema,
+  config_groups: z.array(AppSettingsConfigGroupSchema).default([]),
+  panel_config_snapshot: AppPanelSafeConfigSnapshotSchema.default({}),
+});
+export type AppSettingsPreparation = z.infer<
+  typeof AppSettingsPreparationSchema
+>;
+
+export const AppSettingsPrepareRequestSchema = z.object({
+  project_id: ProjectIdSchema,
+  package_id: z.string().min(1),
+});
+export type AppSettingsPrepareRequest = z.infer<
+  typeof AppSettingsPrepareRequestSchema
+>;
+
+export const AppSettingsSecretMutationOperationSchema = z.enum([
+  'retain',
+  'replace',
+  'clear',
+]);
+export type AppSettingsSecretMutationOperation = z.infer<
+  typeof AppSettingsSecretMutationOperationSchema
+>;
+
+export const AppSettingsSecretMutationSchema = z
+  .object({
+    operation: AppSettingsSecretMutationOperationSchema.default('retain'),
+    value: z.string().min(1).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.operation === 'replace' && !value.value) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'replace requires a secret value',
+        path: ['value'],
+      });
+    }
+    if (value.operation !== 'replace' && value.value !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'secret value is only valid for replace operations',
+        path: ['value'],
+      });
+    }
+  });
+export type AppSettingsSecretMutation = z.infer<
+  typeof AppSettingsSecretMutationSchema
+>;
+
+export const AppSettingsSaveRequestSchema = z.object({
+  project_id: ProjectIdSchema,
+  package_id: z.string().min(1),
+  actor_id: z.string().min(1),
+  expected_config_version: z.string().min(1),
+  config: z.record(z.unknown()).default({}),
+  secrets: z.record(AppSettingsSecretMutationSchema).default({}),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+});
+export type AppSettingsSaveRequest = z.infer<
+  typeof AppSettingsSaveRequestSchema
+>;
+
+export const AppSettingsApplyStatusSchema = z.enum([
+  'applied',
+  'reverted',
+  'blocked',
+]);
+export type AppSettingsApplyStatus = z.infer<
+  typeof AppSettingsApplyStatusSchema
+>;
+
+export const AppSettingsSavePhaseSchema = z.enum([
+  'validation',
+  'deactivation',
+  'config_update',
+  'activation',
+  'recovery',
+  'completed',
+]);
+export type AppSettingsSavePhase = z.infer<
+  typeof AppSettingsSavePhaseSchema
+>;
+
+export const AppSettingsSaveResultSchema = z.object({
+  status: z.enum(['success', 'partial', 'failed']),
+  apply_status: AppSettingsApplyStatusSchema,
+  phase: AppSettingsSavePhaseSchema,
+  validation: InstallValidationResultSchema,
+  requested_config_version: z.string().min(1).optional(),
+  effective_config_version: z.string().min(1),
+  runtime: AppSettingsRuntimeSummarySchema,
+  stored_secrets: z.array(AppSecretConfigStateSchema).default([]),
+  activation_failure: AppInstallActivationFailureSchema.optional(),
+  witness_refs: z.array(z.string().min(1)).default([]),
+  rollback_applied: z.boolean().default(false),
+  recoverable: z.boolean().default(true),
+  metadata: z.record(z.unknown()).default({}),
+});
+export type AppSettingsSaveResult = z.infer<
+  typeof AppSettingsSaveResultSchema
+>;

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -63,6 +63,7 @@ export * from './app-permissions.js';
 export * from './app-manifest.js';
 export * from './app-credentials.js';
 export * from './app-install.js';
+export * from './app-settings.js';
 export * from './app-runtime.js';
 export * from './panel-bridge-protocol.js';
 export * from './package-manifest.js';

--- a/self/shared/src/types/panel-bridge-protocol.ts
+++ b/self/shared/src/types/panel-bridge-protocol.ts
@@ -36,6 +36,7 @@ export const PanelBridgeMessageKindSchema = z.enum([
   'notify.result',
   'persisted_state.result',
   'panel.lifecycle',
+  'config.changed',
   'theme.changed',
   'error',
 ]);
@@ -223,6 +224,7 @@ export type PanelBridgePanelMessage = z.infer<
 export const HostBootstrapMessageSchema = PanelBridgeEnvelopeSchema.extend({
   kind: z.literal('host.bootstrap'),
   message_id: PanelBridgeRequestIdSchema,
+  config_version: z.string().min(1),
   config: PanelBridgeConfigSnapshotSchema,
   theme: PanelBridgeThemeSnapshotSchema,
   capabilities: PanelBridgeCapabilitiesSchema,
@@ -241,6 +243,7 @@ export type PanelToolSuccessResponse = z.infer<
 export const PanelConfigResponseSchema = PanelBridgeEnvelopeSchema.extend({
   kind: z.literal('config.result'),
   request_id: PanelBridgeRequestIdSchema,
+  config_version: z.string().min(1),
   config: PanelBridgeConfigSnapshotSchema,
 });
 export type PanelConfigResponse = z.infer<typeof PanelConfigResponseSchema>;
@@ -281,6 +284,15 @@ export type PanelLifecycleChangedMessage = z.infer<
   typeof PanelLifecycleChangedMessageSchema
 >;
 
+export const PanelConfigChangedMessageSchema = PanelBridgeEnvelopeSchema.extend({
+  kind: z.literal('config.changed'),
+  config_version: z.string().min(1),
+  config: PanelBridgeConfigSnapshotSchema,
+});
+export type PanelConfigChangedMessage = z.infer<
+  typeof PanelConfigChangedMessageSchema
+>;
+
 export const PanelThemeChangedMessageSchema = PanelBridgeEnvelopeSchema.extend({
   kind: z.literal('theme.changed'),
   theme: PanelBridgeThemeSnapshotSchema,
@@ -306,6 +318,7 @@ export const PanelBridgeHostMessageSchema = z.discriminatedUnion('kind', [
   PanelNotifyResponseSchema,
   PanelPersistedStateResponseSchema,
   PanelLifecycleChangedMessageSchema,
+  PanelConfigChangedMessageSchema,
   PanelThemeChangedMessageSchema,
   PanelBridgeErrorResponseSchema,
 ]);
@@ -329,6 +342,7 @@ export const PanelBridgeMessageSchema = z.discriminatedUnion('kind', [
   PanelNotifyResponseSchema,
   PanelPersistedStateResponseSchema,
   PanelLifecycleChangedMessageSchema,
+  PanelConfigChangedMessageSchema,
   PanelThemeChangedMessageSchema,
   PanelBridgeErrorResponseSchema,
 ]);

--- a/self/subcortex/apps/src/panel-registration.ts
+++ b/self/subcortex/apps/src/panel-registration.ts
@@ -33,7 +33,12 @@ export class PanelRegistrationRegistry {
     input: {
       session: Pick<
         AppRuntimeSession,
-        'session_id' | 'app_id' | 'package_id' | 'package_version' | 'project_id'
+        | 'session_id'
+        | 'app_id'
+        | 'package_id'
+        | 'package_version'
+        | 'project_id'
+        | 'config_version'
       >;
       package_root_ref: string;
       manifest_ref: string;
@@ -56,6 +61,7 @@ export class PanelRegistrationRegistry {
       app_id: panel.app_id,
       package_id: input.session.package_id,
       package_version: input.session.package_version,
+      config_version: input.session.config_version,
       project_id: input.session.project_id,
       panel_id: panel.panel_id,
       label: panel.label,

--- a/self/subcortex/projects/src/__tests__/app-settings-service.test.ts
+++ b/self/subcortex/projects/src/__tests__/app-settings-service.test.ts
@@ -1,0 +1,544 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { access, cp, mkdir, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AppRuntimeActivationInput,
+  AppRuntimeSession,
+  CredentialRevokeRequest,
+  CredentialStoreRequest,
+  DocumentFilter,
+  IDocumentStore,
+  IRuntime,
+  PlatformInfo,
+  ProjectId,
+} from '@nous/shared';
+import { AppSettingsService } from '../app-settings/service.js';
+import { DocumentAppConfigStore } from '../app-install/config-store.js';
+
+class TestRuntime implements IRuntime {
+  resolvePath(...segments: string[]): string {
+    return join(...segments);
+  }
+
+  getDataDir(): string {
+    return tmpdir();
+  }
+
+  async exists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async ensureDir(path: string): Promise<void> {
+    await mkdir(path, { recursive: true });
+  }
+
+  async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+  }
+
+  async copyDirectory(from: string, to: string): Promise<void> {
+    await cp(from, to, { recursive: true, force: true });
+  }
+
+  async removePath(path: string): Promise<void> {
+    await rm(path, { recursive: true, force: true });
+  }
+
+  async listDirectory(_path: string): Promise<string[]> {
+    return [];
+  }
+
+  getPlatform(): PlatformInfo {
+    return {
+      os: 'linux',
+      arch: 'x64',
+      nodeVersion: process.version,
+    };
+  }
+}
+
+class InMemoryDocumentStore implements IDocumentStore {
+  private readonly collections = new Map<string, Map<string, unknown>>();
+
+  async put<T>(collection: string, id: string, document: T): Promise<void> {
+    if (!this.collections.has(collection)) {
+      this.collections.set(collection, new Map());
+    }
+    this.collections.get(collection)!.set(id, document);
+  }
+
+  async get<T>(collection: string, id: string): Promise<T | null> {
+    return (this.collections.get(collection)?.get(id) as T | undefined) ?? null;
+  }
+
+  async query<T>(collection: string, filter: DocumentFilter): Promise<T[]> {
+    const values = [...(this.collections.get(collection)?.values() ?? [])] as T[];
+    if (!filter.where) {
+      return values;
+    }
+
+    return values.filter((candidate) => {
+      const record = candidate as Record<string, unknown>;
+      return Object.entries(filter.where ?? {}).every(([key, value]) => record[key] === value);
+    });
+  }
+
+  async delete(collection: string, id: string): Promise<boolean> {
+    return this.collections.get(collection)?.delete(id) ?? false;
+  }
+}
+
+const NOW = '2026-03-19T00:00:00.000Z';
+const PROJECT_ID = '550e8400-e29b-41d4-a716-446655440910' as ProjectId;
+
+function createSession(input: {
+  sessionId?: string;
+  status?: AppRuntimeSession['status'];
+  configVersion: string;
+}): AppRuntimeSession {
+  return {
+    session_id: input.sessionId ?? 'session-1',
+    app_id: 'telegram',
+    package_id: 'telegram-connector',
+    package_version: '1.0.0',
+    project_id: PROJECT_ID,
+    pid: 4321,
+    status: input.status ?? 'active',
+    started_at: NOW,
+    registered_tool_ids: [],
+    panel_ids: [],
+    health_status: 'healthy',
+    config_version: input.configVersion,
+  };
+}
+
+function writeInstalledApp(instanceRoot: string) {
+  mkdirSync(join(instanceRoot, '.apps', 'telegram-connector'), { recursive: true });
+  mkdirSync(join(instanceRoot, '.skills'), { recursive: true });
+  mkdirSync(join(instanceRoot, '.workflows'), { recursive: true });
+  mkdirSync(join(instanceRoot, '.projects'), { recursive: true });
+  mkdirSync(join(instanceRoot, '.contracts'), { recursive: true });
+
+  writeFileSync(
+    join(instanceRoot, '.apps', 'telegram-connector', 'manifest.json'),
+    JSON.stringify({
+      id: 'telegram',
+      name: 'telegram-connector',
+      display_name: 'Telegram Connector',
+      description: 'Reference connector app',
+      version: '1.0.0',
+      package_type: 'app',
+      origin_class: 'nous_first_party',
+      api_contract_range: '^1.0.0',
+      capabilities: ['tool.execute'],
+      permissions: {
+        network: ['api.telegram.org'],
+        credentials: true,
+        witnessLevel: 'session',
+        systemNotify: false,
+        memoryContribute: true,
+      },
+      tools: [
+        {
+          name: 'connector_status',
+          description: 'Connector status',
+          inputSchema: {},
+          outputSchema: {},
+          riskLevel: 'low',
+          idempotent: true,
+          sideEffects: [],
+          memoryRelevance: 'low',
+        },
+      ],
+      config: {
+        region: {
+          type: 'string',
+          required: true,
+          label: 'Region',
+          group: 'connector',
+        },
+        units: {
+          type: 'select',
+          required: false,
+          label: 'Units',
+          group: 'display',
+          default: 'metric',
+          options: ['metric', 'imperial'],
+        },
+        bot_token: {
+          type: 'secret',
+          required: true,
+          label: 'Bot Token',
+          group: 'connector',
+        },
+      },
+    }),
+    'utf8',
+  );
+  writeFileSync(join(instanceRoot, '.apps', 'telegram-connector', 'main.ts'), 'export default {};\n', 'utf8');
+  writeFileSync(
+    join(instanceRoot, '.apps', 'telegram-connector', '.nous-package.json'),
+    JSON.stringify({
+      package_version: '1.0.0',
+    }),
+    'utf8',
+  );
+}
+
+function createDependencies() {
+  const runtime = new TestRuntime();
+  const documentStore = new InMemoryDocumentStore();
+  const configStore = new DocumentAppConfigStore(documentStore);
+  const installHookRunner = {
+    runOnInstall: vi.fn().mockResolvedValue({
+      status: 'success',
+      results: [],
+      metadata: {},
+    }),
+  };
+  const appRuntimeService = {
+    listSessions: vi.fn().mockResolvedValue([createSession({ configVersion: 'cfg-1' })]),
+    deactivate: vi.fn().mockResolvedValue(
+      createSession({
+        sessionId: 'session-1',
+        status: 'stopped',
+        configVersion: 'cfg-1',
+      }),
+    ),
+    activate: vi.fn().mockImplementation(async (input: AppRuntimeActivationInput) =>
+      createSession({
+        sessionId: 'session-2',
+        status: 'active',
+        configVersion: input.launch_spec.config_version,
+      })),
+  };
+  const appCredentialInstallService = {
+    storeSecretField: vi.fn().mockImplementation(async (appId: string, request: CredentialStoreRequest) => ({
+      credential_ref: `credential:${appId}:${request.key}:updated`,
+      metadata: {
+        app_id: appId,
+        user_key: request.key,
+        credential_ref: `credential:${appId}:${request.key}:updated`,
+        credential_type: request.credential_type,
+        target_host: request.target_host,
+        injection_location: request.injection_location,
+        injection_key: request.injection_key,
+        created_at: NOW,
+        updated_at: NOW,
+      },
+    })),
+    revokeCredential: vi.fn().mockImplementation(async (appId: string, request: CredentialRevokeRequest) => ({
+      revoked: true,
+      credential_ref: `credential:${appId}:${request.key}:updated`,
+      reason: request.reason,
+    })),
+    backupCredential: vi.fn().mockImplementation(async (_appId: string, key: string) => ({
+      backup_ref: `backup:${key}`,
+      existed: true,
+    })),
+    restoreCredential: vi.fn().mockResolvedValue({
+      restored: true,
+    }),
+    discardCredentialBackup: vi.fn().mockResolvedValue({
+      discarded: true,
+    }),
+    openOAuthFlow: vi.fn(),
+  };
+
+  return {
+    runtime,
+    configStore,
+    installHookRunner,
+    appRuntimeService,
+    appCredentialInstallService,
+  };
+}
+
+function createService(input: ReturnType<typeof createDependencies>, instanceRoot: string) {
+  return new AppSettingsService({
+    appCredentialInstallService: input.appCredentialInstallService as any,
+    appRuntimeService: input.appRuntimeService as any,
+    configStore: input.configStore,
+    installHookRunner: input.installHookRunner as any,
+    runtime: input.runtime,
+    instanceRoot,
+    now: () => NOW,
+    idFactory: () => 'cfg-2',
+  });
+}
+
+describe('AppSettingsService', () => {
+  const createdRoots: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(
+      createdRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it('prepares canonical grouped settings with runtime and safe panel snapshot state', async () => {
+    const instanceRoot = mkdtempSync(join(tmpdir(), 'nous-app-settings-service-'));
+    createdRoots.push(instanceRoot);
+    writeInstalledApp(instanceRoot);
+
+    const deps = createDependencies();
+    const service = createService(deps, instanceRoot);
+    await deps.configStore.put({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      release_id: 'release-1',
+      app_id: 'telegram',
+      config_version: 'cfg-1',
+      values: {
+        region: 'us',
+      },
+      secret_config: {
+        bot_token: {
+          key: 'bot_token',
+          configured: true,
+          credential_ref: 'credential:telegram:bot_token',
+          source: 'secret_field',
+        },
+      },
+      updated_at: NOW,
+    });
+
+    const preparation = await service.prepareSettings({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+    });
+
+    const connectorGroup = preparation.config_groups.find((group) => group.id === 'connector');
+    const displayGroup = preparation.config_groups.find((group) => group.id === 'display');
+
+    expect(preparation.runtime.status).toBe('active');
+    expect(connectorGroup?.fields.find((field) => field.key === 'region')?.value).toBe('us');
+    expect(connectorGroup?.fields.find((field) => field.key === 'bot_token')?.secret_state?.configured).toBe(true);
+    expect(displayGroup?.fields.find((field) => field.key === 'units')?.value).toBe('metric');
+    expect(preparation.panel_config_snapshot).toEqual({
+      region: {
+        value: 'us',
+        source: 'project_config',
+      },
+      units: {
+        value: 'metric',
+        source: 'manifest_default',
+      },
+    });
+  });
+
+  it('applies governed settings saves with optimistic config updates and secret rotation', async () => {
+    const instanceRoot = mkdtempSync(join(tmpdir(), 'nous-app-settings-service-'));
+    createdRoots.push(instanceRoot);
+    writeInstalledApp(instanceRoot);
+
+    const deps = createDependencies();
+    const service = createService(deps, instanceRoot);
+    await deps.configStore.put({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      release_id: 'release-1',
+      app_id: 'telegram',
+      config_version: 'cfg-1',
+      values: {
+        region: 'us',
+      },
+      secret_config: {
+        bot_token: {
+          key: 'bot_token',
+          configured: true,
+          credential_ref: 'credential:telegram:bot_token',
+          source: 'secret_field',
+        },
+      },
+      updated_at: NOW,
+    });
+
+    const result = await service.saveSettings({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      actor_id: 'web-test',
+      expected_config_version: 'cfg-1',
+      config: {
+        region: 'eu',
+        units: 'imperial',
+      },
+      secrets: {
+        bot_token: {
+          operation: 'replace',
+          value: 'next-secret',
+        },
+      },
+      evidence_refs: ['witness:settings-save'],
+    });
+
+    const updated = await deps.configStore.get(PROJECT_ID, 'telegram-connector');
+
+    expect(result.status).toBe('success');
+    expect(result.apply_status).toBe('applied');
+    expect(result.effective_config_version).toBe('cfg-2');
+    expect(updated?.config_version).toBe('cfg-2');
+    expect(updated?.values).toEqual({
+      region: 'eu',
+      units: 'imperial',
+    });
+    expect(updated?.secret_config.bot_token?.credential_ref).toBe(
+      'credential:telegram:bot_token:updated',
+    );
+    expect(deps.appRuntimeService.deactivate.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.appRuntimeService.activate.mock.invocationCallOrder[0],
+    );
+    expect(deps.installHookRunner.runOnInstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          config: expect.objectContaining({
+            region: 'eu',
+            units: 'imperial',
+            bot_token: '[vault:configured]',
+          }),
+        }),
+      }),
+    );
+    expect(deps.appCredentialInstallService.backupCredential).toHaveBeenCalledWith(
+      'telegram',
+      'bot_token',
+    );
+    expect(deps.appCredentialInstallService.storeSecretField).toHaveBeenCalled();
+    expect(deps.appCredentialInstallService.discardCredentialBackup).toHaveBeenCalledWith(
+      'telegram',
+      'backup:bot_token',
+    );
+  });
+
+  it('blocks stale settings saves before mutation work begins', async () => {
+    const instanceRoot = mkdtempSync(join(tmpdir(), 'nous-app-settings-service-'));
+    createdRoots.push(instanceRoot);
+    writeInstalledApp(instanceRoot);
+
+    const deps = createDependencies();
+    const service = createService(deps, instanceRoot);
+    await deps.configStore.put({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      release_id: 'release-1',
+      app_id: 'telegram',
+      config_version: 'cfg-1',
+      values: {
+        region: 'us',
+      },
+      secret_config: {
+        bot_token: {
+          key: 'bot_token',
+          configured: true,
+          credential_ref: 'credential:telegram:bot_token',
+          source: 'secret_field',
+        },
+      },
+      updated_at: NOW,
+    });
+
+    const result = await service.saveSettings({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      actor_id: 'web-test',
+      expected_config_version: 'cfg-stale',
+      config: {
+        region: 'eu',
+      },
+      secrets: {},
+      evidence_refs: [],
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.apply_status).toBe('blocked');
+    expect(result.phase).toBe('validation');
+    expect(result.metadata.current_config_version).toBe('cfg-1');
+    expect(deps.appRuntimeService.deactivate).not.toHaveBeenCalled();
+    expect(deps.appCredentialInstallService.backupCredential).not.toHaveBeenCalled();
+  });
+
+  it('restores the previous config and secret state when activation fails after mutation', async () => {
+    const instanceRoot = mkdtempSync(join(tmpdir(), 'nous-app-settings-service-'));
+    createdRoots.push(instanceRoot);
+    writeInstalledApp(instanceRoot);
+
+    const deps = createDependencies();
+    deps.appRuntimeService.activate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('activation failed'))
+      .mockResolvedValueOnce(
+        createSession({
+          sessionId: 'session-restored',
+          status: 'active',
+          configVersion: 'cfg-1',
+        }),
+      );
+    const service = createService(deps, instanceRoot);
+    await deps.configStore.put({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      release_id: 'release-1',
+      app_id: 'telegram',
+      config_version: 'cfg-1',
+      values: {
+        region: 'us',
+      },
+      secret_config: {
+        bot_token: {
+          key: 'bot_token',
+          configured: true,
+          credential_ref: 'credential:telegram:bot_token',
+          source: 'secret_field',
+        },
+      },
+      updated_at: NOW,
+    });
+
+    const result = await service.saveSettings({
+      project_id: PROJECT_ID,
+      package_id: 'telegram-connector',
+      actor_id: 'web-test',
+      expected_config_version: 'cfg-1',
+      config: {
+        region: 'eu',
+      },
+      secrets: {
+        bot_token: {
+          operation: 'replace',
+          value: 'next-secret',
+        },
+      },
+      evidence_refs: [],
+    });
+
+    const restored = await deps.configStore.get(PROJECT_ID, 'telegram-connector');
+
+    expect(result.status).toBe('partial');
+    expect(result.apply_status).toBe('reverted');
+    expect(result.phase).toBe('recovery');
+    expect(result.effective_config_version).toBe('cfg-1');
+    expect(result.activation_failure?.code).toBe('APP-SETTINGS-ACTIVATION-FAILED');
+    expect(restored?.config_version).toBe('cfg-1');
+    expect(restored?.values).toEqual({
+      region: 'us',
+    });
+    expect(deps.appCredentialInstallService.restoreCredential).toHaveBeenCalledWith(
+      'telegram',
+      'backup:bot_token',
+    );
+    expect(deps.appCredentialInstallService.discardCredentialBackup).toHaveBeenCalledWith(
+      'telegram',
+      'backup:bot_token',
+    );
+    expect(deps.appRuntimeService.activate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/self/subcortex/projects/src/app-install/config-store.ts
+++ b/self/subcortex/projects/src/app-install/config-store.ts
@@ -7,6 +7,18 @@ import { AppProjectConfigDocumentSchema } from '@nous/shared';
 
 const COLLECTION = 'app_project_config';
 
+export class AppConfigVersionConflictError extends Error {
+  constructor(
+    public readonly currentVersion: string,
+    public readonly expectedVersion: string,
+  ) {
+    super(
+      `App config version conflict: expected ${expectedVersion}, current ${currentVersion}.`,
+    );
+    this.name = 'AppConfigVersionConflictError';
+  }
+}
+
 function buildDocumentId(projectId: ProjectId, packageId: string): string {
   return `${projectId}:${packageId}`;
 }
@@ -30,8 +42,20 @@ export class DocumentAppConfigStore {
     return parsed.success ? parsed.data : null;
   }
 
-  async put(document: AppProjectConfigDocument): Promise<AppProjectConfigDocument> {
+  async put(
+    document: AppProjectConfigDocument,
+    options?: { expectedConfigVersion?: string },
+  ): Promise<AppProjectConfigDocument> {
     const parsed = AppProjectConfigDocumentSchema.parse(document);
+    if (options?.expectedConfigVersion) {
+      const current = await this.get(parsed.project_id, parsed.package_id);
+      if (current && current.config_version !== options.expectedConfigVersion) {
+        throw new AppConfigVersionConflictError(
+          current.config_version,
+          options.expectedConfigVersion,
+        );
+      }
+    }
     await this.documentStore.put(
       COLLECTION,
       buildDocumentId(parsed.project_id, parsed.package_id),

--- a/self/subcortex/projects/src/app-settings/index.ts
+++ b/self/subcortex/projects/src/app-settings/index.ts
@@ -1,0 +1,1 @@
+export { AppSettingsService, type AppSettingsServiceOptions } from './service.js';

--- a/self/subcortex/projects/src/app-settings/service.ts
+++ b/self/subcortex/projects/src/app-settings/service.ts
@@ -1,0 +1,830 @@
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import type {
+  AppConfig,
+  AppConfigField,
+  AppHandshakeConfigEntry,
+  AppInstallHookResult,
+  AppPanelRegistrationProjection,
+  AppProjectConfigDocument,
+  AppSecretConfigState,
+  AppSettingsPrepareRequest,
+  AppSettingsPreparation,
+  AppSettingsRuntimeSummary,
+  AppSettingsSaveRequest,
+  AppSettingsSaveResult,
+  IAppCredentialInstallService,
+  IAppRuntimeService,
+  IAppSettingsService,
+  ProjectId,
+  IRuntime,
+  LoadedAppPackage,
+} from '@nous/shared';
+import {
+  AppSettingsPreparationSchema,
+  AppSettingsSaveRequestSchema,
+  AppSettingsSaveResultSchema,
+} from '@nous/shared';
+import { buildAppLaunchSpec, InstallHookRunner } from '@nous/subcortex-apps';
+import { loadInstalledAppPackage } from '../package-store/index.js';
+import {
+  AppConfigVersionConflictError,
+  DocumentAppConfigStore,
+} from '../app-install/config-store.js';
+
+export interface AppSettingsServiceOptions {
+  appCredentialInstallService: IAppCredentialInstallService;
+  appRuntimeService: IAppRuntimeService;
+  configStore: DocumentAppConfigStore;
+  installHookRunner?: InstallHookRunner;
+  runtime: IRuntime;
+  instanceRoot?: string;
+  now?: () => string;
+  idFactory?: () => string;
+}
+
+const SECRET_SENTINEL = '[vault:configured]';
+
+const sanitizePackageId = (packageId: string): string =>
+  packageId.replace(/[^a-zA-Z0-9._-]+/g, '__');
+
+const startCase = (value: string): string =>
+  value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const hasMeaningfulValue = (value: unknown): boolean => {
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return value !== undefined && value !== null;
+};
+
+function mapRuntimeSummary(
+  session: Awaited<ReturnType<IAppRuntimeService['listSessions']>>[number] | null,
+  fallbackConfigVersion: string,
+): AppSettingsRuntimeSummary {
+  if (!session) {
+    return {
+      status: 'inactive',
+      config_version: fallbackConfigVersion,
+    };
+  }
+
+  return {
+    session_id: session.session_id,
+    status: session.status === 'failed' ? 'failed' : session.status === 'stopped' ? 'inactive' : 'active',
+    health_status: session.health_status,
+    config_version: session.config_version,
+  };
+}
+
+interface StagedSecretMutation {
+  key: string;
+  backupRef?: string;
+}
+
+export class AppSettingsService implements IAppSettingsService {
+  private readonly installHookRunner: InstallHookRunner;
+  private readonly now: () => string;
+  private readonly idFactory: () => string;
+  private readonly instanceRoot: string;
+
+  constructor(private readonly options: AppSettingsServiceOptions) {
+    this.installHookRunner = options.installHookRunner ?? new InstallHookRunner();
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.idFactory = options.idFactory ?? (() => randomUUID());
+    this.instanceRoot = options.instanceRoot ?? process.cwd();
+  }
+
+  async prepareSettings(
+    request: AppSettingsPrepareRequest,
+  ): Promise<AppSettingsPreparation> {
+    const currentDocument = await this.requireCurrentDocument(
+      request.project_id,
+      request.package_id,
+    );
+    const loadedApp = await this.loadInstalledApp(request.package_id);
+    const runtimeSummary = await this.readRuntimeSummary(
+      request.project_id,
+      request.package_id,
+      currentDocument.config_version,
+    );
+
+    const groups = new Map<string, AppSettingsPreparation['config_groups'][number]>();
+    for (const [key, field] of Object.entries(
+      loadedApp.manifest.config ?? {},
+    ) as Array<[string, AppConfigField]>) {
+      const groupId = field.group ?? 'general';
+      const value =
+        field.type === 'secret'
+          ? undefined
+          : currentDocument.values[key] ?? field.default;
+      const valueSource: 'secret_state' | 'project_config' | 'manifest_default' =
+        field.type === 'secret'
+          ? 'secret_state'
+          : currentDocument.values[key] !== undefined
+            ? 'project_config'
+            : 'manifest_default';
+      const descriptor = {
+        ...field,
+        key,
+        secret: field.type === 'secret',
+        value,
+        value_source: valueSource,
+        secret_state:
+          field.type === 'secret'
+            ? currentDocument.secret_config[key] ?? {
+                key,
+                configured: false,
+              }
+            : undefined,
+      };
+      const currentGroup = groups.get(groupId);
+      if (currentGroup) {
+        currentGroup.fields.push(descriptor);
+      } else {
+        groups.set(groupId, {
+          id: groupId,
+          label: startCase(groupId),
+          fields: [descriptor],
+        });
+      }
+    }
+
+    return AppSettingsPreparationSchema.parse({
+      project_id: request.project_id,
+      package_id: request.package_id,
+      release_id: currentDocument.release_id,
+      package_version: loadedApp.packageVersion ?? loadedApp.manifest.version,
+      app_id: loadedApp.manifest.id,
+      display_name: loadedApp.manifest.display_name ?? loadedApp.manifest.name,
+      description: loadedApp.manifest.description,
+      config_version: currentDocument.config_version,
+      runtime: runtimeSummary,
+      config_groups: [...groups.values()],
+      panel_config_snapshot: this.buildPanelConfigSnapshot(
+        loadedApp.manifest.config,
+        currentDocument.values,
+      ),
+    });
+  }
+
+  async saveSettings(request: AppSettingsSaveRequest): Promise<AppSettingsSaveResult> {
+    const parsed = AppSettingsSaveRequestSchema.parse(request);
+    const currentDocument = await this.requireCurrentDocument(
+      parsed.project_id,
+      parsed.package_id,
+    );
+    const loadedApp = await this.loadInstalledApp(parsed.package_id);
+    const currentRuntime = await this.selectRuntimeSession(
+      parsed.project_id,
+      parsed.package_id,
+    );
+
+    if (currentDocument.config_version !== parsed.expected_config_version) {
+      return AppSettingsSaveResultSchema.parse({
+        status: 'failed',
+        apply_status: 'blocked',
+        phase: 'validation',
+        validation: {
+          status: 'failed',
+          results: [
+            {
+              check: 'expected-config-version-match',
+              passed: false,
+              retryable: true,
+              message: 'The settings snapshot is stale. Refresh the canonical settings view before saving again.',
+            },
+          ],
+        },
+        effective_config_version: currentDocument.config_version,
+        runtime: mapRuntimeSummary(currentRuntime, currentDocument.config_version),
+        stored_secrets: Object.values(currentDocument.secret_config),
+        rollback_applied: false,
+        recoverable: true,
+        metadata: {
+          current_config_version: currentDocument.config_version,
+        },
+      });
+    }
+
+    const candidate = this.buildCandidateState({
+      manifestConfig: loadedApp.manifest.config,
+      currentDocument,
+      request: parsed,
+    });
+
+    if (candidate.validation.status === 'failed') {
+      return AppSettingsSaveResultSchema.parse({
+        status: 'failed',
+        apply_status: 'blocked',
+        phase: 'validation',
+        validation: candidate.validation,
+        effective_config_version: currentDocument.config_version,
+        runtime: mapRuntimeSummary(currentRuntime, currentDocument.config_version),
+        stored_secrets: Object.values(currentDocument.secret_config),
+        rollback_applied: false,
+        recoverable: true,
+      });
+    }
+
+    const hookValidation = await this.runValidationHook({
+      loadedApp,
+      projectId: parsed.project_id,
+      packageId: parsed.package_id,
+      values: candidate.values,
+      secretConfig: candidate.secretConfig,
+    });
+    const mergedValidation = {
+      status: hookValidation.status,
+      results: [...candidate.validation.results, ...hookValidation.results],
+    } as const;
+
+    if (hookValidation.status === 'failed') {
+      return AppSettingsSaveResultSchema.parse({
+        status: 'failed',
+        apply_status: 'blocked',
+        phase: 'validation',
+        validation: mergedValidation,
+        effective_config_version: currentDocument.config_version,
+        runtime: mapRuntimeSummary(currentRuntime, currentDocument.config_version),
+        stored_secrets: Object.values(currentDocument.secret_config),
+        rollback_applied: false,
+        recoverable: true,
+        metadata: hookValidation.metadata,
+      });
+    }
+
+    const stagedMutations: StagedSecretMutation[] = [];
+    const previousRuntimeWasActive =
+      currentRuntime != null &&
+      currentRuntime.status !== 'stopped' &&
+      currentRuntime.status !== 'failed';
+
+    try {
+      await this.stageSecretMutations({
+        appId: loadedApp.manifest.id,
+        currentDocument,
+        request: parsed,
+        nextSecretConfig: candidate.secretConfig,
+        stagedMutations,
+      });
+
+      if (previousRuntimeWasActive && currentRuntime) {
+        await this.options.appRuntimeService.deactivate({
+          session_id: currentRuntime.session_id,
+          reason: 'settings apply',
+          disable_package: false,
+        });
+      }
+
+      const requestedConfigVersion = this.idFactory();
+      const nextDocument = this.buildProjectConfigDocument({
+        currentDocument,
+        loadedApp,
+        configVersion: requestedConfigVersion,
+        values: candidate.values,
+        secretConfig: Object.values(candidate.secretConfig),
+      });
+
+      await this.options.configStore.put(nextDocument, {
+        expectedConfigVersion: currentDocument.config_version,
+      });
+
+      const activated = await this.options.appRuntimeService.activate(
+        this.buildActivationInput({
+          projectId: parsed.project_id,
+          loadedApp,
+          releaseId: currentDocument.release_id,
+          configVersion: requestedConfigVersion,
+          values: candidate.values,
+          secretConfig: Object.values(candidate.secretConfig),
+        }),
+      );
+
+      await this.discardSecretBackups(loadedApp.manifest.id, stagedMutations);
+
+      return AppSettingsSaveResultSchema.parse({
+        status: 'success',
+        apply_status: 'applied',
+        phase: 'completed',
+        validation: mergedValidation,
+        requested_config_version: requestedConfigVersion,
+        effective_config_version: requestedConfigVersion,
+        runtime: mapRuntimeSummary(activated, requestedConfigVersion),
+        stored_secrets: Object.values(candidate.secretConfig),
+        rollback_applied: false,
+        recoverable: true,
+        metadata: hookValidation.metadata,
+      });
+    } catch (error) {
+      const recovered = await this.recoverPreviousTruth({
+        appId: loadedApp.manifest.id,
+        currentDocument,
+        currentRuntime,
+        previousRuntimeWasActive,
+        loadedApp,
+        projectId: parsed.project_id,
+        stagedMutations,
+      });
+
+      if (recovered) {
+        return AppSettingsSaveResultSchema.parse({
+          status: 'partial',
+          apply_status: 'reverted',
+          phase: 'recovery',
+          validation: mergedValidation,
+          effective_config_version: currentDocument.config_version,
+          runtime: recovered,
+          stored_secrets: Object.values(currentDocument.secret_config),
+          activation_failure: {
+            code:
+              error instanceof AppConfigVersionConflictError
+                ? 'APP-SETTINGS-CONFIG-VERSION-CONFLICT'
+                : 'APP-SETTINGS-ACTIVATION-FAILED',
+            message: error instanceof Error ? error.message : String(error),
+            retryable: true,
+          },
+          rollback_applied: true,
+          recoverable: true,
+        });
+      }
+
+      return AppSettingsSaveResultSchema.parse({
+        status: 'failed',
+        apply_status: 'blocked',
+        phase: 'recovery',
+        validation: mergedValidation,
+        effective_config_version: currentDocument.config_version,
+        runtime: {
+          status: 'failed',
+          config_version: currentDocument.config_version,
+        },
+        stored_secrets: Object.values(currentDocument.secret_config),
+        activation_failure: {
+          code: 'APP-SETTINGS-RECOVERY-BLOCKED',
+          message: error instanceof Error ? error.message : String(error),
+          retryable: true,
+        },
+        rollback_applied: true,
+        recoverable: true,
+      });
+    }
+  }
+
+  private async requireCurrentDocument(
+    projectId: AppSettingsPrepareRequest['project_id'],
+    packageId: string,
+  ): Promise<AppProjectConfigDocument> {
+    const current = await this.options.configStore.get(projectId, packageId);
+    if (!current) {
+      throw new Error(`App settings are unavailable for ${packageId} in project ${projectId}.`);
+    }
+    return current;
+  }
+
+  private async loadInstalledApp(packageId: string): Promise<LoadedAppPackage> {
+    return loadInstalledAppPackage({
+      instanceRoot: this.instanceRoot,
+      runtime: this.options.runtime,
+      packageId,
+    });
+  }
+
+  private async selectRuntimeSession(
+    projectId: ProjectId,
+    packageId: string,
+  ) {
+    const sessions = await this.options.appRuntimeService.listSessions(packageId);
+    const matching = sessions.filter((session) => session.project_id === projectId);
+    return (
+      matching.find((session) => session.status === 'active') ??
+      matching.find((session) => session.status === 'starting') ??
+      matching.find((session) => session.status === 'draining') ??
+      matching[0] ??
+      null
+    );
+  }
+
+  private async readRuntimeSummary(
+    projectId: ProjectId,
+    packageId: string,
+    fallbackConfigVersion: string,
+  ): Promise<AppSettingsRuntimeSummary> {
+    const session = await this.selectRuntimeSession(projectId, packageId);
+    return mapRuntimeSummary(session, fallbackConfigVersion);
+  }
+
+  private buildCandidateState(input: {
+    manifestConfig?: AppConfig;
+    currentDocument: AppProjectConfigDocument;
+    request: AppSettingsSaveRequest;
+  }): {
+    values: Record<string, unknown>;
+    secretConfig: Record<string, AppSecretConfigState>;
+    validation: AppSettingsSaveResult['validation'];
+  } {
+    const values: Record<string, unknown> = {};
+    const secretConfig: Record<string, AppSecretConfigState> = {
+      ...input.currentDocument.secret_config,
+    };
+    const results: AppSettingsSaveResult['validation']['results'] = [];
+
+    for (const [key, field] of Object.entries(input.manifestConfig ?? {})) {
+      if (field.type === 'secret') {
+        const mutation = input.request.secrets[key];
+        const currentSecret = input.currentDocument.secret_config[key];
+        const operation = mutation?.operation ?? 'retain';
+        if (operation === 'clear') {
+          secretConfig[key] = {
+            key,
+            configured: false,
+            source: currentSecret?.source ?? 'secret_field',
+            provider: currentSecret?.provider,
+          };
+        } else if (operation === 'replace') {
+          secretConfig[key] = {
+            key,
+            configured: true,
+            source: currentSecret?.source ?? 'secret_field',
+            provider: currentSecret?.provider,
+          };
+        } else if (currentSecret) {
+          secretConfig[key] = currentSecret;
+        }
+
+        const configured = secretConfig[key]?.configured === true;
+        if (field.required && !configured) {
+          results.push({
+            field: key,
+            check: 'required-secret-present',
+            passed: false,
+            retryable: true,
+            message: `${field.label ?? startCase(key)} is required.`,
+          });
+        }
+        continue;
+      }
+
+      const explicitValue =
+        input.request.config[key] !== undefined
+          ? input.request.config[key]
+          : input.currentDocument.values[key];
+      const resolvedValue = explicitValue ?? field.default;
+      if (hasMeaningfulValue(resolvedValue)) {
+        values[key] = resolvedValue;
+      }
+
+      if (field.required && !hasMeaningfulValue(resolvedValue)) {
+        results.push({
+          field: key,
+          check: 'required-config-present',
+          passed: false,
+          retryable: true,
+          message: `${field.label ?? startCase(key)} is required.`,
+        });
+        continue;
+      }
+
+      if (!hasMeaningfulValue(resolvedValue)) {
+        continue;
+      }
+
+      if (field.type === 'number' && Number.isNaN(Number(resolvedValue))) {
+        results.push({
+          field: key,
+          check: 'number-config-valid',
+          passed: false,
+          retryable: true,
+          message: `${field.label ?? startCase(key)} must be a number.`,
+        });
+      }
+
+      if (
+        field.type === 'select' &&
+        Array.isArray(field.options) &&
+        !field.options.includes(String(resolvedValue))
+      ) {
+        results.push({
+          field: key,
+          check: 'select-config-valid',
+          passed: false,
+          retryable: true,
+          message: `${field.label ?? startCase(key)} must be one of the declared options.`,
+        });
+      }
+    }
+
+    return {
+      values,
+      secretConfig,
+      validation: {
+        status: results.some((entry) => !entry.passed) ? 'failed' : 'success',
+        results,
+      },
+    };
+  }
+
+  private async runValidationHook(input: {
+    loadedApp: LoadedAppPackage;
+    projectId: ProjectId;
+    packageId: string;
+    values: Record<string, unknown>;
+    secretConfig: Record<string, AppSecretConfigState>;
+  }): Promise<AppInstallHookResult> {
+    return this.installHookRunner.runOnInstall({
+      hook_ref: input.loadedApp.manifest.lifecycle?.onInstall
+        ? join(input.loadedApp.rootRef, input.loadedApp.manifest.lifecycle.onInstall)
+        : undefined,
+      payload: {
+        app_id: input.loadedApp.manifest.id,
+        package_id: input.packageId,
+        project_id: input.projectId,
+        config: this.resolveConfigWithSentinels({
+          manifestConfig: input.loadedApp.manifest.config,
+          values: input.values,
+          secretConfig: input.secretConfig,
+        }),
+        secret_config: input.secretConfig,
+      },
+    });
+  }
+
+  private async stageSecretMutations(input: {
+    appId: string;
+    currentDocument: AppProjectConfigDocument;
+    request: AppSettingsSaveRequest;
+    nextSecretConfig: Record<string, AppSecretConfigState>;
+    stagedMutations: StagedSecretMutation[];
+  }): Promise<void> {
+    for (const [key, mutation] of Object.entries(
+      input.request.secrets,
+    ) as Array<[string, AppSettingsSaveRequest['secrets'][string]]>) {
+      if (!mutation || mutation.operation === 'retain') {
+        continue;
+      }
+
+      const backup = await this.options.appCredentialInstallService.backupCredential(
+        input.appId,
+        key,
+      );
+      input.stagedMutations.push({
+        key,
+        backupRef: backup.backup_ref,
+      });
+
+      if (mutation.operation === 'replace') {
+        const currentState = input.currentDocument.secret_config[key];
+        const stored = await this.options.appCredentialInstallService.storeSecretField(
+          input.appId,
+          {
+            key,
+            value: mutation.value!,
+            credential_type: currentState?.source === 'oauth' ? 'oauth2' : 'custom',
+            target_host: currentState?.provider ?? 'settings-config',
+            injection_location: 'body',
+            injection_key: key,
+          },
+        );
+        input.nextSecretConfig[key] = {
+          key,
+          configured: true,
+          credential_ref: stored.credential_ref,
+          source: currentState?.source ?? 'secret_field',
+          provider: currentState?.provider,
+        };
+        continue;
+      }
+
+      await this.options.appCredentialInstallService.revokeCredential(input.appId, {
+        key,
+        reason: 'settings clear',
+      });
+      input.nextSecretConfig[key] = {
+        key,
+        configured: false,
+        source: input.currentDocument.secret_config[key]?.source ?? 'secret_field',
+        provider: input.currentDocument.secret_config[key]?.provider,
+      };
+    }
+  }
+
+  private async discardSecretBackups(
+    appId: string,
+    stagedMutations: readonly StagedSecretMutation[],
+  ): Promise<void> {
+    for (const mutation of stagedMutations) {
+      if (!mutation.backupRef) {
+        continue;
+      }
+      await this.options.appCredentialInstallService.discardCredentialBackup(
+        appId,
+        mutation.backupRef,
+      );
+    }
+  }
+
+  private async recoverPreviousTruth(input: {
+    appId: string;
+    currentDocument: AppProjectConfigDocument;
+    currentRuntime: Awaited<ReturnType<AppSettingsService['selectRuntimeSession']>>;
+    previousRuntimeWasActive: boolean;
+    loadedApp: LoadedAppPackage;
+    projectId: ProjectId;
+    stagedMutations: readonly StagedSecretMutation[];
+  }): Promise<AppSettingsRuntimeSummary | null> {
+    try {
+      await this.options.configStore.put(input.currentDocument);
+      for (const mutation of [...input.stagedMutations].reverse()) {
+        if (!mutation.backupRef) {
+          continue;
+        }
+        await this.options.appCredentialInstallService.restoreCredential(
+          input.appId,
+          mutation.backupRef,
+        );
+        await this.options.appCredentialInstallService.discardCredentialBackup(
+          input.appId,
+          mutation.backupRef,
+        );
+      }
+
+      if (input.previousRuntimeWasActive) {
+        const restored = await this.options.appRuntimeService.activate(
+          this.buildActivationInput({
+            projectId: input.projectId,
+            loadedApp: input.loadedApp,
+            releaseId: input.currentDocument.release_id,
+            configVersion: input.currentDocument.config_version,
+            values: input.currentDocument.values,
+            secretConfig: Object.values(input.currentDocument.secret_config),
+          }),
+        );
+        return mapRuntimeSummary(restored, input.currentDocument.config_version);
+      }
+
+      return {
+        status: 'inactive',
+        config_version: input.currentDocument.config_version,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private resolveConfigWithSentinels(input: {
+    manifestConfig?: AppConfig;
+    values: Record<string, unknown>;
+    secretConfig: Record<string, AppSecretConfigState>;
+  }): Record<string, unknown> {
+    const resolved: Record<string, unknown> = {};
+
+    for (const [key, field] of Object.entries(input.manifestConfig ?? {})) {
+      if (field.type === 'secret') {
+        if (input.secretConfig[key]?.configured) {
+          resolved[key] = SECRET_SENTINEL;
+        }
+        continue;
+      }
+
+      const value = input.values[key] ?? field.default;
+      if (hasMeaningfulValue(value)) {
+        resolved[key] = value;
+      }
+    }
+
+    return resolved;
+  }
+
+  private buildActivationInput(input: {
+    projectId: ProjectId;
+    loadedApp: LoadedAppPackage;
+    releaseId: string;
+    configVersion: string;
+    values: Record<string, unknown>;
+    secretConfig: AppSecretConfigState[];
+  }) {
+    const resolvedConfigEntries = this.buildHandshakeConfigEntries({
+      manifestConfig: input.loadedApp.manifest.config,
+      values: input.values,
+    });
+    const secretConfig = Object.fromEntries(
+      input.secretConfig.map((entry) => [entry.key, entry]),
+    );
+    const appDataDir = this.options.runtime.resolvePath(
+      this.options.runtime.getDataDir(),
+      'apps',
+      sanitizePackageId(input.loadedApp.packageId),
+    );
+    const panels: AppPanelRegistrationProjection[] = (input.loadedApp.manifest.panels ?? []).map(
+      (panel: LoadedAppPackage['manifest']['panels'][number]) => ({
+        app_id: input.loadedApp.manifest.id,
+        session_id: 'settings-surface',
+        panel_id: panel.panelId,
+        label: panel.label,
+        entry: panel.entry,
+        position: panel.position,
+        preserve_state: panel.preserveState,
+      }),
+    );
+
+    return {
+      project_id: input.projectId,
+      package_root_ref: input.loadedApp.rootRef,
+      manifest_ref: input.loadedApp.manifestRef,
+      manifest: input.loadedApp.manifest,
+      launch_spec: buildAppLaunchSpec({
+        appId: input.loadedApp.manifest.id,
+        packageId: input.loadedApp.packageId,
+        packageVersion: input.loadedApp.packageVersion ?? input.loadedApp.manifest.version,
+        manifest: {
+          permissions: input.loadedApp.manifest.permissions,
+        },
+        entrypoint: input.loadedApp.entrypointRef,
+        workingDirectory: input.loadedApp.rootRef,
+        appDataDir,
+        configVersion: input.configVersion,
+        readPaths: [input.loadedApp.rootRef],
+        writePaths: [appDataDir],
+        lockfilePath: input.loadedApp.lockfileRef,
+        manifestRef: input.loadedApp.manifestRef,
+      }),
+      config: resolvedConfigEntries,
+      secret_config: secretConfig,
+      allowed_outbound_tools: [],
+      panels,
+    };
+  }
+
+  private buildHandshakeConfigEntries(input: {
+    manifestConfig?: AppConfig;
+    values: Record<string, unknown>;
+  }): AppHandshakeConfigEntry[] {
+    const entries: AppHandshakeConfigEntry[] = [];
+
+    for (const [key, field] of Object.entries(input.manifestConfig ?? {})) {
+      if (field.type === 'secret') {
+        continue;
+      }
+      const explicitValue = input.values[key];
+      const value = explicitValue ?? field.default;
+      if (!hasMeaningfulValue(value)) {
+        continue;
+      }
+      entries.push({
+        key,
+        value,
+        source: explicitValue === undefined ? 'manifest_default' : 'project_config',
+        mutable: false,
+      });
+    }
+
+    return entries;
+  }
+
+  private buildProjectConfigDocument(input: {
+    currentDocument: AppProjectConfigDocument;
+    loadedApp: LoadedAppPackage;
+    configVersion: string;
+    values: Record<string, unknown>;
+    secretConfig: AppSecretConfigState[];
+  }): AppProjectConfigDocument {
+    return {
+      project_id: input.currentDocument.project_id,
+      package_id: input.currentDocument.package_id,
+      release_id: input.currentDocument.release_id,
+      app_id: input.loadedApp.manifest.id,
+      config_version: input.configVersion,
+      values: input.values,
+      secret_config: Object.fromEntries(
+        input.secretConfig.map((entry) => [entry.key, entry]),
+      ),
+      updated_at: this.now(),
+    };
+  }
+
+  private buildPanelConfigSnapshot(
+    manifestConfig: AppConfig | undefined,
+    values: Record<string, unknown>,
+  ) {
+    const snapshot: Record<
+      string,
+      { value: unknown; source: AppHandshakeConfigEntry['source'] }
+    > = {};
+
+    for (const entry of this.buildHandshakeConfigEntries({
+      manifestConfig,
+      values,
+    })) {
+      snapshot[entry.key] = {
+        value: entry.value,
+        source: entry.source,
+      };
+    }
+
+    return snapshot;
+  }
+}

--- a/self/subcortex/projects/src/index.ts
+++ b/self/subcortex/projects/src/index.ts
@@ -5,6 +5,7 @@ export { DocumentProjectStore } from './document-project-store.js';
 export { ProjectDocumentSchema } from './schema.js';
 export type { ProjectDocument } from './schema.js';
 export * from './app-install/index.js';
+export * from './app-settings/index.js';
 export * from './package-store/index.js';
 export * from './package-install/index.js';
 export * from './package-lifecycle/index.js';

--- a/self/ui/package.json
+++ b/self/ui/package.json
@@ -9,6 +9,7 @@
     "./panels": "./src/panels/index.ts",
     "./components": "./src/components/index.ts",
     "./install": "./src/install/index.ts",
+    "./settings": "./src/settings/index.ts",
     "./tokens": "./src/tokens/index.ts",
     "./styles": "./src/styles/index.css",
     "./styles/tokens": "./src/styles/tokens.css",

--- a/self/ui/src/index.ts
+++ b/self/ui/src/index.ts
@@ -1,6 +1,7 @@
 export * from './panels/index'
 export * from './components/index'
 export * from './install/index'
+export * from './settings/index'
 export * from './tokens/index'
 export { cn } from './lib/cn'
 export * from './types/skill-graph'

--- a/self/ui/src/install/InstallWizard.tsx
+++ b/self/ui/src/install/InstallWizard.tsx
@@ -21,6 +21,7 @@ export interface InstallWizardProps {
   projectId: string
   actorId: string
   onInstall: (request: AppInstallRequest) => Promise<AppInstallResult>
+  onResult?: (result: AppInstallResult) => Promise<void> | void
   evidenceRefs?: string[]
   disabled?: boolean
   disabledReason?: string
@@ -72,6 +73,7 @@ export function InstallWizard({
   projectId,
   actorId,
   onInstall,
+  onResult,
   evidenceRefs = [],
   disabled = false,
   disabledReason,
@@ -120,6 +122,7 @@ export function InstallWizard({
         evidence_refs: evidenceRefs,
       })
       setResult(next)
+      await onResult?.(next)
       if (next.status === 'failed') {
         window.setTimeout(() => {
           setStage('configuration')

--- a/self/ui/src/panels/AppIframePanel.tsx
+++ b/self/ui/src/panels/AppIframePanel.tsx
@@ -10,6 +10,7 @@ interface AppIframePanelParams {
   panelId: string
   src: string
   preserveState?: boolean
+  configVersion?: string
   configSnapshot?: PanelBridgeConfigSnapshot
 }
 
@@ -40,6 +41,7 @@ export function AppIframePanel({ params, api }: AppIframePanelProps) {
       panelId: params.panelId,
       iframe: iframeRef.current,
       mcpEndpoint: new URL('/mcp', params.src).toString(),
+      configVersion: params.configVersion ?? 'cfg-initial',
       configSnapshot: params.configSnapshot ?? {},
       lifecycleAdapter: async (input) => {
         const response = await fetch(new URL('/mcp', params.src).toString(), {
@@ -74,8 +76,37 @@ export function AppIframePanel({ params, api }: AppIframePanelProps) {
     params?.appId,
     params?.panelId,
     params?.src,
-    JSON.stringify(params?.configSnapshot ?? {}),
   ])
+
+  useEffect(() => {
+    bridgeHostRef.current?.updateConfig({
+      configVersion: params?.configVersion ?? 'cfg-initial',
+      configSnapshot: params?.configSnapshot ?? {},
+    })
+  }, [params?.configVersion, JSON.stringify(params?.configSnapshot ?? {})])
+
+  useEffect(() => {
+    const handleSettingsChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        appId?: string
+        configVersion: string
+        configSnapshot: PanelBridgeConfigSnapshot
+      }>).detail
+      if (!detail || detail.appId !== params?.appId) {
+        return
+      }
+
+      bridgeHostRef.current?.updateConfig({
+        configVersion: detail.configVersion,
+        configSnapshot: detail.configSnapshot,
+      })
+    }
+
+    window.addEventListener('nous:app-settings-changed', handleSettingsChanged as EventListener)
+    return () => {
+      window.removeEventListener('nous:app-settings-changed', handleSettingsChanged as EventListener)
+    }
+  }, [params?.appId])
 
   useEffect(() => {
     if (!api) {

--- a/self/ui/src/panels/panel-bridge-host.ts
+++ b/self/ui/src/panels/panel-bridge-host.ts
@@ -18,6 +18,7 @@ export interface PanelBridgeHostOptions {
   panelId: string;
   iframe: HTMLIFrameElement;
   mcpEndpoint: string;
+  configVersion: string;
   configSnapshot: PanelBridgeConfigSnapshot;
   notifyAdapter?: (notification: PanelBridgeNotification) => Promise<boolean> | boolean;
   lifecycleAdapter?: (input: {
@@ -32,6 +33,8 @@ export interface PanelBridgeHostOptions {
 export class PanelBridgeHost {
   private panelReady = false;
   private lastLifecycleKey?: string;
+  private configVersion: string;
+  private configSnapshot: PanelBridgeConfigSnapshot;
 
   private readonly mediaQuery =
     typeof window.matchMedia === 'function'
@@ -91,6 +94,8 @@ export class PanelBridgeHost {
   };
 
   constructor(private readonly options: PanelBridgeHostOptions) {
+    this.configVersion = options.configVersion;
+    this.configSnapshot = options.configSnapshot;
     window.addEventListener('message', this.handleMessage);
     this.mediaQuery?.addEventListener?.('change', this.handleThemeChange);
   }
@@ -98,6 +103,29 @@ export class PanelBridgeHost {
   destroy(): void {
     window.removeEventListener('message', this.handleMessage);
     this.mediaQuery?.removeEventListener?.('change', this.handleThemeChange);
+  }
+
+  updateConfig(input: {
+    configVersion: string;
+    configSnapshot: PanelBridgeConfigSnapshot;
+  }): void {
+    const changed =
+      input.configVersion !== this.configVersion ||
+      JSON.stringify(input.configSnapshot) !== JSON.stringify(this.configSnapshot);
+
+    this.configVersion = input.configVersion;
+    this.configSnapshot = input.configSnapshot;
+
+    if (!changed || !this.panelReady) {
+      return;
+    }
+
+    this.postToPanel({
+      protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
+      kind: 'config.changed',
+      config_version: this.configVersion,
+      config: this.configSnapshot,
+    });
   }
 
   private async dispatch(message: ReturnType<typeof PanelBridgePanelMessageSchema.parse>) {
@@ -108,7 +136,8 @@ export class PanelBridgeHost {
           protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
           kind: 'host.bootstrap',
           message_id: message.message_id,
-          config: this.options.configSnapshot,
+          config_version: this.configVersion,
+          config: this.configSnapshot,
           theme: this.buildThemeSnapshot(),
           capabilities: {
             tool: true,
@@ -126,7 +155,8 @@ export class PanelBridgeHost {
           protocol: PANEL_BRIDGE_PROTOCOL_VERSION,
           kind: 'config.result',
           request_id: message.request_id,
-          config: this.options.configSnapshot,
+          config_version: this.configVersion,
+          config: this.configSnapshot,
         });
         return;
       case 'theme.get':

--- a/self/ui/src/settings/AppSettingsSurface.tsx
+++ b/self/ui/src/settings/AppSettingsSurface.tsx
@@ -1,0 +1,285 @@
+'use client'
+
+import * as React from 'react'
+import type {
+  AppSettingsPreparation,
+  AppSettingsSaveRequest,
+  AppSettingsSaveResult,
+  AppSettingsSecretMutationOperation,
+} from '@nous/shared'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Select,
+} from '../components/index'
+import { createAppSettingsDraft } from './settings-form-mapper'
+
+export interface AppSettingsSurfaceProps {
+  preparation: AppSettingsPreparation
+  actorId: string
+  onSave: (request: AppSettingsSaveRequest) => Promise<AppSettingsSaveResult>
+  evidenceRefs?: string[]
+  disabled?: boolean
+  disabledReason?: string
+  onSaved?: (result: AppSettingsSaveResult) => Promise<void> | void
+}
+
+function formatRuntimeStatus(preparation: AppSettingsPreparation): string {
+  const runtime = preparation.runtime
+  return `${runtime.status} · cfg ${runtime.config_version}`
+}
+
+export function AppSettingsSurface({
+  preparation,
+  actorId,
+  onSave,
+  evidenceRefs = [],
+  disabled = false,
+  disabledReason,
+  onSaved,
+}: AppSettingsSurfaceProps) {
+  const draft = React.useMemo(
+    () => createAppSettingsDraft(preparation),
+    [preparation],
+  )
+  const deferredGroups = React.useDeferredValue(preparation.config_groups)
+  const [config, setConfig] = React.useState<Record<string, unknown>>(draft.config)
+  const [secrets, setSecrets] = React.useState(draft.secrets)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [result, setResult] = React.useState<AppSettingsSaveResult | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    setConfig(draft.config)
+    setSecrets(draft.secrets)
+    setResult(null)
+    setError(null)
+  }, [draft.config, draft.secrets, preparation])
+
+  const submit = async () => {
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const next = await onSave({
+        project_id: preparation.project_id,
+        package_id: preparation.package_id,
+        actor_id: actorId,
+        expected_config_version: preparation.config_version,
+        config,
+        secrets,
+        evidence_refs: evidenceRefs,
+      })
+      setResult(next)
+      await onSaved?.(next)
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : 'Settings save failed unexpectedly.',
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Card className="border-border/80 bg-background/80">
+      <CardHeader className="space-y-3 border-b border-border">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle>{preparation.display_name}</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {preparation.description ?? preparation.package_id}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline">{preparation.package_version}</Badge>
+            <Badge variant="outline">cfg {preparation.config_version}</Badge>
+            <Badge variant="outline">{formatRuntimeStatus(preparation)}</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6 pt-6">
+        {disabled ? (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-100">
+            {disabledReason ?? 'This settings surface is currently unavailable.'}
+          </div>
+        ) : null}
+
+        <p className="text-sm text-muted-foreground">
+          Settings stay host-owned and save through the governed
+          deactivate-update-reactivate lifecycle. Secret fields stay
+          vault-mediated and never rehydrate into the form as plaintext.
+        </p>
+
+        {deferredGroups.map((group) => (
+          <div key={group.id} className="space-y-4 rounded-md border border-border/80 p-4">
+            <div>
+              <h4 className="text-sm font-semibold">{group.label}</h4>
+              <p className="text-xs text-muted-foreground">
+                {group.fields.some((field) => field.secret)
+                  ? 'Includes vault-backed secret controls.'
+                  : 'Canonical non-secret configuration.'}
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              {group.fields.map((field) => (
+                <label key={field.key} className="space-y-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    <span>{field.label ?? field.key}</span>
+                    {field.required ? (
+                      <Badge variant="outline">Required</Badge>
+                    ) : (
+                      <Badge variant="outline">Optional</Badge>
+                    )}
+                    {field.secret ? <Badge variant="outline">Secret</Badge> : null}
+                  </div>
+                  {field.description ? (
+                    <div className="text-xs text-muted-foreground">
+                      {field.description}
+                    </div>
+                  ) : null}
+                  {field.secret ? (
+                    <div className="space-y-2">
+                      <div className="text-xs text-muted-foreground">
+                        {field.secret_state?.configured
+                          ? 'Configured in the vault.'
+                          : 'Not configured yet.'}
+                      </div>
+                      <Select
+                        value={secrets[field.key]?.operation ?? 'retain'}
+                        onChange={(event) =>
+                          setSecrets((current) => ({
+                            ...current,
+                            [field.key]: {
+                              operation: event.target.value as AppSettingsSecretMutationOperation,
+                            },
+                          }))
+                        }
+                      >
+                        <option value="retain">Retain</option>
+                        <option value="replace">Replace</option>
+                        <option value="clear">Clear</option>
+                      </Select>
+                      {secrets[field.key]?.operation === 'replace' ? (
+                        <Input
+                          type="password"
+                          value={secrets[field.key]?.value ?? ''}
+                          onChange={(event) =>
+                            setSecrets((current) => ({
+                              ...current,
+                              [field.key]: {
+                                operation: 'replace',
+                                value: event.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      ) : null}
+                    </div>
+                  ) : field.type === 'boolean' ? (
+                    <input
+                      type="checkbox"
+                      checked={Boolean(config[field.key])}
+                      onChange={(event) =>
+                        setConfig((current) => ({
+                          ...current,
+                          [field.key]: event.target.checked,
+                        }))
+                      }
+                      className="h-4 w-4 rounded border border-border"
+                    />
+                  ) : field.type === 'select' ? (
+                    <Select
+                      value={String(config[field.key] ?? '')}
+                      onChange={(event) =>
+                        setConfig((current) => ({
+                          ...current,
+                          [field.key]: event.target.value,
+                        }))
+                      }
+                    >
+                      {field.options?.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </Select>
+                  ) : (
+                    <Input
+                      type={field.type === 'number' ? 'number' : 'text'}
+                      value={String(config[field.key] ?? '')}
+                      onChange={(event) =>
+                        setConfig((current) => ({
+                          ...current,
+                          [field.key]: field.type === 'number'
+                            ? event.target.value
+                            : event.target.value,
+                        }))
+                      }
+                    />
+                  )}
+                </label>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        <div className="flex justify-end">
+          <Button onClick={submit} disabled={disabled || isSubmitting}>
+            {isSubmitting ? 'Saving...' : 'Save Settings'}
+          </Button>
+        </div>
+
+        {result ? (
+          <div className="space-y-4 rounded-md border border-border/80 bg-muted/10 p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={result.status === 'failed' ? 'outline' : 'default'}>
+                {result.status}
+              </Badge>
+              <Badge variant="outline">{result.apply_status}</Badge>
+              <Badge variant="outline">{result.phase}</Badge>
+              <Badge variant="outline">
+                effective cfg {result.effective_config_version}
+              </Badge>
+            </div>
+            {result.validation.results.length > 0 ? (
+              <div className="space-y-2">
+                {result.validation.results.map((entry, index) => (
+                  <div
+                    key={`${entry.check}-${entry.field ?? 'general'}-${index}`}
+                    className="rounded-md border border-border/60 p-3 text-sm"
+                  >
+                    <div className="font-medium">
+                      {entry.field ? `${entry.field}: ` : ''}
+                      {entry.check}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {entry.message ?? (entry.passed ? 'Passed' : 'Failed')}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Validation completed without additional per-check output.
+              </p>
+            )}
+          </div>
+        ) : null}
+
+        {error ? (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-100">
+            {error}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/self/ui/src/settings/index.ts
+++ b/self/ui/src/settings/index.ts
@@ -1,0 +1,5 @@
+export { AppSettingsSurface, type AppSettingsSurfaceProps } from './AppSettingsSurface'
+export {
+  createAppSettingsDraft,
+  type AppSettingsDraft,
+} from './settings-form-mapper'

--- a/self/ui/src/settings/settings-form-mapper.ts
+++ b/self/ui/src/settings/settings-form-mapper.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import type {
+  AppSettingsPreparation,
+  AppSettingsSecretMutation,
+} from '@nous/shared'
+import { getInstallFieldInitialValue } from '../install/install-form-mapper'
+
+export interface AppSettingsDraft {
+  config: Record<string, unknown>
+  secrets: Record<string, AppSettingsSecretMutation>
+}
+
+export function createAppSettingsDraft(
+  preparation: AppSettingsPreparation,
+): AppSettingsDraft {
+  const config: Record<string, unknown> = {}
+  const secrets: Record<string, AppSettingsSecretMutation> = {}
+
+  for (const group of preparation.config_groups) {
+    for (const field of group.fields) {
+      if (field.secret) {
+        secrets[field.key] = { operation: 'retain' }
+        continue
+      }
+
+      config[field.key] =
+        field.value !== undefined
+          ? field.value
+          : getInstallFieldInitialValue(field)
+    }
+  }
+
+  return {
+    config,
+    secrets,
+  }
+}


### PR DESCRIPTION
## Phase 15.5 — App Settings Convergence and Track Closure

Delivers the complete host-owned app settings convergence flow: canonical `deactivate -> update config -> reactivate -> recover` lifecycle with optimistic concurrency, vault-mediated secret mutation, `config.changed` push without iframe remount, and explicit `status` / `apply_status` separation.

### What's included

- **Shared contracts** (`app-settings.ts`) — 9 schemas: `AppSettingsPreparation`, `AppSettingsSaveRequest`, `AppSettingsSaveResult`, `AppSettingsMutationIntent` (retain/replace/clear), `AppSettingsValidationResult`, `AppSettingsCheckResult`, `AppSettingsAuditEntry`, `AppSettingsRollbackState`, `AppSettingsStage`
- **`credential-vault-service.ts`** — vault-backed settings credential backup/restore/discard for rollback-safe secret mutation
- **`panel-registration.ts`** — config-push support; `buildPanelSafeConfigSnapshot()` masks secrets with `SECRET_SENTINEL`
- **`AppSettingsService`** (`self/subcortex/projects/src/app-settings/`) — 13-step execution flow with optimistic concurrency (`expected_config_version`), approval gating, vault-backed rollback, panel config push
- **`@nous/app-sdk`** — `subscribeConfig()` bridge method + `useConfig()` update-in-place without remount
- **`@nous/ui`** — `AppSettingsSurface.tsx` with `settings-form-mapper.ts` (shared `getInstallFieldInitialValue()` with install wizard for continuity)
- **`@nous/desktop`** — additive IPC handlers for `packages.prepareAppSettings` / `packages.saveAppSettings`
- **`@nous/web`** — tRPC procedures; marketplace package-detail settings continuation

### Verification

- 45 tests across 10 files — 100% pass rate
- All 5 gate reviews approved on first cycle (no revision cycles)
- All 13 acceptance criteria met, all 17 SDS invariants preserved

### Review

`.worklog/phase-15/phase-15.5/review.mdx` — Verdict: **Approved**

Closes Phase 15.5 (App Settings Convergence and Track Closure).