### PR TITLE
feat(desktop): WR-074 SP3 — wire content surfaces into App.tsx

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -789,7 +789,7 @@ export function App() {
                 onItemSelect={handleNavigate}
               />
             )}
-            chat={<ChatSurface chatApi={window.electronAPI?.chat} />}
+            chat={<ChatSurface chatApi={window.electronAPI?.chat as ChatAPI | undefined} />}
             content={(
               <ContentRouter
                 activeRoute={activeRoute}

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -789,7 +789,7 @@ export function App() {
                 onItemSelect={handleNavigate}
               />
             )}
-            chat={<ChatSurface chatApi={window.electronAPI?.chat as ChatAPI | undefined} />}
+            chat={<ChatSurface chatApi={window.electronAPI?.chat} />}
             content={(
               <ContentRouter
                 activeRoute={activeRoute}

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import {
   useDashboardApi,
   AgentPanel,
   PreferencesPanel,
+  type ChatAPI,
 } from '@nous/ui/panels'
 import {
   ContentRouter,
@@ -789,7 +790,7 @@ export function App() {
                 onItemSelect={handleNavigate}
               />
             )}
-            chat={<ChatSurface chatApi={window.electronAPI?.chat} />}
+            chat={<ChatSurface chatApi={window.electronAPI?.chat as ChatAPI | undefined} />}
             content={(
               <ContentRouter
                 activeRoute={activeRoute}

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { DockviewReact } from 'dockview-react'
 import type {
   DockviewApi,
@@ -27,9 +27,16 @@ import {
   NavigationRail,
   ShellLayout,
   ShellProvider,
+  HomeScreen,
+  CatalogView,
+  ChatSurface,
+  ObservePanel,
+  CommandPalette,
   type ContentRouterRenderProps,
   type RailSection,
   type ShellMode,
+  type CommandGroup,
+  type CatalogItem,
 } from '@nous/ui/components'
 import { AppInstallWizardPanel } from './components/AppInstallWizard'
 import { FirstRunWizard } from './components/FirstRunWizard'
@@ -167,6 +174,30 @@ const RAIL_SECTIONS: RailSection[] = [
   },
 ]
 
+const STUB_THREADS: CatalogItem[] = [
+  { id: 'thread-1', title: 'Project Planning', description: 'Roadmap and milestone discussion', icon: 'T' },
+  { id: 'thread-2', title: 'Architecture Review', description: 'System design feedback', icon: 'T' },
+  { id: 'thread-3', title: 'Bug Triage', description: 'Issue prioritization session', icon: 'T' },
+]
+
+const STUB_WORKFLOWS: CatalogItem[] = [
+  { id: 'wf-1', title: 'Code Review Pipeline', description: 'Automated review and gate checks', icon: 'W' },
+  { id: 'wf-2', title: 'Deploy to Staging', description: 'Build, test, and deploy workflow', icon: 'W' },
+  { id: 'wf-3', title: 'Daily Standup', description: 'Agent-assisted status aggregation', icon: 'W' },
+]
+
+const STUB_SKILLS: CatalogItem[] = [
+  { id: 'skill-1', title: 'Code Generation', description: 'Generate code from natural language', icon: 'S' },
+  { id: 'skill-2', title: 'Document Analysis', description: 'Extract insights from documents', icon: 'S' },
+  { id: 'skill-3', title: 'Test Writing', description: 'Generate test suites from specifications', icon: 'S' },
+]
+
+const STUB_APPS: CatalogItem[] = [
+  { id: 'app-1', title: 'Terminal', description: 'Integrated terminal emulator', icon: 'A' },
+  { id: 'app-2', title: 'File Manager', description: 'Browse and manage project files', icon: 'A' },
+  { id: 'app-3', title: 'Metrics Dashboard', description: 'System and agent performance metrics', icon: 'A' },
+]
+
 function parseShellMode(value: unknown): ShellMode | null {
   return value === 'simple' || value === 'developer' ? value : null
 }
@@ -198,69 +229,12 @@ const modePersistence = {
   },
 }
 
-function ShellPanePlaceholder({
-  title,
-  description,
-}: {
-  title: string
-  description: string
-}) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        padding: 'var(--nous-space-lg)',
-        boxSizing: 'border-box',
-      }}
-    >
-      <div
-        style={{
-          display: 'grid',
-          gap: 'var(--nous-space-xs)',
-          textAlign: 'center',
-        }}
-      >
-        <div
-          style={{
-            fontSize: 'var(--nous-font-size-base)',
-            color: 'var(--nous-fg)',
-          }}
-        >
-          {title}
-        </div>
-        <div
-          style={{
-            fontSize: 'var(--nous-font-size-sm)',
-            color: 'var(--nous-fg-subtle)',
-          }}
-        >
-          {description}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function createContentPlaceholder(title: string) {
-  return function ContentPlaceholder(_props: ContentRouterRenderProps) {
-    return (
-      <ShellPanePlaceholder
-        title={title}
-        description="Content placeholder"
-      />
-    )
-  }
-}
-
-const BASE_SIMPLE_MODE_ROUTES = {
-  home: createContentPlaceholder('Home'),
-  threads: createContentPlaceholder('Threads'),
-  workflows: createContentPlaceholder('Workflows'),
-  skills: createContentPlaceholder('Skills'),
-  apps: createContentPlaceholder('Apps'),
+const BASE_SIMPLE_MODE_ROUTES: Record<string, React.ComponentType<ContentRouterRenderProps>> = {
+  home: HomeScreen,
+  threads: (props: ContentRouterRenderProps) => <CatalogView {...props} items={STUB_THREADS} />,
+  workflows: (props: ContentRouterRenderProps) => <CatalogView {...props} items={STUB_WORKFLOWS} />,
+  skills: (props: ContentRouterRenderProps) => <CatalogView {...props} items={STUB_SKILLS} />,
+  apps: (props: ContentRouterRenderProps) => <CatalogView {...props} items={STUB_APPS} />,
 }
 
 type PreferencesPanelParams = Parameters<typeof PreferencesPanel>[0]['params']
@@ -284,24 +258,6 @@ function SettingsRoute({
         params={preferencesPanelParams}
       />
     </div>
-  )
-}
-
-function ChatPlaceholder() {
-  return (
-    <ShellPanePlaceholder
-      title="Chat"
-      description="Chat placeholder"
-    />
-  )
-}
-
-function ObservePlaceholder() {
-  return (
-    <ShellPanePlaceholder
-      title="Observe"
-      description="Observe placeholder"
-    />
   )
 }
 
@@ -432,6 +388,7 @@ export function App() {
   const [appPanels, setAppPanels] = useState<AppPanelSnapshot[]>([])
   const [mode, setMode] = useState<ShellMode>('simple')
   const [activeRoute, setActiveRoute] = useState(DEFAULT_ROUTE)
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
 
   const initializeApp = useCallback(async () => {
     const runId = ++bootstrapRunRef.current
@@ -652,6 +609,20 @@ export function App() {
     }
   }, [handleModeToggle, phase])
 
+  useEffect(() => {
+    if (phase !== 'main') return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.ctrlKey && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setCommandPaletteOpen((prev) => !prev)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [phase])
+
   const preferencesPanelParams = useMemo(() => ({
     preferencesApi: {
       ...(window as any).electronAPI?.preferences,
@@ -671,6 +642,29 @@ export function App() {
       <SettingsRoute preferencesPanelParams={preferencesPanelParams} />
     ),
   }), [preferencesPanelParams])
+
+  const commands: CommandGroup[] = useMemo(() => [
+    {
+      id: 'navigation',
+      label: 'Navigation',
+      commands: [
+        { id: 'nav-home', label: 'Go to Home', action: () => handleNavigate('home') },
+        { id: 'nav-threads', label: 'Go to Threads', action: () => handleNavigate('threads') },
+        { id: 'nav-workflows', label: 'Go to Workflows', action: () => handleNavigate('workflows') },
+        { id: 'nav-skills', label: 'Go to Skills', action: () => handleNavigate('skills') },
+        { id: 'nav-apps', label: 'Go to Apps', action: () => handleNavigate('apps') },
+        { id: 'nav-settings', label: 'Go to Settings', action: () => handleNavigate('settings') },
+      ],
+    },
+    {
+      id: 'actions',
+      label: 'Actions',
+      commands: [
+        { id: 'action-toggle-mode', label: 'Toggle Mode', shortcut: 'Ctrl+Shift+D', action: handleModeToggle },
+        { id: 'action-command-palette', label: 'Open Command Palette', shortcut: 'Ctrl+K', action: () => setCommandPaletteOpen(true) },
+      ],
+    },
+  ], [handleNavigate, handleModeToggle])
 
   const navigation = {
     activeRoute,
@@ -781,6 +775,11 @@ export function App() {
         navigate={handleNavigate}
         goBack={handleGoBack}
       >
+        <CommandPalette
+          isOpen={commandPaletteOpen}
+          onClose={() => setCommandPaletteOpen(false)}
+          commands={commands}
+        />
         {mode === 'simple' ? (
           <ShellLayout
             rail={(
@@ -790,7 +789,7 @@ export function App() {
                 onItemSelect={handleNavigate}
               />
             )}
-            chat={<ChatPlaceholder />}
+            chat={<ChatSurface chatApi={window.electronAPI?.chat} />}
             content={(
               <ContentRouter
                 activeRoute={activeRoute}
@@ -798,7 +797,7 @@ export function App() {
                 onNavigate={handleNavigate}
               />
             )}
-            observe={<ObservePlaceholder />}
+            observe={<ObservePanel maoApi={(window as any).electronAPI?.mao} />}
           />
         ) : (
           <DockviewShell

--- a/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
@@ -129,9 +129,12 @@ describe('App', () => {
       expect(document.querySelector('[data-shell-area="rail"]')).not.toBeNull()
     })
 
-    expect(screen.getByText('Chat placeholder')).toBeInTheDocument()
-    expect(screen.getByText('Observe placeholder')).toBeInTheDocument()
-    expect(screen.getByText('Content placeholder')).toBeInTheDocument()
+    // HomeScreen renders a greeting (time-dependent)
+    expect(
+      screen.getByText(/Good (morning|afternoon|evening), User/),
+    ).toBeInTheDocument()
+    // Observe column renders (ObservePanel default view text)
+    expect(screen.getByText('No observe content for this view')).toBeInTheDocument()
     expect(screen.queryByText('Dockview shell')).not.toBeInTheDocument()
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
   })
@@ -422,5 +425,95 @@ describe('App', () => {
     })
 
     expect(await screen.findByText('Wizard shell')).toBeInTheDocument()
+  })
+
+  it('opens command palette with Ctrl+K', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState.mockResolvedValue(
+      createFirstRunState({
+        currentStep: 'complete',
+        complete: true,
+      }),
+    )
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-shell-area="rail"]')).not.toBeNull()
+    })
+
+    // Command palette should not be visible initially
+    expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+
+    // Press Ctrl+K
+    fireEvent.keyDown(window, {
+      ctrlKey: true,
+      key: 'k',
+    })
+
+    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument()
+  })
+
+  it('closes command palette with Escape', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState.mockResolvedValue(
+      createFirstRunState({
+        currentStep: 'complete',
+        complete: true,
+      }),
+    )
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-shell-area="rail"]')).not.toBeNull()
+    })
+
+    // Open with Ctrl+K
+    fireEvent.keyDown(window, {
+      ctrlKey: true,
+      key: 'k',
+    })
+
+    const dialog = screen.getByRole('dialog', { name: 'Command palette' })
+    expect(dialog).toBeInTheDocument()
+
+    // Press Escape inside the palette
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+    })
+  })
+
+  it('navigates via command palette', async () => {
+    const mock = installMock()
+    mock.firstRun.getWizardState.mockResolvedValue(
+      createFirstRunState({
+        currentStep: 'complete',
+        complete: true,
+      }),
+    )
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-shell-area="rail"]')).not.toBeNull()
+    })
+
+    // Open command palette
+    fireEvent.keyDown(window, {
+      ctrlKey: true,
+      key: 'k',
+    })
+
+    // Click "Go to Threads" command
+    const threadsCommand = screen.getByTestId('command-item-nav-threads')
+    fireEvent.click(threadsCommand)
+
+    // Palette should close after executing command
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Replace all 5 `BASE_SIMPLE_MODE_ROUTES` placeholders with real components (HomeScreen, CatalogView x4)
- Replace ChatPlaceholder/ObservePlaceholder with ChatSurface/ObservePanel
- Add CommandPalette overlay with Ctrl+K, 6 navigation + 2 action commands
- Remove dead placeholder code (ShellPanePlaceholder, createContentPlaceholder)
- Update App.test.tsx with 3 new command palette tests

**2 files modified** in `@nous/desktop` only — all components imported from `@nous/ui`.

## Worklog

All 5 gate reviews approved Cycle 1. Full SOP pipeline completed for all 3 sub-phases.

## Test plan

- [x] `pnpm --filter @nous/desktop test` — 53 tests, 8 files, all passing
- [x] `pnpm --filter @nous/ui test` — 140 tests, 15 files, all passing (no regressions)
- [x] `tsc --noEmit` — 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)