### PR TITLE
Staging sync: paths-ignore, push trigger cleanup, CI restructure

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -19,6 +19,7 @@ on:
       - '.worklog'
       - '.skills'
       - 'docs/**'
+      - 'LICENSE*'
       - '.github/workflows/ci-release*.yml'
   pull_request:
     branches:
@@ -27,6 +28,15 @@ on:
       - 'fix/**'
       - 'refactor/**'
       - 'chore/**'
+    paths-ignore:
+      - '**.md'
+      - '**.mdx'
+      - '.architecture'
+      - '.worklog'
+      - '.skills'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.github/workflows/ci-release*.yml'
 
 jobs:
   check:

--- a/.github/workflows/ci-release-candidate.yml
+++ b/.github/workflows/ci-release-candidate.yml
@@ -7,8 +7,6 @@ name: CI Release Candidate
 # Coverage + benchmarks
 
 on:
-  push:
-    branches: [staging]
   pull_request:
     branches: [staging]
 

--- a/.github/workflows/ci-release-candidate.yml
+++ b/.github/workflows/ci-release-candidate.yml
@@ -9,6 +9,14 @@ name: CI Release Candidate
 on:
   pull_request:
     branches: [staging]
+    paths-ignore:
+      - '**.md'
+      - '**.mdx'
+      - '.architecture'
+      - '.worklog'
+      - '.skills'
+      - 'docs/**'
+      - 'LICENSE*'
 
 jobs:
   check:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,8 +4,6 @@ name: CI Release
 # Same structure as T3
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,6 +6,14 @@ name: CI Release
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '**.mdx'
+      - '.architecture'
+      - '.worklog'
+      - '.skills'
+      - 'docs/**'
+      - 'LICENSE*'
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

Final sync to align dev → staging → main.

- paths-ignore on all workflow triggers (no CI for docs-only changes)
- Removed push triggers from T3/T4 (PR checks are the gate)
- Dropped 3-OS matrix — ubuntu-only for Node.js checks
- Desktop build matrix (electron-builder, 3 OSes) in T3/T4
- Web app smoke as separate Smoke (web) job
- README badge fixes

## Test plan

- [ ] T3 passes (Check + 3x Desktop + Smoke (web))

🤖 Generated with [Claude Code](https://claude.com/claude-code)