### PR TITLE
feat(shared-server): hardware detection, model recommendations, and multi-step first-run

### DIFF
--- a/self/apps/desktop/__tests__/hardware-firstrun-ipc.test.ts
+++ b/self/apps/desktop/__tests__/hardware-firstrun-ipc.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const preloadSource = readFileSync(
+  join(__dirname, '..', 'src', 'preload', 'index.ts'),
+  'utf-8',
+);
+const mainSource = readFileSync(
+  join(__dirname, '..', 'src', 'main', 'index.ts'),
+  'utf-8',
+);
+const envSource = readFileSync(
+  join(__dirname, '..', 'src', 'renderer', 'src', 'env.d.ts'),
+  'utf-8',
+);
+
+describe('desktop hardware and first-run IPC contract', () => {
+  it('registers the hardware IPC channels in preload and main', () => {
+    expect(preloadSource).toContain('hardware:getSpec');
+    expect(preloadSource).toContain('hardware:getRecommendations');
+    expect(mainSource).toContain("ipcMain.handle('hardware:getSpec'");
+    expect(mainSource).toContain("ipcMain.handle('hardware:getRecommendations'");
+  });
+
+  it('registers the first-run IPC channels in preload and main', () => {
+    expect(preloadSource).toContain('firstRun:getWizardState');
+    expect(preloadSource).toContain('firstRun:checkPrerequisites');
+    expect(preloadSource).toContain('firstRun:downloadModel');
+    expect(preloadSource).toContain('firstRun:configureProvider');
+    expect(preloadSource).toContain('firstRun:assignRoles');
+    expect(preloadSource).toContain('firstRun:completeStep');
+    expect(preloadSource).toContain('firstRun:resetWizard');
+
+    expect(mainSource).toContain("ipcMain.handle('firstRun:getWizardState'");
+    expect(mainSource).toContain("ipcMain.handle('firstRun:checkPrerequisites'");
+    expect(mainSource).toContain("ipcMain.handle('firstRun:downloadModel'");
+    expect(mainSource).toContain("ipcMain.handle('firstRun:configureProvider'");
+    expect(mainSource).toContain("ipcMain.handle('firstRun:assignRoles'");
+    expect(mainSource).toContain("ipcMain.handle('firstRun:completeStep'");
+    expect(mainSource).toContain("ipcMain.handle('firstRun:resetWizard'");
+  });
+
+  it('exposes the hardware and first-run namespaces in the renderer env contract', () => {
+    expect(envSource).toContain('hardware: {');
+    expect(envSource).toContain('getSpec: () => Promise<HardwareSpec>');
+    expect(envSource).toContain('getRecommendations: () => Promise<RecommendationResult>');
+    expect(envSource).toContain('firstRun: {');
+    expect(envSource).toContain('getWizardState: () => Promise<FirstRunState>');
+    expect(envSource).toContain('checkPrerequisites: () => Promise<FirstRunPrerequisites>');
+    expect(envSource).toContain('downloadModel: (model: string) => Promise<FirstRunActionResult>');
+    expect(envSource).toContain('configureProvider: (modelSpec: string) => Promise<FirstRunActionResult>');
+    expect(envSource).toContain('assignRoles: (assignments: FirstRunRoleAssignmentInput[]) => Promise<FirstRunActionResult>');
+    expect(envSource).toContain('completeStep: (step: FirstRunStep) => Promise<FirstRunState>');
+    expect(envSource).toContain('resetWizard: () => Promise<FirstRunState>');
+  });
+});

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -14,6 +14,18 @@ import {
   type OllamaModelPullProgress,
   type OllamaStatus,
 } from '../../../shared-server/src/ollama-detection'
+import {
+  createDefaultFirstRunState,
+  type FirstRunActionResult,
+  type FirstRunPrerequisites,
+  type FirstRunRoleAssignmentInput,
+  type FirstRunState,
+  type FirstRunStep,
+} from '../../../shared-server/src/first-run'
+import type {
+  HardwareSpec,
+  RecommendationResult,
+} from '../../../shared-server/src/hardware-detection'
 import superjson from 'superjson'
 
 interface StoredLayout {
@@ -1240,6 +1252,38 @@ async function ensureBackendReady(): Promise<void> {
   throw new Error('Backend server is not running')
 }
 
+function buildHardwareFallback(): HardwareSpec {
+  return {
+    totalMemoryMB: 0,
+    availableMemoryMB: 0,
+    cpuCores: 0,
+    cpuModel: 'Unknown CPU',
+    platform: process.platform,
+    arch: process.arch,
+    gpu: {
+      detected: false,
+    },
+  }
+}
+
+function buildRecommendationFallback(): RecommendationResult {
+  return {
+    singleModel: null,
+    multiModel: [],
+    hardwareSpec: buildHardwareFallback(),
+    profileName: 'local-only',
+    advisory: 'Hardware recommendations are unavailable while the backend is starting.',
+  }
+}
+
+function buildFirstRunActionFailure(error = 'Backend unavailable'): FirstRunActionResult {
+  return {
+    success: false,
+    state: createDefaultFirstRunState(),
+    error,
+  }
+}
+
 const chatHistory: { role: string; content: string; timestamp: string }[] = []
 
 ipcMain.handle('chat:send', async (_event, message: string) => {
@@ -1325,6 +1369,97 @@ ipcMain.handle('preferences:getModelSelection', async () => {
 })
 ipcMain.handle('preferences:setModelSelection', async (_event, input: unknown) => {
   try { await ensureBackendReady(); const c = getTrpcClient() as any; return await c.preferences.setModelSelection.mutate(input) } catch { return { success: false } }
+})
+ipcMain.handle('hardware:getSpec', async (): Promise<HardwareSpec> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.hardware.getSpec.query()
+  } catch {
+    return buildHardwareFallback()
+  }
+})
+ipcMain.handle('hardware:getRecommendations', async (): Promise<RecommendationResult> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.hardware.getRecommendations.query()
+  } catch {
+    return buildRecommendationFallback()
+  }
+})
+ipcMain.handle('firstRun:getWizardState', async (): Promise<FirstRunState> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.getWizardState.query()
+  } catch {
+    return createDefaultFirstRunState()
+  }
+})
+ipcMain.handle('firstRun:checkPrerequisites', async (): Promise<FirstRunPrerequisites> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.checkPrerequisites.query()
+  } catch {
+    return {
+      ollama: {
+        installed: false,
+        running: false,
+        state: 'not_installed',
+        models: [],
+        defaultModel: null,
+      },
+      hardware: buildHardwareFallback(),
+      recommendations: buildRecommendationFallback(),
+    }
+  }
+})
+ipcMain.handle('firstRun:downloadModel', async (_event, input: { model: string }): Promise<FirstRunActionResult> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.downloadModel.mutate(input)
+  } catch {
+    return buildFirstRunActionFailure()
+  }
+})
+ipcMain.handle('firstRun:configureProvider', async (_event, input: { modelSpec: string }): Promise<FirstRunActionResult> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.configureProvider.mutate(input)
+  } catch {
+    return buildFirstRunActionFailure()
+  }
+})
+ipcMain.handle('firstRun:assignRoles', async (_event, input: { assignments: FirstRunRoleAssignmentInput[] }): Promise<FirstRunActionResult> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.assignRoles.mutate(input)
+  } catch {
+    return buildFirstRunActionFailure()
+  }
+})
+ipcMain.handle('firstRun:completeStep', async (_event, input: { step: FirstRunStep }): Promise<FirstRunState> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.completeStep.mutate(input)
+  } catch {
+    return createDefaultFirstRunState()
+  }
+})
+ipcMain.handle('firstRun:resetWizard', async (): Promise<FirstRunState> => {
+  try {
+    await ensureBackendReady()
+    const client = getTrpcClient() as any
+    return await client.firstRun.resetWizard.mutate()
+  } catch {
+    return createDefaultFirstRunState()
+  }
 })
 
 ipcMain.handle('app-install:prepare', async (_event, input: unknown) => {

--- a/self/apps/desktop/src/preload/index.ts
+++ b/self/apps/desktop/src/preload/index.ts
@@ -103,6 +103,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
       }
     },
   },
+  hardware: {
+    getSpec: (): Promise<unknown> => ipcRenderer.invoke('hardware:getSpec'),
+    getRecommendations: (): Promise<unknown> => ipcRenderer.invoke('hardware:getRecommendations'),
+  },
+  firstRun: {
+    getWizardState: (): Promise<unknown> => ipcRenderer.invoke('firstRun:getWizardState'),
+    checkPrerequisites: (): Promise<unknown> => ipcRenderer.invoke('firstRun:checkPrerequisites'),
+    downloadModel: (model: string): Promise<unknown> => ipcRenderer.invoke('firstRun:downloadModel', { model }),
+    configureProvider: (modelSpec: string): Promise<unknown> => ipcRenderer.invoke('firstRun:configureProvider', { modelSpec }),
+    assignRoles: (assignments: unknown[]): Promise<unknown> => ipcRenderer.invoke('firstRun:assignRoles', { assignments }),
+    completeStep: (step: string): Promise<unknown> => ipcRenderer.invoke('firstRun:completeStep', { step }),
+    resetWizard: (): Promise<unknown> => ipcRenderer.invoke('firstRun:resetWizard'),
+  },
   appInstall: {
     prepare: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-install:prepare', input),
     install: (input: unknown): Promise<unknown> => ipcRenderer.invoke('app-install:install', input),

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -8,6 +8,15 @@ import type {
   AppSettingsSaveRequest,
   AppSettingsSaveResult,
 } from '@nous/shared'
+import type {
+  FirstRunActionResult,
+  FirstRunPrerequisites,
+  FirstRunRoleAssignmentInput,
+  FirstRunState,
+  FirstRunStep,
+  HardwareSpec,
+  RecommendationResult,
+} from '@nous/shared-server'
 
 type OllamaLifecycleState =
   | 'not_installed'
@@ -116,6 +125,19 @@ interface ElectronAPI {
     pullModel: (modelId: string) => Promise<void>
     onPullProgress: (callback: (progress: OllamaModelPullProgress) => void) => () => void
     onStateChange: (callback: (status: OllamaStatus) => void) => () => void
+  }
+  hardware: {
+    getSpec: () => Promise<HardwareSpec>
+    getRecommendations: () => Promise<RecommendationResult>
+  }
+  firstRun: {
+    getWizardState: () => Promise<FirstRunState>
+    checkPrerequisites: () => Promise<FirstRunPrerequisites>
+    downloadModel: (model: string) => Promise<FirstRunActionResult>
+    configureProvider: (modelSpec: string) => Promise<FirstRunActionResult>
+    assignRoles: (assignments: FirstRunRoleAssignmentInput[]) => Promise<FirstRunActionResult>
+    completeStep: (step: FirstRunStep) => Promise<FirstRunState>
+    resetWizard: () => Promise<FirstRunState>
   }
 }
 

--- a/self/apps/shared-server/__tests__/first-run-state.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-state.test.ts
@@ -1,0 +1,144 @@
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'nous-first-run-'));
+}
+
+async function loadModule() {
+  return import('../src/first-run');
+}
+
+describe('first-run state', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns the default wizard state when no state file exists', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    const { getFirstRunState } = await loadModule();
+
+    const state = await getFirstRunState(dir);
+
+    expect(state.currentStep).toBe('ollama_check');
+    expect(state.complete).toBe(false);
+    expect(state.steps.ollama_check.status).toBe('pending');
+    expect(state.steps.model_download.status).toBe('pending');
+    expect(state.steps.provider_config.status).toBe('pending');
+    expect(state.steps.role_assignment.status).toBe('pending');
+  });
+
+  it('falls back to the default state when the state file is corrupted', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    writeFileSync(join(dir, '.nous-first-run-state.json'), '{not valid json', 'utf-8');
+
+    const { getFirstRunState } = await loadModule();
+    const state = await getFirstRunState(dir);
+
+    expect(state.currentStep).toBe('ollama_check');
+    expect(state.complete).toBe(false);
+  });
+
+  it('advances to the next step when a wizard step is completed', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    const {
+      getFirstRunState,
+      markStepComplete,
+    } = await loadModule();
+
+    await markStepComplete(dir, 'ollama_check');
+    const state = await getFirstRunState(dir);
+
+    expect(state.steps.ollama_check.status).toBe('complete');
+    expect(state.currentStep).toBe('model_download');
+  });
+
+  it('marks the entire wizard complete after the final step and writes the legacy flag', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    const {
+      getFirstRunState,
+      markStepComplete,
+    } = await loadModule();
+
+    await markStepComplete(dir, 'ollama_check');
+    await markStepComplete(dir, 'model_download');
+    await markStepComplete(dir, 'provider_config');
+    await markStepComplete(dir, 'role_assignment');
+
+    const state = await getFirstRunState(dir);
+
+    expect(state.currentStep).toBe('complete');
+    expect(state.complete).toBe(true);
+    expect(typeof state.completedAt).toBe('string');
+    expect(existsSync(join(dir, '.nous-first-run-complete'))).toBe(true);
+  });
+
+  it('markFirstRunComplete preserves backward compatibility with the legacy completion flag', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    const {
+      getFirstRunState,
+      isFirstRunComplete,
+      markFirstRunComplete,
+    } = await loadModule();
+
+    markFirstRunComplete(dir);
+
+    const wizardState = await getFirstRunState(dir);
+    const complete = await isFirstRunComplete(dir, {
+      list: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    expect(wizardState.complete).toBe(true);
+    expect(wizardState.currentStep).toBe('complete');
+    expect(complete).toBe(true);
+    expect(existsSync(join(dir, '.nous-first-run-complete'))).toBe(true);
+  });
+
+  it('resetFirstRunState removes completion and returns to the initial step', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    const {
+      getFirstRunState,
+      markFirstRunComplete,
+      resetFirstRunState,
+    } = await loadModule();
+
+    markFirstRunComplete(dir);
+    const resetState = await resetFirstRunState(dir);
+    const state = await getFirstRunState(dir);
+
+    expect(resetState.currentStep).toBe('ollama_check');
+    expect(resetState.complete).toBe(false);
+    expect(state.currentStep).toBe('ollama_check');
+    expect(existsSync(join(dir, '.nous-first-run-complete'))).toBe(false);
+  });
+
+  it('treats existing projects as first-run complete even without the flag file', async () => {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    const { isFirstRunComplete } = await loadModule();
+
+    const complete = await isFirstRunComplete(dir, {
+      list: vi.fn().mockResolvedValue([{ id: 'project-1' }]),
+    } as any);
+
+    expect(complete).toBe(true);
+  });
+});

--- a/self/apps/shared-server/__tests__/first-run-wizard.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-wizard.test.ts
@@ -1,0 +1,417 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const detectHardwareMock = vi.hoisted(() => vi.fn());
+const recommendModelsMock = vi.hoisted(() => vi.fn());
+const detectOllamaMock = vi.hoisted(() => vi.fn());
+const pullOllamaModelMock = vi.hoisted(() => vi.fn());
+const firstRunMock = vi.hoisted(() => ({
+  getFirstRunState: vi.fn(),
+  isFirstRunComplete: vi.fn(),
+  markFirstRunComplete: vi.fn(),
+  markStepComplete: vi.fn(),
+  resetFirstRunState: vi.fn(),
+}));
+const bootstrapConstants = vi.hoisted(() => ({
+  WELL_KNOWN_PROVIDER_IDS: {
+    anthropic: '10000000-0000-0000-0000-000000000001',
+    openai: '10000000-0000-0000-0000-000000000002',
+  },
+  OLLAMA_WELL_KNOWN_PROVIDER_ID: '10000000-0000-0000-0000-000000000003',
+}));
+const bootstrapMock = vi.hoisted(() => ({
+  buildOllamaProviderConfig: vi.fn(),
+  buildProviderConfig: vi.fn(),
+  parseSelectedModelSpec: vi.fn(),
+  updateReasonerAssignment: vi.fn(),
+  updateRoleAssignment: vi.fn(),
+  upsertProviderConfig: vi.fn(),
+}));
+
+vi.mock('../src/hardware-detection', async () => {
+  const actual = await vi.importActual<typeof import('../src/hardware-detection')>(
+    '../src/hardware-detection',
+  );
+
+  return {
+    ...actual,
+    detectHardware: detectHardwareMock,
+    recommendModels: recommendModelsMock,
+  };
+});
+
+vi.mock('../src/ollama-detection', async () => {
+  const actual = await vi.importActual<typeof import('../src/ollama-detection')>(
+    '../src/ollama-detection',
+  );
+
+  return {
+    ...actual,
+    detectOllama: detectOllamaMock,
+    pullOllamaModel: pullOllamaModelMock,
+  };
+});
+
+vi.mock('../src/first-run', async () => {
+  const actual = await vi.importActual<typeof import('../src/first-run')>(
+    '../src/first-run',
+  );
+
+  return {
+    ...actual,
+    getFirstRunState: firstRunMock.getFirstRunState,
+    isFirstRunComplete: firstRunMock.isFirstRunComplete,
+    markFirstRunComplete: firstRunMock.markFirstRunComplete,
+    markStepComplete: firstRunMock.markStepComplete,
+    resetFirstRunState: firstRunMock.resetFirstRunState,
+  };
+});
+
+vi.mock('../src/bootstrap', () => ({
+  OLLAMA_WELL_KNOWN_PROVIDER_ID: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+  WELL_KNOWN_PROVIDER_IDS: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS,
+  buildOllamaProviderConfig: bootstrapMock.buildOllamaProviderConfig,
+  buildProviderConfig: bootstrapMock.buildProviderConfig,
+  parseSelectedModelSpec: bootstrapMock.parseSelectedModelSpec,
+  updateReasonerAssignment: bootstrapMock.updateReasonerAssignment,
+  updateRoleAssignment: bootstrapMock.updateRoleAssignment,
+  upsertProviderConfig: bootstrapMock.upsertProviderConfig,
+}));
+
+function createWizardState(
+  currentStep: 'ollama_check' | 'model_download' | 'provider_config' | 'role_assignment' | 'complete',
+) {
+  const completed = currentStep === 'complete';
+  return {
+    currentStep,
+    complete: completed,
+    steps: {
+      ollama_check: {
+        status:
+          currentStep === 'ollama_check' ? 'pending' : 'complete',
+      },
+      model_download: {
+        status:
+          currentStep === 'ollama_check' || currentStep === 'model_download'
+            ? 'pending'
+            : 'complete',
+      },
+      provider_config: {
+        status:
+          currentStep === 'ollama_check' ||
+          currentStep === 'model_download' ||
+          currentStep === 'provider_config'
+            ? 'pending'
+            : 'complete',
+      },
+      role_assignment: {
+        status:
+          currentStep === 'complete' ? 'complete' : 'pending',
+      },
+    },
+    ...(completed ? { completedAt: '2026-03-22T16:30:00.000Z' } : {}),
+    lastUpdatedAt: '2026-03-22T16:30:00.000Z',
+  };
+}
+
+function parseSelectedModelSpecMock(
+  spec: string | null | undefined,
+): { provider: 'anthropic' | 'openai' | 'ollama'; modelId: string } | null {
+  if (!spec) {
+    return null;
+  }
+
+  const [provider, ...modelParts] = spec.split(':');
+  const modelId = modelParts.join(':');
+  if (
+    (provider !== 'anthropic' &&
+      provider !== 'openai' &&
+      provider !== 'ollama') ||
+    modelId.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    provider,
+    modelId,
+  };
+}
+
+function buildProviderConfigMock(
+  provider: 'anthropic' | 'openai',
+  providerId = bootstrapConstants.WELL_KNOWN_PROVIDER_IDS[provider],
+  modelId = provider === 'anthropic' ? 'claude-sonnet-4-20250514' : 'gpt-4o',
+) {
+  return {
+    id: providerId,
+    name: provider,
+    type: 'text' as const,
+    endpoint:
+      provider === 'anthropic'
+        ? 'https://api.anthropic.com'
+        : 'https://api.openai.com',
+    modelId,
+    isLocal: false,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'remote_text' as const,
+  };
+}
+
+function buildOllamaProviderConfigMock(
+  modelId: string,
+  providerId = bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+) {
+  return {
+    id: providerId,
+    name: 'ollama',
+    type: 'text' as const,
+    endpoint: 'http://localhost:11434',
+    modelId,
+    isLocal: true,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'local_text' as const,
+  };
+}
+
+function createMockContext() {
+  return {
+    dataDir: 'C:/Users/nous/AppData/Roaming/Nous/data',
+    projectStore: {
+      list: vi.fn().mockResolvedValue([]),
+    },
+    config: {
+      get: vi.fn().mockReturnValue({
+        profile: {
+          name: 'local-only',
+          allowLocalProviders: true,
+          allowRemoteProviders: false,
+        },
+      }),
+    },
+  } as any;
+}
+
+async function loadFirstRunRouter() {
+  return (await import('../src/trpc/routers/first-run')).firstRunRouter;
+}
+
+describe('first-run wizard router', () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    detectHardwareMock.mockReset().mockResolvedValue({
+      totalMemoryMB: 16384,
+      availableMemoryMB: 8192,
+      cpuCores: 8,
+      cpuModel: 'AMD Ryzen 7',
+      platform: 'win32',
+      arch: 'x64',
+      gpu: {
+        detected: false,
+      },
+    });
+    recommendModelsMock.mockReset().mockReturnValue({
+      singleModel: {
+        modelId: 'llama3.2:3b',
+        modelSpec: 'ollama:llama3.2:3b',
+        displayName: 'Llama 3.2 3B',
+        ramRequiredMB: 4096,
+        reason: 'Good default.',
+      },
+      multiModel: [],
+      hardwareSpec: {
+        totalMemoryMB: 16384,
+        availableMemoryMB: 8192,
+        cpuCores: 8,
+        cpuModel: 'AMD Ryzen 7',
+        platform: 'win32',
+        arch: 'x64',
+        gpu: {
+          detected: false,
+        },
+      },
+      profileName: 'local-only',
+      advisory: 'Start with a compact local model.',
+    });
+    detectOllamaMock.mockReset().mockResolvedValue({
+      installed: true,
+      running: true,
+      state: 'running',
+      models: ['llama3.2:3b'],
+      defaultModel: 'llama3.2:3b',
+    });
+    pullOllamaModelMock.mockReset().mockResolvedValue(undefined);
+
+    firstRunMock.getFirstRunState.mockReset().mockResolvedValue(createWizardState('ollama_check'));
+    firstRunMock.isFirstRunComplete.mockReset().mockResolvedValue(false);
+    firstRunMock.markFirstRunComplete.mockReset();
+    firstRunMock.markStepComplete.mockReset().mockResolvedValue(createWizardState('provider_config'));
+    firstRunMock.resetFirstRunState.mockReset().mockResolvedValue(createWizardState('ollama_check'));
+
+    bootstrapMock.buildOllamaProviderConfig.mockReset().mockImplementation(buildOllamaProviderConfigMock);
+    bootstrapMock.buildProviderConfig.mockReset().mockImplementation(buildProviderConfigMock);
+    bootstrapMock.parseSelectedModelSpec.mockReset().mockImplementation(parseSelectedModelSpecMock);
+    bootstrapMock.updateReasonerAssignment.mockReset().mockResolvedValue(undefined);
+    bootstrapMock.updateRoleAssignment.mockReset().mockResolvedValue(undefined);
+    bootstrapMock.upsertProviderConfig.mockReset().mockResolvedValue(undefined);
+
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves the existing status and complete endpoints', async () => {
+    const ctx = createMockContext();
+    firstRunMock.isFirstRunComplete.mockResolvedValueOnce(true);
+
+    const firstRunRouter = await loadFirstRunRouter();
+    const caller = firstRunRouter.createCaller(ctx);
+
+    await expect(caller.status()).resolves.toEqual({ complete: true });
+    await expect(caller.complete()).resolves.toBeUndefined();
+    expect(firstRunMock.markFirstRunComplete).toHaveBeenCalledWith(ctx.dataDir);
+  });
+
+  it('returns combined prerequisite data and passes the active profile into recommendations', async () => {
+    const ctx = createMockContext();
+    const firstRunRouter = await loadFirstRunRouter();
+    const caller = firstRunRouter.createCaller(ctx);
+
+    const result = await caller.checkPrerequisites();
+
+    expect(result).toEqual({
+      ollama: expect.objectContaining({
+        state: 'running',
+        models: ['llama3.2:3b'],
+      }),
+      hardware: expect.objectContaining({
+        totalMemoryMB: 16384,
+      }),
+      recommendations: expect.objectContaining({
+        profileName: 'local-only',
+      }),
+    });
+    expect(recommendModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalMemoryMB: 16384,
+      }),
+      {
+        name: 'local-only',
+        allowLocalProviders: true,
+        allowRemoteProviders: false,
+      },
+    );
+  });
+
+  it('downloads a model and marks the download step complete', async () => {
+    const ctx = createMockContext();
+    firstRunMock.markStepComplete.mockResolvedValueOnce(createWizardState('provider_config'));
+
+    const firstRunRouter = await loadFirstRunRouter();
+    const caller = firstRunRouter.createCaller(ctx);
+    const result = await caller.downloadModel({ model: 'llama3.2:3b' });
+
+    expect(pullOllamaModelMock).toHaveBeenCalledWith('llama3.2:3b');
+    expect(firstRunMock.markStepComplete).toHaveBeenCalledWith(
+      ctx.dataDir,
+      'model_download',
+    );
+    expect(result).toEqual({
+      success: true,
+      state: createWizardState('provider_config'),
+    });
+  });
+
+  it('configures the selected provider and updates the default reasoner assignment', async () => {
+    const ctx = createMockContext();
+    firstRunMock.markStepComplete.mockResolvedValueOnce(createWizardState('role_assignment'));
+
+    const firstRunRouter = await loadFirstRunRouter();
+    const caller = firstRunRouter.createCaller(ctx);
+    const result = await caller.configureProvider({
+      modelSpec: 'ollama:llama3.2:3b',
+    });
+
+    expect(bootstrapMock.buildOllamaProviderConfig).toHaveBeenCalledWith(
+      'llama3.2:3b',
+      bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+    );
+    expect(bootstrapMock.upsertProviderConfig).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        id: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+        modelId: 'llama3.2:3b',
+      }),
+    );
+    expect(bootstrapMock.updateReasonerAssignment).toHaveBeenCalledWith(
+      ctx,
+      bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+    );
+    expect(result).toEqual({
+      success: true,
+      state: createWizardState('role_assignment'),
+    });
+  });
+
+  it('assigns roles through the existing provider wiring helpers', async () => {
+    const ctx = createMockContext();
+    firstRunMock.markStepComplete.mockResolvedValueOnce(createWizardState('complete'));
+
+    const firstRunRouter = await loadFirstRunRouter();
+    const caller = firstRunRouter.createCaller(ctx);
+    const result = await caller.assignRoles({
+      assignments: [
+        {
+          role: 'orchestrator',
+          modelSpec: 'ollama:llama3.2:3b',
+        },
+        {
+          role: 'reasoner',
+          modelSpec: 'openai:gpt-4o',
+        },
+      ],
+    });
+
+    expect(bootstrapMock.upsertProviderConfig).toHaveBeenCalledTimes(2);
+    expect(bootstrapMock.updateRoleAssignment).toHaveBeenNthCalledWith(
+      1,
+      ctx,
+      'orchestrator',
+      bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+    );
+    expect(bootstrapMock.updateRoleAssignment).toHaveBeenNthCalledWith(
+      2,
+      ctx,
+      'reasoner',
+      bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
+    );
+    expect(result).toEqual({
+      success: true,
+      state: createWizardState('complete'),
+    });
+  });
+
+  it('delegates completeStep and resetWizard to the first-run state module', async () => {
+    const ctx = createMockContext();
+    firstRunMock.markStepComplete.mockResolvedValueOnce(createWizardState('model_download'));
+    firstRunMock.resetFirstRunState.mockResolvedValueOnce(createWizardState('ollama_check'));
+
+    const firstRunRouter = await loadFirstRunRouter();
+    const caller = firstRunRouter.createCaller(ctx);
+
+    await expect(caller.completeStep({ step: 'ollama_check' })).resolves.toEqual(
+      createWizardState('model_download'),
+    );
+    await expect(caller.resetWizard()).resolves.toEqual(
+      createWizardState('ollama_check'),
+    );
+    expect(firstRunMock.markStepComplete).toHaveBeenCalledWith(
+      ctx.dataDir,
+      'ollama_check',
+    );
+    expect(firstRunMock.resetFirstRunState).toHaveBeenCalledWith(ctx.dataDir);
+  });
+});

--- a/self/apps/shared-server/__tests__/hardware-detection.test.ts
+++ b/self/apps/shared-server/__tests__/hardware-detection.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+const osMocks = vi.hoisted(() => ({
+  totalmem: vi.fn(),
+  freemem: vi.fn(),
+  cpus: vi.fn(),
+  platform: vi.fn(),
+  arch: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock('node:os', () => ({
+  totalmem: osMocks.totalmem,
+  freemem: osMocks.freemem,
+  cpus: osMocks.cpus,
+  platform: osMocks.platform,
+  arch: osMocks.arch,
+}));
+
+function mockExecFile(
+  handlers: Record<string, { stdout?: string; error?: Error }>,
+): void {
+  execFileMock.mockImplementation(
+    (
+      command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const result = handlers[command];
+      if (!result) {
+        callback(Object.assign(new Error('command not found'), { code: 'ENOENT' }), '', '');
+        return {} as never;
+      }
+
+      callback(result.error ?? null, result.stdout ?? '', '');
+      return {} as never;
+    },
+  );
+}
+
+async function loadModule() {
+  return import('../src/hardware-detection');
+}
+
+describe('hardware detection', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    osMocks.totalmem.mockReset().mockReturnValue(16 * 1024 * 1024 * 1024);
+    osMocks.freemem.mockReset().mockReturnValue(10 * 1024 * 1024 * 1024);
+    osMocks.cpus.mockReset().mockReturnValue(
+      Array.from({ length: 8 }, () => ({
+        model: 'AMD Ryzen 7 7840U',
+        speed: 3300,
+        times: {
+          user: 0,
+          nice: 0,
+          sys: 0,
+          idle: 0,
+          irq: 0,
+        },
+      })),
+    );
+    osMocks.platform.mockReset().mockReturnValue('linux');
+    osMocks.arch.mockReset().mockReturnValue('x64');
+
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('detectHardware parses GPU information from nvidia-smi output', async () => {
+    mockExecFile({
+      'nvidia-smi': {
+        stdout: 'NVIDIA GeForce RTX 3060, 12288\n',
+      },
+    });
+
+    const {
+      HardwareSpecSchema,
+      detectHardware,
+    } = await loadModule();
+
+    const result = await detectHardware();
+
+    expect(HardwareSpecSchema.parse(result)).toEqual(result);
+    expect(result.totalMemoryMB).toBe(16384);
+    expect(result.availableMemoryMB).toBe(10240);
+    expect(result.cpuCores).toBe(8);
+    expect(result.cpuModel).toBe('AMD Ryzen 7 7840U');
+    expect(result.platform).toBe('linux');
+    expect(result.arch).toBe('x64');
+    expect(result.gpu).toEqual({
+      detected: true,
+      name: 'NVIDIA GeForce RTX 3060',
+      vramMB: 12288,
+    });
+  });
+
+  it('detectHardware falls back to gpu.detected=false when GPU probing fails', async () => {
+    mockExecFile({
+      'system_profiler': {
+        error: new Error('system_profiler unavailable'),
+      },
+    });
+    osMocks.platform.mockReturnValue('darwin');
+    osMocks.arch.mockReturnValue('arm64');
+
+    const { detectHardware } = await loadModule();
+    const result = await detectHardware();
+
+    expect(result.platform).toBe('darwin');
+    expect(result.arch).toBe('arm64');
+    expect(result.gpu).toEqual({
+      detected: false,
+    });
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('recommendModels returns a compact local model for low-memory systems', async () => {
+    const { recommendModels } = await loadModule();
+
+    const result = recommendModels(
+      {
+        totalMemoryMB: 4096,
+        availableMemoryMB: 2048,
+        cpuCores: 4,
+        cpuModel: 'Intel Core i5',
+        platform: 'win32',
+        arch: 'x64',
+        gpu: {
+          detected: false,
+        },
+      },
+      {
+        name: 'local-only',
+        allowLocalProviders: true,
+        allowRemoteProviders: false,
+      },
+    );
+
+    expect(result.profileName).toBe('local-only');
+    expect(result.singleModel?.modelSpec).toBe('ollama:llama3.2:3b');
+    expect(result.multiModel).toEqual([]);
+  });
+
+  it('recommendModels returns split-role local guidance for mid-spec hardware', async () => {
+    const { recommendModels } = await loadModule();
+
+    const result = recommendModels(
+      {
+        totalMemoryMB: 24576,
+        availableMemoryMB: 18432,
+        cpuCores: 12,
+        cpuModel: 'AMD Ryzen 9',
+        platform: 'linux',
+        arch: 'x64',
+        gpu: {
+          detected: true,
+          name: 'NVIDIA GeForce RTX 4070',
+          vramMB: 12288,
+        },
+      },
+      {
+        name: 'hybrid',
+        allowLocalProviders: true,
+        allowRemoteProviders: true,
+      },
+    );
+
+    expect(result.singleModel?.modelSpec).toBe('ollama:qwen2.5:14b');
+    expect(result.multiModel).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'reasoner',
+          recommendation: expect.objectContaining({
+            modelSpec: 'ollama:qwen2.5:14b',
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('recommendModels honors remote-only profile boundaries', async () => {
+    const { recommendModels } = await loadModule();
+
+    const result = recommendModels(
+      {
+        totalMemoryMB: 32768,
+        availableMemoryMB: 20000,
+        cpuCores: 16,
+        cpuModel: 'Apple M3 Max',
+        platform: 'darwin',
+        arch: 'arm64',
+        gpu: {
+          detected: true,
+          name: 'Apple M3 Max',
+          vramMB: 16384,
+        },
+      },
+      {
+        name: 'remote-only',
+        allowLocalProviders: false,
+        allowRemoteProviders: true,
+      },
+    );
+
+    expect(result.profileName).toBe('remote-only');
+    expect(result.singleModel?.modelSpec.startsWith('anthropic:')).toBe(true);
+    expect(result.multiModel.every((entry) => !entry.recommendation.modelSpec.startsWith('ollama:'))).toBe(true);
+  });
+});

--- a/self/apps/shared-server/src/first-run.ts
+++ b/self/apps/shared-server/src/first-run.ts
@@ -1,26 +1,277 @@
 /**
- * First-run completion flag — server-side only.
+ * First-run wizard state — server-side only.
  */
-import { existsSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
-import type { IProjectStore } from '@nous/shared';
+import { ModelRoleSchema, type IProjectStore } from '@nous/shared';
+import { z } from 'zod';
+import { HardwareSpecSchema, RecommendationResultSchema } from './hardware-detection';
+import { OllamaStatusSchema } from './ollama-detection';
 
 const FLAG_FILE = '.nous-first-run-complete';
+const STATE_FILE = '.nous-first-run-state.json';
+const FIRST_RUN_STEP_VALUES = [
+  'ollama_check',
+  'model_download',
+  'provider_config',
+  'role_assignment',
+] as const;
+
+export const FirstRunStepSchema = z.enum(FIRST_RUN_STEP_VALUES);
+export type FirstRunStep = z.infer<typeof FirstRunStepSchema>;
+
+export const FirstRunCurrentStepSchema = z.union([
+  FirstRunStepSchema,
+  z.literal('complete'),
+]);
+export type FirstRunCurrentStep = z.infer<typeof FirstRunCurrentStepSchema>;
+
+export const FirstRunStepStatusSchema = z.enum(['pending', 'complete']);
+export type FirstRunStepStatus = z.infer<typeof FirstRunStepStatusSchema>;
+
+export const FirstRunStepStateSchema = z.object({
+  status: FirstRunStepStatusSchema,
+  completedAt: z.string().optional(),
+});
+export type FirstRunStepState = z.infer<typeof FirstRunStepStateSchema>;
+
+export const FirstRunStateSchema = z.object({
+  currentStep: FirstRunCurrentStepSchema,
+  complete: z.boolean(),
+  steps: z.object({
+    ollama_check: FirstRunStepStateSchema,
+    model_download: FirstRunStepStateSchema,
+    provider_config: FirstRunStepStateSchema,
+    role_assignment: FirstRunStepStateSchema,
+  }),
+  completedAt: z.string().optional(),
+  lastUpdatedAt: z.string(),
+});
+export type FirstRunState = z.infer<typeof FirstRunStateSchema>;
+
+export const FirstRunRoleAssignmentInputSchema = z.object({
+  role: ModelRoleSchema,
+  modelSpec: z.string().min(1),
+});
+export type FirstRunRoleAssignmentInput = z.infer<
+  typeof FirstRunRoleAssignmentInputSchema
+>;
+
+export const FirstRunActionResultSchema = z.object({
+  success: z.boolean(),
+  state: FirstRunStateSchema,
+  error: z.string().optional(),
+});
+export type FirstRunActionResult = z.infer<typeof FirstRunActionResultSchema>;
+
+export const FirstRunPrerequisitesSchema = z.object({
+  ollama: OllamaStatusSchema,
+  hardware: HardwareSpecSchema,
+  recommendations: RecommendationResultSchema,
+});
+export type FirstRunPrerequisites = z.infer<typeof FirstRunPrerequisitesSchema>;
+
+function flagPath(dataDir: string): string {
+  return join(dataDir, FLAG_FILE);
+}
+
+function statePath(dataDir: string): string {
+  return join(dataDir, STATE_FILE);
+}
+
+function buildPendingStepState(): FirstRunStepState {
+  return {
+    status: 'pending',
+  };
+}
+
+function deriveCurrentStep(
+  steps: FirstRunState['steps'],
+): FirstRunCurrentStep {
+  for (const step of FIRST_RUN_STEP_VALUES) {
+    if (steps[step].status !== 'complete') {
+      return step;
+    }
+  }
+
+  return 'complete';
+}
+
+function normalizeFirstRunState(
+  state: FirstRunState,
+  timestamp = new Date().toISOString(),
+): FirstRunState {
+  const currentStep = deriveCurrentStep(state.steps);
+  const complete = currentStep === 'complete';
+  const completedAt = complete
+    ? state.completedAt ?? timestamp
+    : undefined;
+
+  return FirstRunStateSchema.parse({
+    ...state,
+    currentStep,
+    complete,
+    completedAt,
+    lastUpdatedAt: state.lastUpdatedAt || timestamp,
+  });
+}
+
+export function createDefaultFirstRunState(
+  timestamp = new Date().toISOString(),
+): FirstRunState {
+  return normalizeFirstRunState(
+    {
+      currentStep: 'ollama_check',
+      complete: false,
+      steps: {
+        ollama_check: buildPendingStepState(),
+        model_download: buildPendingStepState(),
+        provider_config: buildPendingStepState(),
+        role_assignment: buildPendingStepState(),
+      },
+      lastUpdatedAt: timestamp,
+    },
+    timestamp,
+  );
+}
+
+function createCompletedFirstRunState(
+  timestamp = new Date().toISOString(),
+): FirstRunState {
+  return normalizeFirstRunState(
+    {
+      currentStep: 'complete',
+      complete: true,
+      steps: {
+        ollama_check: { status: 'complete', completedAt: timestamp },
+        model_download: { status: 'complete', completedAt: timestamp },
+        provider_config: { status: 'complete', completedAt: timestamp },
+        role_assignment: { status: 'complete', completedAt: timestamp },
+      },
+      completedAt: timestamp,
+      lastUpdatedAt: timestamp,
+    },
+    timestamp,
+  );
+}
+
+function writeFlag(dataDir: string): void {
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(flagPath(dataDir), '{}', 'utf-8');
+}
+
+function writeFirstRunStateSync(
+  dataDir: string,
+  state: FirstRunState,
+): FirstRunState {
+  const nextState = normalizeFirstRunState(state);
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(
+    statePath(dataDir),
+    `${JSON.stringify(nextState, null, 2)}\n`,
+    'utf-8',
+  );
+
+  if (nextState.complete) {
+    writeFlag(dataDir);
+  }
+
+  return nextState;
+}
+
+function readStateFromDisk(dataDir: string): FirstRunState {
+  if (existsSync(flagPath(dataDir)) && !existsSync(statePath(dataDir))) {
+    return createCompletedFirstRunState();
+  }
+
+  if (!existsSync(statePath(dataDir))) {
+    return createDefaultFirstRunState();
+  }
+
+  try {
+    const raw = readFileSync(statePath(dataDir), 'utf-8');
+    const parsed = FirstRunStateSchema.safeParse(JSON.parse(raw));
+    if (parsed.success) {
+      return normalizeFirstRunState(parsed.data, parsed.data.lastUpdatedAt);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[nous:first-run] Failed to read state file: ${message}`);
+  }
+
+  if (existsSync(flagPath(dataDir))) {
+    return createCompletedFirstRunState();
+  }
+
+  return createDefaultFirstRunState();
+}
 
 export async function isFirstRunComplete(
   dataDir: string,
   projectStore: IProjectStore,
 ): Promise<boolean> {
-  const flagPath = join(dataDir, FLAG_FILE);
-  if (existsSync(flagPath)) {
+  if (existsSync(flagPath(dataDir))) {
     return true;
   }
+
+  const state = readStateFromDisk(dataDir);
+  if (state.complete) {
+    return true;
+  }
+
   const projects = await projectStore.list();
   return projects.length > 0;
 }
 
+export async function getFirstRunState(dataDir: string): Promise<FirstRunState> {
+  const state = readStateFromDisk(dataDir);
+  const summary = FIRST_RUN_STEP_VALUES.map(
+    (step) => `${step}:${state.steps[step].status}`,
+  ).join(', ');
+  console.debug(`[nous:first-run] State loaded: ${summary}`);
+  return state;
+}
+
+export function getCurrentStep(state: FirstRunState): FirstRunCurrentStep {
+  return deriveCurrentStep(state.steps);
+}
+
+export async function markStepComplete(
+  dataDir: string,
+  step: FirstRunStep,
+): Promise<FirstRunState> {
+  const timestamp = new Date().toISOString();
+  const current = readStateFromDisk(dataDir);
+  const nextState = writeFirstRunStateSync(dataDir, {
+    ...current,
+    steps: {
+      ...current.steps,
+      [step]: {
+        status: 'complete',
+        completedAt: current.steps[step].completedAt ?? timestamp,
+      },
+    },
+    lastUpdatedAt: timestamp,
+  });
+
+  console.info(`[nous:first-run] Step ${step} marked complete`);
+  return nextState;
+}
+
+export async function resetFirstRunState(dataDir: string): Promise<FirstRunState> {
+  rmSync(flagPath(dataDir), { force: true });
+  rmSync(statePath(dataDir), { force: true });
+  return writeFirstRunStateSync(dataDir, createDefaultFirstRunState());
+}
+
 export function markFirstRunComplete(dataDir: string): void {
-  const flagPath = join(dataDir, FLAG_FILE);
-  writeFileSync(flagPath, '{}', 'utf-8');
+  writeFlag(dataDir);
+  writeFirstRunStateSync(dataDir, createCompletedFirstRunState());
   console.log('[nous:first-run] complete');
 }

--- a/self/apps/shared-server/src/hardware-detection.ts
+++ b/self/apps/shared-server/src/hardware-detection.ts
@@ -1,0 +1,457 @@
+/**
+ * Hardware detection and model recommendation helpers for the desktop first-run flow.
+ */
+import { execFile } from 'node:child_process';
+import * as os from 'node:os';
+import { ModelRoleSchema } from '@nous/shared';
+import { z } from 'zod';
+const GPU_COMMAND_TIMEOUT_MS = 4000;
+const GPU_COMMAND_MAX_BUFFER = 1024 * 1024;
+
+export const GpuInfoSchema = z.object({
+  detected: z.boolean(),
+  name: z.string().optional(),
+  vramMB: z.number().int().nonnegative().optional(),
+});
+
+export type GpuInfo = z.infer<typeof GpuInfoSchema>;
+
+export const HardwareSpecSchema = z.object({
+  totalMemoryMB: z.number().int().nonnegative(),
+  availableMemoryMB: z.number().int().nonnegative(),
+  cpuCores: z.number().int().nonnegative(),
+  cpuModel: z.string(),
+  platform: z.string(),
+  arch: z.string(),
+  gpu: GpuInfoSchema,
+});
+
+export type HardwareSpec = z.infer<typeof HardwareSpecSchema>;
+
+export const ModelRecommendationSchema = z.object({
+  modelId: z.string(),
+  modelSpec: z.string(),
+  displayName: z.string(),
+  ramRequiredMB: z.number().int().nonnegative(),
+  reason: z.string(),
+});
+
+export type ModelRecommendation = z.infer<typeof ModelRecommendationSchema>;
+
+export const RoleModelRecommendationSchema = z.object({
+  role: ModelRoleSchema,
+  recommendation: ModelRecommendationSchema,
+});
+
+export type RoleModelRecommendation = z.infer<typeof RoleModelRecommendationSchema>;
+
+export const RecommendationResultSchema = z.object({
+  singleModel: ModelRecommendationSchema.nullable(),
+  multiModel: z.array(RoleModelRecommendationSchema),
+  hardwareSpec: HardwareSpecSchema,
+  profileName: z.string(),
+  advisory: z.string(),
+});
+
+export type RecommendationResult = z.infer<typeof RecommendationResultSchema>;
+
+export type RecommendationProfilePolicy = {
+  name?: string;
+  allowLocalProviders?: boolean;
+  allowRemoteProviders?: boolean;
+};
+
+type RecommendationTier = 'tiny' | 'small' | 'medium' | 'large';
+
+const LOCAL_MODEL_CATALOG: Record<RecommendationTier, ModelRecommendation> = {
+  tiny: {
+    modelId: 'llama3.2:3b',
+    modelSpec: 'ollama:llama3.2:3b',
+    displayName: 'Llama 3.2 3B',
+    ramRequiredMB: 4096,
+    reason: 'Best fit for low-memory systems and first-run downloads.',
+  },
+  small: {
+    modelId: 'qwen2.5:7b',
+    modelSpec: 'ollama:qwen2.5:7b',
+    displayName: 'Qwen 2.5 7B',
+    ramRequiredMB: 8192,
+    reason: 'Balanced local model for everyday desktop orchestration and chat.',
+  },
+  medium: {
+    modelId: 'qwen2.5:14b',
+    modelSpec: 'ollama:qwen2.5:14b',
+    displayName: 'Qwen 2.5 14B',
+    ramRequiredMB: 16384,
+    reason: 'Mid-spec recommendation for stronger reasoning with manageable local requirements.',
+  },
+  large: {
+    modelId: 'qwen2.5:32b',
+    modelSpec: 'ollama:qwen2.5:32b',
+    displayName: 'Qwen 2.5 32B',
+    ramRequiredMB: 32768,
+    reason: 'High-spec recommendation for local-first advanced reasoning.',
+  },
+};
+
+const REMOTE_SINGLE_MODEL: ModelRecommendation = {
+  modelId: 'claude-sonnet-4-20250514',
+  modelSpec: 'anthropic:claude-sonnet-4-20250514',
+  displayName: 'Claude Sonnet 4',
+  ramRequiredMB: 0,
+  reason: 'Remote-first fallback when the active profile does not allow local providers.',
+};
+
+const REMOTE_REASONER_MODEL: ModelRecommendation = {
+  modelId: 'claude-opus-4-20250514',
+  modelSpec: 'anthropic:claude-opus-4-20250514',
+  displayName: 'Claude Opus 4',
+  ramRequiredMB: 0,
+  reason: 'Higher-capability remote reasoner recommendation for remote-only profiles.',
+};
+
+const REMOTE_SUPPORT_MODEL: ModelRecommendation = {
+  modelId: 'gpt-4o',
+  modelSpec: 'openai:gpt-4o',
+  displayName: 'GPT-4o',
+  ramRequiredMB: 0,
+  reason: 'General-purpose remote support model for assistant, tool, and vision roles.',
+};
+
+function bytesToMegabytes(bytes: number): number {
+  return Math.max(0, Math.round(bytes / (1024 * 1024)));
+}
+
+function buildUnknownGpu(): GpuInfo {
+  return { detected: false };
+}
+
+function createRecommendation(
+  recommendation: ModelRecommendation,
+  reason: string,
+): ModelRecommendation {
+  return {
+    ...recommendation,
+    reason,
+  };
+}
+
+async function runCommand(command: string, args: string[]): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      {
+        timeout: GPU_COMMAND_TIMEOUT_MS,
+        maxBuffer: GPU_COMMAND_MAX_BUFFER,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(`${stdout ?? ''}`.trim());
+      },
+    );
+  });
+}
+
+function parseNvidiaSmiOutput(output: string): GpuInfo {
+  const line = output
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.length > 0);
+
+  if (!line) {
+    return buildUnknownGpu();
+  }
+
+  const [namePart, vramPart] = line.split(',').map((entry) => entry?.trim());
+  const vramMB = Number.parseInt(vramPart ?? '', 10);
+
+  return GpuInfoSchema.parse({
+    detected: true,
+    name: namePart || undefined,
+    ...(Number.isFinite(vramMB) ? { vramMB } : {}),
+  });
+}
+
+function parseWmicOutput(output: string): GpuInfo {
+  const nameMatch = output.match(/^Name=(.+)$/m);
+  const adapterRamMatch = output.match(/^AdapterRAM=(\d+)$/m);
+  const adapterRamBytes = adapterRamMatch
+    ? Number.parseInt(adapterRamMatch[1] ?? '', 10)
+    : Number.NaN;
+
+  return GpuInfoSchema.parse({
+    detected: !!nameMatch,
+    ...(nameMatch?.[1]?.trim() ? { name: nameMatch[1].trim() } : {}),
+    ...(Number.isFinite(adapterRamBytes)
+      ? { vramMB: bytesToMegabytes(adapterRamBytes) }
+      : {}),
+  });
+}
+
+function parseSystemProfilerOutput(output: string): GpuInfo {
+  const nameMatch =
+    output.match(/Chipset Model:\s+(.+)$/m) ??
+    output.match(/Model:\s+(.+)$/m);
+  const vramMatch =
+    output.match(/VRAM \(?:Dynamic, Max|Total\):\s+([0-9.]+)\s*(GB|MB)/im) ??
+    output.match(/VRAM:\s+([0-9.]+)\s*(GB|MB)/im);
+
+  let vramMB: number | undefined;
+  if (vramMatch) {
+    const amount = Number.parseFloat(vramMatch[1] ?? '');
+    const unit = (vramMatch[2] ?? 'MB').toUpperCase();
+    if (Number.isFinite(amount)) {
+      vramMB = unit === 'GB'
+        ? Math.round(amount * 1024)
+        : Math.round(amount);
+    }
+  }
+
+  return GpuInfoSchema.parse({
+    detected: !!nameMatch,
+    ...(nameMatch?.[1]?.trim() ? { name: nameMatch[1].trim() } : {}),
+    ...(typeof vramMB === 'number' ? { vramMB } : {}),
+  });
+}
+
+async function detectGpu(): Promise<GpuInfo> {
+  const platform = os.platform();
+
+  try {
+    if (platform === 'win32' || platform === 'linux') {
+      try {
+        return parseNvidiaSmiOutput(
+          await runCommand('nvidia-smi', [
+            '--query-gpu=name,memory.total',
+            '--format=csv,noheader,nounits',
+          ]),
+        );
+      } catch (error) {
+        if (platform === 'linux') {
+          throw error;
+        }
+      }
+
+      return parseWmicOutput(
+        await runCommand('wmic', [
+          'path',
+          'win32_VideoController',
+          'get',
+          'name,AdapterRAM',
+          '/format:list',
+        ]),
+      );
+    }
+
+    if (platform === 'darwin') {
+      return parseSystemProfilerOutput(
+        await runCommand('system_profiler', ['SPDisplaysDataType']),
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[nous:hardware] GPU detection failed: ${message}`);
+  }
+
+  return buildUnknownGpu();
+}
+
+function resolveRecommendationTier(spec: HardwareSpec): RecommendationTier {
+  const totalMemoryMB = spec.totalMemoryMB;
+  const gpuVramMB = spec.gpu.vramMB ?? 0;
+
+  if (totalMemoryMB >= 32768 || gpuVramMB >= 16384) {
+    return 'large';
+  }
+
+  if (totalMemoryMB >= 16384 || gpuVramMB >= 8192) {
+    return 'medium';
+  }
+
+  if (totalMemoryMB >= 8192) {
+    return 'small';
+  }
+
+  return 'tiny';
+}
+
+function buildLocalRecommendations(
+  spec: HardwareSpec,
+  tier: RecommendationTier,
+): RecommendationResult {
+  const singleModel = createRecommendation(
+    LOCAL_MODEL_CATALOG[tier],
+    `${LOCAL_MODEL_CATALOG[tier].displayName} fits the detected RAM tier for this local-first profile.`,
+  );
+
+  const multiModel: RoleModelRecommendation[] =
+    tier === 'medium'
+      ? [
+          {
+            role: 'reasoner',
+            recommendation: createRecommendation(
+              LOCAL_MODEL_CATALOG.medium,
+              'Use the stronger local model for reasoning-heavy work.',
+            ),
+          },
+          {
+            role: 'orchestrator',
+            recommendation: createRecommendation(
+              LOCAL_MODEL_CATALOG.small,
+              'Keep orchestration responsive with a lighter local model.',
+            ),
+          },
+          {
+            role: 'tool-advisor',
+            recommendation: createRecommendation(
+              LOCAL_MODEL_CATALOG.small,
+              'Tool routing benefits from a faster local model on mid-spec systems.',
+            ),
+          },
+        ]
+      : tier === 'large'
+        ? [
+            {
+              role: 'reasoner',
+              recommendation: createRecommendation(
+                LOCAL_MODEL_CATALOG.large,
+                'High-spec hardware can sustain a larger local reasoner.',
+              ),
+            },
+            {
+              role: 'orchestrator',
+              recommendation: createRecommendation(
+                LOCAL_MODEL_CATALOG.medium,
+                'Use a mid-tier model for orchestration to preserve local responsiveness.',
+              ),
+            },
+            {
+              role: 'summarizer',
+              recommendation: createRecommendation(
+                LOCAL_MODEL_CATALOG.small,
+                'Summarization can stay on a lighter model without sacrificing throughput.',
+              ),
+            },
+            {
+              role: 'vision',
+              recommendation: createRecommendation(
+                LOCAL_MODEL_CATALOG.medium,
+                'Vision tasks benefit from the larger context budget on high-spec systems.',
+              ),
+            },
+          ]
+        : [];
+
+  const advisory =
+    tier === 'tiny'
+      ? 'Detected a low-memory system. Start with a compact Ollama model and scale up later if needed.'
+      : tier === 'small'
+        ? 'Detected an entry-to-mid desktop profile. A single local model is the safest first-run default.'
+        : tier === 'medium'
+          ? 'Detected a mid-spec desktop profile. You can run one solid local default or split roles across lighter models.'
+          : 'Detected a high-spec desktop profile. Larger local reasoning models and split-role layouts are viable.';
+
+  console.info(
+    `[nous:hardware] Recommendation: ${singleModel.modelId} for profile local-first`,
+  );
+
+  return RecommendationResultSchema.parse({
+    singleModel,
+    multiModel,
+    hardwareSpec: spec,
+    profileName: 'local-first',
+    advisory,
+  });
+}
+
+function buildRemoteRecommendations(spec: HardwareSpec): RecommendationResult {
+  console.info(
+    `[nous:hardware] Recommendation: ${REMOTE_SINGLE_MODEL.modelId} for profile remote-first`,
+  );
+
+  return RecommendationResultSchema.parse({
+    singleModel: REMOTE_SINGLE_MODEL,
+    multiModel: [
+      {
+        role: 'reasoner',
+        recommendation: REMOTE_REASONER_MODEL,
+      },
+      {
+        role: 'vision',
+        recommendation: REMOTE_SUPPORT_MODEL,
+      },
+      {
+        role: 'summarizer',
+        recommendation: REMOTE_SUPPORT_MODEL,
+      },
+    ],
+    hardwareSpec: spec,
+    profileName: 'remote-first',
+    advisory:
+      'The active profile does not allow local providers, so the recommendation surface is remote-only.',
+  });
+}
+
+/**
+ * Detect the current machine hardware using Node.js OS primitives plus
+ * best-effort GPU probing.
+ */
+export async function detectHardware(): Promise<HardwareSpec> {
+  const cpuInfo = os.cpus();
+  const spec = HardwareSpecSchema.parse({
+    totalMemoryMB: bytesToMegabytes(os.totalmem()),
+    availableMemoryMB: bytesToMegabytes(os.freemem()),
+    cpuCores: cpuInfo.length,
+    cpuModel: cpuInfo[0]?.model?.trim() || 'Unknown CPU',
+    platform: os.platform(),
+    arch: os.arch(),
+    gpu: await detectGpu(),
+  });
+
+  console.info(
+    `[nous:hardware] Detected: ${spec.totalMemoryMB}MB RAM, ${spec.cpuCores} cores, GPU: ${spec.gpu.detected}`,
+  );
+
+  return spec;
+}
+
+/**
+ * Recommend a first-run model layout from the detected hardware and current profile policy.
+ */
+export function recommendModels(
+  spec: HardwareSpec,
+  profile: RecommendationProfilePolicy = {
+    name: 'local-only',
+    allowLocalProviders: true,
+    allowRemoteProviders: false,
+  },
+): RecommendationResult {
+  if (profile.allowLocalProviders === false && profile.allowRemoteProviders === false) {
+    return RecommendationResultSchema.parse({
+      singleModel: null,
+      multiModel: [],
+      hardwareSpec: spec,
+      profileName: profile.name ?? 'unknown',
+      advisory: 'No providers are enabled for the current profile, so no recommendation can be made.',
+    });
+  }
+
+  if (profile.allowLocalProviders === false && profile.allowRemoteProviders === true) {
+    return RecommendationResultSchema.parse({
+      ...buildRemoteRecommendations(spec),
+      profileName: profile.name ?? 'remote-only',
+    });
+  }
+
+  const tier = resolveRecommendationTier(spec);
+  return RecommendationResultSchema.parse({
+    ...buildLocalRecommendations(spec, tier),
+    profileName: profile.name ?? 'local-only',
+  });
+}

--- a/self/apps/shared-server/src/index.ts
+++ b/self/apps/shared-server/src/index.ts
@@ -25,6 +25,23 @@ export { appRouter } from './trpc/root';
 export type { AppRouter } from './trpc/root';
 export { createTRPCContext, router, publicProcedure } from './trpc/trpc';
 export {
+  HardwareSpecSchema,
+  GpuInfoSchema,
+  ModelRecommendationSchema,
+  RoleModelRecommendationSchema,
+  RecommendationResultSchema,
+  detectHardware,
+  recommendModels,
+} from './hardware-detection';
+export type {
+  HardwareSpec,
+  GpuInfo,
+  ModelRecommendation,
+  RoleModelRecommendation,
+  RecommendationResult,
+  RecommendationProfilePolicy,
+} from './hardware-detection';
+export {
   OllamaBinaryResolutionSchema,
   OllamaLifecycleStateSchema,
   OllamaModelPullProgressSchema,
@@ -39,3 +56,28 @@ export type {
   OllamaModelPullProgress,
   OllamaStatus,
 } from './ollama-detection';
+export {
+  FirstRunActionResultSchema,
+  FirstRunCurrentStepSchema,
+  FirstRunPrerequisitesSchema,
+  FirstRunRoleAssignmentInputSchema,
+  FirstRunStateSchema,
+  FirstRunStepSchema,
+  FirstRunStepStateSchema,
+  FirstRunStepStatusSchema,
+  createDefaultFirstRunState,
+  getCurrentStep,
+  getFirstRunState,
+  markStepComplete,
+  resetFirstRunState,
+} from './first-run';
+export type {
+  FirstRunActionResult,
+  FirstRunCurrentStep,
+  FirstRunPrerequisites,
+  FirstRunRoleAssignmentInput,
+  FirstRunState,
+  FirstRunStep,
+  FirstRunStepState,
+  FirstRunStepStatus,
+} from './first-run';

--- a/self/apps/shared-server/src/trpc/root.ts
+++ b/self/apps/shared-server/src/trpc/root.ts
@@ -21,6 +21,7 @@ import { voiceRouter } from './routers/voice';
 import { mobileRouter } from './routers/mobile';
 import { codingAgentsRouter } from './routers/coding-agents';
 import { preferencesRouter } from './routers/preferences';
+import { hardwareRouter } from './routers/hardware';
 
 export const appRouter = router({
   projects: projectsRouter,
@@ -42,6 +43,7 @@ export const appRouter = router({
   mobile: mobileRouter,
   codingAgents: codingAgentsRouter,
   preferences: preferencesRouter,
+  hardware: hardwareRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/self/apps/shared-server/src/trpc/routers/first-run.ts
+++ b/self/apps/shared-server/src/trpc/routers/first-run.ts
@@ -1,8 +1,87 @@
 /**
  * First-run tRPC router.
  */
+import { z } from 'zod';
+import type { ModelProviderConfig, ProviderId } from '@nous/shared';
 import { router, publicProcedure } from '../trpc';
-import { isFirstRunComplete, markFirstRunComplete } from '../../first-run';
+import { detectHardware, recommendModels } from '../../hardware-detection';
+import { detectOllama, pullOllamaModel } from '../../ollama-detection';
+import {
+  FirstRunActionResultSchema,
+  FirstRunRoleAssignmentInputSchema,
+  FirstRunStepSchema,
+  getFirstRunState,
+  isFirstRunComplete,
+  markFirstRunComplete,
+  markStepComplete,
+  resetFirstRunState,
+} from '../../first-run';
+import {
+  OLLAMA_WELL_KNOWN_PROVIDER_ID,
+  WELL_KNOWN_PROVIDER_IDS,
+  buildOllamaProviderConfig,
+  buildProviderConfig,
+  parseSelectedModelSpec,
+  updateReasonerAssignment,
+  updateRoleAssignment,
+  upsertProviderConfig,
+} from '../../bootstrap';
+
+function getProfilePolicy(ctx: { config: { get(): unknown } }) {
+  const config = ctx.config.get() as {
+    profile?: {
+      name?: string;
+      allowLocalProviders?: boolean;
+      allowRemoteProviders?: boolean;
+    };
+  };
+
+  return config.profile ?? {
+    name: 'local-only',
+    allowLocalProviders: true,
+    allowRemoteProviders: false,
+  };
+}
+
+function buildProviderSelection(
+  modelSpec: string,
+): {
+  providerId: ProviderId;
+  providerConfig: ModelProviderConfig;
+} | null {
+  const selectedModel = parseSelectedModelSpec(modelSpec);
+  if (!selectedModel) {
+    return null;
+  }
+
+  if (selectedModel.provider === 'ollama') {
+    return {
+      providerId: OLLAMA_WELL_KNOWN_PROVIDER_ID,
+      providerConfig: buildOllamaProviderConfig(
+        selectedModel.modelId,
+        OLLAMA_WELL_KNOWN_PROVIDER_ID,
+      ),
+    };
+  }
+
+  const providerId = WELL_KNOWN_PROVIDER_IDS[selectedModel.provider];
+  return {
+    providerId,
+    providerConfig: buildProviderConfig(
+      selectedModel.provider,
+      providerId,
+      selectedModel.modelId,
+    ),
+  };
+}
+
+async function actionFailure(ctx: { dataDir: string }, error: string) {
+  return FirstRunActionResultSchema.parse({
+    success: false,
+    state: await getFirstRunState(ctx.dataDir),
+    error,
+  });
+}
 
 export const firstRunRouter = router({
   status: publicProcedure.query(async ({ ctx }) => {
@@ -15,5 +94,147 @@ export const firstRunRouter = router({
 
   complete: publicProcedure.mutation(({ ctx }) => {
     markFirstRunComplete(ctx.dataDir);
+  }),
+
+  getWizardState: publicProcedure.query(async ({ ctx }) => {
+    return getFirstRunState(ctx.dataDir);
+  }),
+
+  checkPrerequisites: publicProcedure.query(async ({ ctx }) => {
+    const [ollama, hardware] = await Promise.all([
+      detectOllama(),
+      detectHardware(),
+    ]);
+    const recommendations = recommendModels(hardware, getProfilePolicy(ctx));
+
+    console.info(
+      `[nous:first-run] Wizard prerequisites: ollama=${ollama.state}, models=${ollama.models.length}`,
+    );
+
+    return {
+      ollama,
+      hardware,
+      recommendations,
+    };
+  }),
+
+  downloadModel: publicProcedure
+    .input(
+      z.object({
+        model: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        console.info(
+          `[nous:first-run] Model download initiated: ${input.model}`,
+        );
+        await pullOllamaModel(input.model);
+        const state = await markStepComplete(ctx.dataDir, 'model_download');
+        return FirstRunActionResultSchema.parse({
+          success: true,
+          state,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return actionFailure(ctx, message);
+      }
+    }),
+
+  configureProvider: publicProcedure
+    .input(
+      z.object({
+        modelSpec: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const selection = buildProviderSelection(input.modelSpec);
+      if (!selection) {
+        const error = `Cannot parse model spec: ${input.modelSpec}`;
+        console.warn(`[nous:first-run] ${error}`);
+        return actionFailure(ctx, error);
+      }
+
+      try {
+        await upsertProviderConfig(ctx, selection.providerConfig);
+        await updateReasonerAssignment(ctx, selection.providerId);
+        const state = await markStepComplete(ctx.dataDir, 'provider_config');
+
+        return FirstRunActionResultSchema.parse({
+          success: true,
+          state,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return actionFailure(ctx, message);
+      }
+    }),
+
+  assignRoles: publicProcedure
+    .input(
+      z.object({
+        assignments: z.array(FirstRunRoleAssignmentInputSchema).min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const resolvedAssignments = input.assignments.map((assignment) => {
+        const selection = buildProviderSelection(assignment.modelSpec);
+        if (!selection) {
+          return {
+            ...assignment,
+            error: `Cannot parse model spec: ${assignment.modelSpec}`,
+          };
+        }
+
+        return {
+          ...assignment,
+          ...selection,
+        };
+      });
+
+      const invalidAssignment = resolvedAssignments.find(
+        (assignment) => 'error' in assignment,
+      );
+      if (invalidAssignment && 'error' in invalidAssignment) {
+        console.warn(`[nous:first-run] ${invalidAssignment.error}`);
+        return actionFailure(ctx, invalidAssignment.error);
+      }
+
+      try {
+        for (const assignment of resolvedAssignments) {
+          if ('error' in assignment) {
+            continue;
+          }
+
+          await upsertProviderConfig(ctx, assignment.providerConfig);
+          await updateRoleAssignment(ctx, assignment.role, assignment.providerId);
+          console.info(
+            `[nous:first-run] Role assignment: ${assignment.role} -> ${assignment.modelSpec}`,
+          );
+        }
+
+        const state = await markStepComplete(ctx.dataDir, 'role_assignment');
+        return FirstRunActionResultSchema.parse({
+          success: true,
+          state,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return actionFailure(ctx, message);
+      }
+    }),
+
+  completeStep: publicProcedure
+    .input(
+      z.object({
+        step: FirstRunStepSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return markStepComplete(ctx.dataDir, input.step);
+    }),
+
+  resetWizard: publicProcedure.mutation(async ({ ctx }) => {
+    return resetFirstRunState(ctx.dataDir);
   }),
 });

--- a/self/apps/shared-server/src/trpc/routers/hardware.ts
+++ b/self/apps/shared-server/src/trpc/routers/hardware.ts
@@ -1,0 +1,33 @@
+/**
+ * Hardware detection tRPC router.
+ */
+import type { NousContext } from '../../context';
+import {
+  detectHardware,
+  recommendModels,
+  type RecommendationProfilePolicy,
+} from '../../hardware-detection';
+import { router, publicProcedure } from '../trpc';
+
+function getProfilePolicy(ctx: NousContext): RecommendationProfilePolicy {
+  const config = ctx.config.get() as {
+    profile?: RecommendationProfilePolicy;
+  };
+
+  return config.profile ?? {
+    name: 'local-only',
+    allowLocalProviders: true,
+    allowRemoteProviders: false,
+  };
+}
+
+export const hardwareRouter = router({
+  getSpec: publicProcedure.query(async () => {
+    return detectHardware();
+  }),
+
+  getRecommendations: publicProcedure.query(async ({ ctx }) => {
+    const hardware = await detectHardware();
+    return recommendModels(hardware, getProfilePolicy(ctx));
+  }),
+});


### PR DESCRIPTION
## Summary

- New hardware detection module: RAM, CPU, platform, arch, best-effort GPU/VRAM detection
- Model recommendation engine: tiered by RAM (tiny/small/medium/large), profile-aware, single and multi-model layouts
- Multi-step first-run state machine replacing binary flag (resumable, backward compatible)
- Extended first-run tRPC router with wizard endpoints (prerequisites, download, roles, step tracking)
- New hardware tRPC router (getSpec, getRecommendations)
- Desktop IPC channels for hardware and firstRun namespaces
- 4 new test files, 2147 total tests passing

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2147 tests, 100%)
- [x] `npx oxlint .` — 0 new warnings
- [x] All 17 acceptance criteria verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sprint: feat/desktop-self-hosted-runtime (WR-010)
Sub-phase: Phase 1.3 — Hardware Detection and First-Run Backend