### PR TITLE
feat(desktop): OS-level child process orphan guard (WR-014)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "better-sqlite3",
       "esbuild",
       "electron",
+      "koffi",
       "unrs-resolver"
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       electron-store:
         specifier: ^8.2.0
         version: 8.2.0
+      koffi:
+        specifier: ^2.9.0
+        version: 2.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -5469,6 +5472,9 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  koffi@2.15.2:
+    resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
 
   langium@3.3.1:
     resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
@@ -11032,7 +11038,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -11055,7 +11061,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11070,14 +11076,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11092,7 +11098,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12160,6 +12166,8 @@ snapshots:
       json-buffer: 3.0.1
 
   khroma@2.1.0: {}
+
+  koffi@2.15.2: {}
 
   langium@3.3.1:
     dependencies:

--- a/self/apps/desktop/__tests__/ollama-lifecycle.test.ts
+++ b/self/apps/desktop/__tests__/ollama-lifecycle.test.ts
@@ -11,6 +11,8 @@ const execFileMock = vi.hoisted(() => vi.fn());
 const forkMock = vi.hoisted(() => vi.fn());
 const spawnMock = vi.hoisted(() => vi.fn());
 const fetchMock = vi.hoisted(() => vi.fn());
+const initOrphanGuardMock = vi.hoisted(() => vi.fn());
+const registerChildMock = vi.hoisted(() => vi.fn());
 
 const originalFetch = globalThis.fetch;
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -112,6 +114,11 @@ vi.mock('node:child_process', () => ({
   execFile: execFileMock,
   fork: forkMock,
   spawn: spawnMock,
+}));
+
+vi.mock('../src/main/orphan-guard', () => ({
+  initOrphanGuard: initOrphanGuardMock,
+  registerChild: registerChildMock,
 }));
 
 function setPlatform(platform: NodeJS.Platform): void {
@@ -253,6 +260,8 @@ describe('desktop Ollama lifecycle', () => {
     forkMock.mockReset();
     spawnMock.mockReset();
     fetchMock.mockReset();
+    initOrphanGuardMock.mockReset();
+    registerChildMock.mockReset();
     appMock.whenReady.mockClear();
     appMock.on.mockClear();
     appMock.getPath.mockClear();

--- a/self/apps/desktop/__tests__/orphan-guard.test.ts
+++ b/self/apps/desktop/__tests__/orphan-guard.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requireState = vi.hoisted(() => ({
+  error: null as Error | null,
+}))
+const namedFunctionMocks = vi.hoisted(() => new Map<string, ReturnType<typeof vi.fn>>())
+const loadKoffiMock = vi.hoisted(() => vi.fn())
+const loadMock = vi.hoisted(() => vi.fn())
+const sizeofMock = vi.hoisted(() => vi.fn())
+const structMock = vi.hoisted(() => vi.fn())
+const pointerMock = vi.hoisted(() => vi.fn())
+const opaqueMock = vi.hoisted(() => vi.fn())
+
+function extractFunctionName(definition: string): string {
+  const match = definition.match(/([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
+  if (!match) {
+    throw new Error(`Unable to parse Koffi definition: ${definition}`)
+  }
+
+  return match[1]
+}
+
+function getFunctionMock(name: string): ReturnType<typeof vi.fn> {
+  let fn = namedFunctionMocks.get(name)
+  if (!fn) {
+    fn = vi.fn()
+    namedFunctionMocks.set(name, fn)
+  }
+
+  return fn
+}
+
+const funcFactoryMock = vi.hoisted(() =>
+  vi.fn((definition: string) => getFunctionMock(extractFunctionName(definition))),
+)
+
+vi.mock('../src/main/orphan-guard-koffi', () => ({
+  loadKoffi: loadKoffiMock,
+}))
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+}
+
+function restorePlatform(): void {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, 'platform', originalPlatformDescriptor)
+  }
+}
+
+function resetKoffiMockState(): void {
+  requireState.error = null
+  namedFunctionMocks.clear()
+  loadKoffiMock.mockReset()
+  loadKoffiMock.mockImplementation(() => {
+    if (requireState.error) {
+      throw requireState.error
+    }
+
+    return {
+      load: loadMock,
+      sizeof: sizeofMock,
+      struct: structMock,
+      pointer: pointerMock,
+      opaque: opaqueMock,
+    }
+  })
+  loadMock.mockReset()
+  loadMock.mockReturnValue({ func: funcFactoryMock })
+  sizeofMock.mockReset()
+  sizeofMock.mockReturnValue(144)
+  structMock.mockReset()
+  structMock.mockImplementation((nameOrDef: unknown, maybeDef?: unknown) => ({
+    name: typeof nameOrDef === 'string' ? nameOrDef : undefined,
+    def: maybeDef ?? nameOrDef,
+  }))
+  pointerMock.mockReset()
+  pointerMock.mockImplementation((...args: unknown[]) => ({ kind: 'pointer', args }))
+  opaqueMock.mockReset()
+  opaqueMock.mockImplementation((name?: string | null) => ({ kind: 'opaque', name: name ?? null }))
+  funcFactoryMock.mockClear()
+
+  getFunctionMock('CreateJobObjectW').mockReturnValue({ kind: 'job-handle' })
+  getFunctionMock('SetInformationJobObject').mockReturnValue(1)
+  getFunctionMock('OpenProcess').mockReturnValue({ kind: 'process-handle' })
+  getFunctionMock('AssignProcessToJobObject').mockReturnValue(1)
+  getFunctionMock('CloseHandle').mockReturnValue(1)
+}
+
+async function loadModule(): Promise<typeof import('../src/main/orphan-guard')> {
+  return import('../src/main/orphan-guard')
+}
+
+describe('desktop orphan guard', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    restorePlatform()
+    resetKoffiMockState()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    restorePlatform()
+    vi.restoreAllMocks()
+  })
+
+  it('initOrphanGuard() on Windows calls CreateJobObjectW and SetInformationJobObject', async () => {
+    setPlatform('win32')
+    const { initOrphanGuard } = await loadModule()
+
+    initOrphanGuard()
+
+    expect(loadMock).toHaveBeenCalledWith('kernel32.dll')
+    expect(getFunctionMock('CreateJobObjectW')).toHaveBeenCalledWith(null, null)
+    expect(getFunctionMock('SetInformationJobObject')).toHaveBeenCalledTimes(1)
+
+    const [, infoClass, info, infoSize] = getFunctionMock('SetInformationJobObject').mock.calls[0]
+    expect(infoClass).toBe(9)
+    expect(infoSize).toBe(144)
+    expect(info).toMatchObject({
+      BasicLimitInformation: {
+        LimitFlags: 0x00002000,
+      },
+    })
+  })
+
+  it('initOrphanGuard() on POSIX is a no-op and does not require koffi', async () => {
+    setPlatform('linux')
+    const { initOrphanGuard } = await loadModule()
+
+    initOrphanGuard()
+
+    expect(loadMock).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: POSIX platform, using process groups (no-op)',
+    )
+  })
+
+  it('registerChild(pid) on Windows calls OpenProcess and AssignProcessToJobObject', async () => {
+    setPlatform('win32')
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(1234)
+
+    const jobHandle = getFunctionMock('CreateJobObjectW').mock.results[0]?.value
+    const processHandle = getFunctionMock('OpenProcess').mock.results[0]?.value
+
+    expect(getFunctionMock('OpenProcess')).toHaveBeenCalledWith(0x0101, false, 1234)
+    expect(getFunctionMock('AssignProcessToJobObject')).toHaveBeenCalledWith(jobHandle, processHandle)
+    expect(getFunctionMock('CloseHandle')).toHaveBeenCalledWith(processHandle)
+  })
+
+  it('registerChild(pid) on POSIX is a no-op', async () => {
+    setPlatform('linux')
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(1234)
+
+    expect(getFunctionMock('OpenProcess')).not.toHaveBeenCalled()
+    expect(getFunctionMock('AssignProcessToJobObject')).not.toHaveBeenCalled()
+  })
+
+  it('initOrphanGuard() is idempotent and the second call is a no-op', async () => {
+    setPlatform('win32')
+    const { initOrphanGuard } = await loadModule()
+
+    initOrphanGuard()
+    initOrphanGuard()
+
+    expect(getFunctionMock('CreateJobObjectW')).toHaveBeenCalledTimes(1)
+    expect(getFunctionMock('SetInformationJobObject')).toHaveBeenCalledTimes(1)
+  })
+
+  it('registerChild() before initOrphanGuard() is a silent no-op', async () => {
+    setPlatform('win32')
+    const { registerChild } = await loadModule()
+
+    registerChild(1234)
+
+    expect(getFunctionMock('OpenProcess')).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('registerChild() after failed initOrphanGuard() is a silent no-op', async () => {
+    setPlatform('win32')
+    requireState.error = new Error('cannot find module')
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(1234)
+
+    expect(getFunctionMock('OpenProcess')).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: initialization failed:',
+      expect.any(Error),
+    )
+  })
+
+  it('initOrphanGuard() logs an error when the koffi require fails and does not throw', async () => {
+    setPlatform('win32')
+    requireState.error = new Error('cannot find module')
+    const { initOrphanGuard } = await loadModule()
+
+    expect(() => initOrphanGuard()).not.toThrow()
+    expect(console.error).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: initialization failed:',
+      expect.any(Error),
+    )
+  })
+
+  it('initOrphanGuard() logs an error when CreateJobObjectW returns NULL', async () => {
+    setPlatform('win32')
+    getFunctionMock('CreateJobObjectW').mockReturnValue(null)
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(1234)
+
+    expect(getFunctionMock('SetInformationJobObject')).not.toHaveBeenCalled()
+    expect(getFunctionMock('OpenProcess')).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: initialization failed:',
+      expect.any(Error),
+    )
+  })
+
+  it('initOrphanGuard() cleans up the job handle when SetInformationJobObject fails', async () => {
+    setPlatform('win32')
+    getFunctionMock('SetInformationJobObject').mockReturnValue(0)
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(1234)
+
+    const jobHandle = getFunctionMock('CreateJobObjectW').mock.results[0]?.value
+
+    expect(getFunctionMock('CloseHandle')).toHaveBeenCalledWith(jobHandle)
+    expect(getFunctionMock('OpenProcess')).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: initialization failed:',
+      expect.any(Error),
+    )
+  })
+
+  it('registerChild() logs an error when OpenProcess returns NULL and does not throw', async () => {
+    setPlatform('win32')
+    getFunctionMock('OpenProcess').mockReturnValue(null)
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+
+    expect(() => registerChild(1234)).not.toThrow()
+    expect(getFunctionMock('AssignProcessToJobObject')).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: failed to register child pid=1234:',
+      expect.any(Error),
+    )
+  })
+
+  it('registerChild() closes the process handle when AssignProcessToJobObject fails', async () => {
+    setPlatform('win32')
+    getFunctionMock('AssignProcessToJobObject').mockReturnValue(0)
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(1234)
+
+    const processHandle = getFunctionMock('OpenProcess').mock.results[0]?.value
+
+    expect(getFunctionMock('CloseHandle')).toHaveBeenCalledWith(processHandle)
+    expect(console.error).toHaveBeenCalledWith(
+      '[nous:desktop] orphan-guard: failed to register child pid=1234:',
+      expect.any(Error),
+    )
+  })
+
+  it('registerChild(undefined/null/NaN) returns early without any FFI calls', async () => {
+    setPlatform('win32')
+    const { initOrphanGuard, registerChild } = await loadModule()
+
+    initOrphanGuard()
+    registerChild(undefined as unknown as number)
+    registerChild(null as unknown as number)
+    registerChild(Number.NaN)
+
+    expect(getFunctionMock('OpenProcess')).not.toHaveBeenCalled()
+    expect(getFunctionMock('AssignProcessToJobObject')).not.toHaveBeenCalled()
+  })
+})

--- a/self/apps/desktop/__tests__/shutdown.test.ts
+++ b/self/apps/desktop/__tests__/shutdown.test.ts
@@ -24,6 +24,8 @@ const createDefaultFirstRunStateMock = vi.hoisted(() =>
     lastUpdatedAt: '2026-03-22T00:00:00.000Z',
   }))
 )
+const initOrphanGuardMock = vi.hoisted(() => vi.fn())
+const registerChildMock = vi.hoisted(() => vi.fn())
 
 let nextPid = 7000
 
@@ -129,6 +131,11 @@ vi.mock('../../shared-server/src/ollama-detection', () => ({
 
 vi.mock('../../shared-server/src/first-run', () => ({
   createDefaultFirstRunState: createDefaultFirstRunStateMock,
+}))
+
+vi.mock('../src/main/orphan-guard', () => ({
+  initOrphanGuard: initOrphanGuardMock,
+  registerChild: registerChildMock,
 }))
 
 function installDefaultMocks(): void {
@@ -270,6 +277,8 @@ describe('desktop graceful shutdown', () => {
     resolveOllamaBinaryMock.mockReset()
     pullOllamaModelMock.mockReset()
     createDefaultFirstRunStateMock.mockClear()
+    initOrphanGuardMock.mockReset()
+    registerChildMock.mockReset()
 
     installDefaultMocks()
 

--- a/self/apps/desktop/electron.vite.config.ts
+++ b/self/apps/desktop/electron.vite.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
     // No externalizeDepsPlugin — bundle all deps into main process.
     // pnpm's strict node_modules breaks electron-builder's dependency
     // resolution, so the main bundle must be self-contained.
+    build: {
+      rollupOptions: {
+        external: ['koffi'],
+      },
+    },
   },
   preload: {
     plugins: [externalizeDepsPlugin()],

--- a/self/apps/desktop/package.json
+++ b/self/apps/desktop/package.json
@@ -32,6 +32,13 @@
       {
         "from": "../../../node_modules/better-sqlite3/build/Release/better_sqlite3.node",
         "to": "app.asar.unpacked/node_modules/better-sqlite3/build/Release"
+      },
+      {
+        "from": "../../../node_modules/koffi/build/koffi",
+        "to": "node_modules/koffi/build/koffi",
+        "filter": [
+          "win32_*/koffi.node"
+        ]
       }
     ],
     "mac": {
@@ -53,6 +60,7 @@
     "@vscode/codicons": "^0.0.44",
     "dockview-react": "^4.2.0",
     "electron-store": "^8.2.0",
+    "koffi": "^2.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "superjson": "^2.2.2"

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -26,6 +26,7 @@ import type {
   HardwareSpec,
   RecommendationResult,
 } from '../../../shared-server/src/hardware-detection'
+import { initOrphanGuard, registerChild } from './orphan-guard'
 import superjson from 'superjson'
 
 interface StoredLayout {
@@ -417,6 +418,7 @@ async function startOllama(): Promise<OllamaStatus> {
 
     console.log(`[nous:desktop] ollama process started (pid=${child.pid ?? 'n/a'})`)
     ollamaChild = child
+    if (child.pid != null) registerChild(child.pid)
     isOllamaManaged = true
     ollamaSuppressRestartOnExit = false
     attachOllamaProcessListeners(child)
@@ -608,6 +610,7 @@ function spawnBackendServer(port: number): Promise<number> {
     }
 
     backendChild = child
+    if (child.pid != null) registerChild(child.pid)
 
     const timeout = setTimeout(() => {
       reject(new Error('Backend server did not signal readiness within 30 seconds'))
@@ -1707,6 +1710,8 @@ app.on('before-quit', (event) => {
 })
 
 app.whenReady().then(async () => {
+  initOrphanGuard()
+
   // Start the backend server before creating the window
   try {
     await startBackend()

--- a/self/apps/desktop/src/main/orphan-guard-koffi.ts
+++ b/self/apps/desktop/src/main/orphan-guard-koffi.ts
@@ -1,0 +1,5 @@
+type KoffiModule = typeof import('koffi')
+
+export function loadKoffi(): KoffiModule {
+  return require('koffi') as KoffiModule
+}

--- a/self/apps/desktop/src/main/orphan-guard.ts
+++ b/self/apps/desktop/src/main/orphan-guard.ts
@@ -1,0 +1,228 @@
+import { loadKoffi } from './orphan-guard-koffi'
+
+type JobObjectBasicLimitInformation = {
+  PerProcessUserTimeLimit: number
+  PerJobUserTimeLimit: number
+  LimitFlags: number
+  MinimumWorkingSetSize: number
+  MaximumWorkingSetSize: number
+  ActiveProcessLimit: number
+  Affinity: number
+  PriorityClass: number
+  SchedulingClass: number
+}
+
+type IoCounters = {
+  ReadOperationCount: number
+  WriteOperationCount: number
+  OtherOperationCount: number
+  ReadTransferCount: number
+  WriteTransferCount: number
+  OtherTransferCount: number
+}
+
+type JobObjectExtendedLimitInformation = {
+  BasicLimitInformation: JobObjectBasicLimitInformation
+  IoInfo: IoCounters
+  ProcessMemoryLimit: number
+  JobMemoryLimit: number
+  PeakProcessMemoryUsed: number
+  PeakJobMemoryUsed: number
+}
+
+type Win32Bindings = {
+  CreateJobObjectW: (attributes: null, name: null) => unknown
+  SetInformationJobObject: (
+    job: unknown,
+    infoClass: number,
+    info: JobObjectExtendedLimitInformation,
+    infoSize: number,
+  ) => number
+  OpenProcess: (access: number, inheritHandle: boolean, processId: number) => unknown
+  AssignProcessToJobObject: (job: unknown, process: unknown) => number
+  CloseHandle: (handle: unknown) => number
+  infoSize: number
+}
+
+const PROCESS_SET_QUOTA = 0x0100
+const PROCESS_TERMINATE = 0x0001
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
+
+let initialized = false
+let jobHandle: unknown | null = null
+let win32Bindings: Win32Bindings | null = null
+
+function isValidPid(pid: number): boolean {
+  return Number.isInteger(pid) && pid > 0
+}
+
+function isNullHandle(handle: unknown): boolean {
+  return handle == null || handle === 0 || handle === 0n
+}
+
+function createExtendedLimitInformation(): JobObjectExtendedLimitInformation {
+  return {
+    BasicLimitInformation: {
+      PerProcessUserTimeLimit: 0,
+      PerJobUserTimeLimit: 0,
+      LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+      MinimumWorkingSetSize: 0,
+      MaximumWorkingSetSize: 0,
+      ActiveProcessLimit: 0,
+      Affinity: 0,
+      PriorityClass: 0,
+      SchedulingClass: 0,
+    },
+    IoInfo: {
+      ReadOperationCount: 0,
+      WriteOperationCount: 0,
+      OtherOperationCount: 0,
+      ReadTransferCount: 0,
+      WriteTransferCount: 0,
+      OtherTransferCount: 0,
+    },
+    ProcessMemoryLimit: 0,
+    JobMemoryLimit: 0,
+    PeakProcessMemoryUsed: 0,
+    PeakJobMemoryUsed: 0,
+  }
+}
+
+function closeHandleSafely(bindings: Win32Bindings, handle: unknown): void {
+  if (isNullHandle(handle)) {
+    return
+  }
+
+  try {
+    bindings.CloseHandle(handle)
+  } catch {
+    // Best-effort cleanup only. The guard must never fail closed.
+  }
+}
+
+function loadWin32Bindings(): Win32Bindings {
+  const koffi = loadKoffi()
+  koffi.pointer('HANDLE', koffi.opaque())
+  const JOBOBJECT_BASIC_LIMIT_INFORMATION = koffi.struct('JOBOBJECT_BASIC_LIMIT_INFORMATION', {
+    PerProcessUserTimeLimit: 'int64_t',
+    PerJobUserTimeLimit: 'int64_t',
+    LimitFlags: 'uint32_t',
+    MinimumWorkingSetSize: 'uintptr_t',
+    MaximumWorkingSetSize: 'uintptr_t',
+    ActiveProcessLimit: 'uint32_t',
+    Affinity: 'uintptr_t',
+    PriorityClass: 'uint32_t',
+    SchedulingClass: 'uint32_t',
+  })
+  const IO_COUNTERS = koffi.struct('IO_COUNTERS', {
+    ReadOperationCount: 'uint64_t',
+    WriteOperationCount: 'uint64_t',
+    OtherOperationCount: 'uint64_t',
+    ReadTransferCount: 'uint64_t',
+    WriteTransferCount: 'uint64_t',
+    OtherTransferCount: 'uint64_t',
+  })
+  const JOBOBJECT_EXTENDED_LIMIT_INFORMATION = koffi.struct('JOBOBJECT_EXTENDED_LIMIT_INFORMATION', {
+    BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION,
+    IoInfo: IO_COUNTERS,
+    ProcessMemoryLimit: 'uintptr_t',
+    JobMemoryLimit: 'uintptr_t',
+    PeakProcessMemoryUsed: 'uintptr_t',
+    PeakJobMemoryUsed: 'uintptr_t',
+  })
+  const kernel32 = koffi.load('kernel32.dll')
+
+  return {
+    CreateJobObjectW: kernel32.func(
+      'HANDLE __stdcall CreateJobObjectW(void *lpJobAttributes, const char16_t *lpName)',
+    ) as Win32Bindings['CreateJobObjectW'],
+    SetInformationJobObject: kernel32.func(
+      'int __stdcall SetInformationJobObject(HANDLE hJob, int JobObjectInfoClass, _Inout_ JOBOBJECT_EXTENDED_LIMIT_INFORMATION *lpJobObjectInfo, uint32_t cbJobObjectInfoLength)',
+    ) as Win32Bindings['SetInformationJobObject'],
+    OpenProcess: kernel32.func(
+      'HANDLE __stdcall OpenProcess(uint32_t dwDesiredAccess, int bInheritHandle, uint32_t dwProcessId)',
+    ) as unknown as Win32Bindings['OpenProcess'],
+    AssignProcessToJobObject: kernel32.func(
+      'int __stdcall AssignProcessToJobObject(HANDLE hJob, HANDLE hProcess)',
+    ) as Win32Bindings['AssignProcessToJobObject'],
+    CloseHandle: kernel32.func(
+      'int __stdcall CloseHandle(HANDLE hObject)',
+    ) as Win32Bindings['CloseHandle'],
+    infoSize: koffi.sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
+  }
+}
+
+export function initOrphanGuard(): void {
+  if (initialized) {
+    return
+  }
+
+  initialized = true
+
+  if (process.platform !== 'win32') {
+    console.log('[nous:desktop] orphan-guard: POSIX platform, using process groups (no-op)')
+    return
+  }
+
+  try {
+    win32Bindings = loadWin32Bindings()
+
+    const handle = win32Bindings.CreateJobObjectW(null, null)
+    if (isNullHandle(handle)) {
+      throw new Error('CreateJobObjectW returned NULL')
+    }
+
+    const limitInfo = createExtendedLimitInformation()
+    const success = win32Bindings.SetInformationJobObject(
+      handle,
+      JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+      limitInfo,
+      win32Bindings.infoSize,
+    )
+
+    if (!success) {
+      closeHandleSafely(win32Bindings, handle)
+      throw new Error('SetInformationJobObject returned FALSE')
+    }
+
+    jobHandle = handle
+    console.log('[nous:desktop] orphan-guard: Job Object created')
+  } catch (error) {
+    jobHandle = null
+    win32Bindings = null
+    console.error('[nous:desktop] orphan-guard: initialization failed:', error)
+  }
+}
+
+export function registerChild(pid: number): void {
+  if (!isValidPid(pid)) {
+    return
+  }
+
+  if (process.platform !== 'win32' || !jobHandle || !win32Bindings) {
+    return
+  }
+
+  let processHandle: unknown = null
+
+  try {
+    processHandle = win32Bindings.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid)
+    if (isNullHandle(processHandle)) {
+      throw new Error('OpenProcess returned NULL')
+    }
+
+    const success = win32Bindings.AssignProcessToJobObject(jobHandle, processHandle)
+    if (!success) {
+      throw new Error('AssignProcessToJobObject returned FALSE')
+    }
+
+    console.log(`[nous:desktop] orphan-guard: registered child pid=${pid}`)
+  } catch (error) {
+    console.error(`[nous:desktop] orphan-guard: failed to register child pid=${pid}:`, error)
+  } finally {
+    if (win32Bindings && !isNullHandle(processHandle)) {
+      closeHandleSafely(win32Bindings, processHandle)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds OS-level orphan guard ensuring child processes (Ollama, backend) are automatically terminated when the parent Electron process dies abnormally (force-kill, crash, freeze)
- Windows: Win32 Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` via koffi FFI to kernel32.dll
- POSIX: no-op (relies on existing process groups + backend disconnect handler)
- All errors caught — graceful degradation, app continues without protection on failure
- 13 unit tests covering guard init, registration, platform branching, and error handling

## Test plan

- [ ] CI passes (typecheck, lint, test, build)
- [ ] Behavioral testing: force-kill Nous via Task Manager on Windows — verify Ollama and backend are terminated
- [ ] Behavioral testing: normal close (window close, Alt+F4) still works via graceful shutdown path
- [ ] Verify no orphaned ollama.exe in Task Manager after force-kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)