### PR TITLE
feat(shared,web): event bus core + SSE transport [WR-030 Phase 1.1]

### DIFF
--- a/self/apps/web/app/api/events/route.ts
+++ b/self/apps/web/app/api/events/route.ts
@@ -1,0 +1,100 @@
+/**
+ * SSE endpoint for the Nous event bus.
+ *
+ * Streams real-time events to connected clients. Supports channel
+ * filtering via ?channels= query parameter (comma-separated, glob
+ * prefix like "health:*").
+ *
+ * Uses the Node.js runtime (not edge) to support long-lived SSE
+ * connections with standard HTTP streaming.
+ */
+import { createNousContext } from '@/server/bootstrap';
+import { createEventSseHandler } from '@/server/sse';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<Response> {
+  const context = createNousContext();
+  const sseHandler = createEventSseHandler(context.eventBus);
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // Create a mock ServerResponse-like object that writes to the ReadableStream
+      const encoder = new TextEncoder();
+
+      const mockRes = {
+        _headersSent: false,
+        _headers: {} as Record<string, string>,
+        _closed: false,
+
+        writeHead(_statusCode: number, headers?: Record<string, string>) {
+          if (headers) {
+            Object.assign(this._headers, headers);
+          }
+          this._headersSent = true;
+        },
+
+        flushHeaders() {
+          // No-op in ReadableStream mode — headers are set on the Response object
+        },
+
+        write(chunk: string) {
+          if (this._closed) return false;
+          try {
+            controller.enqueue(encoder.encode(chunk));
+            return true;
+          } catch {
+            return false;
+          }
+        },
+
+        on(event: string, handler: () => void) {
+          if (event === 'close') {
+            // Store the close handler so we can call it when the request aborts
+            this._closeHandler = handler;
+          }
+        },
+
+        _closeHandler: null as (() => void) | null,
+      };
+
+      // Parse the URL to pass to the SSE handler
+      const url = new URL(request.url);
+      const mockReq = {
+        url: url.pathname + url.search,
+        headers: {
+          host: url.host,
+        },
+      };
+
+      // Wire up request abort to trigger close cleanup
+      request.signal.addEventListener('abort', () => {
+        mockRes._closed = true;
+        if (mockRes._closeHandler) {
+          mockRes._closeHandler();
+        }
+        try {
+          controller.close();
+        } catch {
+          // Already closed
+        }
+      });
+
+      sseHandler(
+        mockReq as unknown as IncomingMessage,
+        mockRes as unknown as ServerResponse,
+      );
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/self/apps/web/server/__tests__/event-bus/event-bus.test.ts
+++ b/self/apps/web/server/__tests__/event-bus/event-bus.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '../../event-bus/event-bus';
+
+describe('EventBus', () => {
+  // --- Tier 1: Contract Tests ---
+
+  describe('Tier 1 — Contract', () => {
+    it('publish() delivers payload to all channel subscribers', () => {
+      const bus = new EventBus();
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      bus.subscribe('health:boot-step', handler1);
+      bus.subscribe('health:boot-step', handler2);
+
+      const payload = { step: 'db-init', status: 'completed' as const };
+      bus.publish('health:boot-step', payload);
+
+      expect(handler1).toHaveBeenCalledOnce();
+      expect(handler1).toHaveBeenCalledWith(payload);
+      expect(handler2).toHaveBeenCalledOnce();
+      expect(handler2).toHaveBeenCalledWith(payload);
+    });
+
+    it('subscribe() returns a unique subscription ID', () => {
+      const bus = new EventBus();
+      const id1 = bus.subscribe('health:boot-step', () => {});
+      const id2 = bus.subscribe('health:boot-step', () => {});
+
+      expect(id1).toBeTruthy();
+      expect(id2).toBeTruthy();
+      expect(id1).not.toBe(id2);
+    });
+
+    it('unsubscribe() stops delivery to the removed handler', () => {
+      const bus = new EventBus();
+      const handler = vi.fn();
+
+      const id = bus.subscribe('health:boot-step', handler);
+      bus.unsubscribe(id);
+
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('dispose() removes all subscriptions', () => {
+      const bus = new EventBus();
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      bus.subscribe('health:boot-step', handler1);
+      bus.subscribe('mao:projection-changed', handler2);
+
+      bus.dispose();
+
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      bus.publish('mao:projection-changed', {});
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).not.toHaveBeenCalled();
+    });
+
+    it('publish() after dispose() is a silent no-op', () => {
+      const bus = new EventBus();
+      const handler = vi.fn();
+
+      bus.subscribe('health:boot-step', handler);
+      bus.dispose();
+
+      // Should not throw
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Tier 2: Behavior Tests ---
+
+  describe('Tier 2 — Behavior', () => {
+    it('publish() on channel A does not trigger channel B subscribers', () => {
+      const bus = new EventBus();
+      const healthHandler = vi.fn();
+      const maoHandler = vi.fn();
+
+      bus.subscribe('health:boot-step', healthHandler);
+      bus.subscribe('mao:projection-changed', maoHandler);
+
+      bus.publish('health:boot-step', { step: 'db-init', status: 'completed' });
+      expect(healthHandler).toHaveBeenCalledOnce();
+      expect(maoHandler).not.toHaveBeenCalled();
+    });
+
+    it('multiple subscribers on same channel all receive the event', () => {
+      const bus = new EventBus();
+      const handlers = [vi.fn(), vi.fn(), vi.fn()];
+      for (const h of handlers) {
+        bus.subscribe('escalation:new', h);
+      }
+
+      const payload = {
+        escalationId: 'e1',
+        severity: 'high' as const,
+        message: 'test',
+      };
+      bus.publish('escalation:new', payload);
+
+      for (const h of handlers) {
+        expect(h).toHaveBeenCalledOnce();
+        expect(h).toHaveBeenCalledWith(payload);
+      }
+    });
+
+    it('unsubscribe() with unknown ID is a no-op (no error)', () => {
+      const bus = new EventBus();
+      expect(() => bus.unsubscribe('nonexistent-id')).not.toThrow();
+    });
+  });
+
+  // --- Tier 3: Edge Case Tests ---
+
+  describe('Tier 3 — Edge Cases', () => {
+    it('a throwing handler does not prevent other handlers from receiving the event', () => {
+      const bus = new EventBus();
+      const handler1 = vi.fn();
+      const throwingHandler = vi.fn(() => {
+        throw new Error('handler failure');
+      });
+      const handler3 = vi.fn();
+
+      bus.subscribe('health:boot-step', handler1);
+      bus.subscribe('health:boot-step', throwingHandler);
+      bus.subscribe('health:boot-step', handler3);
+
+      const payload = { step: 'x', status: 'started' as const };
+      bus.publish('health:boot-step', payload);
+
+      expect(handler1).toHaveBeenCalledOnce();
+      expect(throwingHandler).toHaveBeenCalledOnce();
+      expect(handler3).toHaveBeenCalledOnce();
+    });
+
+    it('a throwing handler error is logged (not swallowed silently)', () => {
+      const bus = new EventBus();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      bus.subscribe('health:boot-step', () => {
+        throw new Error('test error');
+      });
+
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+
+      expect(consoleSpy).toHaveBeenCalledOnce();
+      expect(consoleSpy.mock.calls[0]![0]).toContain('[nous:event-bus] handler-error');
+      expect(consoleSpy.mock.calls[0]![0]).toContain('health:boot-step');
+      expect(consoleSpy.mock.calls[0]![0]).toContain('test error');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('subscribe() after dispose() returns empty string and does not register', () => {
+      const bus = new EventBus();
+      bus.dispose();
+
+      const handler = vi.fn();
+      const id = bus.subscribe('health:boot-step', handler);
+      expect(id).toBe('');
+
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/self/apps/web/server/__tests__/sse/event-sse-handler.test.ts
+++ b/self/apps/web/server/__tests__/sse/event-sse-handler.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createEventSseHandler } from '../../sse/event-sse-handler';
+import { EventBus } from '../../event-bus/event-bus';
+
+/**
+ * Minimal mock for IncomingMessage.
+ */
+function createMockReq(url: string): IncomingMessage {
+  return {
+    url,
+    headers: { host: 'localhost:3000' },
+  } as unknown as IncomingMessage;
+}
+
+/**
+ * Minimal mock for ServerResponse with event emitter for 'close'.
+ */
+function createMockRes() {
+  const emitter = new EventEmitter();
+  const chunks: string[] = [];
+  let headersWritten = false;
+  let statusCode = 0;
+  let headers: Record<string, string> = {};
+
+  const res = {
+    writeHead(code: number, hdrs?: Record<string, string>) {
+      statusCode = code;
+      if (hdrs) headers = { ...hdrs };
+      headersWritten = true;
+    },
+    flushHeaders() {
+      // no-op
+    },
+    write(chunk: string) {
+      chunks.push(chunk);
+      return true;
+    },
+    on(event: string, handler: (...args: unknown[]) => void) {
+      emitter.on(event, handler);
+    },
+    // Test helpers (not part of ServerResponse)
+    _chunks: chunks,
+    _getStatusCode: () => statusCode,
+    _getHeaders: () => headers,
+    _isHeadWritten: () => headersWritten,
+    _emitClose: () => emitter.emit('close'),
+  };
+
+  return res as unknown as ServerResponse & {
+    _chunks: string[];
+    _getStatusCode: () => number;
+    _getHeaders: () => Record<string, string>;
+    _isHeadWritten: () => boolean;
+    _emitClose: () => void;
+  };
+}
+
+describe('createEventSseHandler', () => {
+  let bus: EventBus;
+
+  beforeEach(() => {
+    bus = new EventBus();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    bus.dispose();
+    vi.useRealTimers();
+  });
+
+  // --- Tier 1: Contract Tests ---
+
+  describe('Tier 1 — Contract', () => {
+    it('sets SSE headers (Content-Type, Cache-Control, Connection)', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      expect(res._isHeadWritten()).toBe(true);
+      expect(res._getStatusCode()).toBe(200);
+      const headers = res._getHeaders();
+      expect(headers['Content-Type']).toBe('text/event-stream');
+      expect(headers['Cache-Control']).toBe('no-cache');
+      expect(headers['Connection']).toBe('keep-alive');
+    });
+
+    it('writes events as SSE frames with event: and data: fields', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events?channels=health:boot-step');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      bus.publish('health:boot-step', { step: 'db-init', status: 'completed' });
+
+      expect(res._chunks.length).toBeGreaterThan(0);
+      const frame = res._chunks.join('');
+      expect(frame).toContain('event: health:boot-step');
+      expect(frame).toContain('data: {"step":"db-init","status":"completed"}');
+    });
+
+    it('sends heartbeat comments on interval', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      // Advance past one heartbeat interval (30s)
+      vi.advanceTimersByTime(30_000);
+
+      const allOutput = res._chunks.join('');
+      expect(allOutput).toContain(': heartbeat\n\n');
+    });
+  });
+
+  // --- Tier 2: Behavior Tests ---
+
+  describe('Tier 2 — Behavior', () => {
+    it('filters events by ?channels= query parameter', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events?channels=health:boot-step');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      // Publish to subscribed channel
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      // Publish to non-subscribed channel
+      bus.publish('mao:projection-changed', {});
+
+      const allOutput = res._chunks.join('');
+      expect(allOutput).toContain('event: health:boot-step');
+      expect(allOutput).not.toContain('event: mao:projection-changed');
+    });
+
+    it('supports glob prefix filtering (health:*)', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events?channels=health:*');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      bus.publish('health:gateway-status', { status: 'booted' });
+      bus.publish('mao:projection-changed', {});
+
+      const allOutput = res._chunks.join('');
+      expect(allOutput).toContain('event: health:boot-step');
+      expect(allOutput).toContain('event: health:gateway-status');
+      expect(allOutput).not.toContain('event: mao:projection-changed');
+    });
+
+    it('subscribes to all channels when no ?channels= is specified', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      bus.publish('mao:projection-changed', {});
+      bus.publish('escalation:new', {
+        escalationId: 'e1',
+        severity: 'high',
+        message: 'test',
+      });
+
+      const allOutput = res._chunks.join('');
+      expect(allOutput).toContain('event: health:boot-step');
+      expect(allOutput).toContain('event: mao:projection-changed');
+      expect(allOutput).toContain('event: escalation:new');
+    });
+
+    it('cleans up subscriptions on res close', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events?channels=health:boot-step');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      // Verify subscription is active
+      bus.publish('health:boot-step', { step: 'x', status: 'started' });
+      expect(res._chunks.length).toBeGreaterThan(0);
+
+      // Clear chunks
+      res._chunks.length = 0;
+
+      // Simulate connection close
+      res._emitClose();
+
+      // Publish after close — should not be received
+      bus.publish('health:boot-step', { step: 'y', status: 'completed' });
+      expect(res._chunks.length).toBe(0);
+    });
+
+    it('clears heartbeat interval on res close', () => {
+      const handler = createEventSseHandler(bus);
+      const req = createMockReq('/events');
+      const res = createMockRes();
+
+      handler(req, res);
+
+      // Simulate connection close
+      res._emitClose();
+
+      // Clear chunks
+      res._chunks.length = 0;
+
+      // Advance timers — heartbeat should not fire
+      vi.advanceTimersByTime(60_000);
+      expect(res._chunks.length).toBe(0);
+    });
+  });
+});

--- a/self/apps/web/server/bootstrap.ts
+++ b/self/apps/web/server/bootstrap.ts
@@ -117,6 +117,7 @@ import {
 import { MemoryAccessPolicyEngine } from '@nous/memory-access';
 import type { NousContext } from './context';
 import type { IDocumentStore, IIngressGateway, IVectorStore } from '@nous/shared';
+import { EventBus } from './event-bus';
 
 const MOCK_PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as ProviderId;
 
@@ -765,6 +766,8 @@ export function createNousContext(): NousContext {
     tunnelForwarder: publicMcpTunnelForwarder,
   });
 
+  const eventBus = new EventBus();
+
   const coreExecutor = new GatewayBackedTurnExecutor({
     modelRouter: router,
     getProvider,
@@ -840,6 +843,7 @@ export function createNousContext(): NousContext {
     publicMcpExecutionBridge,
     appRuntimeService,
     panelTranspiler,
+    eventBus,
     dataDir,
   };
   cachedContext = context;

--- a/self/apps/web/server/context.ts
+++ b/self/apps/web/server/context.ts
@@ -25,6 +25,7 @@ import type {
   IVoiceControlService,
   IPublicMcpGatewayService,
   IAppRuntimeService,
+  IEventBus,
 } from '@nous/shared';
 import type { PanelTranspiler } from '@nous/subcortex-apps';
 import type {
@@ -68,5 +69,6 @@ export interface NousContext {
   publicMcpExecutionBridge: IPublicMcpExecutionBridge;
   appRuntimeService: IAppRuntimeService;
   panelTranspiler: PanelTranspiler;
+  eventBus: IEventBus;
   dataDir: string;
 }

--- a/self/apps/web/server/event-bus/event-bus.ts
+++ b/self/apps/web/server/event-bus/event-bus.ts
@@ -1,0 +1,104 @@
+/**
+ * EventBus — In-process typed event bus implementation.
+ *
+ * Implements IEventBus with:
+ * - Dual-indexed subscription storage (by ID and by channel) for O(1) lookups
+ * - UUID-based subscription IDs via crypto.randomUUID()
+ * - Error isolation: each handler invocation is individually try/caught
+ * - Clean disposal semantics
+ */
+import { randomUUID } from 'node:crypto';
+import type { EventChannelMap, IEventBus } from '@nous/shared';
+
+type Handler<T = unknown> = (payload: T) => void;
+
+interface Subscription {
+  channel: string;
+  handler: Handler;
+}
+
+export class EventBus implements IEventBus {
+  /** Map from subscriptionId (UUID) to Subscription. */
+  private subscriptions = new Map<string, Subscription>();
+
+  /** Map from channel name to Set of subscriptionIds for O(1) fan-out. */
+  private channelIndex = new Map<string, Set<string>>();
+
+  /** Once disposed, publish and subscribe become no-ops. */
+  private disposed = false;
+
+  publish<C extends keyof EventChannelMap>(channel: C, payload: EventChannelMap[C]): void {
+    if (this.disposed) {
+      return;
+    }
+
+    const subscriberIds = this.channelIndex.get(channel as string);
+    if (!subscriberIds || subscriberIds.size === 0) {
+      return;
+    }
+
+    for (const id of subscriberIds) {
+      const subscription = this.subscriptions.get(id);
+      if (!subscription) {
+        continue;
+      }
+      try {
+        subscription.handler(payload);
+      } catch (error) {
+        console.error(
+          `[nous:event-bus] handler-error channel=${String(channel)} subscriptionId=${id} error=${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+  }
+
+  subscribe<C extends keyof EventChannelMap>(
+    channel: C,
+    handler: (payload: EventChannelMap[C]) => void,
+  ): string {
+    if (this.disposed) {
+      return '';
+    }
+
+    const subscriptionId = randomUUID();
+    const channelKey = channel as string;
+
+    this.subscriptions.set(subscriptionId, {
+      channel: channelKey,
+      handler: handler as Handler,
+    });
+
+    let channelSet = this.channelIndex.get(channelKey);
+    if (!channelSet) {
+      channelSet = new Set();
+      this.channelIndex.set(channelKey, channelSet);
+    }
+    channelSet.add(subscriptionId);
+
+    return subscriptionId;
+  }
+
+  unsubscribe(subscriptionId: string): void {
+    const subscription = this.subscriptions.get(subscriptionId);
+    if (!subscription) {
+      return;
+    }
+
+    this.subscriptions.delete(subscriptionId);
+    const channelSet = this.channelIndex.get(subscription.channel);
+    if (channelSet) {
+      channelSet.delete(subscriptionId);
+      if (channelSet.size === 0) {
+        this.channelIndex.delete(subscription.channel);
+      }
+    }
+  }
+
+  dispose(): void {
+    this.subscriptions.clear();
+    this.channelIndex.clear();
+    this.disposed = true;
+  }
+}

--- a/self/apps/web/server/event-bus/index.ts
+++ b/self/apps/web/server/event-bus/index.ts
@@ -1,0 +1,1 @@
+export { EventBus } from './event-bus';

--- a/self/apps/web/server/sse/event-sse-handler.ts
+++ b/self/apps/web/server/sse/event-sse-handler.ts
@@ -1,0 +1,134 @@
+/**
+ * SSE handler factory for the Nous event bus.
+ *
+ * Creates a request handler that streams events from the bus to connected
+ * clients as SSE frames. Supports channel filtering via ?channels= query
+ * parameter with glob-like prefix matching (e.g., health:*).
+ *
+ * Design: factory pattern closes over the eventBus reference so the
+ * returned handler has a standard (req, res) => void signature compatible
+ * with both bare http.createServer and Next.js API routes.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { EventChannelMap, IEventBus } from '@nous/shared';
+
+/** All known channel names for subscribing to "all". */
+const ALL_CHANNELS: (keyof EventChannelMap)[] = [
+  'health:boot-step',
+  'health:gateway-status',
+  'health:issue',
+  'health:backlog-analytics',
+  'app-health:change',
+  'app-health:heartbeat',
+  'mao:projection-changed',
+  'mao:control-action',
+  'voice:state-change',
+  'voice:transcription',
+  'lifecycle:transition',
+  'escalation:new',
+  'escalation:resolved',
+];
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * Parse the ?channels= query parameter into a list of channel names.
+ * Supports exact matches and prefix globs (e.g., "health:*" matches all
+ * channels starting with "health:").
+ *
+ * Returns all channels if no filter is specified or the filter is empty.
+ */
+function resolveChannels(channelsParam: string | null): (keyof EventChannelMap)[] {
+  if (!channelsParam || channelsParam.trim() === '') {
+    return ALL_CHANNELS;
+  }
+
+  const filters = channelsParam.split(',').map((f) => f.trim()).filter(Boolean);
+  if (filters.length === 0) {
+    return ALL_CHANNELS;
+  }
+
+  const matched = new Set<keyof EventChannelMap>();
+  for (const filter of filters) {
+    if (filter.endsWith('*')) {
+      // Prefix glob: "health:*" matches "health:boot-step", etc.
+      const prefix = filter.slice(0, -1);
+      for (const channel of ALL_CHANNELS) {
+        if ((channel as string).startsWith(prefix)) {
+          matched.add(channel);
+        }
+      }
+    } else {
+      // Exact match
+      if (ALL_CHANNELS.includes(filter as keyof EventChannelMap)) {
+        matched.add(filter as keyof EventChannelMap);
+      }
+    }
+  }
+
+  // If no valid filters matched, subscribe to all (permissive default).
+  return matched.size > 0 ? [...matched] : ALL_CHANNELS;
+}
+
+/**
+ * Write a single SSE frame to the response.
+ */
+function writeSseFrame(res: ServerResponse, event: string, data: string): void {
+  res.write(`event: ${event}\ndata: ${data}\n\n`);
+}
+
+/**
+ * Create an SSE request handler bound to the given event bus.
+ */
+export function createEventSseHandler(
+  eventBus: IEventBus,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req: IncomingMessage, res: ServerResponse) => {
+    // Parse query string for channel filter
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    const channelsParam = url.searchParams.get('channels');
+    const channels = resolveChannels(channelsParam);
+
+    // Set SSE headers
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+
+    // Flush headers immediately
+    res.flushHeaders();
+
+    // Track subscription IDs for cleanup
+    const subscriptionIds: string[] = [];
+
+    // Subscribe to each requested channel
+    for (const channel of channels) {
+      const id = eventBus.subscribe(channel, (payload) => {
+        try {
+          writeSseFrame(res, channel as string, JSON.stringify(payload));
+        } catch {
+          // Write failed — connection likely closed, cleanup will happen via 'close' event
+        }
+      });
+      subscriptionIds.push(id);
+    }
+
+    // Heartbeat interval to keep the connection alive
+    const heartbeatInterval = setInterval(() => {
+      try {
+        res.write(': heartbeat\n\n');
+      } catch {
+        // Write failed — connection closing
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    // Cleanup on connection close
+    res.on('close', () => {
+      clearInterval(heartbeatInterval);
+      for (const id of subscriptionIds) {
+        eventBus.unsubscribe(id);
+      }
+    });
+  };
+}

--- a/self/apps/web/server/sse/index.ts
+++ b/self/apps/web/server/sse/index.ts
@@ -1,0 +1,1 @@
+export { createEventSseHandler } from './event-sse-handler';

--- a/self/shared/src/event-bus/index.ts
+++ b/self/shared/src/event-bus/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Event bus types, interfaces, and Zod payload schemas.
+ *
+ * No execution logic — the EventBus implementation lives in @nous/web
+ * server-side code. This module provides only the type contracts and
+ * validation schemas.
+ */
+export * from './types.js';
+export type { IEventBus } from './interface.js';

--- a/self/shared/src/event-bus/interface.ts
+++ b/self/shared/src/event-bus/interface.ts
@@ -1,0 +1,37 @@
+/**
+ * IEventBus — Interface contract for the Nous in-process event bus.
+ *
+ * Typed against EventChannelMap for compile-time channel/payload safety.
+ * Implementations must provide error isolation (one failing handler does
+ * not block others) and clean disposal semantics.
+ */
+import type { EventChannelMap } from './types.js';
+
+export interface IEventBus {
+  /**
+   * Publish an event to all subscribers of the given channel.
+   * Synchronous fan-out. Does not throw even if handlers throw.
+   * After dispose(), publish is a silent no-op.
+   */
+  publish<C extends keyof EventChannelMap>(channel: C, payload: EventChannelMap[C]): void;
+
+  /**
+   * Subscribe to events on a channel.
+   * @returns A unique subscription ID (UUID) for later unsubscription.
+   */
+  subscribe<C extends keyof EventChannelMap>(
+    channel: C,
+    handler: (payload: EventChannelMap[C]) => void,
+  ): string;
+
+  /**
+   * Remove a subscription by its ID. No-op if the ID is unknown.
+   */
+  unsubscribe(subscriptionId: string): void;
+
+  /**
+   * Dispose the bus: remove all subscriptions. Subsequent publish
+   * calls become silent no-ops. Subsequent subscribe calls are ignored.
+   */
+  dispose(): void;
+}

--- a/self/shared/src/event-bus/types.ts
+++ b/self/shared/src/event-bus/types.ts
@@ -1,0 +1,134 @@
+/**
+ * EventChannelMap — Typed channel registry for the Nous event bus.
+ *
+ * Each channel name follows the pattern `domain:action`. Payloads are
+ * defined as Zod schemas with inferred TypeScript types, enabling both
+ * compile-time type safety and optional runtime validation.
+ *
+ * This module is additive alongside the existing NousEvent discriminated
+ * union (self/shared/src/events/). The two systems coexist: NousEvent
+ * serves inter-layer tracing; EventChannelMap serves typed pub/sub for
+ * UI-push via the event bus.
+ */
+import { z } from 'zod';
+
+// --- Health Domain ---
+
+export const HealthBootStepPayloadSchema = z.object({
+  step: z.string(),
+  status: z.enum(['started', 'completed', 'failed']),
+});
+export type HealthBootStepPayload = z.infer<typeof HealthBootStepPayloadSchema>;
+
+export const HealthGatewayStatusPayloadSchema = z.object({
+  status: z.enum(['booting', 'booted', 'degraded', 'error']),
+});
+export type HealthGatewayStatusPayload = z.infer<typeof HealthGatewayStatusPayloadSchema>;
+
+export const HealthIssuePayloadSchema = z.object({
+  issueId: z.string(),
+  severity: z.enum(['info', 'warning', 'error', 'critical']),
+  message: z.string(),
+});
+export type HealthIssuePayload = z.infer<typeof HealthIssuePayloadSchema>;
+
+export const HealthBacklogAnalyticsPayloadSchema = z.object({
+  pending: z.number(),
+  inProgress: z.number(),
+  completed: z.number(),
+});
+export type HealthBacklogAnalyticsPayload = z.infer<typeof HealthBacklogAnalyticsPayloadSchema>;
+
+// --- App-Health Domain ---
+
+export const AppHealthChangePayloadSchema = z.object({
+  appId: z.string(),
+  sessionId: z.string(),
+  status: z.enum(['healthy', 'degraded', 'stale', 'disconnected']),
+});
+export type AppHealthChangePayload = z.infer<typeof AppHealthChangePayloadSchema>;
+
+export const AppHealthHeartbeatPayloadSchema = z.object({
+  appId: z.string(),
+  sessionId: z.string(),
+  timestamp: z.string().datetime(),
+});
+export type AppHealthHeartbeatPayload = z.infer<typeof AppHealthHeartbeatPayloadSchema>;
+
+// --- MAO Domain ---
+
+export const MaoProjectionChangedPayloadSchema = z.object({
+  projectId: z.string().optional(),
+  snapshotVersion: z.number().optional(),
+});
+export type MaoProjectionChangedPayload = z.infer<typeof MaoProjectionChangedPayloadSchema>;
+
+export const MaoControlActionPayloadSchema = z.object({
+  projectId: z.string(),
+  action: z.string(),
+  result: z.enum(['success', 'failure']),
+});
+export type MaoControlActionPayload = z.infer<typeof MaoControlActionPayloadSchema>;
+
+// --- Voice Domain ---
+
+export const VoiceStateChangePayloadSchema = z.object({
+  turnId: z.string(),
+  state: z.enum(['recording', 'evaluating', 'barge-in', 'continuation', 'idle']),
+});
+export type VoiceStateChangePayload = z.infer<typeof VoiceStateChangePayloadSchema>;
+
+export const VoiceTranscriptionPayloadSchema = z.object({
+  turnId: z.string(),
+  transcript: z.string(),
+});
+export type VoiceTranscriptionPayload = z.infer<typeof VoiceTranscriptionPayloadSchema>;
+
+// --- Lifecycle Domain ---
+
+export const LifecycleTransitionPayloadSchema = z.object({
+  packageId: z.string(),
+  fromState: z.string(),
+  toState: z.string(),
+  transitionType: z.string(),
+});
+export type LifecycleTransitionPayload = z.infer<typeof LifecycleTransitionPayloadSchema>;
+
+// --- Escalation Domain ---
+
+export const EscalationNewPayloadSchema = z.object({
+  escalationId: z.string(),
+  projectId: z.string().optional(),
+  severity: z.enum(['low', 'medium', 'high', 'critical']),
+  message: z.string(),
+});
+export type EscalationNewPayload = z.infer<typeof EscalationNewPayloadSchema>;
+
+export const EscalationResolvedPayloadSchema = z.object({
+  escalationId: z.string(),
+  resolution: z.enum(['acknowledged', 'resolved', 'dismissed']),
+});
+export type EscalationResolvedPayload = z.infer<typeof EscalationResolvedPayloadSchema>;
+
+// --- Channel Map ---
+
+export interface EventChannelMap {
+  'health:boot-step': HealthBootStepPayload;
+  'health:gateway-status': HealthGatewayStatusPayload;
+  'health:issue': HealthIssuePayload;
+  'health:backlog-analytics': HealthBacklogAnalyticsPayload;
+  'app-health:change': AppHealthChangePayload;
+  'app-health:heartbeat': AppHealthHeartbeatPayload;
+  'mao:projection-changed': MaoProjectionChangedPayload;
+  'mao:control-action': MaoControlActionPayload;
+  'voice:state-change': VoiceStateChangePayload;
+  'voice:transcription': VoiceTranscriptionPayload;
+  'lifecycle:transition': LifecycleTransitionPayload;
+  'escalation:new': EscalationNewPayload;
+  'escalation:resolved': EscalationResolvedPayload;
+}
+
+/**
+ * All valid channel names in the event bus.
+ */
+export type EventChannel = keyof EventChannelMap;

--- a/self/shared/src/index.ts
+++ b/self/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from './types/index.js';
 export * from './interfaces/index.js';
 export * from './events/index.js';
 export * from './errors/index.js';
+export * from './event-bus/index.js';
 export * from './types/app-credentials.js';
 export {
   AppPanelLifecycleEventSchema,


### PR DESCRIPTION
## Summary

- Add typed in-process event bus (`EventBus`) with `IEventBus` interface and `EventChannelMap` type registry (13 Zod-validated channels across 6 domains)
- Add SSE handler factory with channel filtering, heartbeat keep-alive, and connection cleanup
- Mount `/api/events` SSE endpoint on Next.js web server
- Wire `EventBus` singleton into `NousContext` via `createNousContext`
- 19 tests (11 unit + 8 integration), all passing

## Test plan

- [x] `pnpm build` passes (all packages)
- [x] `pnpm test` passes (337 files, 1912 tests, 100%)
- [x] `pnpm exec oxlint` passes (0 errors)
- [x] EventBus unit tests: publish/subscribe/unsubscribe/dispose/error-isolation
- [x] SSE handler tests: connect/receive/heartbeat/channel-filtering/cleanup

## Worklog

- Goals: Approved (Cycle 2 — C5-BLOCKER resolved)
- SDS: Approved
- Implementation Plan: Approved With Notes
- Completion Report: Approved With Notes
- User Documentation: Approved
- Synthesis Review: Approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)