### PR TITLE
fix(shared-server): wire provider lifecycle end-to-end (phase 1.1)

### DIFF
--- a/docs/content/docs/api/overview.mdx
+++ b/docs/content/docs/api/overview.mdx
@@ -37,6 +37,7 @@ When `NOUS_BASIC_AUTH` is set, include the `Authorization: Basic` header. The tR
 | `traces` | Execution traces |
 | `memory` | Memory entries, export, delete |
 | `packages` | Canonical app-install/settings preparation, governed app install/settings save, and active app-panel projection |
+| `preferences` | Vault-backed provider keys, available models, model selection persistence, and system status |
 | `config` | Configuration get/update |
 | `health` | System health check |
 | `firstRun` | First-run flow status and completion |

--- a/docs/content/docs/api/procedures.mdx
+++ b/docs/content/docs/api/procedures.mdx
@@ -270,6 +270,29 @@ Response excerpt:
 | `config.get` | query | — | `SystemConfig` |
 | `config.update` | mutation | `{ pfcTier?, modelRoleAssignments? }` | — |
 
+- `config.update` — Applies non-secret system configuration changes. Vault-backed provider credentials, available-model enumeration, and saved model selections are managed through `preferences.*`.
+
+## preferences
+
+| Procedure | Type | Input | Output |
+|----------|------|-------|--------|
+| `preferences.getApiKeys` | query | — | `{ provider, configured, maskedKey, createdAt }[]` |
+| `preferences.setApiKey` | mutation | `{ provider: 'anthropic' \| 'openai', key }` | `{ stored: boolean }` |
+| `preferences.deleteApiKey` | mutation | `{ provider: 'anthropic' \| 'openai' }` | `{ deleted: boolean }` |
+| `preferences.testApiKey` | mutation | `{ provider: 'anthropic' \| 'openai', key? }` | `{ valid: boolean, error: string \| null }` |
+| `preferences.getAvailableModels` | query | — | `{ models: { id, name, provider, available }[] }` |
+| `preferences.getModelSelection` | query | — | `{ principal: string \| null, system: string \| null }` |
+| `preferences.setModelSelection` | mutation | `{ principal?, system? }` | `{ success: boolean }` |
+| `preferences.getSystemStatus` | query | — | `{ ollama, configuredProviders, credentialVaultHealthy }` |
+
+- `preferences.getApiKeys` — Returns masked vault-backed provider-key state. Raw API keys are never returned to the client.
+- `preferences.setApiKey` — Stores the provider key in the credential vault, updates the active runtime immediately, registers the remote provider, and updates provider routing without requiring a restart.
+- `preferences.deleteApiKey` — Revokes the stored provider key, removes the provider from active routing, and cleans the provider/config state. If no cloud providers remain, runtime falls back to local-only routing posture.
+- `preferences.testApiKey` — Validates the supplied `key` when present; otherwise it tests the already-stored vault key. Returns `{ valid: false, error: 'No API key configured for this provider. Store a key first.' }` when nothing is available to test.
+- `preferences.getAvailableModels` — Returns the combined local Ollama model list plus cloud models for any currently configured Anthropic or OpenAI provider.
+- `preferences.getModelSelection` / `preferences.setModelSelection` — Persist the separate Principal and System model selections that Nous restores on startup.
+- `preferences.getSystemStatus` — Returns current Ollama posture, configured cloud providers, and whether the credential-vault surface is healthy.
+
 ## opctl
 
 | Procedure | Type | Input | Output |

--- a/docs/content/docs/configuration/config-schema.mdx
+++ b/docs/content/docs/configuration/config-schema.mdx
@@ -47,6 +47,8 @@ Nous uses JSON5 for configuration. The config file is validated at load time wit
 
 Legacy names are normalized at runtime. `allowSilentLocalToRemoteFailover` — when false (default), remote is allowed only as explicit fallback in hybrid_controlled.
 
+When Anthropic or OpenAI credentials are restored at startup and the active profile is `local-only` or `local_strict`, Nous promotes the runtime into a hybrid-compatible profile so remote providers can actually be routed. Removing the last cloud provider returns the runtime to local-only posture.
+
 ## Cortex Tier
 
 `pfcTier` is a number 0–5. Higher tiers enable more capabilities (reflection, memory gating, tool authorization, planning, escalation detection). See [Cortex Mode Capability Matrix](/docs/architecture/Cortex-mode-capability-matrix).
@@ -56,13 +58,18 @@ Legacy names are normalized at runtime. `allowSilentLocalToRemoteFailover` — w
 ```json5
 {
   "modelRoleAssignments": [
-    { "role": "reasoner", "providerId": "550e8400-e29b-41d4-a716-446655440001" },
-    { "role": "orchestrator", "providerId": "550e8400-e29b-41d4-a716-446655440001" }
+    {
+      "role": "reasoner",
+      "providerId": "550e8400-e29b-41d4-a716-446655440002",
+      "fallbackProviderId": "550e8400-e29b-41d4-a716-446655440001"
+    }
   ]
 }
 ```
 
-`providerId` must be a valid UUID matching a provider `id` in the providers array. Roles: `orchestrator`, `reasoner`, `tool-advisor`, `summarizer`, `embedder`, `reranker`, `vision`.
+`providerId` and optional `fallbackProviderId` must be valid UUIDs matching provider `id` values in the `providers` array. Roles: `orchestrator`, `reasoner`, `tool-advisor`, `summarizer`, `embedder`, `reranker`, `vision`.
+
+Saved Principal and System model selections are restored into this structure at startup. When both saved selections are available, Nous uses the primary selection as `providerId` and the secondary selection as `fallbackProviderId` for the active `reasoner` assignment.
 
 ## Providers
 
@@ -75,18 +82,18 @@ Legacy names are normalized at runtime. `allowSilentLocalToRemoteFailover` — w
       "type": "text",
       "modelId": "llama3.2:3b",
       "isLocal": true,
-      "capabilities": ["text"],
+      "capabilities": ["chat", "streaming"],
       "providerClass": "local_text",
       "meetsProfiles": ["review-standard", "prompt-generation"]
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440002",
-      "name": "OpenAI-compatible",
+      "name": "openai",
       "type": "text",
-      "endpoint": "https://api.openai.com/v1",
-      "modelId": "gpt-4o-mini",
+      "endpoint": "https://api.openai.com",
+      "modelId": "gpt-4o",
       "isLocal": false,
-      "capabilities": ["text"],
+      "capabilities": ["chat", "streaming"],
       "providerClass": "remote_text",
       "meetsProfiles": ["review-standard", "review-implementation"]
     }
@@ -96,6 +103,7 @@ Legacy names are normalized at runtime. `allowSilentLocalToRemoteFailover` — w
 
 - **providerClass** (optional): `local_text` | `remote_text` — used for credential segregation and profile boundary.
 - **meetsProfiles** (optional): Array of capability profiles (e.g. `review-standard`, `review-implementation`). Router enforces that the selected provider meets the required profile unless Principal override evidence is present.
+- **endpoint** (optional): Use the provider base URL (for example `https://api.openai.com` or `https://api.anthropic.com`), not the full `/v1/chat/completions` path.
 
 Provider types: `text`, `image`, `video`, `vision`, `embedding`, `external-api`.
 
@@ -164,14 +172,18 @@ These apply to newly created projects.
 
 ## Environment Variables
 
-| Variable | Overrides |
-|----------|-----------|
-| `NOUS_DATA_DIR` | `storage.dataDir` |
-| `NOUS_CONFIG_PATH` | Config file path |
-| `NOUS_BASIC_AUTH` | Basic auth for tRPC (format: `user:password`) |
+| Variable | Purpose |
+|----------|---------|
+| `NOUS_DATA_DIR` | Overrides `storage.dataDir` |
+| `NOUS_CONFIG_PATH` | Overrides the config file path |
+| `NOUS_BASIC_AUTH` | Enables basic auth for tRPC (format: `user:password`) |
+| `OPENAI_API_KEY` | Enables the built-in OpenAI remote provider at startup |
+| `ANTHROPIC_API_KEY` | Enables the built-in Anthropic remote provider at startup |
 | `NOUS_PUBLIC_BASE_URL` | Base URL used in OAuth discovery documents for the public MCP edge (default: `http://localhost:3000`). Set this when deploying behind a non-localhost public endpoint. |
 | `NOUS_PUBLIC_MCP_HOSTED_BINDINGS_JSON` | Seeded hosted public-MCP binding records used to map a public host or user handle onto a hosted tenant runtime. Accepts a JSON object or JSON array of binding records. |
 | `NOUS_PUBLIC_MCP_TUNNEL_SESSIONS_JSON` | Seeded public-MCP tunnel session records used to map a public host or user handle onto a local tunnel runtime. Accepts a JSON object or JSON array of session records. |
+
+When `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is present at startup, Nous registers the matching remote provider, updates available cloud models, restores saved model selections against stable provider IDs, and enables hybrid-compatible routing. These variables can be supplied directly or populated from stored vault credentials during bootstrap.
 
 Phase 13.5 config audit result: public MCP deployment routing adds two operator-facing seed
 variables for hosted and local-tunnel routing. `NOUS_PUBLIC_BASE_URL` remains the public MCP edge

--- a/docs/content/docs/guides/config.mdx
+++ b/docs/content/docs/guides/config.mdx
@@ -5,15 +5,48 @@ description: Model assignments, Cortex tier, and system health
 
 # Configuration
 
-The Configuration panel in the web UI lets you view and modify key settings.
+The Configuration panel lets you manage Cortex tier, provider credentials, model selections, and runtime health.
+
+Both the web and desktop hosts use the same shared-server bootstrap. When you change provider keys or model selections here, the runtime behavior is the same in both surfaces.
 
 ## Cortex Tier
 
 The Cortex (Prefrontal Cortex) tier controls how much oversight Nous applies. Tiers 0–5; higher tiers enable more reflection, memory gating, and tool authorization. See [Cortex Mode Capability Matrix](/docs/architecture/Cortex-mode-capability-matrix).
 
+## Provider Keys
+
+Nous currently supports vault-backed API-key setup for:
+
+- **Anthropic**
+- **OpenAI**
+
+Saving a key does three things immediately:
+
+- Stores the secret in the credential vault instead of the plain-text config file
+- Registers the matching remote provider in the active runtime
+- Adds that provider's cloud models to the available-model list without requiring a restart
+
+Deleting a key removes that provider from active routing and from the cloud-model list. If no cloud providers remain, Nous falls back to local-only routing behavior.
+
+The key-test action can validate either:
+
+- A newly pasted key
+- The already-stored vault key when you leave the key field empty
+
+## Available Models
+
+The model picker combines:
+
+- Local Ollama models detected from the running Ollama instance
+- Cloud models for any configured Anthropic or OpenAI provider
+
+Saved cloud keys are restored on startup, so configured cloud models should reappear automatically after restart.
+
 ## Model Assignments
 
-Assign model roles to providers. For example, the `reasoner` role might be fulfilled by Ollama or an OpenAI-compatible API. The router uses these assignments to route requests.
+Assign model roles to providers. For example, the `reasoner` role might be fulfilled by Ollama, OpenAI, or Anthropic. The router uses these assignments to route requests.
+
+Principal and System model selections are saved separately and restored on startup. When a saved cloud selection is restored, Nous automatically moves out of a strict local-only profile so the remote provider can be routed without hand-editing config.
 
 ## System Health
 
@@ -21,5 +54,7 @@ The health check shows:
 
 - **Storage** — Document store status
 - **Ollama** — Local model availability (if configured)
+- **Configured providers** — Which cloud providers currently have stored credentials
+- **Credential vault** — Whether vault-backed provider secret lookups are healthy
 
 When Ollama is not running, the Ollama component shows "unhealthy". Start Ollama to resolve.

--- a/self/apps/desktop/server/main.ts
+++ b/self/apps/desktop/server/main.ts
@@ -9,7 +9,15 @@
  * Usage: node server/main.ts --port=<port> [--data-dir=<path>]
  */
 import { createServer } from 'node:http';
-import { createNousServices, appRouter, createTRPCContext, detectOllama } from '@nous/shared-server';
+import {
+  createNousServices,
+  appRouter,
+  createTRPCContext,
+  detectOllama,
+  loadStoredApiKeys,
+  loadModelSelection,
+  registerStoredProviders,
+} from '@nous/shared-server';
 import type { OllamaStatus } from '@nous/shared-server';
 import { createHTTPHandler } from '@trpc/server/adapters/standalone';
 
@@ -52,6 +60,9 @@ async function main() {
     runtimeLabel: 'desktop',
     publicBaseUrl: `http://localhost:${args.port}`,
   });
+  await loadStoredApiKeys(context);
+  await registerStoredProviders(context);
+  await loadModelSelection(context);
 
   // Create tRPC HTTP handler with basePath matching the web app's endpoint
   const trpcHandler = createHTTPHandler({

--- a/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
+++ b/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
@@ -1,0 +1,384 @@
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderId, TraceId } from '@nous/shared';
+import { DEFAULT_PROFILES } from '@nous/autonomic-config';
+import {
+  WELL_KNOWN_PROVIDER_IDS,
+  createNousServices,
+  loadModelSelection,
+  loadStoredApiKeys,
+  registerStoredProviders,
+} from '../src/bootstrap';
+import { preferencesRouter } from '../src/trpc/routers/preferences';
+
+const SYSTEM_APP_ID = 'nous:system';
+const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
+const MODEL_SELECTION_ID = 'current';
+
+type ConfigState = {
+  profile: (typeof DEFAULT_PROFILES)[keyof typeof DEFAULT_PROFILES] & {
+    allowSilentLocalToRemoteFailover?: boolean;
+  };
+  providers: Array<{
+    id: ProviderId;
+    name: string;
+    type: 'text';
+    endpoint?: string;
+    modelId: string;
+    isLocal: boolean;
+    capabilities: string[];
+    providerClass?: 'remote_text' | 'local_text';
+    meetsProfiles?: string[];
+  }>;
+  modelRoleAssignments: Array<{
+    role: 'reasoner';
+    providerId: ProviderId;
+    fallbackProviderId?: ProviderId;
+  }>;
+};
+
+function vaultKey(provider: 'anthropic' | 'openai'): string {
+  return `api_key_${provider}`;
+}
+
+function createMockVault() {
+  const entries = new Map<string, { value: string; metadata: Record<string, unknown> }>();
+
+  return {
+    store: async (
+      appId: string,
+      request: {
+        key: string;
+        value: string;
+        credential_type: string;
+        target_host: string;
+        injection_location: string;
+        injection_key: string;
+      },
+    ) => {
+      const key = `${appId}:${request.key}`;
+      const metadata = {
+        app_id: appId,
+        user_key: request.key,
+        credential_type: request.credential_type,
+        target_host: request.target_host,
+        injection_location: request.injection_location,
+        injection_key: request.injection_key,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      entries.set(key, { value: request.value, metadata });
+      return { credential_ref: `credential:${key}`, metadata };
+    },
+    getMetadata: async (appId: string, key: string) => {
+      return entries.get(`${appId}:${key}`)?.metadata ?? null;
+    },
+    revoke: async (appId: string, request: { key: string; reason: string }) => {
+      const entryKey = `${appId}:${request.key}`;
+      const revoked = entries.delete(entryKey);
+      return { revoked };
+    },
+    resolveForInjection: async (appId: string, key: string) => {
+      const entry = entries.get(`${appId}:${key}`);
+      if (!entry) {
+        return null;
+      }
+      return {
+        metadata: entry.metadata,
+        secretValue: entry.value,
+      };
+    },
+  };
+}
+
+function createMockDocumentStore() {
+  const documents = new Map<string, unknown>();
+
+  return {
+    put: async <T>(collection: string, id: string, document: T) => {
+      documents.set(`${collection}:${id}`, document);
+    },
+    get: async <T>(collection: string, id: string): Promise<T | null> => {
+      return (documents.get(`${collection}:${id}`) as T) ?? null;
+    },
+    query: async () => [],
+    delete: async (collection: string, id: string) => {
+      return documents.delete(`${collection}:${id}`);
+    },
+  };
+}
+
+function createMockConfig(initial?: Partial<ConfigState>) {
+  const state: ConfigState = {
+    profile: { ...DEFAULT_PROFILES['local-only']! },
+    providers: [],
+    modelRoleAssignments: [],
+    ...initial,
+  };
+
+  return {
+    state,
+    get: () => ({
+      profile: { ...state.profile },
+      providers: [...state.providers],
+      modelRoleAssignments: [...state.modelRoleAssignments],
+    }),
+    getSection: vi.fn(),
+    update: async (section: keyof ConfigState, value: unknown) => {
+      const currentSection = state[section];
+      if (
+        typeof currentSection === 'object' &&
+        currentSection != null &&
+        !Array.isArray(currentSection)
+      ) {
+        state[section] = {
+          ...(currentSection as Record<string, unknown>),
+          ...(value as Record<string, unknown>),
+        } as ConfigState[typeof section];
+        return;
+      }
+
+      state[section] = value as ConfigState[typeof section];
+    },
+    reload: vi.fn(),
+  };
+}
+
+function createLifecycleContext(initialConfig?: Partial<ConfigState>) {
+  const config = createMockConfig(initialConfig);
+  const providerConfigs = new Map<ProviderId, { id: ProviderId; modelId: string; name: string }>();
+  const providerRegistry = {
+    registerProvider: (providerConfig: {
+      id: ProviderId;
+      name: string;
+      modelId: string;
+    }) => {
+      providerConfigs.set(providerConfig.id, providerConfig);
+    },
+    removeProvider: (providerId: ProviderId) => providerConfigs.delete(providerId),
+    listProviders: () => Array.from(providerConfigs.values()),
+    getProvider: (providerId: ProviderId) => {
+      const provider = providerConfigs.get(providerId);
+      return provider
+        ? {
+            getConfig: () => provider,
+          }
+        : null;
+    },
+  };
+  const credentialVaultService = createMockVault();
+  const documentStore = createMockDocumentStore();
+
+  return {
+    state: config.state,
+    config,
+    providerRegistry,
+    credentialVaultService,
+    documentStore,
+    ctx: {
+      config,
+      providerRegistry,
+      credentialVaultService,
+      documentStore,
+    } as any,
+  };
+}
+
+describe('provider lifecycle wiring', () => {
+  const originalFetch = globalThis.fetch;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+    savedEnv.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('localhost:11434')) {
+        throw { cause: { code: 'ECONNREFUSED' } };
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('loads stored keys and exposes cloud models on cold start', async () => {
+    const { ctx, credentialVaultService } = createLifecycleContext();
+    const caller = preferencesRouter.createCaller(ctx);
+
+    await credentialVaultService.store(SYSTEM_APP_ID, {
+      key: vaultKey('openai'),
+      value: 'sk-test-openai',
+      credential_type: 'api_key',
+      target_host: 'api.openai.com',
+      injection_location: 'header',
+      injection_key: 'Authorization',
+    });
+
+    await loadStoredApiKeys(ctx);
+
+    const result = await caller.getAvailableModels();
+    expect(result.models.some((model) => model.provider === 'openai')).toBe(true);
+    expect(process.env.OPENAI_API_KEY).toBe('sk-test-openai');
+  });
+
+  it('registerStoredProviders updates providers, assignments, and profile for cloud keys', async () => {
+    const { ctx, state } = createLifecycleContext();
+    process.env.OPENAI_API_KEY = 'sk-test-openai';
+
+    await registerStoredProviders(ctx);
+
+    expect(state.profile.name).toBe('hybrid');
+    expect(state.profile.allowSilentLocalToRemoteFailover).toBe(true);
+    expect(state.providers).toHaveLength(1);
+    expect(state.providers[0]!.id).toBe(WELL_KNOWN_PROVIDER_IDS.openai);
+    expect(state.modelRoleAssignments).toEqual([
+      {
+        role: 'reasoner',
+        providerId: WELL_KNOWN_PROVIDER_IDS.openai,
+      },
+    ]);
+  });
+
+  it('loadModelSelection applies saved model selections to config', async () => {
+    const { ctx, state, documentStore } = createLifecycleContext();
+    process.env.OPENAI_API_KEY = 'sk-test-openai';
+    process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
+
+    await registerStoredProviders(ctx);
+    await documentStore.put(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID, {
+      principal: 'openai:gpt-4o-mini',
+      system: 'anthropic:claude-opus-4-20250514',
+    });
+
+    await loadModelSelection(ctx);
+
+    expect(
+      state.providers.find((provider) => provider.id === WELL_KNOWN_PROVIDER_IDS.openai)
+        ?.modelId,
+    ).toBe('gpt-4o-mini');
+    expect(
+      state.providers.find((provider) => provider.id === WELL_KNOWN_PROVIDER_IDS.anthropic)
+        ?.modelId,
+    ).toBe('claude-opus-4-20250514');
+    expect(state.modelRoleAssignments).toEqual([
+      {
+        role: 'reasoner',
+        providerId: WELL_KNOWN_PROVIDER_IDS.openai,
+        fallbackProviderId: WELL_KNOWN_PROVIDER_IDS.anthropic,
+      },
+    ]);
+  });
+
+  it('setApiKey registers the provider and updates config state', async () => {
+    const { ctx, state } = createLifecycleContext();
+    const caller = preferencesRouter.createCaller(ctx);
+
+    await caller.setApiKey({
+      provider: 'openai',
+      key: 'sk-test-openai',
+    });
+
+    expect(process.env.OPENAI_API_KEY).toBe('sk-test-openai');
+    expect(state.profile.name).toBe('hybrid');
+    expect(state.profile.allowSilentLocalToRemoteFailover).toBe(true);
+    expect(state.providers.map((provider) => provider.id)).toContain(
+      WELL_KNOWN_PROVIDER_IDS.openai,
+    );
+    expect(state.modelRoleAssignments).toEqual([
+      {
+        role: 'reasoner',
+        providerId: WELL_KNOWN_PROVIDER_IDS.openai,
+      },
+    ]);
+  });
+
+  it('deleteApiKey removes the provider and restores local-only profile', async () => {
+    const { ctx, state } = createLifecycleContext();
+    const caller = preferencesRouter.createCaller(ctx);
+
+    await caller.setApiKey({
+      provider: 'openai',
+      key: 'sk-test-openai',
+    });
+    await caller.deleteApiKey({
+      provider: 'openai',
+    });
+
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(state.providers).toHaveLength(0);
+    expect(state.modelRoleAssignments).toHaveLength(0);
+    expect(state.profile.name).toBe('local-only');
+  });
+
+  it('testApiKey resolves a stored key when the input omits key', async () => {
+    const { ctx, credentialVaultService } = createLifecycleContext();
+    const caller = preferencesRouter.createCaller(ctx);
+
+    await credentialVaultService.store(SYSTEM_APP_ID, {
+      key: vaultKey('openai'),
+      value: 'sk-stored-openai',
+      credential_type: 'api_key',
+      target_host: 'api.openai.com',
+      injection_location: 'header',
+      injection_key: 'Authorization',
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('localhost:11434')) {
+        throw { cause: { code: 'ECONNREFUSED' } };
+      }
+
+      expect(init?.headers).toEqual({
+        Authorization: 'Bearer sk-stored-openai',
+      });
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await caller.testApiKey({
+      provider: 'openai',
+    });
+
+    expect(result).toEqual({ valid: true, error: null });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('keeps mock fallback active when no keys are configured', async () => {
+    const dataDir = join(tmpdir(), `nous-shared-server-${randomUUID()}`);
+    mkdirSync(dataDir, { recursive: true });
+    const ctx = createNousServices({
+      dataDir,
+      runtimeLabel: 'test',
+      publicBaseUrl: 'http://localhost:3000',
+    });
+
+    const result = await ctx.coreExecutor.executeTurn({
+      message: 'hello mock',
+      traceId: randomUUID() as TraceId,
+    });
+
+    expect(result.response).toContain('[Mock]');
+  });
+});

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -16,13 +16,22 @@ import {
 } from '@nous/shared';
 import type {
   ProjectId,
+  ModelProviderConfig,
   ProviderId,
   TraceId,
   StmCompactionPolicy,
   WorkflowNodeKind,
   IWorkflowNodeHandler,
 } from '@nous/shared';
-import { ConfigManager } from '@nous/autonomic-config';
+import {
+  ConfigManager,
+  DEFAULT_PROFILES,
+} from '@nous/autonomic-config';
+import type {
+  ModelRoleAssignment,
+  Profile,
+  ProviderConfigEntry,
+} from '@nous/autonomic-config';
 import {
   AppCredentialInstallService,
   CredentialInjector,
@@ -124,6 +133,25 @@ import type { NousContext } from './context';
 import type { IDocumentStore, IIngressGateway, IVectorStore } from '@nous/shared';
 
 const MOCK_PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as ProviderId;
+type CloudProviderName = 'anthropic' | 'openai';
+
+const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
+const MODEL_SELECTION_ID = 'current';
+
+const CLOUD_PROVIDER_ENV_VARS: Record<CloudProviderName, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+};
+
+export const WELL_KNOWN_PROVIDER_IDS: Record<CloudProviderName, ProviderId> = {
+  anthropic: '10000000-0000-0000-0000-000000000001' as ProviderId,
+  openai: '10000000-0000-0000-0000-000000000002' as ProviderId,
+};
+
+const CLOUD_PROVIDER_DEFAULT_MODELS: Record<CloudProviderName, string> = {
+  anthropic: 'claude-sonnet-4-20250514',
+  openai: 'gpt-4o',
+};
 
 // ─── Configuration helpers ─────────────────────────────────────────────────
 
@@ -131,6 +159,217 @@ const MOCK_PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as ProviderId;
  * Config shim that adds a mock provider when config has no providers.
  * Enables the app to run without a config file (development mode).
  */
+function hasConfiguredCloudKey(): boolean {
+  return (Object.values(CLOUD_PROVIDER_ENV_VARS) as string[]).some(
+    (envVar) => !!process.env[envVar],
+  );
+}
+
+function hasConfiguredProviderKey(provider: CloudProviderName): boolean {
+  return !!process.env[CLOUD_PROVIDER_ENV_VARS[provider]];
+}
+
+function currentProviderEntries(ctx: NousContext): ProviderConfigEntry[] {
+  const config = ctx.config.get() as { providers?: ProviderConfigEntry[] };
+  return Array.isArray(config.providers) ? config.providers : [];
+}
+
+function currentReasonerAssignment(
+  ctx: NousContext,
+): ModelRoleAssignment | undefined {
+  const config = ctx.config.get() as {
+    modelRoleAssignments?: ModelRoleAssignment[];
+  };
+  return config.modelRoleAssignments?.find(
+    (assignment) => assignment.role === 'reasoner',
+  );
+}
+
+function sortProvidersForDefault(
+  providers: ProviderConfigEntry[],
+): ProviderConfigEntry[] {
+  return [...providers].sort((a, b) => {
+    if (a.isLocal !== b.isLocal) {
+      return a.isLocal ? 1 : -1;
+    }
+
+    return a.name.localeCompare(b.name);
+  });
+}
+
+async function updateReasonerAssignment(
+  ctx: NousContext,
+  providerId: ProviderId | null,
+  fallbackProviderId?: ProviderId,
+): Promise<void> {
+  const nextAssignments: ModelRoleAssignment[] = providerId
+    ? [
+        {
+          role: 'reasoner',
+          providerId,
+          ...(fallbackProviderId &&
+          fallbackProviderId !== providerId
+            ? { fallbackProviderId }
+            : {}),
+        },
+      ]
+    : [];
+
+  await ctx.config.update(
+    'modelRoleAssignments',
+    // IConfig.update() exposes section values as unknown through the shared
+    // index-signature config contract; ConfigManager.update() runtime-validates
+    // the full config with SystemConfigSchema before committing.
+    nextAssignments as any,
+  );
+}
+
+async function ensureCloudCompatibleProfile(ctx: NousContext): Promise<void> {
+  if (!hasConfiguredCloudKey()) {
+    return;
+  }
+
+  const config = ctx.config.get() as { profile?: Profile };
+  const profileName = config.profile?.name;
+  if (profileName !== 'local-only' && profileName !== 'local_strict') {
+    return;
+  }
+
+  await ctx.config.update('profile', {
+    ...DEFAULT_PROFILES.hybrid,
+    allowSilentLocalToRemoteFailover: true,
+  });
+}
+
+async function ensureLocalCompatibleProfile(ctx: NousContext): Promise<void> {
+  if (hasConfiguredCloudKey()) {
+    return;
+  }
+
+  const providers = currentProviderEntries(ctx);
+  const hasRemoteProviders = providers.some((provider) => !provider.isLocal);
+  if (hasRemoteProviders) {
+    return;
+  }
+
+  const config = ctx.config.get() as { profile?: Profile };
+  const profileName = config.profile?.name;
+  if (profileName === 'local-only' || profileName === 'local_strict') {
+    return;
+  }
+
+  await ctx.config.update('profile', DEFAULT_PROFILES['local-only']);
+}
+
+function parseSelectedModelSpec(
+  spec: string | null | undefined,
+): { provider: CloudProviderName; modelId: string } | null {
+  if (!spec) {
+    return null;
+  }
+
+  const [provider, ...modelParts] = spec.split(':');
+  if (
+    (provider !== 'anthropic' && provider !== 'openai') ||
+    modelParts.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    provider,
+    modelId: modelParts.join(':'),
+  };
+}
+
+export function buildProviderConfig(
+  provider: CloudProviderName,
+  providerId: ProviderId = WELL_KNOWN_PROVIDER_IDS[provider],
+  modelId: string = CLOUD_PROVIDER_DEFAULT_MODELS[provider],
+): ModelProviderConfig {
+  if (provider === 'anthropic') {
+    return {
+      id: providerId,
+      name: provider,
+      type: 'text',
+      endpoint: 'https://api.anthropic.com',
+      modelId,
+      isLocal: false,
+      capabilities: ['chat', 'streaming'],
+      providerClass: 'remote_text',
+    };
+  }
+
+  return {
+    id: providerId,
+    name: provider,
+    type: 'text',
+    endpoint: 'https://api.openai.com',
+    modelId,
+    isLocal: false,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'remote_text',
+  };
+}
+
+function toProviderConfigEntry(
+  config: ModelProviderConfig,
+): ProviderConfigEntry {
+  return {
+    id: config.id,
+    name: config.name,
+    type: config.type,
+    endpoint: config.endpoint,
+    modelId: config.modelId,
+    isLocal: config.isLocal,
+    maxTokens: config.maxTokens,
+    capabilities: config.capabilities,
+    providerClass: config.providerClass,
+    meetsProfiles: config.meetsProfiles,
+  };
+}
+
+async function upsertProviderConfig(
+  ctx: NousContext,
+  providerConfig: ModelProviderConfig,
+): Promise<void> {
+  ctx.providerRegistry.registerProvider(providerConfig);
+
+  const existingProviders = currentProviderEntries(ctx);
+  const nextProviders = [
+    ...existingProviders.filter((provider) => provider.id !== providerConfig.id),
+    toProviderConfigEntry(providerConfig),
+  ];
+
+  await ctx.config.update(
+    'providers',
+    // IConfig.update() exposes section values as unknown through the shared
+    // index-signature config contract; ConfigManager.update() runtime-validates
+    // the full config with SystemConfigSchema before committing.
+    nextProviders as any,
+  );
+}
+
+async function removeProviderConfig(
+  ctx: NousContext,
+  providerId: ProviderId,
+): Promise<void> {
+  ctx.providerRegistry.removeProvider(providerId);
+
+  const existingProviders = currentProviderEntries(ctx);
+  const nextProviders = existingProviders.filter(
+    (provider) => provider.id !== providerId,
+  );
+
+  await ctx.config.update(
+    'providers',
+    // IConfig.update() exposes section values as unknown through the shared
+    // index-signature config contract; ConfigManager.update() runtime-validates
+    // the full config with SystemConfigSchema before committing.
+    nextProviders as any,
+  );
+}
+
 function configWithFallback(base: ConfigManager) {
   return {
     get: () => {
@@ -138,6 +377,12 @@ function configWithFallback(base: ConfigManager) {
       const assignments = c.modelRoleAssignments as Array<{ role: string; providerId: string }> | undefined;
       const providers = c.providers as Array<Record<string, unknown>> | undefined;
       if (!assignments?.length || !providers?.length) {
+        if (hasConfiguredCloudKey()) {
+          console.log(
+            '[nous:bootstrap] Mock fallback suppressed — real API keys detected',
+          );
+          return c;
+        }
         return {
           ...c,
           modelRoleAssignments: [{ role: 'reasoner', providerId: MOCK_PROVIDER_ID }],
@@ -918,6 +1163,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     publicMcpExecutionBridge,
     appRuntimeService,
     credentialVaultService,
+    providerRegistry,
     panelTranspiler,
     dataDir,
     codingAgentMaoEvents,
@@ -936,9 +1182,6 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
  * Call this after `createNousServices()`.
  */
 export async function loadModelSelection(ctx: NousContext): Promise<void> {
-  const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
-  const MODEL_SELECTION_ID = 'current';
-
   try {
     const saved = await ctx.documentStore.get<{
       principal: string | null;
@@ -957,8 +1200,73 @@ export async function loadModelSelection(ctx: NousContext): Promise<void> {
         );
       }
     }
+
+    const primarySelection = parseSelectedModelSpec(saved?.principal);
+    const secondarySelection = parseSelectedModelSpec(saved?.system);
+    const primaryProviderId =
+      primarySelection && hasConfiguredProviderKey(primarySelection.provider)
+        ? WELL_KNOWN_PROVIDER_IDS[primarySelection.provider]
+        : null;
+    const secondaryProviderId =
+      secondarySelection && hasConfiguredProviderKey(secondarySelection.provider)
+        ? WELL_KNOWN_PROVIDER_IDS[secondarySelection.provider]
+        : null;
+
+    if (primarySelection && primaryProviderId) {
+      await upsertProviderConfig(
+        ctx,
+        buildProviderConfig(
+          primarySelection.provider,
+          WELL_KNOWN_PROVIDER_IDS[primarySelection.provider],
+          primarySelection.modelId,
+        ),
+      );
+    }
+
+    if (
+      secondarySelection &&
+      secondaryProviderId &&
+      (!primarySelection ||
+        secondarySelection.provider !== primarySelection.provider ||
+        secondarySelection.modelId !== primarySelection.modelId)
+    ) {
+      await upsertProviderConfig(
+        ctx,
+        buildProviderConfig(
+          secondarySelection.provider,
+          WELL_KNOWN_PROVIDER_IDS[secondarySelection.provider],
+          secondarySelection.modelId,
+        ),
+      );
+    }
+
+    if (primaryProviderId) {
+      await updateReasonerAssignment(
+        ctx,
+        primaryProviderId,
+        secondaryProviderId ?? undefined,
+      );
+      return;
+    }
+
+    if (secondaryProviderId) {
+      await updateReasonerAssignment(
+        ctx,
+        secondaryProviderId,
+      );
+      return;
+    }
+
+    const availableProviders = sortProvidersForDefault(currentProviderEntries(ctx));
+    if (availableProviders.length > 0) {
+      await updateReasonerAssignment(ctx, availableProviders[0]!.id);
+    }
   } catch {
     // Model selection not yet persisted — use auto-detect defaults.
+    const availableProviders = sortProvidersForDefault(currentProviderEntries(ctx));
+    if (availableProviders.length > 0) {
+      await updateReasonerAssignment(ctx, availableProviders[0]!.id);
+    }
   }
 }
 
@@ -988,4 +1296,68 @@ export async function loadStoredApiKeys(ctx: NousContext): Promise<void> {
       // Ignore — key may not exist
     }
   }
+}
+
+export async function registerStoredProviders(ctx: NousContext): Promise<void> {
+  await ensureCloudCompatibleProfile(ctx);
+
+  const availableProviders = (
+    Object.keys(WELL_KNOWN_PROVIDER_IDS) as CloudProviderName[]
+  ).filter((provider) => !!process.env[CLOUD_PROVIDER_ENV_VARS[provider]]);
+
+  for (const provider of availableProviders) {
+    await upsertProviderConfig(
+      ctx,
+      buildProviderConfig(provider),
+    );
+  }
+
+  if (!currentReasonerAssignment(ctx) && availableProviders.length > 0) {
+    await updateReasonerAssignment(ctx, WELL_KNOWN_PROVIDER_IDS[availableProviders[0]!]);
+  }
+
+  if (availableProviders.length === 0) {
+    await ensureLocalCompatibleProfile(ctx);
+  }
+}
+
+export async function registerConfiguredProvider(
+  ctx: NousContext,
+  provider: CloudProviderName,
+  modelId: string = CLOUD_PROVIDER_DEFAULT_MODELS[provider],
+): Promise<void> {
+  await ensureCloudCompatibleProfile(ctx);
+  await upsertProviderConfig(
+    ctx,
+    buildProviderConfig(
+      provider,
+      WELL_KNOWN_PROVIDER_IDS[provider],
+      modelId,
+    ),
+  );
+
+  const existingAssignment = currentReasonerAssignment(ctx);
+  await updateReasonerAssignment(
+    ctx,
+    WELL_KNOWN_PROVIDER_IDS[provider],
+    existingAssignment?.providerId &&
+      existingAssignment.providerId !== WELL_KNOWN_PROVIDER_IDS[provider]
+      ? existingAssignment.providerId
+      : undefined,
+  );
+}
+
+export async function removeConfiguredProvider(
+  ctx: NousContext,
+  provider: CloudProviderName,
+): Promise<void> {
+  const providerId = WELL_KNOWN_PROVIDER_IDS[provider];
+  await removeProviderConfig(ctx, providerId);
+
+  const remainingProviders = sortProvidersForDefault(currentProviderEntries(ctx));
+  const nextPrimary = remainingProviders[0]?.id ?? null;
+  const nextFallback = remainingProviders[1]?.id;
+
+  await updateReasonerAssignment(ctx, nextPrimary, nextFallback);
+  await ensureLocalCompatibleProfile(ctx);
 }

--- a/self/apps/shared-server/src/context.ts
+++ b/self/apps/shared-server/src/context.ts
@@ -29,6 +29,7 @@ import type {
   ICredentialVaultService,
 } from '@nous/shared';
 import type { PanelTranspiler } from '@nous/subcortex-apps';
+import type { ProviderRegistry } from '@nous/subcortex-providers';
 import type {
   IPrincipalSystemGatewayRuntime,
   IPublicMcpExecutionBridge,
@@ -94,6 +95,7 @@ export interface NousContext {
   appRuntimeService: IAppRuntimeService;
   panelTranspiler: PanelTranspiler;
   credentialVaultService: ICredentialVaultService;
+  providerRegistry: ProviderRegistry;
   dataDir: string;
   /** MAO events emitted by coding agent runs. */
   codingAgentMaoEvents: Array<{ type: string; data: unknown; timestamp: string }>;

--- a/self/apps/shared-server/src/index.ts
+++ b/self/apps/shared-server/src/index.ts
@@ -7,7 +7,14 @@
  * - `NousContext` — the tRPC context type
  * - `createTRPCContext` — tRPC context factory
  */
-export { createNousServices, loadStoredApiKeys, loadModelSelection } from './bootstrap';
+export {
+  createNousServices,
+  loadStoredApiKeys,
+  loadModelSelection,
+  registerStoredProviders,
+  WELL_KNOWN_PROVIDER_IDS,
+  buildProviderConfig,
+} from './bootstrap';
 export type { BootstrapConfig } from './bootstrap';
 export type { NousContext, AgentSessionEntry } from './context';
 export { appRouter } from './trpc/root';

--- a/self/apps/shared-server/src/trpc/routers/preferences.ts
+++ b/self/apps/shared-server/src/trpc/routers/preferences.ts
@@ -4,6 +4,10 @@
 import { z } from 'zod';
 import { router, publicProcedure } from '../trpc';
 import { detectOllama } from '../../ollama-detection';
+import {
+  registerConfiguredProvider,
+  removeConfiguredProvider,
+} from '../../bootstrap';
 
 const SYSTEM_APP_ID = 'nous:system';
 const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
@@ -106,6 +110,10 @@ export const preferencesRouter = router({
 
       // Set in process environment for immediate SDK access
       process.env[config.envVar] = input.key;
+      await registerConfiguredProvider(ctx, input.provider);
+      console.log(
+        `[nous:preferences] setApiKey: registered provider ${input.provider}`,
+      );
 
       return { stored: true };
     }),
@@ -126,6 +134,10 @@ export const preferencesRouter = router({
 
       // Clear from process environment
       delete process.env[config.envVar];
+      await removeConfiguredProvider(ctx, input.provider);
+      console.log(
+        `[nous:preferences] deleteApiKey: removed provider ${input.provider}`,
+      );
 
       return { deleted: result.revoked };
     }),
@@ -134,16 +146,32 @@ export const preferencesRouter = router({
     .input(
       z.object({
         provider: ProviderSchema,
-        key: z.string().min(1),
+        key: z.string().min(1).optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       try {
+        const resolvedKey =
+          input.key ??
+          (
+            await ctx.credentialVaultService.resolveForInjection(
+              SYSTEM_APP_ID,
+              vaultKey(input.provider),
+            )
+          )?.secretValue;
+
+        if (!resolvedKey) {
+          return {
+            valid: false,
+            error: 'No API key configured for this provider. Store a key first.',
+          };
+        }
+
         if (input.provider === 'anthropic') {
           const response = await fetch('https://api.anthropic.com/v1/models', {
             method: 'GET',
             headers: {
-              'x-api-key': input.key,
+              'x-api-key': resolvedKey,
               'anthropic-version': '2023-06-01',
             },
           });
@@ -158,7 +186,7 @@ export const preferencesRouter = router({
           const response = await fetch('https://api.openai.com/v1/models', {
             method: 'GET',
             headers: {
-              Authorization: `Bearer ${input.key}`,
+              Authorization: `Bearer ${resolvedKey}`,
             },
           });
           if (response.ok) {

--- a/self/apps/web/app/api/trpc/[trpc]/route.ts
+++ b/self/apps/web/app/api/trpc/[trpc]/route.ts
@@ -2,15 +2,16 @@
  * tRPC API route handler.
  */
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { createNousContext } from '@/server/bootstrap';
+import { createTRPCContext } from '@nous/shared-server';
+import { initializeNousContext } from '@/server/bootstrap';
 import { appRouter } from '@/server/trpc/root';
 
-const handler = (req: Request) =>
+const handler = async (req: Request) =>
   fetchRequestHandler({
     endpoint: '/api/trpc',
     req,
     router: appRouter,
-    createContext: () => createNousContext(),
+    createContext: async () => createTRPCContext(await initializeNousContext()),
   });
 
 export { handler as GET, handler as POST };

--- a/self/apps/web/server/bootstrap.ts
+++ b/self/apps/web/server/bootstrap.ts
@@ -4,15 +4,22 @@
  * Thin adapter over @nous/shared-server. The platform-agnostic service graph
  * lives in shared-server; this file adds web-specific caching and env wiring.
  */
-import { createNousServices } from '@nous/shared-server';
+import {
+  createNousServices,
+  loadStoredApiKeys,
+  loadModelSelection,
+  registerStoredProviders,
+} from '@nous/shared-server';
 import type { NousContext } from '@nous/shared-server';
 
 export type { NousContext };
 
 let cachedContext: NousContext | null = null;
+let initPromise: Promise<NousContext> | null = null;
 
 export function clearNousContextCache(): void {
   cachedContext = null;
+  initPromise = null;
 }
 
 export function createNousContext(): NousContext {
@@ -25,4 +32,20 @@ export function createNousContext(): NousContext {
   });
 
   return cachedContext;
+}
+
+export async function initializeNousContext(): Promise<NousContext> {
+  if (initPromise) {
+    return initPromise;
+  }
+
+  const ctx = createNousContext();
+  initPromise = (async () => {
+    await loadStoredApiKeys(ctx);
+    await registerStoredProviders(ctx);
+    await loadModelSelection(ctx);
+    return ctx;
+  })();
+
+  return initPromise;
 }

--- a/self/subcortex/providers/src/__tests__/provider-registry.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-registry.test.ts
@@ -1,3 +1,4 @@
+import { ConfigError } from '@nous/shared';
 import { describe, expect, it, vi } from 'vitest';
 import { ProviderRegistry } from '../provider-registry.js';
 import { LaneAwareProvider } from '../lane-aware-provider.js';
@@ -28,5 +29,155 @@ describe('ProviderRegistry', () => {
 
     expect(provider).toBeInstanceOf(LaneAwareProvider);
     expect(registry.listProviders()).toHaveLength(1);
+  });
+
+  it('registerProvider adds a provider that can be retrieved', () => {
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    registry.registerProvider({
+      id: '00000000-0000-0000-0000-000000000010' as any,
+      name: 'local-extra',
+      type: 'text',
+      modelId: 'llama3.2:3b',
+      isLocal: true,
+      capabilities: ['text'],
+    });
+
+    expect(
+      registry.getProvider('00000000-0000-0000-0000-000000000010' as any),
+    ).toBeInstanceOf(LaneAwareProvider);
+    expect(registry.listProviders()).toHaveLength(1);
+  });
+
+  it('registerProvider replaces an existing provider with the same id', () => {
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    const providerId = '00000000-0000-0000-0000-000000000011' as any;
+
+    registry.registerProvider({
+      id: providerId,
+      name: 'first',
+      type: 'text',
+      modelId: 'llama3.2',
+      isLocal: true,
+      capabilities: ['text'],
+    });
+
+    registry.registerProvider({
+      id: providerId,
+      name: 'second',
+      type: 'text',
+      modelId: 'codellama:7b',
+      isLocal: true,
+      capabilities: ['text'],
+    });
+
+    expect(registry.listProviders()).toHaveLength(1);
+    expect(registry.getProvider(providerId)?.getConfig().name).toBe('second');
+    expect(registry.getProvider(providerId)?.getConfig().modelId).toBe('codellama:7b');
+  });
+
+  it('registerProvider throws ConfigError for invalid config', () => {
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    expect(() =>
+      registry.registerProvider({
+        id: 'not-a-uuid' as any,
+        name: 'invalid',
+        type: 'text',
+        modelId: 'llama3.2',
+        isLocal: true,
+        capabilities: ['text'],
+      }),
+    ).toThrow(ConfigError);
+  });
+
+  it('removeProvider removes an existing provider and returns true', () => {
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    const providerId = '00000000-0000-0000-0000-000000000012' as any;
+
+    registry.registerProvider({
+      id: providerId,
+      name: 'local-remove',
+      type: 'text',
+      modelId: 'llama3.2',
+      isLocal: true,
+      capabilities: ['text'],
+    });
+
+    expect(registry.removeProvider(providerId)).toBe(true);
+    expect(registry.getProvider(providerId)).toBeNull();
+    expect(registry.listProviders()).toHaveLength(0);
+  });
+
+  it('removeProvider returns false for an unknown provider id', () => {
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    expect(
+      registry.removeProvider('00000000-0000-0000-0000-000000000099' as any),
+    ).toBe(false);
+  });
+
+  it('normalizes anthropic remote providers to the Anthropic endpoint', () => {
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
+
+    try {
+      const registry = new ProviderRegistry({
+        get: () => ({ providers: [] }),
+        getSection: vi.fn(),
+        update: vi.fn(),
+        reload: vi.fn(),
+      } as any);
+
+      registry.registerProvider({
+        id: '00000000-0000-0000-0000-000000000013' as any,
+        name: 'anthropic',
+        type: 'text',
+        endpoint: 'https://api.openai.com',
+        modelId: 'claude-sonnet-4-20250514',
+        isLocal: false,
+        capabilities: ['chat', 'streaming'],
+        providerClass: 'remote_text',
+      });
+
+      expect(
+        registry
+          .getProvider('00000000-0000-0000-0000-000000000013' as any)
+          ?.getConfig().endpoint,
+      ).toBe('https://api.anthropic.com');
+    } finally {
+      if (originalKey === undefined) {
+        delete process.env.ANTHROPIC_API_KEY;
+      } else {
+        process.env.ANTHROPIC_API_KEY = originalKey;
+      }
+    }
   });
 });

--- a/self/subcortex/providers/src/provider-registry.ts
+++ b/self/subcortex/providers/src/provider-registry.ts
@@ -25,6 +25,7 @@ import { OpenAiCompatibleProvider } from './openai-provider.js';
 export class ProviderRegistry {
   private readonly providers = new Map<string, IModelProvider>();
   readonly laneRegistry: InferenceLaneRegistry;
+  private static readonly ANTHROPIC_ENDPOINT = 'https://api.anthropic.com';
 
   constructor(config: IConfig, options?: { laneRegistry?: InferenceLaneRegistry }) {
     this.laneRegistry = options?.laneRegistry ?? new InferenceLaneRegistry();
@@ -53,23 +54,9 @@ export class ProviderRegistry {
         meetsProfiles: entry.meetsProfiles,
       };
 
-      const validated = ModelProviderConfigSchema.safeParse(providerConfig);
-      if (!validated.success) {
-        throw new ConfigError(
-          `Provider "${entry.name}" has invalid configuration`,
-          {
-            providerName: entry.name,
-            providerId: entry.id,
-            errors: validated.error.issues.map((issue) => ({
-              path: issue.path.join('.'),
-              message: issue.message,
-            })),
-          },
-        );
-      }
-
-      const provider = this.createProvider(validated.data);
-      this.providers.set(validated.data.id, provider);
+      const validated = this.validateProviderConfig(providerConfig);
+      const provider = this.createProvider(validated);
+      this.providers.set(validated.id, provider);
     }
   }
 
@@ -81,14 +68,83 @@ export class ProviderRegistry {
     return Array.from(this.providers.values()).map((p) => p.getConfig());
   }
 
+  registerProvider(config: ModelProviderConfig): void {
+    const validated = this.validateProviderConfig(config);
+    const provider = this.createProvider(validated);
+    this.providers.set(validated.id, provider);
+    console.log(
+      `[nous:providers] registerProvider: registered ${validated.name} (${validated.id})`,
+    );
+  }
+
+  removeProvider(id: ProviderId): boolean {
+    const removed = this.providers.delete(id);
+    if (removed) {
+      console.log(`[nous:providers] removeProvider: removed ${id}`);
+    }
+    return removed;
+  }
+
   onLeaseReleased(listener: (event: LaneLeaseReleasedEvent) => void): () => void {
     return this.laneRegistry.onLeaseReleased(listener);
   }
 
+  private validateProviderConfig(config: ModelProviderConfig): ModelProviderConfig {
+    const validated = ModelProviderConfigSchema.safeParse(config);
+    if (!validated.success) {
+      throw new ConfigError(
+        `Provider "${config.name}" has invalid configuration`,
+        {
+          providerName: config.name,
+          providerId: config.id,
+          errors: validated.error.issues.map((issue) => ({
+            path: issue.path.join('.'),
+            message: issue.message,
+          })),
+        },
+      );
+    }
+
+    return validated.data;
+  }
+
+  private resolveRemoteApiKey(config: ModelProviderConfig): string | undefined {
+    const endpoint = config.endpoint?.toLowerCase() ?? '';
+    const providerName = config.name.toLowerCase();
+
+    if (endpoint.includes('anthropic') || providerName.includes('anthropic')) {
+      return process.env.ANTHROPIC_API_KEY;
+    }
+
+    return process.env.OPENAI_API_KEY;
+  }
+
+  private normalizeRemoteConfig(config: ModelProviderConfig): ModelProviderConfig {
+    const endpoint = config.endpoint?.toLowerCase() ?? '';
+    const providerName = config.name.toLowerCase();
+
+    if (endpoint.includes('anthropic') || providerName.includes('anthropic')) {
+      return {
+        ...config,
+        endpoint: ProviderRegistry.ANTHROPIC_ENDPOINT,
+      };
+    }
+
+    return config;
+  }
+
   private createProvider(config: ModelProviderConfig): IModelProvider {
+    const normalizedConfig = config.isLocal
+      ? config
+      : this.normalizeRemoteConfig(config);
     const provider = config.isLocal
-      ? new OllamaProvider(config)
-      : new OpenAiCompatibleProvider(config);
-    return new LaneAwareProvider(provider, this.laneRegistry.getOrCreate(config));
+      ? new OllamaProvider(normalizedConfig)
+      : new OpenAiCompatibleProvider(normalizedConfig, {
+          apiKey: this.resolveRemoteApiKey(normalizedConfig),
+        });
+    return new LaneAwareProvider(
+      provider,
+      this.laneRegistry.getOrCreate(normalizedConfig),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Wire `loadStoredApiKeys()` and `loadModelSelection()` into desktop and web entry points after `createNousServices()`
- Add `registerProvider()` and `removeProvider()` to `ProviderRegistry` with provider-specific API key resolution (Anthropic → `ANTHROPIC_API_KEY`, OpenAI → `OPENAI_API_KEY`)
- Make `configWithFallback()` conditional — only inject mock when no real keys exist in `process.env`
- Build and register real `ProviderConfigEntry` objects after key loading, with config profile transition from `local-only` to `hybrid`
- Wire `setApiKey` to trigger provider registration, `deleteApiKey` to trigger removal
- Make `testApiKey` key parameter optional with credential vault fallback
- Expose `providerRegistry` on `NousContext` for tRPC access
- Map saved model selections to `modelRoleAssignments` via `config.update()`

## Test plan

- [ ] Unit tests for `registerProvider` and `removeProvider` on `ProviderRegistry`
- [ ] Integration tests for key lifecycle (store → register → enumerate → delete → verify)
- [ ] `testApiKey` vault fallback test
- [ ] Regression: no keys configured → mock fallback active
- [ ] `pnpm build` passes (excluding docs)
- [ ] `pnpm test` passes

## Worklog

- Discovery: `.worklog/sprints/fix/shared-server-provider-wiring/discovery/root-cause-manifest.mdx`
- Goals: `.worklog/sprints/fix/shared-server-provider-wiring/phase-1/phase-1.1/goals.mdx`
- SDS: `.worklog/sprints/fix/shared-server-provider-wiring/phase-1/phase-1.1/sds.mdx`
- Implementation Plan: `.worklog/sprints/fix/shared-server-provider-wiring/phase-1/phase-1.1/implementation-plan.mdx`
- Completion Report: `.worklog/sprints/fix/shared-server-provider-wiring/phase-1/phase-1.1/completion-report.mdx`
- User Documentation: `.worklog/sprints/fix/shared-server-provider-wiring/phase-1/phase-1.1/user-documentation.mdx`
- Review: `.worklog/sprints/fix/shared-server-provider-wiring/phase-1/phase-1.1/review.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)