### PR TITLE
fix(desktop): koffi FFI boolean-to-int type mismatch (WR-014 P1.2)

### DIFF
--- a/self/apps/desktop/__tests__/orphan-guard.test.ts
+++ b/self/apps/desktop/__tests__/orphan-guard.test.ts
@@ -152,7 +152,7 @@ describe('desktop orphan guard', () => {
     const jobHandle = getFunctionMock('CreateJobObjectW').mock.results[0]?.value
     const processHandle = getFunctionMock('OpenProcess').mock.results[0]?.value
 
-    expect(getFunctionMock('OpenProcess')).toHaveBeenCalledWith(0x0101, false, 1234)
+    expect(getFunctionMock('OpenProcess')).toHaveBeenCalledWith(0x0101, 0, 1234)
     expect(getFunctionMock('AssignProcessToJobObject')).toHaveBeenCalledWith(jobHandle, processHandle)
     expect(getFunctionMock('CloseHandle')).toHaveBeenCalledWith(processHandle)
   })

--- a/self/apps/desktop/src/main/orphan-guard.ts
+++ b/self/apps/desktop/src/main/orphan-guard.ts
@@ -38,7 +38,7 @@ type Win32Bindings = {
     info: JobObjectExtendedLimitInformation,
     infoSize: number,
   ) => number
-  OpenProcess: (access: number, inheritHandle: boolean, processId: number) => unknown
+  OpenProcess: (access: number, inheritHandle: number, processId: number) => unknown
   AssignProcessToJobObject: (job: unknown, process: unknown) => number
   CloseHandle: (handle: unknown) => number
   infoSize: number
@@ -207,7 +207,7 @@ export function registerChild(pid: number): void {
   let processHandle: unknown = null
 
   try {
-    processHandle = win32Bindings.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid)
+    processHandle = win32Bindings.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid)
     if (isNullHandle(processHandle)) {
       throw new Error('OpenProcess returned NULL')
     }


### PR DESCRIPTION
## Summary

- Fix `TypeError: Unexpected Boolean value, expected number` in orphan guard `registerChild()`
- `OpenProcess` `bInheritHandle`: `false` (boolean) → `0` (int) to match koffi's C `int` type
- TypeScript type corrected, unit test assertion updated
- 3-line fix from behavioral testing Round 1

## Test plan

- [ ] CI passes
- [ ] Behavioral testing Round 2: force-kill → verify children terminated
- [ ] No regressions in graceful shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)