### PR TITLE
feat(desktop): first-run wizard and Ollama download UI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,12 @@ importers:
         specifier: ^2.2.2
         version: 2.2.6
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.0.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/node':
         specifier: ^20
         version: 20.19.33
@@ -276,6 +282,9 @@ importers:
       electron-vite:
         specifier: ^2.3.0
         version: 2.3.0(vite@5.4.21(@types/node@20.19.33)(lightningcss@1.30.2))
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
       postcss:
         specifier: ^8.4.49
         version: 8.5.6
@@ -1186,6 +1195,9 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3045,6 +3057,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -4033,6 +4049,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -4342,6 +4361,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
@@ -5149,6 +5171,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -5829,6 +5855,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -6441,6 +6471,10 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -6808,6 +6842,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -7535,6 +7573,8 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -9183,6 +9223,15 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -10320,6 +10369,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   cssstyle@4.6.0:
@@ -10660,6 +10711,8 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  dom-accessibility-api@0.6.3: {}
+
   dompurify@3.3.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -10979,7 +11032,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -11002,7 +11055,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11017,14 +11070,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11039,7 +11092,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11810,6 +11863,8 @@ snapshots:
   import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -12748,6 +12803,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -13383,6 +13440,11 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -13921,6 +13983,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 

--- a/self/apps/desktop/package.json
+++ b/self/apps/desktop/package.json
@@ -14,6 +14,7 @@
     "build:dist:win": "electron-vite build && electron-builder --win --dir",
     "preview": "electron-vite preview",
     "test": "vitest run --config vitest.config.mts",
+    "test:renderer": "vitest run --config vitest.renderer.config.mts",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.web.json --noEmit"
   },
   "build": {
@@ -51,6 +52,8 @@
     "superjson": "^2.2.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -59,6 +62,7 @@
     "electron": "34.0.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^2.3.0",
+    "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
     "tsx": "^4.19.0",

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -23,8 +23,10 @@ import {
   PreferencesPanel,
 } from '@nous/ui/panels'
 import { AppInstallWizardPanel } from './components/AppInstallWizard'
+import { FirstRunWizard } from './components/FirstRunWizard'
 import { TitleBar } from './components/TitleBar'
 import { StatusBar } from './components/StatusBar'
+import type { FirstRunState } from './components/wizard/types'
 
 import 'dockview-react/dist/styles/dockview.css'
 
@@ -198,6 +200,13 @@ function stripNonSerializableFromLayout(layout: SerializedDockview): SerializedD
 
 // Loading state: undefined = not yet fetched; null = fetched, no saved layout
 type LayoutState = SerializedDockview | null | undefined
+type AppPhase = 'loading' | 'wizard' | 'main'
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, delayMs)
+  })
+}
 
 // Outer chrome shell — titlebar + content area + statusbar
 function ChromeShell({
@@ -229,20 +238,130 @@ function ChromeShell({
 }
 
 export function App() {
+  const bootstrapRunRef = useRef(0)
+  const [phase, setPhase] = useState<AppPhase>('loading')
+  const [loadingMessage, setLoadingMessage] = useState('Connecting to backend…')
+  const [bootError, setBootError] = useState<string | null>(null)
+  const [firstRunState, setFirstRunState] = useState<FirstRunState | null>(null)
   const [savedLayout, setSavedLayout] = useState<LayoutState>(undefined)
   const [dockviewApi, setDockviewApi] = useState<DockviewApi | null>(null)
   const [appPanels, setAppPanels] = useState<AppPanelSnapshot[]>([])
   const panelDefs = [...NATIVE_PANEL_DEFS, ...appPanels.map(toAppPanelDef)]
 
-  useEffect(() => {
-    window.electronAPI.layout.get().then((layout: unknown) => {
-      setSavedLayout((layout as SerializedDockview | null) ?? null)
-    }).catch(() => {
-      setSavedLayout(null)
-    })
+  const initializeApp = useCallback(async () => {
+    const runId = ++bootstrapRunRef.current
+    const isStale = () => bootstrapRunRef.current !== runId
+
+    setBootError(null)
+    setLoadingMessage('Connecting to backend…')
+    setPhase('loading')
+    setFirstRunState(null)
+    setSavedLayout(undefined)
+    setDockviewApi(null)
+    setAppPanels([])
+
+    const startedAt = Date.now()
+    let backendReady = false
+    let delayMs = 500
+
+    while (!backendReady && Date.now() - startedAt < 30000) {
+      try {
+        const status = await window.electronAPI.backend.getStatus()
+        if (status.ready) {
+          backendReady = true
+          break
+        }
+      } catch {
+        // Keep waiting until timeout or successful readiness.
+      }
+
+      if (isStale()) {
+        return
+      }
+
+      const elapsedMs = Date.now() - startedAt
+      console.log(`[nous:wizard] Backend readiness wait: ${elapsedMs}ms`)
+      setLoadingMessage(`Connecting to backend… (${Math.max(1, Math.ceil(elapsedMs / 1000))}s)`)
+      await wait(delayMs)
+      delayMs = Math.min(delayMs * 2, 4000)
+    }
+
+    if (isStale()) {
+      return
+    }
+
+    if (!backendReady) {
+      setBootError('The desktop backend did not become ready within 30 seconds.')
+      return
+    }
+
+    setLoadingMessage('Loading first-run state…')
+
+    try {
+      const nextFirstRunState = await window.electronAPI.firstRun.getWizardState()
+      if (isStale()) {
+        return
+      }
+
+      setFirstRunState(nextFirstRunState)
+      if (nextFirstRunState.complete) {
+        console.log('[nous:wizard] Phase: loading → main')
+        setPhase('main')
+      } else {
+        console.log('[nous:wizard] Phase: loading → wizard')
+        setPhase('wizard')
+      }
+    } catch (error) {
+      if (isStale()) {
+        return
+      }
+
+      const message = error instanceof Error ? error.message : String(error)
+      setBootError(message)
+    }
   }, [])
 
   useEffect(() => {
+    void initializeApp()
+
+    return () => {
+      bootstrapRunRef.current += 1
+    }
+  }, [initializeApp])
+
+  useEffect(() => {
+    if (phase !== 'main') {
+      return
+    }
+
+    let cancelled = false
+    setLoadingMessage('Loading workspace layout…')
+
+    window.electronAPI.layout.get().then((layout: unknown) => {
+      if (cancelled) {
+        return
+      }
+
+      setSavedLayout((layout as SerializedDockview | null) ?? null)
+    }).catch(() => {
+      if (cancelled) {
+        return
+      }
+
+      setSavedLayout(null)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [phase])
+
+  useEffect(() => {
+    if (phase !== 'main') {
+      setAppPanels([])
+      return
+    }
+
     let cancelled = false
 
     const syncAppPanels = async () => {
@@ -265,26 +384,79 @@ export function App() {
       cancelled = true
       window.clearInterval(intervalId)
     }
+  }, [phase])
+
+  const handleWizardComplete = useCallback(() => {
+    console.log('[nous:wizard] Phase: wizard → main')
+    setSavedLayout(undefined)
+    setDockviewApi(null)
+    setPhase('main')
   }, [])
 
-  if (savedLayout === undefined) {
+  const loadingShell = (
+    <ChromeShell dockviewApi={null} panelDefs={panelDefs}>
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'var(--nous-bg)',
+          color: 'var(--nous-fg-subtle)',
+          fontSize: 'var(--nous-font-size-base)',
+          padding: 'var(--nous-space-3xl)',
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ display: 'grid', gap: 'var(--nous-space-lg)' }}>
+          {bootError ? (
+            <>
+              <div>{bootError}</div>
+              <div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void initializeApp()
+                  }}
+                  style={{
+                    minHeight: '40px',
+                    padding: '0 var(--nous-space-3xl)',
+                    border: '1px solid var(--nous-btn-secondary-border)',
+                    borderRadius: 'var(--nous-input-radius)',
+                    background: 'var(--nous-btn-secondary-bg)',
+                    color: 'var(--nous-btn-secondary-fg)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  Retry
+                </button>
+              </div>
+            </>
+          ) : (
+            <div>{loadingMessage}</div>
+          )}
+        </div>
+      </div>
+    </ChromeShell>
+  )
+
+  if (phase === 'loading' || bootError) {
+    return loadingShell
+  }
+
+  if (phase === 'wizard' && firstRunState) {
     return (
       <ChromeShell dockviewApi={null} panelDefs={panelDefs}>
-        <div
-          style={{
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'var(--nous-bg)',
-            color: 'var(--nous-fg-subtle)',
-            fontSize: 'var(--nous-font-size-base)',
-          }}
-        >
-          Loading...
-        </div>
+        <FirstRunWizard
+          initialState={firstRunState}
+          onComplete={handleWizardComplete}
+        />
       </ChromeShell>
     )
+  }
+
+  if (savedLayout === undefined) {
+    return loadingShell
   }
 
   return (

--- a/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
@@ -1,0 +1,195 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createElectronAPIMock,
+  createFirstRunState,
+} from '../test-setup'
+
+vi.mock('dockview-react', async () => {
+  const React = await import('react')
+
+  return {
+    DockviewReact: ({
+      onReady,
+    }: {
+      onReady?: (event: {
+        api: {
+          panels: never[]
+          fromJSON: ReturnType<typeof vi.fn>
+          onDidLayoutChange: ReturnType<typeof vi.fn>
+          toJSON: ReturnType<typeof vi.fn>
+          addPanel: ReturnType<typeof vi.fn>
+          removePanel: ReturnType<typeof vi.fn>
+        }
+      }) => void
+    }) => {
+      React.useEffect(() => {
+        onReady?.({
+          api: {
+            panels: [],
+            fromJSON: vi.fn(),
+            onDidLayoutChange: vi.fn(),
+            toJSON: vi.fn(() => null),
+            addPanel: vi.fn(),
+            removePanel: vi.fn(),
+          },
+        })
+      }, [onReady])
+
+      return <div>Dockview shell</div>
+    },
+  }
+})
+
+vi.mock('@nous/ui/panels', () => {
+  const Panel = () => null
+
+  return {
+    AppIframePanel: Panel,
+    PlaceholderPanel: Panel,
+    ChatPanel: Panel,
+    FileBrowserPanel: Panel,
+    NodeProjectionPanel: Panel,
+    MAOPanel: Panel,
+    CodexBarPanel: Panel,
+    CodexBarHeaderActions: Panel,
+    DashboardPanel: Panel,
+    DashboardWidgetMenu: Panel,
+    AgentPanel: Panel,
+    PreferencesPanel: Panel,
+    useCodexBarApi: () => null,
+    useDashboardApi: () => null,
+  }
+})
+
+vi.mock('../components/AppInstallWizard', () => ({
+  AppInstallWizardPanel: () => null,
+}))
+
+vi.mock('../components/TitleBar', () => ({
+  TitleBar: () => <div>Title bar</div>,
+}))
+
+vi.mock('../components/StatusBar', () => ({
+  StatusBar: () => <div>Status bar</div>,
+}))
+
+vi.mock('../components/FirstRunWizard', () => ({
+  FirstRunWizard: ({
+    onComplete,
+  }: {
+    onComplete: () => void
+  }) => (
+    <div>
+      <div>Wizard shell</div>
+      <button type="button" onClick={onComplete}>
+        Complete wizard
+      </button>
+    </div>
+  ),
+}))
+
+import { App } from '../App'
+
+function installMock() {
+  const mock = createElectronAPIMock()
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: mock,
+  })
+  return mock
+}
+
+describe('App', () => {
+  it('shows the wizard shell when first-run is incomplete', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState.mockResolvedValue(
+      createFirstRunState({ complete: false, currentStep: 'ollama_check' }),
+    )
+
+    render(<App />)
+
+    expect(await screen.findByText('Wizard shell')).toBeInTheDocument()
+  })
+
+  it('shows the dockview shell when first-run is already complete', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState.mockResolvedValue(
+      createFirstRunState({
+        currentStep: 'complete',
+        complete: true,
+      }),
+    )
+
+    render(<App />)
+
+    expect(await screen.findByText('Dockview shell')).toBeInTheDocument()
+  })
+
+  it('transitions from the wizard shell to dockview after completion', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState.mockResolvedValue(
+      createFirstRunState({ complete: false, currentStep: 'ollama_check' }),
+    )
+
+    render(<App />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Complete wizard' }))
+
+    expect(await screen.findByText('Dockview shell')).toBeInTheDocument()
+  })
+
+  it('polls backend readiness before loading first-run state', async () => {
+    vi.useFakeTimers()
+    const mock = installMock()
+    mock.backend.getStatus
+      .mockResolvedValueOnce({
+        ready: false,
+        port: 0,
+        trpcUrl: '',
+      })
+      .mockResolvedValueOnce({
+        ready: true,
+        port: 4317,
+        trpcUrl: 'http://127.0.0.1:4317/trpc',
+      })
+
+    render(<App />)
+
+    expect(screen.getByText(/Connecting to backend/)).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(mock.backend.getStatus).toHaveBeenCalledTimes(2)
+    expect(mock.firstRun.getWizardState).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Wizard shell')).toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
+  it('shows an error and retries when loading the first-run state fails', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState
+      .mockRejectedValueOnce(new Error('wizard state failed'))
+      .mockResolvedValueOnce(createFirstRunState({ complete: false }))
+
+    render(<App />)
+
+    expect(await screen.findByText('wizard state failed')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(mock.firstRun.getWizardState).toHaveBeenCalledTimes(2)
+    })
+
+    expect(await screen.findByText('Wizard shell')).toBeInTheDocument()
+  })
+})

--- a/self/apps/desktop/src/renderer/src/components/DownloadProgressPanel.css
+++ b/self/apps/desktop/src/renderer/src/components/DownloadProgressPanel.css
@@ -1,0 +1,105 @@
+.nous-progress-panel {
+  display: grid;
+  gap: var(--nous-space-xl);
+  margin-top: var(--nous-space-2xl);
+  padding: var(--nous-space-2xl);
+  border-radius: var(--nous-card-radius);
+  border: 1px solid var(--nous-card-border);
+  background: color-mix(in srgb, var(--nous-card-bg) 92%, transparent);
+}
+
+.nous-progress-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--nous-space-lg);
+  align-items: flex-start;
+}
+
+.nous-progress-panel__title {
+  font-size: var(--nous-font-size-md);
+  font-weight: var(--nous-font-weight-semibold);
+  color: var(--nous-fg);
+}
+
+.nous-progress-panel__subtitle {
+  margin-top: var(--nous-space-sm);
+  color: var(--nous-fg-muted);
+}
+
+.nous-progress-panel__percent {
+  color: var(--nous-fg);
+  font-size: 20px;
+  font-weight: var(--nous-font-weight-semibold);
+}
+
+.nous-progress-panel__track {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: var(--nous-progress-height);
+  border-radius: var(--nous-progress-radius);
+  background: var(--nous-progress-track);
+}
+
+.nous-progress-panel__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--nous-progress-fill);
+  transition: width var(--nous-duration-fast) var(--nous-ease-in-out);
+}
+
+.nous-progress-panel__fill--indeterminate {
+  width: 35%;
+  animation: nous-progress-indeterminate 1.35s linear infinite;
+}
+
+.nous-progress-panel__meta {
+  display: grid;
+  gap: var(--nous-space-lg);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.nous-progress-panel__meta-label {
+  color: var(--nous-fg-subtle);
+  font-size: var(--nous-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.nous-progress-panel__meta-value {
+  margin-top: var(--nous-space-sm);
+  color: var(--nous-fg);
+}
+
+.nous-progress-panel__status {
+  color: var(--nous-fg-muted);
+}
+
+.nous-progress-panel__status--success {
+  color: var(--nous-state-complete);
+}
+
+.nous-progress-panel__status--error {
+  color: var(--nous-state-blocked);
+}
+
+@keyframes nous-progress-indeterminate {
+  0% {
+    transform: translateX(-140%);
+  }
+
+  100% {
+    transform: translateX(320%);
+  }
+}
+
+@media (max-width: 720px) {
+  .nous-progress-panel__header,
+  .nous-progress-panel__meta {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .nous-progress-panel__header {
+    display: grid;
+  }
+}

--- a/self/apps/desktop/src/renderer/src/components/DownloadProgressPanel.tsx
+++ b/self/apps/desktop/src/renderer/src/components/DownloadProgressPanel.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useRef, useState } from 'react'
+import type { OllamaModelPullProgress } from './wizard/types'
+import './DownloadProgressPanel.css'
+
+export interface DownloadProgressPanelProps {
+  modelId: string
+  modelDisplayName?: string
+  onComplete?: () => void
+  onError?: (error: string) => void
+  /**
+   * Called when the component unmounts while a download is still in progress
+   * (for example, when the user navigates away). This does not cancel the
+   * Ollama pull; the server-side download continues.
+   */
+  onCancel?: () => void
+}
+
+type DownloadState = {
+  status: string
+  percent: number | null
+  completed: number
+  total: number
+  speed: number
+  isComplete: boolean
+  error: string | null
+}
+
+const ERROR_STATUS_PATTERN = /(error|failed|failure)/i
+
+function formatBytes(value: number): string {
+  if (value <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = value
+  let index = 0
+
+  while (size >= 1024 && index < units.length - 1) {
+    size /= 1024
+    index += 1
+  }
+
+  return `${size.toFixed(index === 0 ? 0 : 1)} ${units[index]}`
+}
+
+function formatSpeed(value: number): string {
+  if (value <= 0) {
+    return 'Calculating...'
+  }
+
+  return `${formatBytes(value)}/s`
+}
+
+function getPercent(progress: OllamaModelPullProgress): number | null {
+  if (typeof progress.percent === 'number' && Number.isFinite(progress.percent)) {
+    return Math.max(0, Math.min(progress.percent, 100))
+  }
+
+  if (
+    typeof progress.completed === 'number' &&
+    typeof progress.total === 'number' &&
+    progress.total > 0
+  ) {
+    return Math.max(0, Math.min((progress.completed / progress.total) * 100, 100))
+  }
+
+  return null
+}
+
+function getErrorMessage(status: string): string | null {
+  return ERROR_STATUS_PATTERN.test(status) ? status : null
+}
+
+export function DownloadProgressPanel({
+  modelId,
+  modelDisplayName,
+  onComplete,
+  onError,
+  onCancel,
+}: DownloadProgressPanelProps) {
+  const [downloadState, setDownloadState] = useState<DownloadState>({
+    status: 'Waiting for download progress…',
+    percent: 0,
+    completed: 0,
+    total: 0,
+    speed: 0,
+    isComplete: false,
+    error: null,
+  })
+
+  const lastSampleRef = useRef<{ completed: number; timestamp: number } | null>(null)
+  const speedSamplesRef = useRef<number[]>([])
+  const lastLoggedBucketRef = useRef(-10)
+  const hasCompletedRef = useRef(false)
+  const hasErroredRef = useRef(false)
+  const latestStateRef = useRef(downloadState)
+
+  useEffect(() => {
+    latestStateRef.current = downloadState
+  }, [downloadState])
+
+  useEffect(() => {
+    const handleProgress = (progress: OllamaModelPullProgress) => {
+      const nextPercent = getPercent(progress)
+      const nextCompleted = typeof progress.completed === 'number' ? progress.completed : 0
+      const nextTotal = typeof progress.total === 'number' ? progress.total : 0
+      const nextStatus = progress.status || 'Downloading…'
+      const nextError = getErrorMessage(nextStatus)
+      const timestamp = Date.now()
+
+      let nextSpeed = latestStateRef.current.speed
+      if (lastSampleRef.current && nextCompleted > lastSampleRef.current.completed) {
+        const elapsedMs = timestamp - lastSampleRef.current.timestamp
+        if (elapsedMs > 0) {
+          const bytesPerSecond =
+            ((nextCompleted - lastSampleRef.current.completed) / elapsedMs) * 1000
+          const nextSamples = [...speedSamplesRef.current, bytesPerSecond].slice(-5)
+          speedSamplesRef.current = nextSamples
+          nextSpeed =
+            nextSamples.reduce((total, sample) => total + sample, 0) / nextSamples.length
+        }
+      }
+
+      lastSampleRef.current = {
+        completed: nextCompleted,
+        timestamp,
+      }
+
+      if (typeof nextPercent === 'number') {
+        const bucket = Math.floor(nextPercent / 10) * 10
+        if (bucket >= 0 && bucket > lastLoggedBucketRef.current) {
+          lastLoggedBucketRef.current = bucket
+          console.log(`[nous:wizard] Download progress: ${bucket}%`)
+        }
+      }
+
+      const isComplete = nextStatus === 'success'
+      setDownloadState({
+        status: nextStatus,
+        percent: isComplete ? 100 : nextPercent,
+        completed: nextCompleted,
+        total: nextTotal,
+        speed: nextSpeed,
+        isComplete,
+        error: nextError,
+      })
+
+      if (isComplete && !hasCompletedRef.current) {
+        hasCompletedRef.current = true
+        console.log(`[nous:wizard] Download complete: ${modelId}`)
+        onComplete?.()
+      }
+
+      if (nextError && !hasErroredRef.current) {
+        hasErroredRef.current = true
+        console.log(`[nous:wizard] Download error: ${nextError}`)
+        onError?.(nextError)
+      }
+    }
+
+    const cleanup = window.electronAPI.ollama.onPullProgress(handleProgress)
+
+    return () => {
+      cleanup()
+      const currentState = latestStateRef.current
+      if (!currentState.isComplete && !currentState.error) {
+        onCancel?.()
+      }
+    }
+  }, [modelId, onCancel, onComplete, onError])
+
+  const progressLabel =
+    typeof downloadState.percent === 'number'
+      ? `${Math.round(downloadState.percent)}%`
+      : 'Syncing…'
+  const fillClassName =
+    downloadState.percent === null && !downloadState.isComplete
+      ? 'nous-progress-panel__fill nous-progress-panel__fill--indeterminate'
+      : 'nous-progress-panel__fill'
+  const fillStyle =
+    downloadState.percent === null && !downloadState.isComplete
+      ? undefined
+      : { width: `${downloadState.percent ?? 0}%` }
+  const transferredLabel =
+    downloadState.total > 0
+      ? `${formatBytes(downloadState.completed)} / ${formatBytes(downloadState.total)}`
+      : formatBytes(downloadState.completed)
+  const statusClassName = downloadState.error
+    ? 'nous-progress-panel__status nous-progress-panel__status--error'
+    : downloadState.isComplete
+      ? 'nous-progress-panel__status nous-progress-panel__status--success'
+      : 'nous-progress-panel__status'
+
+  return (
+    <section className="nous-progress-panel" aria-live="polite">
+      <header className="nous-progress-panel__header">
+        <div>
+          <div className="nous-progress-panel__title">
+            Downloading {modelDisplayName ?? modelId}
+          </div>
+          <div className="nous-progress-panel__subtitle">{modelId}</div>
+        </div>
+        <div className="nous-progress-panel__percent" data-testid="download-percent">
+          {progressLabel}
+        </div>
+      </header>
+
+      <div
+        className="nous-progress-panel__track"
+        role="progressbar"
+        aria-label={`Download progress for ${modelDisplayName ?? modelId}`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={downloadState.percent ?? undefined}
+      >
+        <div
+          className={fillClassName}
+          style={fillStyle}
+          data-testid="download-progress-fill"
+        />
+      </div>
+
+      <div className="nous-progress-panel__meta">
+        <div>
+          <div className="nous-progress-panel__meta-label">Transferred</div>
+          <div className="nous-progress-panel__meta-value">{transferredLabel}</div>
+        </div>
+        <div>
+          <div className="nous-progress-panel__meta-label">Speed</div>
+          <div className="nous-progress-panel__meta-value">
+            {formatSpeed(downloadState.speed)}
+          </div>
+        </div>
+        <div>
+          <div className="nous-progress-panel__meta-label">Status</div>
+          <div className={statusClassName}>{downloadState.error ?? downloadState.status}</div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/FirstRunWizard.tsx
+++ b/self/apps/desktop/src/renderer/src/components/FirstRunWizard.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from 'react'
+import { WizardStepConfirmation } from './wizard/WizardStepConfirmation'
+import { WizardStepIndicator } from './wizard/WizardStepIndicator'
+import { WizardStepModelDownload } from './wizard/WizardStepModelDownload'
+import { WizardStepOllamaSetup } from './wizard/WizardStepOllamaSetup'
+import { WizardStepRoleAssignment } from './wizard/WizardStepRoleAssignment'
+import { WizardStepWelcome } from './wizard/WizardStepWelcome'
+import './wizard/wizard.css'
+import {
+  BACKEND_STEP_TO_WIZARD_STEP,
+  WIZARD_STEPS,
+  getRecommendedModelSpec,
+  type FirstRunPrerequisites,
+  type FirstRunState,
+  type OllamaStatus,
+  type RoleAssignments,
+} from './wizard/types'
+
+type RoleAssignmentMode = 'default' | 'advanced'
+
+export interface FirstRunWizardProps {
+  initialState: FirstRunState
+  onComplete: () => void
+}
+
+export function FirstRunWizard({
+  initialState,
+  onComplete,
+}: FirstRunWizardProps) {
+  const [firstRunState, setFirstRunState] = useState(initialState)
+  const [prerequisites, setPrerequisites] = useState<FirstRunPrerequisites | null>(null)
+  const [prerequisitesLoading, setPrerequisitesLoading] = useState(true)
+  const [prerequisitesError, setPrerequisitesError] = useState<string | null>(null)
+  const [ollamaStatus, setOllamaStatus] = useState<OllamaStatus | null>(null)
+  const [selectedModelSpec, setSelectedModelSpec] = useState<string | null>(null)
+  const [roleAssignments, setRoleAssignments] = useState<RoleAssignments>({})
+  const [roleAssignmentMode, setRoleAssignmentMode] =
+    useState<RoleAssignmentMode>('default')
+  const [actionInProgress, setActionInProgress] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [welcomeCompleted, setWelcomeCompleted] = useState(
+    initialState.currentStep !== 'ollama_check',
+  )
+
+  const currentWizardStep =
+    firstRunState.currentStep === 'ollama_check' && !welcomeCompleted
+      ? 'welcome'
+      : BACKEND_STEP_TO_WIZARD_STEP[firstRunState.currentStep]
+
+  useEffect(() => {
+    console.log(`[nous:wizard] Step rendered: ${currentWizardStep}`)
+  }, [currentWizardStep])
+
+  useEffect(() => {
+    if (actionError) {
+      console.log(`[nous:wizard] Error: ${actionError}`)
+    }
+  }, [actionError])
+
+  useEffect(() => {
+    if (prerequisitesError) {
+      console.log(`[nous:wizard] Error: ${prerequisitesError}`)
+    }
+  }, [prerequisitesError])
+
+  const loadPrerequisites = async () => {
+    setPrerequisitesLoading(true)
+    setPrerequisitesError(null)
+
+    try {
+      const nextPrerequisites = await window.electronAPI.firstRun.checkPrerequisites()
+      setPrerequisites(nextPrerequisites)
+      setOllamaStatus(nextPrerequisites.ollama)
+      setSelectedModelSpec(
+        (currentModelSpec) =>
+          currentModelSpec ?? getRecommendedModelSpec(nextPrerequisites),
+      )
+      console.log('[nous:wizard] Prerequisites loaded')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setPrerequisitesError(message)
+    } finally {
+      setPrerequisitesLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadPrerequisites()
+
+    const cleanup = window.electronAPI.ollama.onStateChange((status) => {
+      setOllamaStatus(status)
+    })
+
+    return () => {
+      cleanup()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (firstRunState.currentStep !== 'ollama_check') {
+      setWelcomeCompleted(true)
+    }
+  }, [firstRunState.currentStep])
+
+  const refreshOllamaStatus = async () => {
+    const nextStatus = await window.electronAPI.ollama.getStatus()
+    setOllamaStatus(nextStatus)
+  }
+
+  const applyStepCompletion = (label: string, nextState: FirstRunState) => {
+    console.log(`[nous:wizard] Step completed: ${label}`)
+    setFirstRunState(nextState)
+    setActionError(null)
+    setActionInProgress(false)
+  }
+
+  const handleResetWizard = async () => {
+    setActionError(null)
+    setActionInProgress(true)
+
+    try {
+      const nextState = await window.electronAPI.firstRun.resetWizard()
+      setFirstRunState(nextState)
+      setWelcomeCompleted(false)
+      setRoleAssignments({})
+      setRoleAssignmentMode('default')
+      setSelectedModelSpec(getRecommendedModelSpec(prerequisites))
+      await loadPrerequisites()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setActionError(message)
+      setActionInProgress(false)
+      return
+    }
+
+    setActionInProgress(false)
+  }
+
+  const sharedProps = {
+    state: firstRunState,
+    prerequisites,
+    actionInProgress,
+    actionError,
+    setActionInProgress,
+    setActionError,
+  }
+
+  return (
+    <div className="nous-wizard">
+      <div className="nous-wizard__container">
+        {actionError || prerequisitesError ? (
+          <div className="nous-wizard__alert" role="alert">
+            <div>{actionError ?? prerequisitesError}</div>
+            <div className="nous-wizard__button-row">
+              <button
+                type="button"
+                className="nous-wizard__button nous-wizard__button--secondary"
+                onClick={() => {
+                  void loadPrerequisites()
+                }}
+                disabled={actionInProgress}
+              >
+                Retry prerequisites
+              </button>
+              <button
+                type="button"
+                className="nous-wizard__button nous-wizard__button--ghost"
+                onClick={() => {
+                  void handleResetWizard()
+                }}
+                disabled={actionInProgress}
+              >
+                Reset wizard
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {prerequisitesLoading && !prerequisites ? (
+          <div className="nous-wizard__status nous-wizard__status--action">
+            <span className="nous-wizard__status-dot" />
+            <span>Loading hardware, Ollama status, and model recommendations…</span>
+          </div>
+        ) : null}
+
+        <WizardStepIndicator steps={WIZARD_STEPS} currentStepId={currentWizardStep} />
+
+        {currentWizardStep === 'welcome' ? (
+          <WizardStepWelcome
+            {...sharedProps}
+            onStepComplete={(nextState) => {
+              applyStepCompletion('welcome', nextState)
+            }}
+            onContinue={() => {
+              console.log('[nous:wizard] Step completed: welcome')
+              setWelcomeCompleted(true)
+            }}
+          />
+        ) : null}
+
+        {currentWizardStep === 'ollama-setup' ? (
+          <WizardStepOllamaSetup
+            {...sharedProps}
+            ollamaStatus={ollamaStatus}
+            refreshOllamaStatus={refreshOllamaStatus}
+            onStepComplete={(nextState) => {
+              applyStepCompletion('ollama_check', nextState)
+            }}
+          />
+        ) : null}
+
+        {currentWizardStep === 'model-download' ? (
+          <WizardStepModelDownload
+            {...sharedProps}
+            selectedModelSpec={selectedModelSpec}
+            setSelectedModelSpec={setSelectedModelSpec}
+            onStepComplete={(nextState) => {
+              applyStepCompletion('model_download/provider_config', nextState)
+            }}
+          />
+        ) : null}
+
+        {currentWizardStep === 'role-assignment' ? (
+          <WizardStepRoleAssignment
+            {...sharedProps}
+            selectedModelSpec={selectedModelSpec}
+            roleAssignments={roleAssignments}
+            setRoleAssignments={setRoleAssignments}
+            roleAssignmentMode={roleAssignmentMode}
+            setRoleAssignmentMode={setRoleAssignmentMode}
+            onStepComplete={(nextState) => {
+              applyStepCompletion('role_assignment', nextState)
+            }}
+          />
+        ) : null}
+
+        {currentWizardStep === 'confirmation' ? (
+          <WizardStepConfirmation
+            {...sharedProps}
+            selectedModelSpec={selectedModelSpec}
+            roleAssignments={roleAssignments}
+            ollamaStatus={ollamaStatus}
+            onStepComplete={(nextState) => {
+              applyStepCompletion('confirmation', nextState)
+            }}
+            onFinish={() => {
+              console.log('[nous:wizard] Step completed: confirmation')
+              onComplete()
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/__tests__/DownloadProgressPanel.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/__tests__/DownloadProgressPanel.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createElectronAPIMock,
+} from '../../test-setup'
+import { DownloadProgressPanel } from '../DownloadProgressPanel'
+
+function installMock() {
+  const mock = createElectronAPIMock()
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: mock,
+  })
+  return mock
+}
+
+describe('DownloadProgressPanel', () => {
+  it('renders with required props', () => {
+    installMock()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+
+    expect(screen.getByText('Downloading qwen2.5:7b')).toBeInTheDocument()
+    expect(screen.getByTestId('download-percent')).toHaveTextContent('0%')
+  })
+
+  it('subscribes to pull progress when mounted', () => {
+    const mock = installMock()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+
+    expect(mock.ollama.onPullProgress).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up the pull progress subscription on unmount', () => {
+    const mock = installMock()
+    const cleanup = vi.fn()
+    mock.ollama.onPullProgress.mockImplementation(() => cleanup)
+
+    const view = render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+    view.unmount()
+
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates the progress bar width and percentage text from progress events', async () => {
+    const mock = installMock()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+
+    mock.__emitPullProgress({
+      status: 'downloading',
+      percent: 42,
+      completed: 42,
+      total: 100,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-percent')).toHaveTextContent('42%')
+      expect(screen.getByTestId('download-progress-fill')).toHaveStyle({
+        width: '42%',
+      })
+    })
+  })
+
+  it('calls onComplete when the success status is received', async () => {
+    const mock = installMock()
+    const onComplete = vi.fn()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" onComplete={onComplete} />)
+
+    mock.__emitPullProgress({
+      status: 'success',
+      percent: 100,
+      completed: 100,
+      total: 100,
+    })
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('calls onError when the progress stream reports an error status', async () => {
+    const mock = installMock()
+    const onError = vi.fn()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" onError={onError} />)
+
+    mock.__emitPullProgress({
+      status: 'download failed: disk full',
+    })
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('download failed: disk full')
+    })
+  })
+
+  it('shows an indeterminate state when percentage information is unavailable', async () => {
+    const mock = installMock()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+
+    mock.__emitPullProgress({
+      status: 'pulling manifest',
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-percent')).toHaveTextContent('Syncing…')
+      expect(screen.getByTestId('download-progress-fill').className).toContain(
+        'nous-progress-panel__fill--indeterminate',
+      )
+    })
+  })
+
+  it('calculates a percent from completed and total bytes when percent is missing', async () => {
+    const mock = installMock()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+
+    mock.__emitPullProgress({
+      status: 'downloading',
+      completed: 25,
+      total: 100,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-percent')).toHaveTextContent('25%')
+    })
+  })
+
+  it('handles a zero total value without rendering NaN progress', async () => {
+    const mock = installMock()
+    render(<DownloadProgressPanel modelId="qwen2.5:7b" />)
+
+    mock.__emitPullProgress({
+      status: 'downloading',
+      completed: 12,
+      total: 0,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-percent')).toHaveTextContent('Syncing…')
+      expect(screen.getByRole('progressbar')).not.toHaveAttribute('aria-valuenow', 'NaN')
+    })
+  })
+
+  it('calls onCancel when the component unmounts during an active download', async () => {
+    const mock = installMock()
+    const onCancel = vi.fn()
+    const view = render(
+      <DownloadProgressPanel modelId="qwen2.5:7b" onCancel={onCancel} />,
+    )
+
+    mock.__emitPullProgress({
+      status: 'downloading',
+      percent: 10,
+      completed: 10,
+      total: 100,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-percent')).toHaveTextContent('10%')
+    })
+
+    view.unmount()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/self/apps/desktop/src/renderer/src/components/__tests__/FirstRunWizard.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/__tests__/FirstRunWizard.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createElectronAPIMock,
+  createFirstRunState,
+  createPrerequisites,
+} from '../../test-setup'
+import { FirstRunWizard } from '../FirstRunWizard'
+
+function installMock() {
+  const mock = createElectronAPIMock()
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: mock,
+  })
+  return mock
+}
+
+describe('FirstRunWizard', () => {
+  it('renders the welcome step for a fresh ollama_check state', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    expect(
+      await screen.findByText('Set up your local runtime in a few guided steps.'),
+    ).toBeInTheDocument()
+  })
+
+  it('loads prerequisites and subscribes to Ollama state changes on mount', async () => {
+    const mock = installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mock.firstRun.checkPrerequisites).toHaveBeenCalledTimes(1)
+      expect(mock.ollama.onStateChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('cleans up the Ollama state subscription on unmount', () => {
+    const mock = installMock()
+    const cleanup = vi.fn()
+    mock.ollama.onStateChange.mockImplementation(() => cleanup)
+
+    const view = render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    view.unmount()
+
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('advances from the welcome step to the Ollama setup step', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue setup' }))
+
+    expect(
+      await screen.findByText('Make sure Ollama is installed and running.'),
+    ).toBeInTheDocument()
+  })
+
+  it('resumes directly at the model download step when the backend state says so', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState({
+          currentStep: 'model_download',
+          steps: {
+            ollama_check: {
+              status: 'complete',
+              completedAt: '2026-03-22T00:04:00.000Z',
+            },
+            model_download: { status: 'pending' },
+            provider_config: { status: 'pending' },
+            role_assignment: { status: 'pending' },
+          },
+        })}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    expect(
+      await screen.findByText('Download the local model that fits this machine.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a prerequisites error and retries the request', async () => {
+    const mock = installMock()
+    mock.firstRun.checkPrerequisites
+      .mockRejectedValueOnce(new Error('prerequisites failed'))
+      .mockResolvedValueOnce(createPrerequisites())
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByText('prerequisites failed')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry prerequisites' }))
+
+    await waitFor(() => {
+      expect(mock.firstRun.checkPrerequisites).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('reacts to live Ollama status updates from the preload subscription', async () => {
+    const mock = installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue setup' }))
+
+    mock.__emitOllamaStateChange({
+      installed: false,
+      running: false,
+      state: 'not_installed',
+      models: [],
+      defaultModel: null,
+    })
+
+    expect((await screen.findAllByText('Not installed')).length).toBeGreaterThan(0)
+  })
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepConfirmation.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepConfirmation.tsx
@@ -1,0 +1,101 @@
+import {
+  MODEL_ROLES,
+  buildRecommendedRoleAssignments,
+  formatLifecycleState,
+  formatRoleLabel,
+  getModelDisplayName,
+  type OllamaStatus,
+  type RoleAssignments,
+  type WizardStepProps,
+} from './types'
+
+export interface WizardStepConfirmationProps extends WizardStepProps {
+  selectedModelSpec: string | null
+  roleAssignments: RoleAssignments
+  ollamaStatus: OllamaStatus | null
+  onFinish: () => void
+}
+
+export function WizardStepConfirmation({
+  prerequisites,
+  selectedModelSpec,
+  roleAssignments,
+  ollamaStatus,
+  onFinish,
+}: WizardStepConfirmationProps) {
+  const effectiveAssignments =
+    Object.keys(roleAssignments).length > 0
+      ? roleAssignments
+      : buildRecommendedRoleAssignments(prerequisites, selectedModelSpec)
+
+  return (
+    <div className="nous-wizard__stack">
+      <section className="nous-wizard__hero">
+        <div className="nous-wizard__status nous-wizard__status--complete">
+          <span className="nous-wizard__status-dot" />
+          <span>Configuration saved</span>
+        </div>
+        <h1 className="nous-wizard__title">Your desktop runtime is ready.</h1>
+        <p className="nous-wizard__subtitle">
+          The backend state machine is complete, the local provider is configured,
+          and role assignments are stored. Finish the wizard to open the main
+          desktop workspace.
+        </p>
+      </section>
+
+      <div className="nous-wizard__grid">
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Runtime summary</h2>
+
+          <div className="nous-wizard__summary-list">
+            <div className="nous-wizard__summary-item">
+              <span>Hardware profile</span>
+              <span>{prerequisites?.recommendations.profileName ?? 'Unknown'}</span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Selected model</span>
+              <span>
+                {selectedModelSpec
+                  ? getModelDisplayName(selectedModelSpec, prerequisites)
+                  : 'Not recorded'}
+              </span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Ollama</span>
+              <span>
+                {ollamaStatus ? formatLifecycleState(ollamaStatus.state) : 'Unknown'}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Role assignments</h2>
+
+          <div className="nous-wizard__summary-list">
+            {MODEL_ROLES.map((role) => (
+              <div key={role} className="nous-wizard__summary-item">
+                <span>{formatRoleLabel(role)}</span>
+                <span>
+                  {effectiveAssignments[role]
+                    ? getModelDisplayName(effectiveAssignments[role] ?? '', prerequisites)
+                    : 'Not assigned'}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <div className="nous-wizard__button-row">
+        <button
+          type="button"
+          className="nous-wizard__button nous-wizard__button--primary"
+          onClick={onFinish}
+        >
+          Open workspace
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepIndicator.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepIndicator.tsx
@@ -1,0 +1,41 @@
+import type { WizardStepDefinition, WizardStepId } from './types'
+
+interface WizardStepIndicatorProps {
+  steps: WizardStepDefinition[]
+  currentStepId: WizardStepId
+}
+
+export function WizardStepIndicator({
+  steps,
+  currentStepId,
+}: WizardStepIndicatorProps) {
+  const currentIndex = steps.findIndex((step) => step.id === currentStepId)
+
+  return (
+    <nav className="nous-wizard__stepper" aria-label="First-run wizard steps">
+      {steps.map((step, index) => {
+        const isCurrent = step.id === currentStepId
+        const isComplete = currentIndex > index
+        const itemClassName = [
+          'nous-wizard__stepper-item',
+          isCurrent ? 'nous-wizard__stepper-item--current' : '',
+          isComplete ? 'nous-wizard__stepper-item--complete' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')
+
+        return (
+          <div key={step.id} className={itemClassName}>
+            <span className="nous-wizard__stepper-index">
+              {isComplete ? '✓' : index + 1}
+            </span>
+            <span className="nous-wizard__stepper-label">{step.label}</span>
+            <span className="nous-wizard__stepper-caption">
+              {step.backendStep ?? 'UI-only'}
+            </span>
+          </div>
+        )
+      })}
+    </nav>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepModelDownload.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepModelDownload.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { DownloadProgressPanel } from '../DownloadProgressPanel'
+import {
+  buildWizardModelOptions,
+  getRecommendedModelSpec,
+  parseModelSpec,
+  toOllamaModelSpec,
+  type WizardStepProps,
+} from './types'
+
+export interface WizardStepModelDownloadProps extends WizardStepProps {
+  selectedModelSpec: string | null
+  setSelectedModelSpec: (value: string | null) => void
+}
+
+function formatRamRequiredLabel(memoryMB: number): string {
+  if (memoryMB <= 0) {
+    return 'No local RAM estimate'
+  }
+
+  return `${Math.max(1, Math.round(memoryMB / 1024))} GB recommended`
+}
+
+export function WizardStepModelDownload({
+  state,
+  prerequisites,
+  selectedModelSpec,
+  setSelectedModelSpec,
+  actionInProgress,
+  setActionError,
+  setActionInProgress,
+  onStepComplete,
+}: WizardStepModelDownloadProps) {
+  const [customModelId, setCustomModelId] = useState('')
+  const [downloadRequested, setDownloadRequested] = useState(false)
+  const [localError, setLocalError] = useState<string | null>(null)
+  const finalizeRef = useRef(false)
+  const recommendedModelSpec = getRecommendedModelSpec(prerequisites)
+  const options = useMemo(
+    () => buildWizardModelOptions(prerequisites, selectedModelSpec ?? recommendedModelSpec),
+    [prerequisites, recommendedModelSpec, selectedModelSpec],
+  )
+
+  const resolvedModelSpec = selectedModelSpec ?? recommendedModelSpec
+  const parsedModel = resolvedModelSpec ? parseModelSpec(resolvedModelSpec) : null
+  const selectedOption = options.find((option) => option.modelSpec === resolvedModelSpec)
+  const canDownload =
+    Boolean(parsedModel?.modelId) && parsedModel?.provider === 'ollama'
+  const modelAlreadyDownloaded = state.steps.model_download.status === 'complete'
+  const providerNeedsConfiguration =
+    state.steps.model_download.status === 'complete' &&
+    state.steps.provider_config.status !== 'complete'
+
+  useEffect(() => {
+    if (!selectedModelSpec && recommendedModelSpec) {
+      setSelectedModelSpec(recommendedModelSpec)
+    }
+  }, [recommendedModelSpec, selectedModelSpec, setSelectedModelSpec])
+
+  useEffect(() => {
+    setCustomModelId(parsedModel?.modelId ?? '')
+  }, [parsedModel?.modelId])
+
+  const persistDownloadedModel = async (skipDownloadStep = false) => {
+    if (!resolvedModelSpec || !parsedModel) {
+      return
+    }
+
+    if (finalizeRef.current) {
+      return
+    }
+
+    finalizeRef.current = true
+    setActionInProgress(true)
+    setActionError(null)
+    setLocalError(null)
+
+    try {
+      if (!skipDownloadStep) {
+        const downloadResult = await window.electronAPI.firstRun.downloadModel(
+          parsedModel.modelId,
+        )
+        if (!downloadResult.success) {
+          throw new Error(downloadResult.error ?? 'The backend could not mark the model as downloaded.')
+        }
+      }
+
+      const providerResult = await window.electronAPI.firstRun.configureProvider(
+        resolvedModelSpec,
+      )
+      if (!providerResult.success) {
+        throw new Error(providerResult.error ?? 'The backend could not configure the selected model.')
+      }
+
+      onStepComplete(providerResult.state)
+    } catch (error) {
+      finalizeRef.current = false
+      const message = error instanceof Error ? error.message : String(error)
+      setLocalError(message)
+      setActionError(message)
+      setActionInProgress(false)
+    }
+  }
+
+  const handleDownload = async () => {
+    if (!parsedModel || parsedModel.provider !== 'ollama') {
+      setActionError('Choose an Ollama model before starting the download.')
+      return
+    }
+
+    finalizeRef.current = false
+    setActionError(null)
+    setLocalError(null)
+    setDownloadRequested(true)
+    setActionInProgress(true)
+
+    try {
+      await window.electronAPI.ollama.pullModel(parsedModel.modelId)
+    } catch (error) {
+      finalizeRef.current = false
+      const message = error instanceof Error ? error.message : String(error)
+      setLocalError(message)
+      setActionError(message)
+      setDownloadRequested(false)
+      setActionInProgress(false)
+    }
+  }
+
+  return (
+    <div className="nous-wizard__stack">
+      <section className="nous-wizard__hero">
+        <div className="nous-wizard__eyebrow">Model recommendation</div>
+        <h1 className="nous-wizard__title">Download the local model that fits this machine.</h1>
+        <p className="nous-wizard__subtitle">
+          The recommendation engine has already picked a starting point from your
+          hardware profile. You can keep the default, switch to a recommended
+          alternative, or type a custom Ollama model id.
+        </p>
+      </section>
+
+      <div className="nous-wizard__grid">
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Recommended models</h2>
+          <p className="nous-wizard__section-copy">
+            {prerequisites?.recommendations.advisory ?? 'Loading recommendations…'}
+          </p>
+
+          <div className="nous-wizard__option-list">
+            {options.map((option) => {
+              const isSelected = option.modelSpec === resolvedModelSpec
+              return (
+                <button
+                  key={option.modelSpec}
+                  type="button"
+                  className={`nous-wizard__option ${isSelected ? 'nous-wizard__option--selected' : ''}`}
+                  onClick={() => setSelectedModelSpec(option.modelSpec)}
+                >
+                  <div className="nous-wizard__option-title">{option.displayName}</div>
+                  <div className="nous-wizard__option-copy">{option.reason}</div>
+                  <div className="nous-wizard__option-meta">
+                    {option.modelSpec} · {formatRamRequiredLabel(option.ramRequiredMB)}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Selected download</h2>
+          <p className="nous-wizard__section-copy">
+            Ollama downloads use the raw model id. The wizard keeps the full
+            provider spec separately so the next step can register it as the
+            desktop default provider.
+          </p>
+
+          <label className="nous-wizard__label">
+            <span>Custom Ollama model id</span>
+            <input
+              className="nous-wizard__input"
+              value={customModelId}
+              onChange={(event) => {
+                const nextModelId = event.target.value
+                setCustomModelId(nextModelId)
+                const trimmed = nextModelId.trim()
+                setSelectedModelSpec(trimmed ? toOllamaModelSpec(trimmed) : null)
+              }}
+              placeholder="qwen2.5:7b"
+            />
+          </label>
+
+          <div className="nous-wizard__summary-list">
+            <div className="nous-wizard__summary-item">
+              <span>Provider spec</span>
+              <span>{resolvedModelSpec ?? 'Choose a model to continue'}</span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Download source</span>
+              <span>{parsedModel?.provider ?? 'Unknown'}</span>
+            </div>
+          </div>
+
+          {parsedModel && parsedModel.provider !== 'ollama' ? (
+            <div className="nous-wizard__alert" role="alert">
+              This first-run flow downloads Ollama models only. Choose an Ollama
+              recommendation or type an Ollama model id to continue.
+            </div>
+          ) : null}
+
+          {localError ? (
+            <div className="nous-wizard__alert" role="alert">
+              {localError}
+            </div>
+          ) : null}
+
+          {modelAlreadyDownloaded ? (
+            <div className="nous-wizard__status nous-wizard__status--complete">
+              <span className="nous-wizard__status-dot" />
+              <span>
+                {providerNeedsConfiguration
+                  ? 'Model download is already complete. Finish provider configuration to continue.'
+                  : 'This model is already downloaded and configured.'}
+              </span>
+            </div>
+          ) : null}
+
+          {!modelAlreadyDownloaded && downloadRequested && parsedModel ? (
+            <DownloadProgressPanel
+              modelId={parsedModel.modelId}
+              modelDisplayName={selectedOption?.displayName}
+              onComplete={() => {
+                void persistDownloadedModel(false)
+              }}
+              onError={(message) => {
+                finalizeRef.current = false
+                setLocalError(message)
+                setActionError(message)
+                setActionInProgress(false)
+              }}
+              onCancel={() => {
+                console.log('[nous:wizard] Download panel unmounted before completion')
+              }}
+            />
+          ) : null}
+
+          <div className="nous-wizard__button-row">
+            {providerNeedsConfiguration ? (
+              <button
+                type="button"
+                className="nous-wizard__button nous-wizard__button--primary"
+                onClick={() => {
+                  void persistDownloadedModel(true)
+                }}
+                disabled={actionInProgress || !resolvedModelSpec}
+              >
+                {actionInProgress ? 'Saving…' : 'Use downloaded model'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="nous-wizard__button nous-wizard__button--primary"
+                onClick={() => {
+                  void handleDownload()
+                }}
+                disabled={actionInProgress || !canDownload || modelAlreadyDownloaded}
+              >
+                {actionInProgress ? 'Working…' : 'Download model'}
+              </button>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepOllamaSetup.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepOllamaSetup.tsx
@@ -1,0 +1,200 @@
+import {
+  formatLifecycleState,
+  type OllamaStatus,
+  type WizardStepProps,
+} from './types'
+
+export interface WizardStepOllamaSetupProps extends WizardStepProps {
+  ollamaStatus: OllamaStatus | null
+  refreshOllamaStatus: () => Promise<void>
+}
+
+function getStatusTone(state: OllamaStatus['state'] | null): string {
+  switch (state) {
+    case 'running':
+      return 'nous-wizard__status nous-wizard__status--running'
+    case 'starting':
+    case 'stopping':
+      return 'nous-wizard__status nous-wizard__status--action'
+    case 'error':
+      return 'nous-wizard__status nous-wizard__status--error'
+    default:
+      return 'nous-wizard__status nous-wizard__status--warning'
+  }
+}
+
+export function WizardStepOllamaSetup({
+  ollamaStatus,
+  actionInProgress,
+  setActionError,
+  setActionInProgress,
+  onStepComplete,
+  refreshOllamaStatus,
+}: WizardStepOllamaSetupProps) {
+  const state = ollamaStatus?.state ?? null
+  const canContinue = state === 'running'
+
+  const handleRefresh = async () => {
+    setActionError(null)
+    setActionInProgress(true)
+    try {
+      await refreshOllamaStatus()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setActionError(message)
+    } finally {
+      setActionInProgress(false)
+    }
+  }
+
+  const handleStart = async () => {
+    setActionError(null)
+    setActionInProgress(true)
+    try {
+      const result = await window.electronAPI.ollama.start()
+      if (!result.success) {
+        throw new Error(result.error ?? 'Ollama did not report a successful start.')
+      }
+
+      await refreshOllamaStatus()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setActionError(message)
+    } finally {
+      setActionInProgress(false)
+    }
+  }
+
+  const handleContinue = async () => {
+    if (!canContinue) {
+      return
+    }
+
+    setActionError(null)
+    setActionInProgress(true)
+    try {
+      const nextState = await window.electronAPI.firstRun.completeStep('ollama_check')
+      onStepComplete(nextState)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setActionError(message)
+      setActionInProgress(false)
+    }
+  }
+
+  let description = 'Checking whether Ollama is available on this desktop…'
+  if (state === 'not_installed') {
+    description =
+      'Ollama is not installed yet. Download it first, then return here and re-check the status.'
+  } else if (state === 'installed_stopped') {
+    description =
+      'Ollama is installed, but the local runtime is not running yet. Start it here, or launch it manually.'
+  } else if (state === 'starting') {
+    description = 'Ollama is starting. Leave this step open while the runtime comes online.'
+  } else if (state === 'running') {
+    description = 'Ollama is ready. You can move to model download whenever you are ready.'
+  } else if (state === 'error') {
+    description =
+      'Ollama reported an error. Re-check the status after fixing the local runtime.'
+  }
+
+  return (
+    <div className="nous-wizard__stack">
+      <section className="nous-wizard__hero">
+        <div className={getStatusTone(state)}>
+          <span className="nous-wizard__status-dot" />
+          <span>{formatLifecycleState(ollamaStatus?.state ?? 'not_installed')}</span>
+        </div>
+        <h1 className="nous-wizard__title">Make sure Ollama is installed and running.</h1>
+        <p className="nous-wizard__subtitle">{description}</p>
+      </section>
+
+      <div className="nous-wizard__grid">
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Current status</h2>
+          <p className="nous-wizard__section-copy">
+            This step stays reactive while you install or start Ollama outside the
+            app. The status below updates through the preload subscription.
+          </p>
+
+          <div className="nous-wizard__meta-list">
+            <div className="nous-wizard__meta-item">
+              <span className="nous-wizard__meta-label">State</span>
+              <span className="nous-wizard__meta-value">
+                {ollamaStatus ? formatLifecycleState(ollamaStatus.state) : 'Loading…'}
+              </span>
+            </div>
+            <div className="nous-wizard__meta-item">
+              <span className="nous-wizard__meta-label">Installed</span>
+              <span className="nous-wizard__meta-value">
+                {ollamaStatus?.installed ? 'Yes' : 'Not yet'}
+              </span>
+            </div>
+            <div className="nous-wizard__meta-item">
+              <span className="nous-wizard__meta-label">Running</span>
+              <span className="nous-wizard__meta-value">
+                {ollamaStatus?.running ? 'Yes' : 'No'}
+              </span>
+            </div>
+          </div>
+
+          {ollamaStatus?.error ? (
+            <div className="nous-wizard__alert" role="alert">
+              {ollamaStatus.error}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">What to do next</h2>
+          <p className="nous-wizard__section-copy">
+            Download Ollama if you do not have it yet, or start the runtime and
+            wait for this step to show a running state.
+          </p>
+
+          <div className="nous-wizard__button-row">
+            {state === 'not_installed' ? (
+              <a
+                className="nous-wizard__button nous-wizard__button--primary"
+                href="https://ollama.com/download"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Download Ollama
+              </a>
+            ) : null}
+
+            {state === 'installed_stopped' ? (
+              <button
+                type="button"
+                className="nous-wizard__button nous-wizard__button--primary"
+                onClick={handleStart}
+                disabled={actionInProgress}
+              >
+                {actionInProgress ? 'Starting…' : 'Start Ollama'}
+              </button>
+            ) : null}
+
+            <button
+              type="button"
+              className="nous-wizard__button nous-wizard__button--secondary"
+              onClick={handleRefresh}
+              disabled={actionInProgress}
+            >
+              Check again
+            </button>
+
+            <button
+              type="button"
+              className="nous-wizard__button nous-wizard__button--primary"
+              onClick={handleContinue}
+              disabled={!canContinue || actionInProgress}
+            >
+              Continue
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepRoleAssignment.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepRoleAssignment.tsx
@@ -1,0 +1,244 @@
+import { useEffect } from 'react'
+import {
+  MODEL_ROLES,
+  buildRecommendedRoleAssignments,
+  buildWizardModelOptions,
+  formatRoleLabel,
+  getModelDisplayName,
+  type RoleAssignments,
+  type WizardStepProps,
+} from './types'
+
+type RoleAssignmentMode = 'default' | 'advanced'
+
+export interface WizardStepRoleAssignmentProps extends WizardStepProps {
+  selectedModelSpec: string | null
+  roleAssignments: RoleAssignments
+  setRoleAssignments: (value: RoleAssignments) => void
+  roleAssignmentMode: RoleAssignmentMode
+  setRoleAssignmentMode: (value: RoleAssignmentMode) => void
+}
+
+export function WizardStepRoleAssignment({
+  prerequisites,
+  selectedModelSpec,
+  roleAssignments,
+  setRoleAssignments,
+  roleAssignmentMode,
+  setRoleAssignmentMode,
+  actionInProgress,
+  setActionError,
+  setActionInProgress,
+  onStepComplete,
+}: WizardStepRoleAssignmentProps) {
+  const defaultAssignments = buildRecommendedRoleAssignments(
+    prerequisites,
+    selectedModelSpec,
+  )
+  const effectiveAssignments =
+    Object.keys(roleAssignments).length > 0 ? roleAssignments : defaultAssignments
+  const options = buildWizardModelOptions(prerequisites, selectedModelSpec)
+
+  useEffect(() => {
+    if (selectedModelSpec && Object.keys(roleAssignments).length === 0) {
+      setRoleAssignments(defaultAssignments)
+    }
+  }, [defaultAssignments, roleAssignments, selectedModelSpec, setRoleAssignments])
+
+  const missingAssignments = MODEL_ROLES.filter((role) => {
+    if (roleAssignmentMode === 'default') {
+      return !selectedModelSpec
+    }
+
+    return !effectiveAssignments[role]
+  })
+
+  const handleContinue = async () => {
+    if (!selectedModelSpec) {
+      setActionError('Choose and configure a model before assigning roles.')
+      return
+    }
+
+    const nextAssignments: RoleAssignments =
+      roleAssignmentMode === 'default'
+        ? MODEL_ROLES.reduce<RoleAssignments>((result, role) => {
+            result[role] = selectedModelSpec
+            return result
+          }, {})
+        : MODEL_ROLES.reduce<RoleAssignments>((result, role) => {
+            const modelSpec = effectiveAssignments[role]
+            if (modelSpec) {
+              result[role] = modelSpec
+            }
+            return result
+          }, {})
+
+    if (MODEL_ROLES.some((role) => !nextAssignments[role])) {
+      setActionError('Assign a model to every role before continuing.')
+      return
+    }
+
+    setActionError(null)
+    setActionInProgress(true)
+    try {
+      const assignments = MODEL_ROLES.map((role) => ({
+        role,
+        modelSpec: nextAssignments[role] ?? selectedModelSpec,
+      }))
+      const result = await window.electronAPI.firstRun.assignRoles(assignments)
+      if (!result.success) {
+        throw new Error(result.error ?? 'Role assignment did not complete successfully.')
+      }
+
+      setRoleAssignments(nextAssignments)
+      onStepComplete(result.state)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setActionError(message)
+      setActionInProgress(false)
+    }
+  }
+
+  return (
+    <div className="nous-wizard__stack">
+      <section className="nous-wizard__hero">
+        <div className="nous-wizard__eyebrow">Role assignment</div>
+        <h1 className="nous-wizard__title">Decide how Nous should use your local model.</h1>
+        <p className="nous-wizard__subtitle">
+          Simple mode assigns one downloaded model to all seven roles. Advanced
+          mode lets you override individual roles using the recommendations from
+          your detected hardware profile.
+        </p>
+      </section>
+
+      <div className="nous-wizard__grid">
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Assignment mode</h2>
+          <p className="nous-wizard__section-copy">
+            The shared default right now is{' '}
+            {selectedModelSpec
+              ? getModelDisplayName(selectedModelSpec, prerequisites)
+              : 'not selected yet'}
+            .
+          </p>
+
+          <div className="nous-wizard__button-row">
+            <button
+              type="button"
+              className={`nous-wizard__button ${
+                roleAssignmentMode === 'default'
+                  ? 'nous-wizard__button--primary'
+                  : 'nous-wizard__button--secondary'
+              }`}
+              onClick={() => setRoleAssignmentMode('default')}
+            >
+              Simple mode
+            </button>
+            <button
+              type="button"
+              className={`nous-wizard__button ${
+                roleAssignmentMode === 'advanced'
+                  ? 'nous-wizard__button--primary'
+                  : 'nous-wizard__button--secondary'
+              }`}
+              onClick={() => setRoleAssignmentMode('advanced')}
+            >
+              Advanced mode
+            </button>
+          </div>
+
+          {roleAssignmentMode === 'default' ? (
+            <div className="nous-wizard__summary-list">
+              {MODEL_ROLES.map((role) => (
+                <div key={role} className="nous-wizard__summary-item">
+                  <span>{formatRoleLabel(role)}</span>
+                  <span>
+                    {selectedModelSpec
+                      ? getModelDisplayName(selectedModelSpec, prerequisites)
+                      : 'Pending model selection'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="nous-wizard__stack">
+              {MODEL_ROLES.map((role) => {
+                const recommendation = prerequisites?.recommendations.multiModel.find(
+                  (item) => item.role === role,
+                )
+
+                return (
+                  <label key={role} className="nous-wizard__label">
+                    <span>{formatRoleLabel(role)}</span>
+                    <select
+                      className="nous-wizard__select"
+                      aria-label={formatRoleLabel(role)}
+                      value={effectiveAssignments[role] ?? ''}
+                      onChange={(event) => {
+                        setRoleAssignments({
+                          ...effectiveAssignments,
+                          [role]: event.target.value || undefined,
+                        })
+                      }}
+                    >
+                      <option value="">Select a model</option>
+                      {options.map((option) => (
+                        <option key={`${role}-${option.modelSpec}`} value={option.modelSpec}>
+                          {option.displayName}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="nous-wizard__hint">
+                      {recommendation?.recommendation.reason ??
+                        'Falls back to the single-model recommendation.'}
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Configuration summary</h2>
+          <p className="nous-wizard__section-copy">
+            Review the assignments that will be written through the first-run IPC
+            route before the wizard transitions to confirmation.
+          </p>
+
+          <div className="nous-wizard__summary-list">
+            <div className="nous-wizard__summary-item">
+              <span>Mode</span>
+              <span>{roleAssignmentMode === 'default' ? 'Simple' : 'Advanced'}</span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Configured roles</span>
+              <span>{MODEL_ROLES.length - missingAssignments.length} / {MODEL_ROLES.length}</span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Fallback model</span>
+              <span>
+                {selectedModelSpec
+                  ? getModelDisplayName(selectedModelSpec, prerequisites)
+                  : 'None selected'}
+              </span>
+            </div>
+          </div>
+
+          <div className="nous-wizard__button-row">
+            <button
+              type="button"
+              className="nous-wizard__button nous-wizard__button--primary"
+              onClick={() => {
+                void handleContinue()
+              }}
+              disabled={actionInProgress || missingAssignments.length > 0}
+            >
+              {actionInProgress ? 'Saving…' : 'Continue'}
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepWelcome.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepWelcome.tsx
@@ -1,0 +1,122 @@
+import {
+  formatLifecycleState,
+  type WizardStepProps,
+} from './types'
+
+export interface WizardStepWelcomeProps extends WizardStepProps {
+  onContinue: () => void
+}
+
+function formatMemoryLabel(memoryMB: number): string {
+  const memoryGB = memoryMB / 1024
+  return `${memoryGB.toFixed(memoryGB >= 10 ? 0 : 1)} GB`
+}
+
+export function WizardStepWelcome({
+  prerequisites,
+  onContinue,
+}: WizardStepWelcomeProps) {
+  const hardware = prerequisites?.hardware
+  const ollama = prerequisites?.ollama
+
+  return (
+    <div className="nous-wizard__stack">
+      <section className="nous-wizard__hero">
+        <div className="nous-wizard__eyebrow">Desktop Self-Hosted Runtime</div>
+        <h1 className="nous-wizard__title">Set up your local runtime in a few guided steps.</h1>
+        <p className="nous-wizard__subtitle">
+          This first-run flow checks your hardware, helps you get Ollama running,
+          downloads a recommended model, and assigns that model to the core Nous
+          roles for this desktop workspace.
+        </p>
+
+        <div className="nous-wizard__button-row">
+          <button
+            type="button"
+            className="nous-wizard__button nous-wizard__button--primary"
+            onClick={onContinue}
+          >
+            Continue setup
+          </button>
+        </div>
+      </section>
+
+      <div className="nous-wizard__grid">
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">System snapshot</h2>
+          <p className="nous-wizard__section-copy">
+            The backend has already collected the basics we need for the wizard.
+            You can keep moving even if Ollama is not installed yet.
+          </p>
+
+          <div className="nous-wizard__meta-list">
+            <div className="nous-wizard__meta-item">
+              <span className="nous-wizard__meta-label">Memory</span>
+              <span className="nous-wizard__meta-value">
+                {hardware ? formatMemoryLabel(hardware.totalMemoryMB) : 'Loading…'}
+              </span>
+            </div>
+            <div className="nous-wizard__meta-item">
+              <span className="nous-wizard__meta-label">CPU</span>
+              <span className="nous-wizard__meta-value">
+                {hardware
+                  ? `${hardware.cpuModel} (${hardware.cpuCores} cores)`
+                  : 'Loading…'}
+              </span>
+            </div>
+            <div className="nous-wizard__meta-item">
+              <span className="nous-wizard__meta-label">GPU</span>
+              <span className="nous-wizard__meta-value">
+                {hardware
+                  ? hardware.gpu.detected
+                    ? `${hardware.gpu.name ?? 'Detected'}${hardware.gpu.vramMB ? ` (${formatMemoryLabel(hardware.gpu.vramMB)})` : ''}`
+                    : 'No dedicated GPU detected'
+                  : 'Loading…'}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className="nous-wizard__card">
+          <h2 className="nous-wizard__section-title">Ollama readiness</h2>
+          <p className="nous-wizard__section-copy">
+            The next step focuses on Ollama, the local model runtime used by this
+            desktop flow.
+          </p>
+
+          <div
+            className={`nous-wizard__status ${
+              ollama?.state === 'running'
+                ? 'nous-wizard__status--running'
+                : ollama
+                  ? 'nous-wizard__status--warning'
+                  : 'nous-wizard__status--action'
+            }`}
+          >
+            <span className="nous-wizard__status-dot" />
+            <span>
+              {ollama ? formatLifecycleState(ollama.state) : 'Checking Ollama status…'}
+            </span>
+          </div>
+
+          <div className="nous-wizard__divider" />
+
+          <div className="nous-wizard__summary-list">
+            <div className="nous-wizard__summary-item">
+              <span>Available models</span>
+              <span>{ollama ? ollama.models.length : 0}</span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Default model</span>
+              <span>{ollama?.defaultModel ?? 'None yet'}</span>
+            </div>
+            <div className="nous-wizard__summary-item">
+              <span>Next action</span>
+              <span>Install or start Ollama</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardSteps.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardSteps.test.tsx
@@ -1,0 +1,310 @@
+import { useState } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createElectronAPIMock,
+  createFirstRunActionResult,
+  createFirstRunState,
+  createPrerequisites,
+} from '../../../test-setup'
+import { WizardStepConfirmation } from '../WizardStepConfirmation'
+import { WizardStepModelDownload } from '../WizardStepModelDownload'
+import { WizardStepOllamaSetup } from '../WizardStepOllamaSetup'
+import { WizardStepRoleAssignment } from '../WizardStepRoleAssignment'
+import { WizardStepWelcome } from '../WizardStepWelcome'
+
+function installMock() {
+  const mock = createElectronAPIMock()
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: mock,
+  })
+  return mock
+}
+
+function createStepProps() {
+  return {
+    state: createFirstRunState(),
+    prerequisites: createPrerequisites(),
+    actionInProgress: false,
+    actionError: null,
+    setActionInProgress: vi.fn(),
+    setActionError: vi.fn(),
+    onStepComplete: vi.fn(),
+  }
+}
+
+describe('Wizard step components', () => {
+  it('renders the welcome step shell', () => {
+    installMock()
+    const props = createStepProps()
+
+    render(<WizardStepWelcome {...props} onContinue={vi.fn()} />)
+
+    expect(
+      screen.getByText('Set up your local runtime in a few guided steps.'),
+    ).toBeInTheDocument()
+  })
+
+  it('displays hardware information in the welcome step', () => {
+    installMock()
+    const props = createStepProps()
+
+    render(<WizardStepWelcome {...props} onContinue={vi.fn()} />)
+
+    expect(screen.getByText('32 GB')).toBeInTheDocument()
+    expect(screen.getByText(/AMD Ryzen 9/)).toBeInTheDocument()
+    expect(screen.getByText(/RTX 4080/)).toBeInTheDocument()
+  })
+
+  it('shows download guidance when Ollama is not installed', () => {
+    installMock()
+    const props = createStepProps()
+
+    render(
+      <WizardStepOllamaSetup
+        {...props}
+        ollamaStatus={{
+          installed: false,
+          running: false,
+          state: 'not_installed',
+          models: [],
+          defaultModel: null,
+        }}
+        refreshOllamaStatus={vi.fn(async () => {})}
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: 'Download Ollama' })).toBeInTheDocument()
+  })
+
+  it('shows a start button when Ollama is installed but stopped', () => {
+    installMock()
+    const props = createStepProps()
+
+    render(
+      <WizardStepOllamaSetup
+        {...props}
+        ollamaStatus={{
+          installed: true,
+          running: false,
+          state: 'installed_stopped',
+          models: [],
+          defaultModel: null,
+        }}
+        refreshOllamaStatus={vi.fn(async () => {})}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Start Ollama' })).toBeInTheDocument()
+  })
+
+  it('marks the Ollama check complete when running and Continue is clicked', async () => {
+    const mock = installMock()
+    const props = createStepProps()
+
+    render(
+      <WizardStepOllamaSetup
+        {...props}
+        ollamaStatus={createPrerequisites().ollama}
+        refreshOllamaStatus={vi.fn(async () => {})}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(mock.firstRun.completeStep).toHaveBeenCalledWith('ollama_check')
+      expect(props.onStepComplete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows the recommended model in the download step', () => {
+    installMock()
+    const props = createStepProps()
+
+    render(
+      <WizardStepModelDownload
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        setSelectedModelSpec={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Qwen 2.5 7B')).toBeInTheDocument()
+    expect(screen.getByText(/Detected a high-spec desktop profile/)).toBeInTheDocument()
+  })
+
+  it('runs the download flow and finalizes provider configuration on success', async () => {
+    const mock = installMock()
+    const props = createStepProps()
+    const nextState = createFirstRunState({
+      currentStep: 'role_assignment',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+        role_assignment: { status: 'pending' },
+      },
+    })
+    mock.firstRun.downloadModel.mockResolvedValue(
+      createFirstRunActionResult(nextState),
+    )
+    mock.firstRun.configureProvider.mockResolvedValue(
+      createFirstRunActionResult(nextState),
+    )
+
+    render(
+      <WizardStepModelDownload
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        setSelectedModelSpec={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download model' }))
+    await waitFor(() => {
+      expect(mock.ollama.pullModel).toHaveBeenCalledWith('qwen2.5:7b')
+    })
+
+    mock.__emitPullProgress({
+      status: 'success',
+      percent: 100,
+      completed: 100,
+      total: 100,
+    })
+
+    await waitFor(() => {
+      expect(mock.firstRun.downloadModel).toHaveBeenCalledWith('qwen2.5:7b')
+      expect(mock.firstRun.configureProvider).toHaveBeenCalledWith('ollama:qwen2.5:7b')
+      expect(props.onStepComplete).toHaveBeenCalledWith(nextState)
+    })
+  })
+
+  it('shows the resume action when the model is already downloaded', () => {
+    installMock()
+    const props = createStepProps()
+    const state = createFirstRunState({
+      currentStep: 'provider_config',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'pending' },
+        role_assignment: { status: 'pending' },
+      },
+    })
+
+    render(
+      <WizardStepModelDownload
+        {...props}
+        state={state}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        setSelectedModelSpec={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Use downloaded model' })).toBeInTheDocument()
+  })
+
+  it('assigns the selected model to all seven roles in simple mode', async () => {
+    const mock = installMock()
+    const props = createStepProps()
+
+    render(
+      <WizardStepRoleAssignment
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        roleAssignments={{}}
+        setRoleAssignments={vi.fn()}
+        roleAssignmentMode="default"
+        setRoleAssignmentMode={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(mock.firstRun.assignRoles).toHaveBeenCalledTimes(1)
+      const assignments = mock.firstRun.assignRoles.mock.calls[0]?.[0] ?? []
+      expect(assignments).toHaveLength(7)
+      expect(assignments.every((entry: { modelSpec: string }) => entry.modelSpec === 'ollama:qwen2.5:7b')).toBe(true)
+    })
+  })
+
+  it('supports switching to advanced mode and editing per-role assignments', async () => {
+    installMock()
+    const props = createStepProps()
+
+    function Harness() {
+      const [roleAssignments, setRoleAssignments] = useState({})
+      const [mode, setMode] = useState<'default' | 'advanced'>('default')
+
+      return (
+        <WizardStepRoleAssignment
+          {...props}
+          selectedModelSpec="ollama:qwen2.5:7b"
+          roleAssignments={roleAssignments}
+          setRoleAssignments={setRoleAssignments}
+          roleAssignmentMode={mode}
+          setRoleAssignmentMode={setMode}
+        />
+      )
+    }
+
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Advanced mode' }))
+    const reasonerSelect = screen.getByLabelText('Reasoner')
+    fireEvent.change(reasonerSelect, {
+      target: { value: 'ollama:qwen2.5:14b' },
+    })
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Reasoner') as HTMLSelectElement).value).toBe(
+        'ollama:qwen2.5:14b',
+      )
+    })
+  })
+
+  it('shows the completion summary after setup', () => {
+    installMock()
+    const props = createStepProps()
+
+    render(
+      <WizardStepConfirmation
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        roleAssignments={{
+          orchestrator: 'ollama:qwen2.5:7b',
+          reasoner: 'ollama:qwen2.5:14b',
+        }}
+        ollamaStatus={createPrerequisites().ollama}
+        onFinish={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Configuration saved')).toBeInTheDocument()
+    expect(screen.getByText('Role assignments')).toBeInTheDocument()
+  })
+
+  it('calls onFinish from the confirmation step', () => {
+    installMock()
+    const props = createStepProps()
+    const onFinish = vi.fn()
+
+    render(
+      <WizardStepConfirmation
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        roleAssignments={{}}
+        ollamaStatus={createPrerequisites().ollama}
+        onFinish={onFinish}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open workspace' }))
+
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/types.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/types.ts
@@ -1,0 +1,222 @@
+type ElectronAPI = Window['electronAPI']
+
+export type FirstRunState = Awaited<ReturnType<ElectronAPI['firstRun']['getWizardState']>>
+export type FirstRunPrerequisites = Awaited<ReturnType<ElectronAPI['firstRun']['checkPrerequisites']>>
+export type FirstRunActionResult = Awaited<ReturnType<ElectronAPI['firstRun']['downloadModel']>>
+export type FirstRunStep = Parameters<ElectronAPI['firstRun']['completeStep']>[0]
+export type FirstRunCurrentStep = FirstRunState['currentStep']
+export type OllamaStatus = Awaited<ReturnType<ElectronAPI['ollama']['getStatus']>>
+export type OllamaLifecycleState = OllamaStatus['state']
+export type OllamaModelPullProgress = Parameters<ElectronAPI['ollama']['onPullProgress']>[0] extends (
+  progress: infer T,
+) => void
+  ? T
+  : never
+export type ModelRole = Parameters<ElectronAPI['firstRun']['assignRoles']>[0][number]['role']
+export type RoleAssignments = Partial<Record<ModelRole, string>>
+export type ModelRecommendation = NonNullable<FirstRunPrerequisites['recommendations']['singleModel']>
+export type RoleModelRecommendation = FirstRunPrerequisites['recommendations']['multiModel'][number]
+
+export type WizardStepId =
+  | 'welcome'
+  | 'ollama-setup'
+  | 'model-download'
+  | 'role-assignment'
+  | 'confirmation'
+
+export type WizardModelOption = {
+  modelId: string
+  modelSpec: string
+  displayName: string
+  reason: string
+  ramRequiredMB: number
+}
+
+export type WizardStepDefinition = {
+  id: WizardStepId
+  label: string
+  backendStep: FirstRunStep | null
+}
+
+export interface WizardStepProps {
+  state: FirstRunState
+  prerequisites: FirstRunPrerequisites | null
+  actionInProgress: boolean
+  actionError: string | null
+  setActionInProgress: (value: boolean) => void
+  setActionError: (value: string | null) => void
+  onStepComplete: (nextState: FirstRunState) => void
+}
+
+export const MODEL_ROLES = [
+  'orchestrator',
+  'reasoner',
+  'tool-advisor',
+  'summarizer',
+  'embedder',
+  'reranker',
+  'vision',
+] as const satisfies readonly ModelRole[]
+
+export const MODEL_ROLE_LABELS: Record<ModelRole, string> = {
+  orchestrator: 'Orchestrator',
+  reasoner: 'Reasoner',
+  'tool-advisor': 'Tool Advisor',
+  summarizer: 'Summarizer',
+  embedder: 'Embedder',
+  reranker: 'Reranker',
+  vision: 'Vision',
+}
+
+export const BACKEND_STEP_TO_WIZARD_STEP: Record<FirstRunCurrentStep, WizardStepId> = {
+  ollama_check: 'ollama-setup',
+  model_download: 'model-download',
+  provider_config: 'model-download',
+  role_assignment: 'role-assignment',
+  complete: 'confirmation',
+}
+
+export const WIZARD_STEPS: WizardStepDefinition[] = [
+  { id: 'welcome', label: 'Welcome', backendStep: null },
+  { id: 'ollama-setup', label: 'Ollama', backendStep: 'ollama_check' },
+  { id: 'model-download', label: 'Model', backendStep: 'model_download' },
+  { id: 'role-assignment', label: 'Roles', backendStep: 'role_assignment' },
+  { id: 'confirmation', label: 'Finish', backendStep: null },
+]
+
+export function parseModelSpec(modelSpec: string): { provider: string; modelId: string } | null {
+  const [provider, ...modelIdParts] = modelSpec.split(':')
+  if (!provider || modelIdParts.length === 0) {
+    return null
+  }
+
+  return {
+    provider,
+    modelId: modelIdParts.join(':'),
+  }
+}
+
+export function toOllamaModelSpec(modelId: string): string {
+  return `ollama:${modelId}`
+}
+
+export function getRecommendedModelSpec(
+  prerequisites: FirstRunPrerequisites | null,
+): string | null {
+  return prerequisites?.recommendations.singleModel?.modelSpec ?? null
+}
+
+export function getModelDisplayName(
+  modelSpec: string,
+  prerequisites: FirstRunPrerequisites | null,
+): string {
+  const recommended = buildWizardModelOptions(prerequisites).find(
+    (option) => option.modelSpec === modelSpec,
+  )
+  if (recommended) {
+    return recommended.displayName
+  }
+
+  const parsed = parseModelSpec(modelSpec)
+  return parsed?.modelId ?? modelSpec
+}
+
+export function buildWizardModelOptions(
+  prerequisites: FirstRunPrerequisites | null,
+  selectedModelSpec?: string | null,
+): WizardModelOption[] {
+  if (!prerequisites) {
+    return selectedModelSpec
+      ? [
+          {
+            modelId: parseModelSpec(selectedModelSpec)?.modelId ?? selectedModelSpec,
+            modelSpec: selectedModelSpec,
+            displayName: parseModelSpec(selectedModelSpec)?.modelId ?? selectedModelSpec,
+            reason: 'Currently selected model.',
+            ramRequiredMB: 0,
+          },
+        ]
+      : []
+  }
+
+  const options = new Map<string, WizardModelOption>()
+  const singleModel = prerequisites.recommendations.singleModel
+  if (singleModel) {
+    options.set(singleModel.modelSpec, {
+      modelId: singleModel.modelId,
+      modelSpec: singleModel.modelSpec,
+      displayName: singleModel.displayName,
+      reason: singleModel.reason,
+      ramRequiredMB: singleModel.ramRequiredMB,
+    })
+  }
+
+  for (const item of prerequisites.recommendations.multiModel) {
+    options.set(item.recommendation.modelSpec, {
+      modelId: item.recommendation.modelId,
+      modelSpec: item.recommendation.modelSpec,
+      displayName: item.recommendation.displayName,
+      reason: item.recommendation.reason,
+      ramRequiredMB: item.recommendation.ramRequiredMB,
+    })
+  }
+
+  if (selectedModelSpec && !options.has(selectedModelSpec)) {
+    const parsed = parseModelSpec(selectedModelSpec)
+    options.set(selectedModelSpec, {
+      modelId: parsed?.modelId ?? selectedModelSpec,
+      modelSpec: selectedModelSpec,
+      displayName: parsed?.modelId ?? selectedModelSpec,
+      reason: 'Currently selected model.',
+      ramRequiredMB: 0,
+    })
+  }
+
+  return [...options.values()]
+}
+
+export function buildRecommendedRoleAssignments(
+  prerequisites: FirstRunPrerequisites | null,
+  fallbackModelSpec: string | null,
+): RoleAssignments {
+  const assignments: RoleAssignments = {}
+
+  if (fallbackModelSpec) {
+    for (const role of MODEL_ROLES) {
+      assignments[role] = fallbackModelSpec
+    }
+  }
+
+  if (!prerequisites) {
+    return assignments
+  }
+
+  for (const item of prerequisites.recommendations.multiModel) {
+    assignments[item.role] = item.recommendation.modelSpec
+  }
+
+  return assignments
+}
+
+export function formatRoleLabel(role: ModelRole): string {
+  return MODEL_ROLE_LABELS[role]
+}
+
+export function formatLifecycleState(state: OllamaLifecycleState): string {
+  switch (state) {
+    case 'not_installed':
+      return 'Not installed'
+    case 'installed_stopped':
+      return 'Installed, not running'
+    case 'starting':
+      return 'Starting'
+    case 'running':
+      return 'Running'
+    case 'stopping':
+      return 'Stopping'
+    case 'error':
+      return 'Error'
+    default:
+      return state
+  }
+}

--- a/self/apps/desktop/src/renderer/src/components/wizard/wizard.css
+++ b/self/apps/desktop/src/renderer/src/components/wizard/wizard.css
@@ -1,0 +1,409 @@
+.nous-wizard {
+  height: 100%;
+  overflow: auto;
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--nous-accent) 18%, transparent), transparent 35%),
+    linear-gradient(180deg, var(--nous-bg), var(--nous-surface));
+}
+
+.nous-wizard__container {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: var(--nous-space-4xl) var(--nous-space-3xl);
+}
+
+.nous-wizard__hero,
+.nous-wizard__card,
+.nous-wizard__stepper {
+  background: color-mix(in srgb, var(--nous-card-bg) 92%, transparent);
+  border: 1px solid var(--nous-card-border);
+  border-radius: var(--nous-card-radius);
+  box-shadow: var(--nous-card-shadow);
+}
+
+.nous-wizard__hero,
+.nous-wizard__card {
+  padding: var(--nous-space-3xl);
+}
+
+.nous-wizard__hero {
+  margin-bottom: var(--nous-space-3xl);
+}
+
+.nous-wizard__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--nous-space-sm);
+  padding: var(--nous-space-xs) var(--nous-space-lg);
+  border: 1px solid var(--nous-badge-border);
+  border-radius: var(--nous-badge-radius);
+  color: var(--nous-badge-fg);
+  background: var(--nous-badge-bg);
+  font-size: var(--nous-font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nous-wizard__title {
+  margin-top: var(--nous-space-2xl);
+  font-size: clamp(26px, 4vw, 38px);
+  line-height: 1.05;
+  font-weight: var(--nous-font-weight-semibold);
+  color: var(--nous-fg);
+}
+
+.nous-wizard__subtitle {
+  margin-top: var(--nous-space-xl);
+  max-width: 68ch;
+  color: var(--nous-fg-muted);
+  font-size: var(--nous-font-size-md);
+  line-height: 1.6;
+}
+
+.nous-wizard__stepper {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--nous-space-md);
+  margin-bottom: var(--nous-space-3xl);
+  padding: var(--nous-space-xl);
+}
+
+.nous-wizard__stepper-item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--nous-space-sm);
+  padding: var(--nous-space-md);
+  border-radius: var(--nous-radius-md);
+}
+
+.nous-wizard__stepper-item::after {
+  content: '';
+  position: absolute;
+  top: 20px;
+  left: calc(100% + var(--nous-space-sm));
+  width: calc(100% - var(--nous-space-md));
+  height: 1px;
+  background: var(--nous-divider);
+}
+
+.nous-wizard__stepper-item:last-child::after {
+  display: none;
+}
+
+.nous-wizard__stepper-item--current {
+  background: color-mix(in srgb, var(--nous-accent) 12%, transparent);
+}
+
+.nous-wizard__stepper-item--complete::after {
+  background: var(--nous-accent);
+}
+
+.nous-wizard__stepper-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--nous-radius-full);
+  background: color-mix(in srgb, var(--nous-bg-input) 70%, transparent);
+  border: 1px solid var(--nous-divider);
+  font-size: var(--nous-font-size-sm);
+  color: var(--nous-fg-muted);
+}
+
+.nous-wizard__stepper-item--current .nous-wizard__stepper-index,
+.nous-wizard__stepper-item--complete .nous-wizard__stepper-index {
+  background: var(--nous-accent);
+  border-color: transparent;
+  color: var(--nous-fg-on-color);
+}
+
+.nous-wizard__stepper-label {
+  color: var(--nous-fg);
+  font-size: var(--nous-font-size-sm);
+  font-weight: var(--nous-font-weight-medium);
+}
+
+.nous-wizard__stepper-caption {
+  color: var(--nous-fg-subtle);
+  font-size: var(--nous-font-size-xs);
+}
+
+.nous-wizard__grid {
+  display: grid;
+  gap: var(--nous-space-2xl);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.nous-wizard__grid--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.nous-wizard__stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nous-space-2xl);
+}
+
+.nous-wizard__section-title {
+  font-size: 20px;
+  line-height: 1.2;
+  font-weight: var(--nous-font-weight-semibold);
+  color: var(--nous-fg);
+}
+
+.nous-wizard__section-copy {
+  margin-top: var(--nous-space-md);
+  color: var(--nous-fg-muted);
+  line-height: 1.6;
+}
+
+.nous-wizard__meta-list {
+  display: grid;
+  gap: var(--nous-space-xl);
+  margin-top: var(--nous-space-2xl);
+}
+
+.nous-wizard__meta-item {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--nous-space-lg);
+  padding-bottom: var(--nous-space-lg);
+  border-bottom: 1px solid var(--nous-divider-subtle);
+}
+
+.nous-wizard__meta-item:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.nous-wizard__meta-label {
+  color: var(--nous-fg-subtle);
+}
+
+.nous-wizard__meta-value {
+  color: var(--nous-fg);
+  text-align: right;
+}
+
+.nous-wizard__status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--nous-space-sm);
+  padding: var(--nous-space-sm) var(--nous-space-lg);
+  border-radius: var(--nous-badge-radius);
+  border: 1px solid var(--nous-badge-border);
+  color: var(--nous-fg-muted);
+  background: color-mix(in srgb, var(--nous-bg-input) 64%, transparent);
+  font-size: var(--nous-font-size-sm);
+}
+
+.nous-wizard__status-dot {
+  width: var(--nous-indicator-size);
+  height: var(--nous-indicator-size);
+  border-radius: var(--nous-radius-full);
+  background: var(--nous-state-idle);
+}
+
+.nous-wizard__status--running .nous-wizard__status-dot,
+.nous-wizard__status--complete .nous-wizard__status-dot {
+  background: var(--nous-state-complete);
+}
+
+.nous-wizard__status--action .nous-wizard__status-dot {
+  background: var(--nous-state-active);
+}
+
+.nous-wizard__status--warning .nous-wizard__status-dot {
+  background: var(--nous-state-waiting);
+}
+
+.nous-wizard__status--error .nous-wizard__status-dot {
+  background: var(--nous-state-blocked);
+}
+
+.nous-wizard__button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--nous-space-lg);
+  margin-top: var(--nous-space-3xl);
+}
+
+.nous-wizard__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--nous-space-sm);
+  min-height: 40px;
+  padding: 0 var(--nous-space-3xl);
+  border-radius: var(--nous-input-radius);
+  border: 1px solid transparent;
+  font-size: var(--nous-font-size-sm);
+  font-weight: var(--nous-font-weight-medium);
+  transition:
+    background var(--nous-duration-fast) var(--nous-ease-in-out),
+    color var(--nous-duration-fast) var(--nous-ease-in-out),
+    border-color var(--nous-duration-fast) var(--nous-ease-in-out),
+    opacity var(--nous-duration-fast) var(--nous-ease-in-out);
+  cursor: pointer;
+}
+
+.nous-wizard__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.nous-wizard__button--primary {
+  background: var(--nous-btn-primary-bg);
+  color: var(--nous-btn-primary-fg);
+}
+
+.nous-wizard__button--primary:hover:not(:disabled) {
+  background: var(--nous-btn-primary-hover);
+}
+
+.nous-wizard__button--secondary {
+  background: var(--nous-btn-secondary-bg);
+  color: var(--nous-btn-secondary-fg);
+  border-color: var(--nous-btn-secondary-border);
+}
+
+.nous-wizard__button--secondary:hover:not(:disabled) {
+  background: var(--nous-btn-hover);
+}
+
+.nous-wizard__button--ghost {
+  background: transparent;
+  color: var(--nous-fg-muted);
+  padding-inline: 0;
+}
+
+.nous-wizard__button--ghost:hover:not(:disabled) {
+  color: var(--nous-fg);
+}
+
+.nous-wizard__input,
+.nous-wizard__select,
+.nous-wizard__textarea {
+  width: 100%;
+  min-height: 40px;
+  padding: 0 var(--nous-space-lg);
+  background: var(--nous-input-bg);
+  color: var(--nous-input-fg);
+  border: 1px solid var(--nous-input-border);
+  border-radius: var(--nous-input-radius);
+  outline: none;
+}
+
+.nous-wizard__textarea {
+  min-height: 88px;
+  padding-block: var(--nous-space-lg);
+  resize: vertical;
+}
+
+.nous-wizard__input:focus,
+.nous-wizard__select:focus,
+.nous-wizard__textarea:focus {
+  border-color: var(--nous-input-border-focus);
+}
+
+.nous-wizard__label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nous-space-sm);
+  color: var(--nous-fg-muted);
+  font-size: var(--nous-font-size-sm);
+}
+
+.nous-wizard__option-list {
+  display: grid;
+  gap: var(--nous-space-lg);
+  margin-top: var(--nous-space-2xl);
+}
+
+.nous-wizard__option {
+  padding: var(--nous-space-xl);
+  border-radius: var(--nous-radius-md);
+  border: 1px solid var(--nous-divider);
+  background: color-mix(in srgb, var(--nous-bg-input) 56%, transparent);
+  cursor: pointer;
+}
+
+.nous-wizard__option--selected {
+  border-color: var(--nous-accent);
+  background: color-mix(in srgb, var(--nous-accent) 14%, transparent);
+}
+
+.nous-wizard__option-title {
+  color: var(--nous-fg);
+  font-weight: var(--nous-font-weight-medium);
+}
+
+.nous-wizard__option-copy {
+  margin-top: var(--nous-space-sm);
+  color: var(--nous-fg-muted);
+  line-height: 1.5;
+}
+
+.nous-wizard__option-meta {
+  margin-top: var(--nous-space-lg);
+  color: var(--nous-fg-subtle);
+  font-size: var(--nous-font-size-xs);
+}
+
+.nous-wizard__alert {
+  margin-bottom: var(--nous-space-2xl);
+  padding: var(--nous-space-lg) var(--nous-space-xl);
+  border-radius: var(--nous-radius-md);
+  border: 1px solid color-mix(in srgb, var(--nous-state-blocked) 32%, transparent);
+  background: color-mix(in srgb, var(--nous-state-blocked) 12%, transparent);
+  color: var(--nous-fg);
+}
+
+.nous-wizard__inline-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--nous-space-md);
+}
+
+.nous-wizard__summary-list {
+  display: grid;
+  gap: var(--nous-space-lg);
+  margin-top: var(--nous-space-2xl);
+}
+
+.nous-wizard__summary-item {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--nous-space-lg);
+  padding: var(--nous-space-lg);
+  border-radius: var(--nous-radius-md);
+  background: color-mix(in srgb, var(--nous-bg-input) 48%, transparent);
+}
+
+.nous-wizard__hint {
+  color: var(--nous-fg-subtle);
+  font-size: var(--nous-font-size-sm);
+}
+
+.nous-wizard__divider {
+  height: 1px;
+  margin: var(--nous-space-2xl) 0;
+  background: var(--nous-divider-subtle);
+}
+
+@media (max-width: 900px) {
+  .nous-wizard__container {
+    padding: var(--nous-space-3xl) var(--nous-space-2xl);
+  }
+
+  .nous-wizard__grid,
+  .nous-wizard__stepper {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .nous-wizard__stepper-item::after {
+    display: none;
+  }
+}

--- a/self/apps/desktop/src/renderer/src/test-setup.ts
+++ b/self/apps/desktop/src/renderer/src/test-setup.ts
@@ -1,0 +1,347 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, vi } from 'vitest'
+
+type ElectronAPI = Window['electronAPI']
+type FirstRunState = Awaited<ReturnType<ElectronAPI['firstRun']['getWizardState']>>
+type FirstRunPrerequisites = Awaited<ReturnType<ElectronAPI['firstRun']['checkPrerequisites']>>
+type FirstRunActionResult = Awaited<ReturnType<ElectronAPI['firstRun']['downloadModel']>>
+type FirstRunRoleAssignmentInput = Parameters<ElectronAPI['firstRun']['assignRoles']>[0]
+type OllamaStatus = Awaited<ReturnType<ElectronAPI['ollama']['getStatus']>>
+type OllamaModelPullProgress = Parameters<ElectronAPI['ollama']['onPullProgress']>[0] extends (
+  progress: infer T,
+) => void
+  ? T
+  : never
+
+export const DEFAULT_OLLAMA_STATUS: OllamaStatus = {
+  installed: true,
+  running: true,
+  state: 'running',
+  models: ['qwen2.5:7b'],
+  defaultModel: 'qwen2.5:7b',
+}
+
+export const DEFAULT_WIZARD_STATE: FirstRunState = {
+  currentStep: 'ollama_check',
+  complete: false,
+  steps: {
+    ollama_check: { status: 'pending' },
+    model_download: { status: 'pending' },
+    provider_config: { status: 'pending' },
+    role_assignment: { status: 'pending' },
+  },
+  lastUpdatedAt: '2026-03-22T00:00:00.000Z',
+}
+
+export const DEFAULT_PREREQUISITES: FirstRunPrerequisites = {
+  ollama: DEFAULT_OLLAMA_STATUS,
+  hardware: {
+    totalMemoryMB: 32768,
+    availableMemoryMB: 24576,
+    cpuCores: 12,
+    cpuModel: 'AMD Ryzen 9',
+    platform: 'win32',
+    arch: 'x64',
+    gpu: {
+      detected: true,
+      name: 'RTX 4080',
+      vramMB: 16384,
+    },
+  },
+  recommendations: {
+    singleModel: {
+      modelId: 'qwen2.5:7b',
+      modelSpec: 'ollama:qwen2.5:7b',
+      displayName: 'Qwen 2.5 7B',
+      ramRequiredMB: 8192,
+      reason: 'Balanced local default for desktop orchestration.',
+    },
+    multiModel: [
+      {
+        role: 'reasoner',
+        recommendation: {
+          modelId: 'qwen2.5:14b',
+          modelSpec: 'ollama:qwen2.5:14b',
+          displayName: 'Qwen 2.5 14B',
+          ramRequiredMB: 16384,
+          reason: 'Use the stronger local model for heavier reasoning.',
+        },
+      },
+      {
+        role: 'vision',
+        recommendation: {
+          modelId: 'llama3.2:3b',
+          modelSpec: 'ollama:llama3.2:3b',
+          displayName: 'Llama 3.2 3B',
+          ramRequiredMB: 4096,
+          reason: 'Lightweight support model for specialist roles.',
+        },
+      },
+    ],
+    hardwareSpec: {
+      totalMemoryMB: 32768,
+      availableMemoryMB: 24576,
+      cpuCores: 12,
+      cpuModel: 'AMD Ryzen 9',
+      platform: 'win32',
+      arch: 'x64',
+      gpu: {
+        detected: true,
+        name: 'RTX 4080',
+        vramMB: 16384,
+      },
+    },
+    profileName: 'local-first',
+    advisory: 'Detected a high-spec desktop profile. Larger local reasoning models are viable.',
+  },
+}
+
+export function createFirstRunState(overrides: Partial<FirstRunState> = {}): FirstRunState {
+  return {
+    ...DEFAULT_WIZARD_STATE,
+    ...overrides,
+    steps: {
+      ...DEFAULT_WIZARD_STATE.steps,
+      ...overrides.steps,
+    },
+  }
+}
+
+export function createFirstRunActionResult(
+  state: FirstRunState,
+  success = true,
+  error?: string,
+): FirstRunActionResult {
+  return {
+    success,
+    state,
+    ...(error ? { error } : {}),
+  }
+}
+
+export function createPrerequisites(
+  overrides: Partial<FirstRunPrerequisites> = {},
+): FirstRunPrerequisites {
+  return {
+    ...DEFAULT_PREREQUISITES,
+    ...overrides,
+    ollama: {
+      ...DEFAULT_PREREQUISITES.ollama,
+      ...overrides.ollama,
+    },
+    hardware: {
+      ...DEFAULT_PREREQUISITES.hardware,
+      ...overrides.hardware,
+      gpu: {
+        ...DEFAULT_PREREQUISITES.hardware.gpu,
+        ...overrides.hardware?.gpu,
+      },
+    },
+    recommendations: {
+      ...DEFAULT_PREREQUISITES.recommendations,
+      ...overrides.recommendations,
+      hardwareSpec: {
+        ...DEFAULT_PREREQUISITES.recommendations.hardwareSpec,
+        ...overrides.recommendations?.hardwareSpec,
+        gpu: {
+          ...DEFAULT_PREREQUISITES.recommendations.hardwareSpec.gpu,
+          ...overrides.recommendations?.hardwareSpec?.gpu,
+        },
+      },
+    },
+  }
+}
+
+export function createElectronAPIMock() {
+  const pullProgressListeners = new Set<(progress: OllamaModelPullProgress) => void>()
+  const ollamaStateListeners = new Set<(status: OllamaStatus) => void>()
+
+  const api = {
+    layout: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+    },
+    fs: {
+      readDir: vi.fn(async () => []),
+      readFile: vi.fn(async () => null),
+    },
+    chat: {
+      send: vi.fn(async () => ({ response: 'ok', traceId: 'trace-1' })),
+      getHistory: vi.fn(async () => []),
+    },
+    usage: {
+      getSnapshot: vi.fn(async () => ({})),
+    },
+    win: {
+      minimize: vi.fn(async () => {}),
+      maximize: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      isMaximized: vi.fn(async () => false),
+      toggleDevTools: vi.fn(async () => {}),
+      toggleFullScreen: vi.fn(async () => {}),
+      isFullScreen: vi.fn(async () => false),
+    },
+    app: {
+      quit: vi.fn(async () => {}),
+      newWindow: vi.fn(async () => {}),
+    },
+    appInstall: {
+      prepare: vi.fn(async () => {
+        throw new Error('Not implemented in renderer tests')
+      }),
+      install: vi.fn(async () => {
+        throw new Error('Not implemented in renderer tests')
+      }),
+    },
+    appSettings: {
+      prepare: vi.fn(async () => {
+        throw new Error('Not implemented in renderer tests')
+      }),
+      save: vi.fn(async () => {
+        throw new Error('Not implemented in renderer tests')
+      }),
+    },
+    appPanels: {
+      list: vi.fn(async () => []),
+    },
+    backend: {
+      getStatus: vi.fn(async () => ({
+        ready: true,
+        port: 4317,
+        trpcUrl: 'http://127.0.0.1:4317/trpc',
+      })),
+      getOllamaStatus: vi.fn(async () => DEFAULT_OLLAMA_STATUS),
+    },
+    ollama: {
+      getStatus: vi.fn(async () => DEFAULT_OLLAMA_STATUS),
+      start: vi.fn(async () => ({ success: true })),
+      stop: vi.fn(async () => ({ success: true })),
+      pullModel: vi.fn(async () => {}),
+      onPullProgress: vi.fn((callback: (progress: OllamaModelPullProgress) => void) => {
+        pullProgressListeners.add(callback)
+        return () => {
+          pullProgressListeners.delete(callback)
+        }
+      }),
+      onStateChange: vi.fn((callback: (status: OllamaStatus) => void) => {
+        ollamaStateListeners.add(callback)
+        return () => {
+          ollamaStateListeners.delete(callback)
+        }
+      }),
+    },
+    hardware: {
+      getSpec: vi.fn(async () => DEFAULT_PREREQUISITES.hardware),
+      getRecommendations: vi.fn(async () => DEFAULT_PREREQUISITES.recommendations),
+    },
+    firstRun: {
+      getWizardState: vi.fn(async () => DEFAULT_WIZARD_STATE),
+      checkPrerequisites: vi.fn(async () => DEFAULT_PREREQUISITES),
+      downloadModel: vi.fn(async () => createFirstRunActionResult(createFirstRunState({
+        currentStep: 'provider_config',
+        steps: {
+          ...DEFAULT_WIZARD_STATE.steps,
+          model_download: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:05:00.000Z',
+          },
+        },
+      }))),
+      configureProvider: vi.fn(async () => createFirstRunActionResult(createFirstRunState({
+        currentStep: 'role_assignment',
+        steps: {
+          ...DEFAULT_WIZARD_STATE.steps,
+          model_download: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:05:00.000Z',
+          },
+          provider_config: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:06:00.000Z',
+          },
+        },
+      }))),
+      assignRoles: vi.fn(async (_assignments: FirstRunRoleAssignmentInput) => createFirstRunActionResult(createFirstRunState({
+        currentStep: 'complete',
+        complete: true,
+        completedAt: '2026-03-22T00:07:00.000Z',
+        steps: {
+          ollama_check: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:04:00.000Z',
+          },
+          model_download: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:05:00.000Z',
+          },
+          provider_config: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:06:00.000Z',
+          },
+          role_assignment: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:07:00.000Z',
+          },
+        },
+      }))),
+      completeStep: vi.fn(async (step) => createFirstRunState({
+        currentStep: step === 'ollama_check' ? 'model_download' : 'complete',
+        complete: step === 'role_assignment',
+        completedAt: step === 'role_assignment' ? '2026-03-22T00:07:00.000Z' : undefined,
+        steps: {
+          ...DEFAULT_WIZARD_STATE.steps,
+          [step]: {
+            status: 'complete',
+            completedAt: '2026-03-22T00:04:00.000Z',
+          },
+        },
+      })),
+      resetWizard: vi.fn(async () => DEFAULT_WIZARD_STATE),
+    },
+  } satisfies ElectronAPI
+
+  return Object.assign(api, {
+    __emitPullProgress: (progress: OllamaModelPullProgress) => {
+      for (const listener of pullProgressListeners) {
+        listener(progress)
+      }
+    },
+    __emitOllamaStateChange: (status: OllamaStatus) => {
+      for (const listener of ollamaStateListeners) {
+        listener(status)
+      }
+    },
+  })
+}
+
+export type ElectronAPIMock = ReturnType<typeof createElectronAPIMock>
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: createElectronAPIMock(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})

--- a/self/apps/desktop/vitest.renderer.config.mts
+++ b/self/apps/desktop/vitest.renderer.config.mts
@@ -1,0 +1,12 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    include: ['src/renderer/src/**/*.test.{ts,tsx}'],
+    setupFiles: ['src/renderer/src/test-setup.ts'],
+    css: true,
+  },
+})


### PR DESCRIPTION
## Summary

- Add multi-step first-run wizard (5 UI steps mapped to 4 backend steps) that gates the main app on first launch
- Add reusable `DownloadProgressPanel` component with real-time Ollama pull progress streaming
- Integrate wizard into `App.tsx` with three-phase rendering (loading/wizard/main) and backend readiness polling
- Add renderer test infrastructure (`@testing-library/react`, jsdom vitest config) with 34 tests across 4 files

**Phase 1.4 of `feat/desktop-self-hosted-runtime` (WR-010)**

## Test plan

- [x] `pnpm --filter @nous/desktop typecheck` passes
- [x] `pnpm --filter @nous/desktop test:renderer` — 34 tests pass
- [x] `pnpm test` — 2147 tests, 356 files, 100% pass
- [x] `pnpm build` — full workspace build succeeds
- [x] `npx oxlint` — 0 new warnings on touched files
- [ ] Behavioral testing (pending — post-merge to dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)