### PR TITLE
feat(desktop): Ollama lifecycle management

### DIFF
--- a/self/apps/desktop/__tests__/health-endpoint.test.ts
+++ b/self/apps/desktop/__tests__/health-endpoint.test.ts
@@ -1,14 +1,13 @@
 /**
  * Tests for the desktop backend health endpoint enhancement.
  *
- * Verifies that the /health endpoint includes Ollama status
- * and that the /ollama-status endpoint returns correct shape.
+ * Verifies the static contract shapes used by the desktop server and preload
+ * bridge without requiring a running Electron instance.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('desktop backend health endpoint contract', () => {
-  it('/health response includes ollama field with expected shape', () => {
-    // Verify the contract shape returned by the enhanced health endpoint
+  it('/health response includes the enriched Ollama status shape', () => {
     const healthResponse = {
       status: 'ok',
       runtime: 'desktop',
@@ -16,6 +15,7 @@ describe('desktop backend health endpoint contract', () => {
       ollama: {
         installed: true,
         running: true,
+        state: 'running' as const,
         models: ['llama3.2:3b'],
         defaultModel: 'llama3.2:3b',
       },
@@ -25,6 +25,7 @@ describe('desktop backend health endpoint contract', () => {
     expect(healthResponse.ollama).toBeDefined();
     expect(typeof healthResponse.ollama.installed).toBe('boolean');
     expect(typeof healthResponse.ollama.running).toBe('boolean');
+    expect(typeof healthResponse.ollama.state).toBe('string');
     expect(Array.isArray(healthResponse.ollama.models)).toBe(true);
     expect(
       healthResponse.ollama.defaultModel === null ||
@@ -32,7 +33,7 @@ describe('desktop backend health endpoint contract', () => {
     ).toBe(true);
   });
 
-  it('/health response with no Ollama has correct fallback shape', () => {
+  it('/health fallback includes the not_installed lifecycle state', () => {
     const healthResponse = {
       status: 'ok',
       runtime: 'desktop',
@@ -40,6 +41,7 @@ describe('desktop backend health endpoint contract', () => {
       ollama: {
         installed: false,
         running: false,
+        state: 'not_installed' as const,
         models: [] as string[],
         defaultModel: null,
       },
@@ -47,28 +49,31 @@ describe('desktop backend health endpoint contract', () => {
 
     expect(healthResponse.ollama.installed).toBe(false);
     expect(healthResponse.ollama.running).toBe(false);
+    expect(healthResponse.ollama.state).toBe('not_installed');
     expect(healthResponse.ollama.models).toEqual([]);
     expect(healthResponse.ollama.defaultModel).toBeNull();
   });
 
-  it('/ollama-status endpoint returns OllamaStatus shape', () => {
-    // The /ollama-status endpoint returns the same shape as OllamaStatus
+  it('/ollama-status endpoint returns the enriched OllamaStatus shape', () => {
     const ollamaStatus = {
       installed: true,
       running: true,
+      state: 'running' as const,
       models: ['llama3.2:3b', 'codellama:7b'],
       defaultModel: 'llama3.2:3b',
+      error: undefined as string | undefined,
     };
 
     expect(ollamaStatus).toHaveProperty('installed');
     expect(ollamaStatus).toHaveProperty('running');
+    expect(ollamaStatus).toHaveProperty('state');
     expect(ollamaStatus).toHaveProperty('models');
     expect(ollamaStatus).toHaveProperty('defaultModel');
   });
 });
 
-describe('renderer backend status IPC contract', () => {
-  it('backend:getStatus returns expected shape', () => {
+describe('renderer Ollama IPC contract', () => {
+  it('backend:getStatus returns the expected shape', () => {
     const status = {
       ready: true,
       port: 54321,
@@ -81,28 +86,50 @@ describe('renderer backend status IPC contract', () => {
     expect(status.trpcUrl).toContain('/api/trpc');
   });
 
-  it('backend:getStatus returns null port/trpcUrl when not ready', () => {
-    const status = {
-      ready: false,
-      port: null,
-      trpcUrl: null,
-    };
-
-    expect(status.ready).toBe(false);
-    expect(status.port).toBeNull();
-    expect(status.trpcUrl).toBeNull();
-  });
-
-  it('backend:getOllamaStatus returns OllamaStatus shape', () => {
+  it('backend:getOllamaStatus includes the new lifecycle state', () => {
     const status = {
       installed: true,
       running: true,
+      state: 'running' as const,
       models: ['llama3.2:3b'],
       defaultModel: 'llama3.2:3b',
     };
 
     expect(typeof status.installed).toBe('boolean');
     expect(typeof status.running).toBe('boolean');
+    expect(typeof status.state).toBe('string');
     expect(Array.isArray(status.models)).toBe(true);
+  });
+
+  it('ollama:getStatus returns the enriched status shape', () => {
+    const status = {
+      installed: true,
+      running: false,
+      state: 'installed_stopped' as const,
+      models: [] as string[],
+      defaultModel: null,
+    };
+
+    expect(status.state).toBe('installed_stopped');
+    expect(Array.isArray(status.models)).toBe(true);
+  });
+
+  it('ollama:start and ollama:stop return operation results', () => {
+    const result = { success: true };
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('ollama:pullProgress uses the expected progress event shape', () => {
+    const progress = {
+      status: 'downloading',
+      digest: 'sha256:abc',
+      total: 100,
+      completed: 50,
+      percent: 50,
+    };
+
+    expect(progress.percent).toBe(50);
+    expect(progress.digest).toBe('sha256:abc');
   });
 });

--- a/self/apps/desktop/__tests__/ollama-lifecycle.test.ts
+++ b/self/apps/desktop/__tests__/ollama-lifecycle.test.ts
@@ -1,0 +1,367 @@
+import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ipcHandlers = vi.hoisted(() => new Map<string, (...args: any[]) => any>());
+const appEventHandlers = vi.hoisted(() => new Map<string, (...args: any[]) => any>());
+const browserWindows = vi.hoisted(() => [] as MockBrowserWindow[]);
+const webContentsSendMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
+const forkMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+const originalFetch = globalThis.fetch;
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+const ollamaRuntime = {
+  binaryAvailable: false,
+  running: false,
+  models: ['llama3.2:3b'],
+  taskkillCalls: [] as string[][],
+};
+
+let nextPid = 4000;
+
+class MockChildProcess extends EventEmitter {
+  pid: number;
+  send = vi.fn();
+  kill = vi.fn((signal?: NodeJS.Signals) => {
+    ollamaRuntime.running = false;
+    this.emit('exit', signal === 'SIGKILL' ? 1 : 0, signal ?? null);
+    return true;
+  });
+
+  constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+}
+
+class MockBrowserWindow extends EventEmitter {
+  webContents = {
+    send: webContentsSendMock,
+    openDevTools: vi.fn(),
+    on: vi.fn(),
+    toggleDevTools: vi.fn(),
+    inspectElement: vi.fn(),
+  };
+  loadURL = vi.fn();
+  loadFile = vi.fn();
+  minimize = vi.fn();
+  maximize = vi.fn();
+  unmaximize = vi.fn();
+  close = vi.fn(() => {
+    this.emit('closed');
+  });
+  isMaximized = vi.fn(() => false);
+  setFullScreen = vi.fn();
+  isFullScreen = vi.fn(() => false);
+
+  constructor() {
+    super();
+    browserWindows.push(this);
+  }
+
+  static getAllWindows(): MockBrowserWindow[] {
+    return browserWindows;
+  }
+}
+
+const appMock = vi.hoisted(() => ({
+  whenReady: vi.fn(() => Promise.resolve()),
+  on: vi.fn((event: string, handler: (...args: any[]) => any) => {
+    appEventHandlers.set(event, handler);
+  }),
+  getPath: vi.fn(() => 'C:/Users/nous/AppData/Roaming/Nous'),
+  quit: vi.fn(),
+}));
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+    ipcHandlers.set(channel, handler);
+  }),
+}));
+
+class MockStore {
+  get = vi.fn();
+  set = vi.fn();
+}
+
+vi.mock('electron', () => ({
+  app: appMock,
+  BrowserWindow: MockBrowserWindow,
+  ipcMain: ipcMainMock,
+}));
+
+vi.mock('electron-store', () => ({
+  default: MockStore,
+}));
+
+vi.mock('@trpc/client', () => ({
+  createTRPCClient: vi.fn(() => ({})),
+  httpBatchLink: vi.fn(() => ({})),
+}));
+
+vi.mock('superjson', () => ({
+  default: {},
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  fork: forkMock,
+  spawn: spawnMock,
+}));
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function restorePlatform(): void {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+  }
+}
+
+function createConnectionError(): Error {
+  const error = new Error('connect refused') as Error & {
+    cause?: { code: string };
+  };
+  error.cause = { code: 'ECONNREFUSED' };
+  return error;
+}
+
+function installDefaultMocks(): void {
+  execFileMock.mockImplementation(
+    (
+      command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (command === 'taskkill') {
+        ollamaRuntime.taskkillCalls.push(_args.map(String));
+        callback(null, '', '');
+        const latestChild = spawnMock.mock.results.at(-1)?.value as MockChildProcess | undefined;
+        queueMicrotask(() => {
+          ollamaRuntime.running = false;
+          latestChild?.emit('exit', 0, null);
+        });
+        return {} as never;
+      }
+
+      if (
+        command === 'ollama' ||
+        command === '/usr/local/bin/ollama' ||
+        command.endsWith('\\ollama.exe')
+      ) {
+        if (ollamaRuntime.binaryAvailable) {
+          callback(null, 'ollama version 0.6.0', '');
+          return {} as never;
+        }
+
+        callback(Object.assign(new Error('not found'), { code: 'ENOENT' }), '', '');
+        return {} as never;
+      }
+
+      callback(Object.assign(new Error('not found'), { code: 'ENOENT' }), '', '');
+      return {} as never;
+    },
+  );
+
+  forkMock.mockImplementation(() => {
+    const child = new MockChildProcess(nextPid++);
+    queueMicrotask(() => {
+      child.emit('message', { type: 'ready', port: 54321 });
+    });
+    return child as any;
+  });
+
+  spawnMock.mockImplementation((_command: string, _args: string[], _options: unknown) => {
+    const child = new MockChildProcess(nextPid++);
+    ollamaRuntime.running = true;
+    return child as any;
+  });
+
+  fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+
+    if (url.includes('/api/tags')) {
+      if (!ollamaRuntime.running) {
+        throw createConnectionError();
+      }
+
+      return new Response(
+        JSON.stringify({
+          models: ollamaRuntime.models.map((name) => ({ name })),
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    }
+
+    if (url.includes('/api/pull')) {
+      return new Response('{"status":"success"}\n', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/x-ndjson',
+        },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  });
+}
+
+async function flushStartup(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function loadMainModule(): Promise<void> {
+  await import('../src/main/index');
+  await flushStartup();
+}
+
+function getHandler<T extends (...args: any[]) => any>(channel: string): T {
+  const handler = ipcHandlers.get(channel);
+  if (!handler) {
+    throw new Error(`IPC handler not registered: ${channel}`);
+  }
+  return handler as T;
+}
+
+describe('desktop Ollama lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.clearAllTimers();
+    ipcHandlers.clear();
+    appEventHandlers.clear();
+    browserWindows.length = 0;
+    webContentsSendMock.mockReset();
+    execFileMock.mockReset();
+    forkMock.mockReset();
+    spawnMock.mockReset();
+    fetchMock.mockReset();
+    appMock.whenReady.mockClear();
+    appMock.on.mockClear();
+    appMock.getPath.mockClear();
+    appMock.quit.mockClear();
+
+    nextPid = 4000;
+    ollamaRuntime.binaryAvailable = false;
+    ollamaRuntime.running = false;
+    ollamaRuntime.models = ['llama3.2:3b'];
+    ollamaRuntime.taskkillCalls = [];
+
+    restorePlatform();
+    setPlatform('linux');
+    installDefaultMocks();
+    globalThis.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    restorePlatform();
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('transitions through installed_stopped, starting, running, stopping, and back to installed_stopped', async () => {
+    await loadMainModule();
+
+    const getStatus = getHandler<() => Promise<{ state: string }>>('ollama:getStatus');
+    const start = getHandler<() => Promise<{ success: boolean }>>('ollama:start');
+    const stop = getHandler<() => Promise<{ success: boolean }>>('ollama:stop');
+
+    await expect(getStatus()).resolves.toMatchObject({ state: 'not_installed' });
+
+    ollamaRuntime.binaryAvailable = true;
+    await expect(getStatus()).resolves.toMatchObject({ state: 'installed_stopped' });
+    await expect(start()).resolves.toEqual({ success: true });
+    await expect(getStatus()).resolves.toMatchObject({ state: 'running' });
+    await expect(stop()).resolves.toEqual({ success: true });
+    await expect(getStatus()).resolves.toMatchObject({ state: 'installed_stopped' });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ollama',
+      ['serve'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ELECTRON_RUN_AS_NODE: undefined,
+        }),
+      }),
+    );
+  });
+
+  it('detects an externally managed Ollama instance and does not spawn or stop it', async () => {
+    ollamaRuntime.binaryAvailable = true;
+    ollamaRuntime.running = true;
+
+    await loadMainModule();
+
+    const getStatus = getHandler<() => Promise<{ state: string }>>('ollama:getStatus');
+    const stop = getHandler<() => Promise<{ success: boolean; error?: string }>>('ollama:stop');
+
+    await expect(getStatus()).resolves.toMatchObject({ state: 'running' });
+    expect(spawnMock).not.toHaveBeenCalled();
+    await expect(stop()).resolves.toEqual({
+      success: false,
+      error: 'Ollama is already running under an external process and will not be stopped by the desktop app.',
+    });
+  });
+
+  it('defines the exponential backoff schedule in the main-process source', () => {
+    const source = readFileSync(join(__dirname, '..', 'src', 'main', 'index.ts'), 'utf-8');
+
+    expect(source).toContain('Math.min(2000 * 2 ** restartCount, 30_000)');
+    expect(source).toContain('const OLLAMA_MAX_RESTARTS = 5');
+    expect(source).toContain('ollama restart attempt');
+  });
+
+  it('restarts Ollama after three consecutive health-check failures', async () => {
+    ollamaRuntime.binaryAvailable = true;
+
+    await loadMainModule();
+    const start = getHandler<() => Promise<{ success: boolean }>>('ollama:start');
+    await expect(start()).resolves.toEqual({ success: true });
+
+    const initialSpawnCount = spawnMock.mock.calls.length;
+
+    ollamaRuntime.running = false;
+    await vi.advanceTimersByTimeAsync(OLLAMA_HEALTH_WINDOW_MS);
+    expect(spawnMock.mock.calls.length).toBeGreaterThan(initialSpawnCount);
+  });
+
+  it('uses taskkill on Windows when stopping a managed Ollama process', async () => {
+    setPlatform('win32');
+    ollamaRuntime.binaryAvailable = true;
+
+    await loadMainModule();
+    const start = getHandler<() => Promise<{ success: boolean }>>('ollama:start');
+    await expect(start()).resolves.toEqual({ success: true });
+    await flushStartup();
+
+    const stop = getHandler<() => Promise<{ success: boolean }>>('ollama:stop');
+    await expect(stop()).resolves.toEqual({ success: true });
+    expect(ollamaRuntime.taskkillCalls).toHaveLength(1);
+    expect(ollamaRuntime.taskkillCalls[0]).toEqual([
+      '/PID',
+      expect.any(String),
+      '/T',
+      '/F',
+    ]);
+  });
+});
+
+const OLLAMA_HEALTH_WINDOW_MS = 10_000 * 3 + 2000;

--- a/self/apps/desktop/__tests__/server-spawn.test.ts
+++ b/self/apps/desktop/__tests__/server-spawn.test.ts
@@ -8,7 +8,7 @@
  * - Backend readiness guard behavior (Tier 2)
  * - Anti-regression source-level smoke tests (Tier 3)
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createServer } from 'node:net';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -173,6 +173,18 @@ describe('desktop backend server', () => {
 
     it('main/index.ts contains spawnBackendServer — spawn orchestrator must be present', () => {
       expect(source).toContain('spawnBackendServer');
+    });
+
+    it('main/index.ts contains startOllama — managed Ollama startup must be present', () => {
+      expect(source).toContain('startOllama');
+    });
+
+    it('main/index.ts contains stopOllama — managed Ollama shutdown must be present', () => {
+      expect(source).toContain('stopOllama');
+    });
+
+    it('main/index.ts contains ollama:getStatus — Ollama IPC status channel must be present', () => {
+      expect(source).toContain('ollama:getStatus');
     });
   });
 });

--- a/self/apps/desktop/server/main.ts
+++ b/self/apps/desktop/server/main.ts
@@ -8,7 +8,8 @@
  *
  * Usage: node server/main.ts --port=<port> [--data-dir=<path>]
  */
-import { createServer } from 'node:http';
+import { EventEmitter } from 'node:events';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import {
   createNousServices,
   appRouter,
@@ -16,12 +17,35 @@ import {
   detectOllama,
   loadStoredApiKeys,
   loadModelSelection,
+  pullOllamaModel,
   registerStoredProviders,
 } from '@nous/shared-server';
-import type { OllamaStatus } from '@nous/shared-server';
+import type { OllamaModelPullProgress, OllamaStatus } from '@nous/shared-server';
 import { createHTTPHandler } from '@trpc/server/adapters/standalone';
 
-// ─── Parse CLI arguments ────────────────────────────────────────────────────
+type ParentOllamaAction = 'getStatus' | 'start' | 'stop';
+
+interface ParentOllamaResponseMessage {
+  type: 'ollama:response';
+  requestId: string;
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+type PendingParentRequest = {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+const pullProgressEvents = new EventEmitter();
+pullProgressEvents.setMaxListeners(0);
+
+let latestPullProgress: OllamaModelPullProgress | null = null;
+let activePull: Promise<void> | null = null;
+let parentRequestSequence = 0;
+const pendingParentRequests = new Map<string, PendingParentRequest>();
 
 function parseArgs(argv: string[]): { port: number; dataDir?: string; configPath?: string } {
   let port = 0;
@@ -46,14 +70,141 @@ function parseArgs(argv: string[]): { port: number; dataDir?: string; configPath
   return { port, dataDir, configPath };
 }
 
-// ─── Main ───────────────────────────────────────────────────────────────────
+function defaultOllamaStatus(): OllamaStatus {
+  return {
+    installed: false,
+    running: false,
+    state: 'not_installed',
+    models: [],
+    defaultModel: null,
+  };
+}
+
+function isParentOllamaResponseMessage(value: unknown): value is ParentOllamaResponseMessage {
+  return typeof value === 'object' &&
+    value !== null &&
+    (value as { type?: string }).type === 'ollama:response' &&
+    typeof (value as { requestId?: string }).requestId === 'string' &&
+    typeof (value as { ok?: boolean }).ok === 'boolean';
+}
+
+function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) {
+    return null;
+  }
+
+  return JSON.parse(raw);
+}
+
+function writeSseEvent(res: ServerResponse, event: string, payload: unknown): void {
+  res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function registerParentResponseListener(): void {
+  process.on('message', (message: unknown) => {
+    if (!isParentOllamaResponseMessage(message)) {
+      return;
+    }
+
+    const pending = pendingParentRequests.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+
+    pendingParentRequests.delete(message.requestId);
+    clearTimeout(pending.timeout);
+
+    if (message.ok) {
+      pending.resolve(message.data);
+      return;
+    }
+
+    pending.reject(new Error(message.error ?? 'Parent Ollama request failed.'));
+  });
+}
+
+function requestParentOllamaAction<T>(action: ParentOllamaAction): Promise<T> {
+  if (!process.send) {
+    return Promise.reject(new Error('Parent IPC channel is unavailable.'));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const requestId = `ollama-${Date.now()}-${++parentRequestSequence}`;
+    const timeout = setTimeout(() => {
+      pendingParentRequests.delete(requestId);
+      reject(new Error(`Timed out waiting for parent Ollama action "${action}".`));
+    }, 10_000);
+    timeout.unref();
+
+    pendingParentRequests.set(requestId, { resolve, reject, timeout });
+    process.send?.({
+      type: 'ollama:request',
+      requestId,
+      action,
+    });
+  });
+}
+
+async function getBestEffortOllamaStatus(): Promise<OllamaStatus> {
+  try {
+    return await requestParentOllamaAction<OllamaStatus>('getStatus');
+  } catch {
+    try {
+      return await detectOllama();
+    } catch {
+      return defaultOllamaStatus();
+    }
+  }
+}
+
+function emitPullProgress(progress: OllamaModelPullProgress): void {
+  latestPullProgress = progress;
+  pullProgressEvents.emit('progress', progress);
+}
+
+function startModelPull(model: string): void {
+  if (activePull) {
+    throw new Error('An Ollama model pull is already in progress.');
+  }
+
+  latestPullProgress = { status: `Starting pull for ${model}` };
+  pullProgressEvents.emit('progress', latestPullProgress);
+
+  activePull = pullOllamaModel(model, {
+    onProgress: emitPullProgress,
+  })
+    .then(async () => {
+      console.log(`[nous:desktop-server] model pull complete: ${model}`);
+      await getBestEffortOllamaStatus().catch(() => defaultOllamaStatus());
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : `Model pull failed for ${model}`;
+      console.error(`[nous:desktop-server] model pull failed: ${model} — ${message}`);
+      emitPullProgress({ status: message });
+    })
+    .finally(() => {
+      activePull = null;
+    });
+}
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
 
   console.log(`[nous:desktop-server] starting on port ${args.port}...`);
+  registerParentResponseListener();
 
-  // Create the full Nous service graph
   const context = createNousServices({
     configPath: args.configPath,
     dataDir: args.dataDir,
@@ -64,16 +215,13 @@ async function main() {
   await registerStoredProviders(context);
   await loadModelSelection(context);
 
-  // Create tRPC HTTP handler with basePath matching the web app's endpoint
   const trpcHandler = createHTTPHandler({
     router: appRouter,
     createContext: () => createTRPCContext(context),
     basePath: '/api/trpc/',
   });
 
-  // Create bare HTTP server with CORS support for the renderer
-  const server = createServer((req, res) => {
-    // CORS headers — renderer runs on a different origin in dev mode
+  const server = createServer(async (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
@@ -84,61 +232,121 @@ async function main() {
       return;
     }
 
-    // Health check endpoint — includes Ollama status for renderer awareness
     if (req.url === '/health') {
-      detectOllama().then((ollama) => {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok', runtime: 'desktop', port: args.port, ollama }));
-      }).catch(() => {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          status: 'ok', runtime: 'desktop', port: args.port,
-          ollama: { installed: false, running: false, models: [], defaultModel: null } satisfies OllamaStatus,
-        }));
+      const ollama = await getBestEffortOllamaStatus();
+      writeJson(res, 200, {
+        status: 'ok',
+        runtime: 'desktop',
+        port: args.port,
+        ollama,
       });
       return;
     }
 
-    // Dedicated Ollama status endpoint for polling
     if (req.url === '/ollama-status') {
-      detectOllama().then((ollama) => {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(ollama));
-      }).catch(() => {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ installed: false, running: false, models: [], defaultModel: null } satisfies OllamaStatus));
+      const ollama = await getBestEffortOllamaStatus();
+      writeJson(res, 200, ollama);
+      return;
+    }
+
+    if (req.url === '/ollama/start' && req.method === 'POST') {
+      try {
+        const result = await requestParentOllamaAction<{ success: boolean; error?: string }>('start');
+        writeJson(res, 200, result);
+      } catch (err) {
+        writeJson(res, 503, {
+          success: false,
+          error: err instanceof Error ? err.message : 'Unable to start Ollama.',
+        });
+      }
+      return;
+    }
+
+    if (req.url === '/ollama/stop' && req.method === 'POST') {
+      try {
+        const result = await requestParentOllamaAction<{ success: boolean; error?: string }>('stop');
+        writeJson(res, 200, result);
+      } catch (err) {
+        writeJson(res, 503, {
+          success: false,
+          error: err instanceof Error ? err.message : 'Unable to stop Ollama.',
+        });
+      }
+      return;
+    }
+
+    if (req.url === '/ollama/pull' && req.method === 'POST') {
+      try {
+        const body = await readJsonBody(req);
+        const model = typeof (body as { model?: unknown } | null)?.model === 'string'
+          ? (body as { model: string }).model.trim()
+          : '';
+
+        if (!model) {
+          writeJson(res, 400, {
+            started: false,
+            error: 'Request body must include a non-empty "model" string.',
+          });
+          return;
+        }
+
+        console.log(`[nous:desktop-server] model pull started: ${model}`);
+        startModelPull(model);
+        writeJson(res, 202, { started: true });
+      } catch (err) {
+        writeJson(res, 409, {
+          started: false,
+          error: err instanceof Error ? err.message : 'Unable to start model pull.',
+        });
+      }
+      return;
+    }
+
+    if (req.url === '/ollama/pull-progress' && req.method === 'GET') {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+      });
+      res.write(': connected\n\n');
+
+      if (latestPullProgress) {
+        writeSseEvent(res, 'progress', latestPullProgress);
+      }
+
+      const onProgress = (progress: OllamaModelPullProgress) => {
+        writeSseEvent(res, 'progress', progress);
+      };
+
+      pullProgressEvents.on('progress', onProgress);
+      req.on('close', () => {
+        pullProgressEvents.off('progress', onProgress);
       });
       return;
     }
 
-    // Route tRPC requests
     trpcHandler(req, res);
   });
 
   server.listen(args.port, '127.0.0.1', () => {
     console.log(`[nous:desktop-server] listening on http://127.0.0.1:${args.port}`);
 
-    // Signal readiness to the parent Electron main process
     if (process.send) {
       process.send({ type: 'ready', port: args.port });
     }
   });
 
-  // Graceful shutdown
   const shutdown = () => {
     console.log('[nous:desktop-server] shutting down...');
     server.close(() => {
       console.log('[nous:desktop-server] closed');
       process.exit(0);
     });
-    // Force exit after 5 seconds if graceful shutdown hangs
     setTimeout(() => process.exit(1), 5000).unref();
   };
 
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
-
-  // Parent process disconnect — Electron closed
   process.on('disconnect', shutdown);
 }
 

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -6,6 +6,14 @@ import { promisify } from 'node:util'
 import { readdir, readFile } from 'node:fs/promises'
 import Store from 'electron-store'
 import { createTRPCClient, httpBatchLink } from '@trpc/client'
+import {
+  detectOllama,
+  pullOllamaModel,
+  resolveOllamaBinary,
+  type OllamaLifecycleState,
+  type OllamaModelPullProgress,
+  type OllamaStatus,
+} from '../../../shared-server/src/ollama-detection'
 import superjson from 'superjson'
 
 interface StoredLayout {
@@ -27,6 +35,477 @@ let backendPort: number | null = null
 let backendReady = false
 let backendReadyPromise: Promise<number> | null = null
 let isAppQuitting = false
+
+type BackendOllamaRequestAction = 'getStatus' | 'start' | 'stop'
+
+interface BackendOllamaRequestMessage {
+  type: 'ollama:request'
+  requestId: string
+  action: BackendOllamaRequestAction
+}
+
+interface BackendOllamaResponseMessage {
+  type: 'ollama:response'
+  requestId: string
+  ok: boolean
+  data?: unknown
+  error?: string
+}
+
+const OLLAMA_HEALTH_INTERVAL_MS = 10_000
+const OLLAMA_HEALTH_FAILURE_THRESHOLD = 3
+const OLLAMA_READY_TIMEOUT_MS = 30_000
+const OLLAMA_READY_POLL_INTERVAL_MS = 500
+const OLLAMA_STOP_TIMEOUT_MS = 5000
+const OLLAMA_MAX_RESTARTS = 5
+
+let ollamaChild: ChildProcess | null = null
+let ollamaState: OllamaLifecycleState = 'not_installed'
+let ollamaStatus: OllamaStatus = {
+  installed: false,
+  running: false,
+  state: 'not_installed',
+  models: [],
+  defaultModel: null,
+}
+let isOllamaManaged = false
+let ollamaHealthInterval: ReturnType<typeof setInterval> | null = null
+let ollamaHealthFailures = 0
+let ollamaRestartCount = 0
+let ollamaRestartTimer: ReturnType<typeof setTimeout> | null = null
+let ollamaStartPromise: Promise<OllamaStatus> | null = null
+let ollamaStopPromise: Promise<void> | null = null
+let ollamaSuppressRestartOnExit = false
+let ollamaHealthCheckInFlight = false
+let activeOllamaPull: Promise<void> | null = null
+
+function buildOllamaStatus(
+  state: OllamaLifecycleState,
+  options?: {
+    models?: string[]
+    error?: string
+  },
+): OllamaStatus {
+  const models = options?.models ?? []
+
+  return {
+    installed: state !== 'not_installed',
+    running: state === 'running',
+    state,
+    models,
+    defaultModel: models[0] ?? null,
+    ...(options?.error ? { error: options.error } : {}),
+  }
+}
+
+function clearOllamaRestartTimer(): void {
+  if (ollamaRestartTimer) {
+    clearTimeout(ollamaRestartTimer)
+    ollamaRestartTimer = null
+  }
+}
+
+function clearOllamaHealthMonitor(): void {
+  if (ollamaHealthInterval) {
+    clearInterval(ollamaHealthInterval)
+    ollamaHealthInterval = null
+  }
+  ollamaHealthFailures = 0
+  ollamaHealthCheckInFlight = false
+}
+
+function emitOllamaStateChanged(nextStatus = ollamaStatus): void {
+  win?.webContents.send('ollama:stateChanged', nextStatus)
+}
+
+function setOllamaStatus(nextStatus: OllamaStatus): OllamaStatus {
+  ollamaState = nextStatus.state
+  ollamaStatus = nextStatus
+  emitOllamaStateChanged(nextStatus)
+  return nextStatus
+}
+
+function setOllamaState(
+  state: OllamaLifecycleState,
+  options?: {
+    models?: string[]
+    error?: string
+  },
+): OllamaStatus {
+  return setOllamaStatus(buildOllamaStatus(state, options))
+}
+
+function getOllamaRestartDelay(restartCount: number): number {
+  return Math.min(2000 * 2 ** restartCount, 30_000)
+}
+
+function isBackendOllamaRequestMessage(value: unknown): value is BackendOllamaRequestMessage {
+  return typeof value === 'object' &&
+    value !== null &&
+    (value as { type?: string }).type === 'ollama:request' &&
+    typeof (value as { requestId?: string }).requestId === 'string' &&
+    (
+      (value as { action?: string }).action === 'getStatus' ||
+      (value as { action?: string }).action === 'start' ||
+      (value as { action?: string }).action === 'stop'
+    )
+}
+
+async function refreshOllamaStatus(): Promise<OllamaStatus> {
+  if (ollamaState === 'starting' || ollamaState === 'stopping') {
+    return ollamaStatus
+  }
+
+  if (ollamaState === 'error') {
+    return ollamaStatus
+  }
+
+  const detected = await detectOllama()
+  return setOllamaStatus(detected)
+}
+
+function scheduleOllamaRestart(reason: string): void {
+  if (isAppQuitting || !isOllamaManaged) {
+    return
+  }
+
+  if (ollamaRestartCount >= OLLAMA_MAX_RESTARTS) {
+    setOllamaState('error', {
+      error: `Ollama restart limit reached after ${reason}.`,
+    })
+    return
+  }
+
+  clearOllamaRestartTimer()
+
+  const delay = getOllamaRestartDelay(ollamaRestartCount)
+  const attempt = ollamaRestartCount + 1
+  ollamaRestartCount += 1
+  console.log(`[nous:desktop] ollama restart attempt ${attempt}/${OLLAMA_MAX_RESTARTS} (backoff=${delay}ms)`)
+
+  ollamaRestartTimer = setTimeout(() => {
+    ollamaRestartTimer = null
+    if (!isAppQuitting) {
+      startOllama().catch((err) => {
+        console.error('[nous:desktop] ollama restart failed:', err)
+      })
+    }
+  }, delay)
+  ollamaRestartTimer.unref()
+}
+
+async function waitForOllamaReady(): Promise<OllamaStatus> {
+  const start = Date.now()
+
+  while (Date.now() - start < OLLAMA_READY_TIMEOUT_MS) {
+    const detected = await detectOllama()
+    if (detected.state === 'running') {
+      return detected
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, OLLAMA_READY_POLL_INTERVAL_MS))
+  }
+
+  throw new Error(`Ollama did not become ready within ${OLLAMA_READY_TIMEOUT_MS / 1000}s.`)
+}
+
+function attachOllamaProcessListeners(child: ChildProcess): void {
+  child.on('error', (err) => {
+    console.error('[nous:desktop] ollama process error:', err)
+  })
+
+  child.on('exit', (code, signal) => {
+    console.log(`[nous:desktop] ollama process exited (code=${code}, signal=${signal})`)
+
+    if (ollamaChild === child) {
+      ollamaChild = null
+    }
+
+    clearOllamaHealthMonitor()
+
+    const expectedExit =
+      ollamaSuppressRestartOnExit ||
+      isAppQuitting ||
+      !isOllamaManaged ||
+      ollamaState === 'stopping'
+
+    if (expectedExit) {
+      ollamaSuppressRestartOnExit = false
+      if (ollamaState !== 'error') {
+        setOllamaState('installed_stopped')
+      }
+      return
+    }
+
+    setOllamaState('installed_stopped')
+    scheduleOllamaRestart(`unexpected exit (code=${code}, signal=${signal})`)
+  })
+}
+
+async function terminateManagedOllamaProcess(child: ChildProcess): Promise<void> {
+  const exitPromise = new Promise<void>((resolve) => {
+    child.once('exit', () => resolve())
+  })
+
+  if (process.platform === 'win32') {
+    if (child.pid) {
+      try {
+        await execFileAsync('taskkill', ['/PID', String(child.pid), '/T', '/F'])
+      } catch {
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          // Ignore force-kill failures during shutdown cleanup.
+        }
+      }
+    }
+
+    await exitPromise
+    return
+  }
+
+  try {
+    child.kill('SIGTERM')
+  } catch {
+    return
+  }
+
+  const forceKillTimer = setTimeout(() => {
+    if (ollamaChild === child) {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // Ignore force-kill failures during shutdown cleanup.
+      }
+    }
+  }, OLLAMA_STOP_TIMEOUT_MS)
+  forceKillTimer.unref()
+
+  await exitPromise.finally(() => clearTimeout(forceKillTimer))
+}
+
+function startOllamaHealthMonitor(): void {
+  clearOllamaHealthMonitor()
+
+  ollamaHealthInterval = setInterval(() => {
+    if (ollamaHealthCheckInFlight || ollamaState !== 'running') {
+      return
+    }
+
+    ollamaHealthCheckInFlight = true
+    void detectOllama()
+      .then((detected) => {
+        if (detected.state === 'running') {
+          ollamaHealthFailures = 0
+          if (ollamaRestartCount > 0) {
+            ollamaRestartCount = 0
+          }
+          setOllamaStatus(detected)
+          return
+        }
+
+        ollamaHealthFailures += 1
+        console.warn(`[nous:desktop] ollama health check failed (${ollamaHealthFailures}/${OLLAMA_HEALTH_FAILURE_THRESHOLD})`)
+
+        if (ollamaHealthFailures < OLLAMA_HEALTH_FAILURE_THRESHOLD) {
+          return
+        }
+
+        if (!isOllamaManaged) {
+          clearOllamaHealthMonitor()
+          setOllamaStatus(detected)
+          return
+        }
+
+        clearOllamaHealthMonitor()
+        setOllamaState('error', {
+          error: 'Ollama failed three consecutive health checks.',
+        })
+
+        const child = ollamaChild
+        if (child) {
+          ollamaSuppressRestartOnExit = true
+          void terminateManagedOllamaProcess(child).finally(() => {
+            scheduleOllamaRestart('health check failures')
+          })
+          return
+        }
+
+        scheduleOllamaRestart('health check failures')
+      })
+      .catch((err) => {
+        ollamaHealthFailures += 1
+        console.warn(`[nous:desktop] ollama health check error (${ollamaHealthFailures}/${OLLAMA_HEALTH_FAILURE_THRESHOLD}):`, err)
+
+        if (ollamaHealthFailures >= OLLAMA_HEALTH_FAILURE_THRESHOLD) {
+          clearOllamaHealthMonitor()
+          setOllamaState('error', {
+            error: err instanceof Error ? err.message : 'Ollama health check failed.',
+          })
+          scheduleOllamaRestart('health check errors')
+        }
+      })
+      .finally(() => {
+        ollamaHealthCheckInFlight = false
+      })
+  }, OLLAMA_HEALTH_INTERVAL_MS)
+}
+
+async function startOllama(): Promise<OllamaStatus> {
+  if (ollamaStartPromise) {
+    return ollamaStartPromise
+  }
+
+  ollamaStartPromise = (async () => {
+    clearOllamaRestartTimer()
+
+    if (ollamaStopPromise) {
+      await ollamaStopPromise
+    }
+
+    const detected = await detectOllama()
+    if (detected.state === 'running') {
+      isOllamaManaged = false
+      ollamaRestartCount = 0
+      setOllamaStatus(detected)
+      startOllamaHealthMonitor()
+      return detected
+    }
+
+    const binary = await resolveOllamaBinary()
+    if (!binary.found || !binary.command) {
+      isOllamaManaged = false
+      ollamaChild = null
+      return setOllamaState('not_installed')
+    }
+
+    setOllamaState('starting')
+
+    let child: ChildProcess
+    try {
+      child = spawn(binary.command, ['serve'], {
+        shell: false,
+        stdio: 'ignore',
+        detached: false,
+        windowsHide: true,
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: undefined,
+        },
+      })
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      setOllamaState('error', { error })
+      scheduleOllamaRestart('spawn failure')
+      return ollamaStatus
+    }
+
+    console.log(`[nous:desktop] ollama process started (pid=${child.pid ?? 'n/a'})`)
+    ollamaChild = child
+    isOllamaManaged = true
+    ollamaSuppressRestartOnExit = false
+    attachOllamaProcessListeners(child)
+
+    try {
+      const readyStatus = await waitForOllamaReady()
+      ollamaHealthFailures = 0
+      setOllamaStatus(readyStatus)
+      startOllamaHealthMonitor()
+      return readyStatus
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      setOllamaState('error', { error })
+
+      if (ollamaChild === child) {
+        ollamaSuppressRestartOnExit = true
+        await terminateManagedOllamaProcess(child).catch(() => undefined)
+      }
+
+      if (!ollamaRestartTimer) {
+        scheduleOllamaRestart('startup readiness timeout')
+      }
+
+      return ollamaStatus
+    }
+  })().finally(() => {
+    ollamaStartPromise = null
+  })
+
+  return ollamaStartPromise
+}
+
+async function stopOllama(): Promise<void> {
+  if (ollamaStopPromise) {
+    return ollamaStopPromise
+  }
+
+  ollamaStopPromise = (async () => {
+    clearOllamaRestartTimer()
+    clearOllamaHealthMonitor()
+
+    if (!isOllamaManaged || !ollamaChild) {
+      isOllamaManaged = false
+      const detected = await detectOllama()
+      setOllamaStatus(detected)
+      return
+    }
+
+    const child = ollamaChild
+    setOllamaState('stopping')
+    ollamaSuppressRestartOnExit = true
+    await terminateManagedOllamaProcess(child)
+
+    isOllamaManaged = false
+    setOllamaState('installed_stopped')
+  })().finally(() => {
+    ollamaStopPromise = null
+  })
+
+  return ollamaStopPromise
+}
+
+async function handleBackendOllamaRequest(
+  message: BackendOllamaRequestMessage,
+): Promise<BackendOllamaResponseMessage> {
+  try {
+    if (message.action === 'getStatus') {
+      return {
+        type: 'ollama:response',
+        requestId: message.requestId,
+        ok: true,
+        data: await refreshOllamaStatus(),
+      }
+    }
+
+    if (message.action === 'start') {
+      const status = await startOllama()
+      return {
+        type: 'ollama:response',
+        requestId: message.requestId,
+        ok: true,
+        data: {
+          success: status.state === 'running',
+          error: status.state === 'running' ? undefined : status.error ?? `Ollama is ${status.state}.`,
+        },
+      }
+    }
+
+    await stopOllama()
+    return {
+      type: 'ollama:response',
+      requestId: message.requestId,
+      ok: true,
+      data: { success: true },
+    }
+  } catch (err) {
+    return {
+      type: 'ollama:response',
+      requestId: message.requestId,
+      ok: false,
+      error: err instanceof Error ? err.message : 'Unknown Ollama request error.',
+    }
+  }
+}
 
 /**
  * Find a free port by binding to port 0 and reading the assigned port.
@@ -126,6 +605,13 @@ function spawnBackendServer(port: number): Promise<number> {
         backendReady = true
         console.log(`[nous:desktop] backend server ready on port ${backendPort}`)
         resolve(backendPort!)
+        return
+      }
+
+      if (isBackendOllamaRequestMessage(msg)) {
+        void handleBackendOllamaRequest(msg).then((response) => {
+          child.send?.(response)
+        })
       }
     })
 
@@ -658,22 +1144,68 @@ ipcMain.handle('backend:getStatus', () => ({
   trpcUrl: backendPort ? `http://127.0.0.1:${backendPort}/api/trpc` : null,
 }))
 
-// Ollama status — fetched from the backend server's dedicated endpoint
+// Ollama status — retained for backward compatibility with older renderer code.
+/** @deprecated Use ollama:getStatus instead. */
 ipcMain.handle('backend:getOllamaStatus', async () => {
-  if (!backendReady || !backendPort) {
-    return { installed: false, running: false, models: [], defaultModel: null }
-  }
   try {
-    const res = await fetch(`http://127.0.0.1:${backendPort}/ollama-status`, {
-      signal: AbortSignal.timeout(5000),
-    })
-    if (!res.ok) {
-      return { installed: false, running: false, models: [], defaultModel: null }
-    }
-    return await res.json()
+    return await refreshOllamaStatus()
   } catch {
-    return { installed: false, running: false, models: [], defaultModel: null }
+    return ollamaStatus
   }
+})
+
+ipcMain.handle('ollama:getStatus', async () => {
+  try {
+    return await refreshOllamaStatus()
+  } catch {
+    return ollamaStatus
+  }
+})
+
+ipcMain.handle('ollama:start', async () => {
+  const status = await startOllama()
+  if (status.state === 'running') {
+    return { success: true }
+  }
+
+  return {
+    success: false,
+    error: status.error ?? `Ollama is ${status.state}.`,
+  }
+})
+
+ipcMain.handle('ollama:stop', async () => {
+  if (ollamaState === 'running' && !isOllamaManaged) {
+    return {
+      success: false,
+      error: 'Ollama is already running under an external process and will not be stopped by the desktop app.',
+    }
+  }
+
+  await stopOllama()
+  return { success: true }
+})
+
+ipcMain.handle('ollama:pullModel', async (_event, modelId: string) => {
+  if (activeOllamaPull) {
+    throw new Error('An Ollama model pull is already in progress.')
+  }
+
+  activeOllamaPull = pullOllamaModel(modelId, {
+    onProgress: (progress: OllamaModelPullProgress) => {
+      win?.webContents.send('ollama:pullProgress', progress)
+    },
+  })
+    .then(async () => {
+      await refreshOllamaStatus().catch(() => undefined)
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : 'Ollama model pull failed.'
+      win?.webContents.send('ollama:pullProgress', { status: message })
+    })
+    .finally(() => {
+      activeOllamaPull = null
+    })
 })
 
 // Chat handlers — tRPC proxy to the self-hosted backend
@@ -874,6 +1406,7 @@ function createWindow(): void {
     win.loadFile(join(__dirname, '../renderer/index.html'))
   }
 
+  emitOllamaStateChanged()
   win.on('closed', () => { win = null })
 }
 
@@ -881,6 +1414,9 @@ function createWindow(): void {
 
 app.on('before-quit', () => {
   isAppQuitting = true
+  void stopOllama().catch((err) => {
+    console.error('[nous:desktop] failed to stop ollama during shutdown:', err)
+  })
   stopBackend()
 })
 
@@ -894,6 +1430,9 @@ app.whenReady().then(async () => {
     // Still create the window — the UI will show "Starting..." messages
   }
 
+  void startOllama().catch((err) => {
+    console.error('[nous:desktop] failed to start ollama:', err)
+  })
   createWindow()
 
   app.on('activate', () => {

--- a/self/apps/desktop/src/preload/index.ts
+++ b/self/apps/desktop/src/preload/index.ts
@@ -31,6 +31,78 @@ contextBridge.exposeInMainWorld('electronAPI', {
     quit:      (): Promise<void> => ipcRenderer.invoke('app:quit'),
     newWindow: (): Promise<void> => ipcRenderer.invoke('app:newWindow'),
   },
+  backend: {
+    getStatus: (): Promise<{
+      ready: boolean
+      port: number | null
+      trpcUrl: string | null
+    }> => ipcRenderer.invoke('backend:getStatus'),
+    getOllamaStatus: (): Promise<{
+      installed: boolean
+      running: boolean
+      state: 'not_installed' | 'installed_stopped' | 'starting' | 'running' | 'stopping' | 'error'
+      models: string[]
+      defaultModel: string | null
+      error?: string
+    }> => ipcRenderer.invoke('backend:getOllamaStatus'),
+  },
+  ollama: {
+    getStatus: (): Promise<{
+      installed: boolean
+      running: boolean
+      state: 'not_installed' | 'installed_stopped' | 'starting' | 'running' | 'stopping' | 'error'
+      models: string[]
+      defaultModel: string | null
+      error?: string
+    }> => ipcRenderer.invoke('ollama:getStatus'),
+    start: (): Promise<{ success: boolean; error?: string }> => ipcRenderer.invoke('ollama:start'),
+    stop: (): Promise<{ success: boolean; error?: string }> => ipcRenderer.invoke('ollama:stop'),
+    pullModel: (modelId: string): Promise<void> => ipcRenderer.invoke('ollama:pullModel', modelId),
+    onPullProgress: (
+      callback: (progress: {
+        status: string
+        digest?: string
+        total?: number
+        completed?: number
+        percent?: number
+      }) => void,
+    ): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, progress: {
+        status: string
+        digest?: string
+        total?: number
+        completed?: number
+        percent?: number
+      }) => callback(progress)
+      ipcRenderer.on('ollama:pullProgress', listener)
+      return () => {
+        ipcRenderer.removeListener('ollama:pullProgress', listener)
+      }
+    },
+    onStateChange: (
+      callback: (status: {
+        installed: boolean
+        running: boolean
+        state: 'not_installed' | 'installed_stopped' | 'starting' | 'running' | 'stopping' | 'error'
+        models: string[]
+        defaultModel: string | null
+        error?: string
+      }) => void,
+    ): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, status: {
+        installed: boolean
+        running: boolean
+        state: 'not_installed' | 'installed_stopped' | 'starting' | 'running' | 'stopping' | 'error'
+        models: string[]
+        defaultModel: string | null
+        error?: string
+      }) => callback(status)
+      ipcRenderer.on('ollama:stateChanged', listener)
+      return () => {
+        ipcRenderer.removeListener('ollama:stateChanged', listener)
+      }
+    },
+  },
   appInstall: {
     prepare: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-install:prepare', input),
     install: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-install:install', input),

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -9,6 +9,36 @@ import type {
   AppSettingsSaveResult,
 } from '@nous/shared'
 
+type OllamaLifecycleState =
+  | 'not_installed'
+  | 'installed_stopped'
+  | 'starting'
+  | 'running'
+  | 'stopping'
+  | 'error'
+
+type OllamaStatus = {
+  installed: boolean
+  running: boolean
+  state: OllamaLifecycleState
+  models: string[]
+  defaultModel: string | null
+  error?: string
+}
+
+type OllamaModelPullProgress = {
+  status: string
+  digest?: string
+  total?: number
+  completed?: number
+  percent?: number
+}
+
+type OllamaOperationResult = {
+  success: boolean
+  error?: string
+}
+
 interface ElectronAPI {
   layout: {
     get: () => Promise<unknown>
@@ -76,12 +106,16 @@ interface ElectronAPI {
       port: number | null
       trpcUrl: string | null
     }>
-    getOllamaStatus: () => Promise<{
-      installed: boolean
-      running: boolean
-      models: string[]
-      defaultModel: string | null
-    }>
+    /** @deprecated Use `window.electronAPI.ollama.getStatus()` instead. */
+    getOllamaStatus: () => Promise<OllamaStatus>
+  }
+  ollama: {
+    getStatus: () => Promise<OllamaStatus>
+    start: () => Promise<OllamaOperationResult>
+    stop: () => Promise<OllamaOperationResult>
+    pullModel: (modelId: string) => Promise<void>
+    onPullProgress: (callback: (progress: OllamaModelPullProgress) => void) => () => void
+    onStateChange: (callback: (status: OllamaStatus) => void) => () => void
   }
 }
 

--- a/self/apps/shared-server/__tests__/ollama-binary-resolution.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-binary-resolution.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalEnv = {
+  LOCALAPPDATA: process.env.LOCALAPPDATA,
+  OLLAMA_PATH: process.env.OLLAMA_PATH,
+};
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function restorePlatform(): void {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+  }
+}
+
+function mockExecFile(successByCommand: Record<string, boolean>): void {
+  execFileMock.mockImplementation(
+    (
+      command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (successByCommand[command]) {
+        callback(null, 'ollama version 0.6.0', '');
+        return {} as never;
+      }
+
+      callback(Object.assign(new Error('command not found'), { code: 'ENOENT' }), '', '');
+      return {} as never;
+    },
+  );
+}
+
+async function loadModule() {
+  return import('../src/ollama-detection');
+}
+
+describe('resolveOllamaBinary', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    delete process.env.OLLAMA_PATH;
+    delete process.env.LOCALAPPDATA;
+    restorePlatform();
+  });
+
+  afterEach(() => {
+    restorePlatform();
+    process.env.LOCALAPPDATA = originalEnv.LOCALAPPDATA;
+    process.env.OLLAMA_PATH = originalEnv.OLLAMA_PATH;
+    vi.restoreAllMocks();
+  });
+
+  it('prefers the OLLAMA_PATH env override when it probes successfully', async () => {
+    setPlatform('win32');
+    process.env.OLLAMA_PATH = 'C:\\custom\\ollama.exe';
+    mockExecFile({
+      'C:\\custom\\ollama.exe': true,
+    });
+
+    const { resolveOllamaBinary } = await loadModule();
+    await expect(resolveOllamaBinary()).resolves.toEqual({
+      found: true,
+      command: 'C:\\custom\\ollama.exe',
+      resolvedVia: 'env_override',
+      platform: 'win32',
+    });
+  });
+
+  it('falls back from an invalid OLLAMA_PATH to PATH lookup', async () => {
+    setPlatform('linux');
+    process.env.OLLAMA_PATH = '/custom/ollama';
+    mockExecFile({
+      ollama: true,
+    });
+
+    const { resolveOllamaBinary } = await loadModule();
+    await expect(resolveOllamaBinary()).resolves.toEqual({
+      found: true,
+      command: 'ollama',
+      resolvedVia: 'path_lookup',
+      platform: 'linux',
+    });
+  });
+
+  it('uses the Windows LOCALAPPDATA default path when PATH lookup fails', async () => {
+    setPlatform('win32');
+    process.env.LOCALAPPDATA = 'C:\\Users\\nous\\AppData\\Local';
+    const expectedPath = 'C:\\Users\\nous\\AppData\\Local\\Programs\\Ollama\\ollama.exe';
+    mockExecFile({
+      [expectedPath]: true,
+    });
+
+    const { resolveOllamaBinary } = await loadModule();
+    await expect(resolveOllamaBinary()).resolves.toEqual({
+      found: true,
+      command: expectedPath,
+      resolvedVia: 'platform_default',
+      platform: 'win32',
+    });
+  });
+
+  it('uses the macOS default path when PATH lookup fails', async () => {
+    setPlatform('darwin');
+    mockExecFile({
+      '/usr/local/bin/ollama': true,
+    });
+
+    const { resolveOllamaBinary } = await loadModule();
+    await expect(resolveOllamaBinary()).resolves.toEqual({
+      found: true,
+      command: '/usr/local/bin/ollama',
+      resolvedVia: 'platform_default',
+      platform: 'darwin',
+    });
+  });
+
+  it('returns not found on Linux when neither env nor PATH resolution succeeds', async () => {
+    setPlatform('linux');
+    mockExecFile({});
+
+    const { resolveOllamaBinary } = await loadModule();
+    await expect(resolveOllamaBinary()).resolves.toEqual({
+      found: false,
+      command: null,
+      resolvedVia: null,
+      platform: 'linux',
+    });
+  });
+});

--- a/self/apps/shared-server/__tests__/ollama-detection.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-detection.test.ts
@@ -1,12 +1,40 @@
 /**
  * Tests for the Ollama detection service.
  *
- * Uses mock HTTP responses to verify detection logic without
- * requiring a real Ollama instance.
+ * Uses mock HTTP responses and a mocked CLI probe so the results are
+ * deterministic regardless of the machine running the tests.
  */
-import { describe, it, expect } from 'vitest';
-import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
-import { detectOllama } from '../src/ollama-detection';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+function mockExecFile(found = false): void {
+  execFileMock.mockImplementation(
+    (
+      _command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (found) {
+        callback(null, 'ollama version 0.6.0', '');
+        return {} as never;
+      }
+
+      callback(Object.assign(new Error('command not found'), { code: 'ENOENT' }), '', '');
+      return {} as never;
+    },
+  );
+}
+
+async function loadModule() {
+  return import('../src/ollama-detection');
+}
 
 function startMockServer(
   handler: (req: IncomingMessage, res: ServerResponse) => void,
@@ -29,7 +57,18 @@ function stopServer(server: Server): Promise<void> {
 }
 
 describe('detectOllama', () => {
-  it('returns running=true with models when Ollama responds with model list', async () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    mockExecFile(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns running state with models when Ollama responds with a model list', async () => {
+    const { detectOllama } = await loadModule();
     const { server, port } = await startMockServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(
@@ -46,6 +85,7 @@ describe('detectOllama', () => {
       const status = await detectOllama(`http://127.0.0.1:${port}`);
       expect(status.installed).toBe(true);
       expect(status.running).toBe(true);
+      expect(status.state).toBe('running');
       expect(status.models).toEqual(['llama3.2:3b', 'codellama:7b']);
       expect(status.defaultModel).toBe('llama3.2:3b');
     } finally {
@@ -53,7 +93,8 @@ describe('detectOllama', () => {
     }
   });
 
-  it('returns running=true with empty models when Ollama has no models', async () => {
+  it('returns running state with empty models when Ollama has no models', async () => {
+    const { detectOllama } = await loadModule();
     const { server, port } = await startMockServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ models: [] }));
@@ -63,6 +104,7 @@ describe('detectOllama', () => {
       const status = await detectOllama(`http://127.0.0.1:${port}`);
       expect(status.installed).toBe(true);
       expect(status.running).toBe(true);
+      expect(status.state).toBe('running');
       expect(status.models).toEqual([]);
       expect(status.defaultModel).toBeNull();
     } finally {
@@ -70,7 +112,8 @@ describe('detectOllama', () => {
     }
   });
 
-  it('returns running=true when Ollama returns non-200 status', async () => {
+  it('returns running state when Ollama responds with a non-200 status', async () => {
+    const { detectOllama } = await loadModule();
     const { server, port } = await startMockServer((_req, res) => {
       res.writeHead(500);
       res.end('Internal Server Error');
@@ -80,6 +123,7 @@ describe('detectOllama', () => {
       const status = await detectOllama(`http://127.0.0.1:${port}`);
       expect(status.installed).toBe(true);
       expect(status.running).toBe(true);
+      expect(status.state).toBe('running');
       expect(status.models).toEqual([]);
       expect(status.defaultModel).toBeNull();
     } finally {
@@ -87,15 +131,31 @@ describe('detectOllama', () => {
     }
   });
 
-  it('returns running=false when connection is refused', async () => {
-    // Use a port that nothing is listening on
+  it('returns not_installed when the API is unreachable and no binary is detected', async () => {
+    const { detectOllama } = await loadModule();
     const status = await detectOllama('http://127.0.0.1:1');
+
+    expect(status.installed).toBe(false);
     expect(status.running).toBe(false);
+    expect(status.state).toBe('not_installed');
+    expect(status.models).toEqual([]);
+    expect(status.defaultModel).toBeNull();
+  });
+
+  it('returns installed_stopped when the API is unreachable but the binary is present', async () => {
+    mockExecFile(true);
+    const { detectOllama } = await loadModule();
+    const status = await detectOllama('http://127.0.0.1:1');
+
+    expect(status.installed).toBe(true);
+    expect(status.running).toBe(false);
+    expect(status.state).toBe('installed_stopped');
     expect(status.models).toEqual([]);
     expect(status.defaultModel).toBeNull();
   });
 
   it('filters out entries with missing or empty names', async () => {
+    const { detectOllama } = await loadModule();
     const { server, port } = await startMockServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(
@@ -112,6 +172,7 @@ describe('detectOllama', () => {
 
     try {
       const status = await detectOllama(`http://127.0.0.1:${port}`);
+      expect(status.state).toBe('running');
       expect(status.models).toEqual(['llama3.2:3b', 'phi3:mini']);
       expect(status.defaultModel).toBe('llama3.2:3b');
     } finally {
@@ -119,7 +180,8 @@ describe('detectOllama', () => {
     }
   });
 
-  it('handles missing models key in response', async () => {
+  it('handles missing models key in the response', async () => {
+    const { detectOllama } = await loadModule();
     const { server, port } = await startMockServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({}));
@@ -129,6 +191,7 @@ describe('detectOllama', () => {
       const status = await detectOllama(`http://127.0.0.1:${port}`);
       expect(status.installed).toBe(true);
       expect(status.running).toBe(true);
+      expect(status.state).toBe('running');
       expect(status.models).toEqual([]);
       expect(status.defaultModel).toBeNull();
     } finally {

--- a/self/apps/shared-server/__tests__/ollama-model-pull.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-model-pull.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pullOllamaModel } from '../src/ollama-detection';
+
+const originalFetch = globalThis.fetch;
+
+function createNdjsonResponse(chunks: string[], status = 200): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+      },
+    },
+  );
+}
+
+describe('pullOllamaModel', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('parses NDJSON progress events and computes percentages', async () => {
+    const onProgress = vi.fn();
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      createNdjsonResponse([
+        '{"status":"pulling manifest"}\n',
+        '{"status":"downloading","digest":"sha256:abc","total":100,"completed":25}\n',
+        '{"status":"success","total":100,"completed":100}\n',
+      ]),
+    );
+
+    await expect(
+      pullOllamaModel('llama3.2:3b', { onProgress }),
+    ).resolves.toBeUndefined();
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, {
+      status: 'pulling manifest',
+    });
+    expect(onProgress).toHaveBeenNthCalledWith(2, {
+      status: 'downloading',
+      digest: 'sha256:abc',
+      total: 100,
+      completed: 25,
+      percent: 25,
+    });
+    expect(onProgress).toHaveBeenNthCalledWith(3, {
+      status: 'success',
+      total: 100,
+      completed: 100,
+      percent: 100,
+    });
+  });
+
+  it('keeps percent undefined when total and completed are missing', async () => {
+    const onProgress = vi.fn();
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      createNdjsonResponse([
+        '{"status":"pulling manifest"}\n',
+        '{"status":"success"}\n',
+      ]),
+    );
+
+    await pullOllamaModel('mistral:latest', { onProgress });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, {
+      status: 'pulling manifest',
+    });
+    expect(onProgress).toHaveBeenNthCalledWith(2, {
+      status: 'success',
+    });
+  });
+
+  it('throws when the stream reports an Ollama error', async () => {
+    const onProgress = vi.fn();
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      createNdjsonResponse([
+        '{"status":"pulling manifest"}\n',
+        '{"error":"model not found"}\n',
+      ]),
+    );
+
+    await expect(
+      pullOllamaModel('missing:model', { onProgress }),
+    ).rejects.toThrow('model not found');
+
+    expect(onProgress).toHaveBeenLastCalledWith({
+      status: 'model not found',
+    });
+  });
+
+  it('throws for non-200 HTTP responses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response('bad request', { status: 400 }),
+    );
+
+    await expect(pullOllamaModel('llama3.2:3b')).rejects.toThrow(
+      'Ollama model pull failed with HTTP 400: bad request',
+    );
+  });
+
+  it('throws when the stream ends without success', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      createNdjsonResponse([
+        '{"status":"pulling manifest"}\n',
+        '{"status":"downloading","total":100,"completed":50}\n',
+      ]),
+    );
+
+    await expect(pullOllamaModel('llama3.2:3b')).rejects.toThrow(
+      'ended before reporting success',
+    );
+  });
+
+  it('supports aborting an in-flight stream', async () => {
+    const abortController = new AbortController();
+    const onProgress = vi.fn(() => {
+      abortController.abort(new Error('aborted by test'));
+    });
+
+    vi.mocked(globalThis.fetch).mockImplementationOnce(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        const encoder = new TextEncoder();
+
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode('{"status":"downloading","total":100,"completed":5}\n'),
+              );
+
+              const timer = setTimeout(() => {
+                controller.enqueue(encoder.encode('{"status":"success"}\n'));
+                controller.close();
+              }, 50);
+
+              signal?.addEventListener(
+                'abort',
+                () => {
+                  clearTimeout(timer);
+                  controller.error(signal.reason ?? new Error('aborted'));
+                },
+                { once: true },
+              );
+            },
+          }),
+          { status: 200 },
+        );
+      },
+    );
+
+    await expect(
+      pullOllamaModel('llama3.2:3b', {
+        signal: abortController.signal,
+        onProgress,
+      }),
+    ).rejects.toThrow('aborted by test');
+  });
+});

--- a/self/apps/shared-server/__tests__/preferences-router.test.ts
+++ b/self/apps/shared-server/__tests__/preferences-router.test.ts
@@ -242,6 +242,7 @@ describe('preferences router', () => {
     detectOllamaMock.mockResolvedValue({
       installed: false,
       running: false,
+      state: 'not_installed',
       models: [],
       defaultModel: null,
     });
@@ -315,7 +316,7 @@ describe('preferences router', () => {
           maskedKey: 'sk-ant-...1234',
         }),
       );
-    });
+    }, 10000);
 
     it('deletes a key, clears env state, and removes the provider', async () => {
       const { ctx } = createMockContext();
@@ -782,6 +783,7 @@ describe('preferences router', () => {
       detectOllamaMock.mockResolvedValueOnce({
         installed: true,
         running: true,
+        state: 'running',
         models: ['llama3.2:3b'],
         defaultModel: 'llama3.2:3b',
       });

--- a/self/apps/shared-server/src/index.ts
+++ b/self/apps/shared-server/src/index.ts
@@ -24,5 +24,18 @@ export type { NousContext, AgentSessionEntry } from './context';
 export { appRouter } from './trpc/root';
 export type { AppRouter } from './trpc/root';
 export { createTRPCContext, router, publicProcedure } from './trpc/trpc';
-export { detectOllama } from './ollama-detection';
-export type { OllamaStatus } from './ollama-detection';
+export {
+  OllamaBinaryResolutionSchema,
+  OllamaLifecycleStateSchema,
+  OllamaModelPullProgressSchema,
+  OllamaStatusSchema,
+  detectOllama,
+  pullOllamaModel,
+  resolveOllamaBinary,
+} from './ollama-detection';
+export type {
+  OllamaBinaryResolution,
+  OllamaLifecycleState,
+  OllamaModelPullProgress,
+  OllamaStatus,
+} from './ollama-detection';

--- a/self/apps/shared-server/src/ollama-detection.ts
+++ b/self/apps/shared-server/src/ollama-detection.ts
@@ -1,58 +1,337 @@
 /**
- * Ollama Detection Service — checks Ollama availability and model list.
+ * Ollama Detection Service — checks Ollama availability, binary resolution,
+ * and model pull progress.
  *
- * Used by the desktop backend to report LLM readiness to the renderer.
+ * Used by the desktop backend and Electron main process to report LLM
+ * readiness and manage model downloads.
  */
 
-export interface OllamaStatus {
-  installed: boolean;
-  running: boolean;
-  models: string[];
-  defaultModel: string | null;
-}
+import { execFile } from 'node:child_process';
+import { z } from 'zod';
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+const OLLAMA_DETECTION_TIMEOUT_MS = 3000;
+const OLLAMA_COMMAND_TIMEOUT_MS = 8000;
+
+export const OllamaLifecycleStateSchema = z.enum([
+  'not_installed',
+  'installed_stopped',
+  'starting',
+  'running',
+  'stopping',
+  'error',
+]);
+
+export type OllamaLifecycleState = z.infer<typeof OllamaLifecycleStateSchema>;
+
+export const OllamaStatusSchema = z.object({
+  installed: z.boolean(),
+  running: z.boolean(),
+  state: OllamaLifecycleStateSchema,
+  models: z.array(z.string()),
+  defaultModel: z.string().nullable(),
+  error: z.string().optional(),
+});
+
+export type OllamaStatus = z.infer<typeof OllamaStatusSchema>;
+
+export const OllamaModelPullProgressSchema = z.object({
+  status: z.string(),
+  digest: z.string().optional(),
+  total: z.number().optional(),
+  completed: z.number().optional(),
+  percent: z.number().optional(),
+});
+
+export type OllamaModelPullProgress = z.infer<typeof OllamaModelPullProgressSchema>;
+
+export const OllamaBinaryResolutionSchema = z.object({
+  found: z.boolean(),
+  command: z.string().nullable(),
+  resolvedVia: z.enum(['env_override', 'path_lookup', 'platform_default']).nullable(),
+  platform: z.string(),
+});
+
+export type OllamaBinaryResolution = z.infer<typeof OllamaBinaryResolutionSchema>;
+
+export const OllamaModelPullRequestSchema = z.object({
+  model: z.string().min(1),
+});
+
+const OllamaTagsResponseSchema = z.object({
+  models: z
+    .array(
+      z.object({
+        name: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+const OllamaPullProgressLineSchema = z
+  .object({
+    status: z.string().optional(),
+    digest: z.string().optional(),
+    total: z.number().optional(),
+    completed: z.number().optional(),
+    error: z.string().optional(),
+  })
+  .passthrough();
+
+function normalizeOllamaBaseUrl(baseUrl?: string): string {
+  return (baseUrl ?? DEFAULT_OLLAMA_BASE_URL).replace(/\/+$/, '');
+}
+
+function buildOllamaStatus(
+  state: OllamaLifecycleState,
+  options?: {
+    models?: string[];
+    error?: string;
+  },
+): OllamaStatus {
+  const models = options?.models ?? [];
+
+  return {
+    installed: state !== 'not_installed',
+    running: state === 'running',
+    state,
+    models,
+    defaultModel: models[0] ?? null,
+    ...(options?.error ? { error: options.error } : {}),
+  };
+}
+
+function extractOllamaModels(body: unknown): string[] {
+  const parsed = OllamaTagsResponseSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return [];
+  }
+
+  return parsed.data.models
+    ?.map((model) => model.name)
+    .filter((name): name is string => typeof name === 'string' && name.length > 0) ?? [];
+}
+
+function getPlatformDefaultBinaryCandidates(platform: NodeJS.Platform): string[] {
+  if (platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (!localAppData) {
+      return [];
+    }
+
+    return [`${localAppData}\\Programs\\Ollama\\ollama.exe`];
+  }
+
+  if (platform === 'darwin') {
+    return ['/usr/local/bin/ollama'];
+  }
+
+  return [];
+}
+
+function probeOllamaCommand(command: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      command,
+      ['--version'],
+      {
+        timeout: OLLAMA_COMMAND_TIMEOUT_MS,
+        windowsHide: true,
+      },
+      (error) => {
+        resolve(!error);
+      },
+    );
+  });
+}
+
+function computeProgressPercent(completed?: number, total?: number): number | undefined {
+  if (typeof completed !== 'number' || typeof total !== 'number' || total <= 0) {
+    return undefined;
+  }
+
+  return (completed / total) * 100;
+}
+
+async function emitPullProgressLine(
+  line: string,
+  onProgress?: (progress: OllamaModelPullProgress) => void,
+): Promise<{ success: boolean }> {
+  const parsedJson = JSON.parse(line) as unknown;
+  const parsed = OllamaPullProgressLineSchema.parse(parsedJson);
+
+  if (parsed.error) {
+    onProgress?.({ status: parsed.error });
+    throw new Error(parsed.error);
+  }
+
+  if (!parsed.status) {
+    return { success: false };
+  }
+
+  const progress = OllamaModelPullProgressSchema.parse({
+    status: parsed.status,
+    digest: parsed.digest,
+    total: parsed.total,
+    completed: parsed.completed,
+    percent: computeProgressPercent(parsed.completed, parsed.total),
+  });
+
+  onProgress?.(progress);
+  return { success: parsed.status === 'success' };
+}
 
 /**
- * Detect Ollama availability by probing its local HTTP API.
- *
- * - GET /api/tags returns the list of downloaded models.
- * - Connection refused means Ollama is not running (or not installed).
+ * Resolve the Ollama CLI using env override, PATH lookup, then known platform
+ * defaults.
+ */
+export async function resolveOllamaBinary(): Promise<OllamaBinaryResolution> {
+  const platform = process.platform;
+  const envOverride = process.env.OLLAMA_PATH?.trim();
+
+  if (envOverride && (await probeOllamaCommand(envOverride))) {
+    return {
+      found: true,
+      command: envOverride,
+      resolvedVia: 'env_override',
+      platform,
+    };
+  }
+
+  if (await probeOllamaCommand('ollama')) {
+    return {
+      found: true,
+      command: 'ollama',
+      resolvedVia: 'path_lookup',
+      platform,
+    };
+  }
+
+  for (const candidate of getPlatformDefaultBinaryCandidates(platform)) {
+    if (await probeOllamaCommand(candidate)) {
+      return {
+        found: true,
+        command: candidate,
+        resolvedVia: 'platform_default',
+        platform,
+      };
+    }
+  }
+
+  return {
+    found: false,
+    command: null,
+    resolvedVia: null,
+    platform,
+  };
+}
+
+/**
+ * Detect Ollama availability by probing its local HTTP API and falling back to
+ * binary detection when the server is unavailable.
  */
 export async function detectOllama(baseUrl?: string): Promise<OllamaStatus> {
-  const url = `${baseUrl ?? DEFAULT_OLLAMA_BASE_URL}/api/tags`;
+  const normalizedBaseUrl = normalizeOllamaBaseUrl(baseUrl);
 
   try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(3000),
+    const response = await fetch(`${normalizedBaseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(OLLAMA_DETECTION_TIMEOUT_MS),
     });
 
-    if (!res.ok) {
-      // Ollama is running but returned an error — still "installed"
-      return { installed: true, running: true, models: [], defaultModel: null };
+    if (!response.ok) {
+      return buildOllamaStatus('running');
     }
 
-    const body = (await res.json()) as { models?: Array<{ name?: string }> };
-    const models = (body.models ?? [])
-      .map((m) => m.name)
-      .filter((name): name is string => typeof name === 'string' && name.length > 0);
+    const body = await response.json();
+    const models = extractOllamaModels(body);
 
-    return {
-      installed: true,
-      running: true,
-      models,
-      defaultModel: models.length > 0 ? models[0] : null,
-    };
-  } catch (err: unknown) {
-    // Connection refused / timeout → not running
-    const code = (err as { cause?: { code?: string } })?.cause?.code;
-    if (code === 'ECONNREFUSED' || code === 'UND_ERR_CONNECT_TIMEOUT') {
-      // Ollama may be installed but not running — we can't distinguish without
-      // checking the filesystem, so we report installed: false conservatively.
-      return { installed: false, running: false, models: [], defaultModel: null };
+    return buildOllamaStatus('running', { models });
+  } catch {
+    const binaryResolution = await resolveOllamaBinary();
+
+    if (binaryResolution.found) {
+      return buildOllamaStatus('installed_stopped');
     }
 
-    // Any other fetch error (e.g., AbortError from timeout)
-    return { installed: false, running: false, models: [], defaultModel: null };
+    return buildOllamaStatus('not_installed');
+  }
+}
+
+/**
+ * Pull an Ollama model over the HTTP API and stream NDJSON progress updates.
+ */
+export async function pullOllamaModel(
+  model: string,
+  options?: {
+    baseUrl?: string;
+    signal?: AbortSignal;
+    onProgress?: (progress: OllamaModelPullProgress) => void;
+  },
+): Promise<void> {
+  options?.signal?.throwIfAborted?.();
+
+  const request = OllamaModelPullRequestSchema.parse({ model });
+  const normalizedBaseUrl = normalizeOllamaBaseUrl(options?.baseUrl);
+  const response = await fetch(`${normalizedBaseUrl}/api/pull`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: request.model,
+      stream: true,
+    }),
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text()).trim();
+    throw new Error(
+      `Ollama model pull failed with HTTP ${response.status}${detail ? `: ${detail.slice(0, 200)}` : ''}`,
+    );
+  }
+
+  if (!response.body) {
+    throw new Error('Ollama model pull response did not include a body stream.');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let sawSuccess = false;
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      buffer += decoder.decode();
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+
+    let newlineIndex = buffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+
+      if (line.length > 0) {
+        const result = await emitPullProgressLine(line, options?.onProgress);
+        sawSuccess ||= result.success;
+      }
+
+      newlineIndex = buffer.indexOf('\n');
+    }
+  }
+
+  const trailingLine = buffer.trim();
+  if (trailingLine.length > 0) {
+    const result = await emitPullProgressLine(trailingLine, options?.onProgress);
+    sawSuccess ||= result.success;
+  }
+
+  if (!sawSuccess) {
+    throw new Error(`Ollama model pull for "${request.model}" ended before reporting success.`);
   }
 }


### PR DESCRIPTION
## Summary

- Extend Ollama detection with tri-state lifecycle (`not_installed` / `installed_stopped` / `running`) via platform-specific binary resolution
- Add `pullOllamaModel()` with NDJSON progress streaming and abort support
- Desktop main process: `startOllama`/`stopOllama` with managed vs external instance detection, health monitoring, exponential backoff crash recovery
- IPC bridge: `ollama` namespace with 6 channels (getStatus, start, stop, pullModel, onPullProgress, onStateChange)
- Desktop server: `/ollama/start`, `/ollama/stop`, `/ollama/pull`, `/ollama/pull-progress` HTTP endpoints
- 3 new test files, 2129 total tests passing

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2129 tests, 100%)
- [x] `npx oxlint .` — 0 new warnings
- [x] All 14 acceptance criteria verified in completion report
- [ ] Behavioral testing: Ollama start/stop, model pull, health monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sprint: feat/desktop-self-hosted-runtime (WR-010)
Sub-phase: Phase 1.2 — Ollama Lifecycle Management