### PR TITLE
feat(cortex-core): gateway runtime wiring and integration tests — Phase 1.3

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-lifecycle-integration.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-lifecycle-integration.test.ts
@@ -1,59 +1,14 @@
+import { NousError } from '@nous/shared';
 import { describe, expect, it } from 'vitest';
 import { createInternalMcpSurfaceBundle } from '../../internal-mcp/index.js';
+import { WorkmodeAdmissionGuard } from '../../workmode/admission-guard.js';
 import {
   createBaseInput,
   createGatewayHarness,
   createProjectApi,
+  createStampedPacket,
   createWorkmodeAdmissionGuard,
 } from './helpers.js';
-
-function createStampedPacket() {
-  return {
-    nous: { v: 3 },
-    route: {
-      emitter: { id: 'internal-mcp::worker::node-test::task-complete' },
-      target: { id: 'internal-mcp::parent::run-test::receive-task-complete' },
-    },
-    envelope: {
-      direction: 'internal' as const,
-      type: 'response_packet' as const,
-    },
-    correlation: {
-      handoff_id: 'handoff-1',
-      correlation_id: createBaseInput().correlation.runId,
-      cycle: 'n/a',
-      emitted_at_utc: '2026-03-12T19:00:00.000Z',
-      emitted_at_unix_ms: '1773342000000',
-      emitted_at_unix_us: '1773342000000000',
-      sequence_in_run: '1',
-    },
-    payload: {
-      schema: 'n/a',
-      artifact_type: 'n/a',
-      data: { done: true },
-    },
-    retry: {
-      policy: 'value-proportional' as const,
-      depth: 'lightweight' as const,
-      importance_tier: 'standard' as const,
-      expected_quality_gain: 'n/a',
-      estimated_tokens: 'n/a',
-      estimated_compute_minutes: 'n/a',
-      token_price_ref: 'runtime:gateway',
-      compute_price_ref: 'runtime:gateway',
-      decision: 'accept' as const,
-      decision_log_ref: 'runtime:gateway/task-complete',
-      benchmark_tier: 'n/a' as const,
-      self_repair: {
-        required_on_fail_close: true as const,
-        orchestration_state: 'deferred' as const,
-        approval_role: 'Cortex:System',
-        implementation_mode: 'direct' as const,
-        plan_ref: 'runtime:gateway/self-repair',
-      },
-    },
-  };
-}
 
 describe('AgentGateway lifecycle integration', () => {
   it('executes multiple dispatch_agent calls concurrently and preserves result order', async () => {
@@ -189,5 +144,315 @@ describe('AgentGateway lifecycle integration', () => {
 
     expect(result.status).toBe('completed');
     expect(outbox.events.some((event) => event.type === 'observation')).toBe(true);
+  });
+
+  describe('dispatch authority enforcement', () => {
+    it('Worker dispatch blocked at tool-surface level — no dispatch_agent hook', () => {
+      const bundle = createInternalMcpSurfaceBundle({
+        agentClass: 'Worker',
+        agentId: createBaseInput().correlation.parentId!,
+        deps: {
+          workmodeAdmissionGuard: new WorkmodeAdmissionGuard(),
+          getProjectApi: () => createProjectApi(),
+          outputSchemaValidator: {
+            validate: async () => ({ success: true }),
+          },
+        },
+      });
+
+      // Worker agent class does not include dispatch_agent in its tool set,
+      // so the lifecycle hook is undefined (Layer 1: structural enforcement).
+      expect(bundle.lifecycleHooks.dispatchAgent).toBeUndefined();
+    });
+
+    it('Worker dispatch blocked at admission-guard level (Layer 2)', () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      const result = guard.evaluateDispatchAdmission({
+        sourceActor: 'worker_agent',
+        targetActor: 'worker_agent',
+        action: 'dispatch_agent',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result).toHaveProperty('reasonCode', 'WMODE-010');
+    });
+
+    it('Orchestrator-to-Orchestrator nesting blocked by admission guard', () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      const result = guard.evaluateDispatchAdmission({
+        sourceActor: 'orchestration_agent',
+        targetActor: 'orchestration_agent',
+        action: 'dispatch_agent',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result).toHaveProperty('reasonCode', 'WMODE-003');
+    });
+
+    it('authority widening blocked by admission guard', () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      const result = guard.evaluateDispatchAdmission({
+        sourceActor: 'orchestration_agent',
+        targetActor: 'nous_cortex',
+        action: 'dispatch_agent',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result).toHaveProperty('reasonCode', 'WMODE-002');
+    });
+
+    it('scope guard fail-close produces denial with evidence refs', () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      // Scope-requiring action without execution context triggers fail-close.
+      const result = guard.evaluateScopeGuard({
+        sourceActor: 'orchestration_agent',
+        targetActor: 'worker_agent',
+        action: 'execute_subphase',
+        // No executionContext — triggers fail-close
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result).toHaveProperty('reasonCode', 'WMODE-SCOPE-GUARD-VIOLATION');
+      expect(result).toHaveProperty('evidenceRefs');
+      expect((result as { evidenceRefs: string[] }).evidenceRefs.length).toBeGreaterThan(0);
+    });
+
+    it('emitter_agent_class provenance field present in task completion packets', async () => {
+      // Worker bundle
+      const workerBundle = createInternalMcpSurfaceBundle({
+        agentClass: 'Worker',
+        agentId: createBaseInput().correlation.parentId!,
+        deps: {
+          workmodeAdmissionGuard: new WorkmodeAdmissionGuard(),
+          getProjectApi: () => createProjectApi(),
+          outputSchemaValidator: {
+            validate: async () => ({ success: true }),
+          },
+        },
+      });
+
+      const { gateway: workerGateway } = createGatewayHarness({
+        agentClass: 'Worker',
+        toolSurface: workerBundle.toolSurface,
+        lifecycleHooks: workerBundle.lifecycleHooks,
+        outputs: [
+          JSON.stringify({
+            response: 'done',
+            toolCalls: [
+              {
+                name: 'task_complete',
+                params: { output: { done: true }, summary: 'completed' },
+              },
+            ],
+          }),
+        ],
+      });
+
+      const workerResult = await workerGateway.run(createBaseInput());
+      expect(workerResult.status).toBe('completed');
+      expect(workerResult.v3Packet).toBeDefined();
+      expect(workerResult.v3Packet?.emitter_agent_class).toBe('Worker');
+
+      // Orchestrator bundle
+      const orchBundle = createInternalMcpSurfaceBundle({
+        agentClass: 'Orchestrator',
+        agentId: createBaseInput().correlation.parentId!,
+        deps: {
+          workmodeAdmissionGuard: new WorkmodeAdmissionGuard(),
+          getProjectApi: () => createProjectApi(),
+          outputSchemaValidator: {
+            validate: async () => ({ success: true }),
+          },
+        },
+      });
+
+      const { gateway: orchGateway } = createGatewayHarness({
+        agentClass: 'Orchestrator',
+        toolSurface: orchBundle.toolSurface,
+        lifecycleHooks: orchBundle.lifecycleHooks,
+        outputs: [
+          JSON.stringify({
+            response: 'done',
+            toolCalls: [
+              {
+                name: 'task_complete',
+                params: { output: { done: true }, summary: 'completed' },
+              },
+            ],
+          }),
+        ],
+      });
+
+      const orchResult = await orchGateway.run(createBaseInput());
+      expect(orchResult.status).toBe('completed');
+      expect(orchResult.v3Packet).toBeDefined();
+      expect(orchResult.v3Packet?.emitter_agent_class).toBe('Orchestrator');
+    });
+
+    it('all valid dispatch edges succeed through admission guard', async () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      // Cortex::System -> Orchestrator
+      const cortexToOrch = guard.evaluateDispatchAdmission({
+        sourceActor: 'nous_cortex',
+        targetActor: 'orchestration_agent',
+        action: 'dispatch_agent',
+      });
+      expect(cortexToOrch.allowed).toBe(true);
+
+      // Cortex::System -> Worker
+      const cortexToWorker = guard.evaluateDispatchAdmission({
+        sourceActor: 'nous_cortex',
+        targetActor: 'worker_agent',
+        action: 'dispatch_agent',
+      });
+      expect(cortexToWorker.allowed).toBe(true);
+
+      // Orchestrator -> Worker (through full lifecycle handler chain)
+      const orchBundle = createInternalMcpSurfaceBundle({
+        agentClass: 'Orchestrator',
+        agentId: createBaseInput().correlation.parentId!,
+        deps: {
+          workmodeAdmissionGuard: guard,
+          getProjectApi: () => createProjectApi(),
+          dispatchRuntime: {
+            dispatchChild: async ({ request }) => ({
+              status: 'completed' as const,
+              output: { dispatched: request.taskInstructions },
+              v3Packet: createStampedPacket(),
+              correlation: createBaseInput().correlation,
+              usage: {
+                turnsUsed: 1,
+                tokensUsed: 20,
+                elapsedMs: 10,
+                spawnUnitsUsed: 0,
+              },
+              evidenceRefs: [],
+            }),
+          },
+          outputSchemaValidator: {
+            validate: async () => ({ success: true }),
+          },
+        },
+      });
+
+      const { gateway } = createGatewayHarness({
+        agentClass: 'Orchestrator',
+        toolSurface: orchBundle.toolSurface,
+        lifecycleHooks: orchBundle.lifecycleHooks,
+        outputs: [
+          JSON.stringify({
+            response: 'dispatch worker',
+            toolCalls: [
+              {
+                name: 'dispatch_agent',
+                params: {
+                  target_class: 'Worker',
+                  task_instructions: 'valid-dispatch',
+                },
+              },
+            ],
+          }),
+          JSON.stringify({
+            response: 'complete',
+            toolCalls: [{ name: 'task_complete', params: { output: { done: true } } }],
+          }),
+        ],
+      });
+
+      const result = await gateway.run(createBaseInput());
+      expect(result.status).toBe('completed');
+    });
+
+    it('Orchestrator dispatching Orchestrator denied through lifecycle handler', async () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      const orchBundle = createInternalMcpSurfaceBundle({
+        agentClass: 'Orchestrator',
+        agentId: createBaseInput().correlation.parentId!,
+        deps: {
+          workmodeAdmissionGuard: guard,
+          getProjectApi: () => createProjectApi(),
+          dispatchRuntime: {
+            dispatchChild: async () => {
+              throw new Error('should not reach dispatch runtime');
+            },
+          },
+          outputSchemaValidator: {
+            validate: async () => ({ success: true }),
+          },
+        },
+      });
+
+      // The dispatch_agent lifecycle hook should throw before reaching dispatchRuntime.
+      expect(orchBundle.lifecycleHooks.dispatchAgent).toBeDefined();
+
+      try {
+        await orchBundle.lifecycleHooks.dispatchAgent!(
+          {
+            targetClass: 'Orchestrator',
+            taskInstructions: 'nested-orchestrator',
+          },
+          {
+            agentId: createBaseInput().correlation.parentId!,
+            correlation: createBaseInput().correlation,
+            execution: createBaseInput().execution,
+            turn: 1,
+          },
+        );
+        // Should not reach here
+        expect.unreachable('Expected DISPATCH_ADMISSION_DENIED error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NousError);
+        const nousError = error as NousError;
+        expect(nousError.code).toBe('DISPATCH_ADMISSION_DENIED');
+        expect(nousError.context).toHaveProperty('evidenceRefs');
+        expect(Array.isArray(nousError.context?.evidenceRefs)).toBe(true);
+      }
+    });
+
+    it('denied dispatch produces witness-compatible evidence (START-005)', () => {
+      const guard = new WorkmodeAdmissionGuard();
+
+      // Worker -> Worker denied
+      const result = guard.evaluateDispatchAdmission({
+        sourceActor: 'worker_agent',
+        targetActor: 'worker_agent',
+        action: 'dispatch_agent',
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result).toHaveProperty('evidenceRefs');
+      const refs = (result as { evidenceRefs: string[] }).evidenceRefs;
+      expect(refs.length).toBeGreaterThan(0);
+      // Evidence ref contains context for witness audit trail
+      expect(refs[0]).toContain('worker');
+
+      // Worker -> Orchestrator denied
+      const result2 = guard.evaluateDispatchAdmission({
+        sourceActor: 'worker_agent',
+        targetActor: 'orchestration_agent',
+        action: 'dispatch_agent',
+      });
+
+      expect(result2.allowed).toBe(false);
+      expect(result2).toHaveProperty('evidenceRefs');
+      expect((result2 as { evidenceRefs: string[] }).evidenceRefs.length).toBeGreaterThan(0);
+
+      // Orchestrator -> Cortex authority widening denied
+      const result3 = guard.evaluateDispatchAdmission({
+        sourceActor: 'orchestration_agent',
+        targetActor: 'nous_cortex',
+        action: 'dispatch_agent',
+      });
+
+      expect(result3.allowed).toBe(false);
+      expect(result3).toHaveProperty('evidenceRefs');
+      expect((result3 as { evidenceRefs: string[] }).evidenceRefs.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
+++ b/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
@@ -32,6 +32,7 @@ import {
 import { AgentGatewayFactory } from '../agent-gateway/index.js';
 import { createInternalMcpSurfaceBundle } from '../internal-mcp/index.js';
 import type { InternalMcpOutputSchemaValidator } from '../internal-mcp/types.js';
+import type { IWorkmodeAdmissionGuard } from '@nous/shared';
 import { WorkmodeAdmissionGuard } from '../workmode/admission-guard.js';
 import { parseModelOutput } from '../output-parser.js';
 import { GatewayTraceRecorder } from './trace-recorder.js';
@@ -122,6 +123,7 @@ export interface GatewayBackedTurnExecutorDeps {
   instanceRoot?: string;
   outputSchemaValidator?: InternalMcpOutputSchemaValidator;
   agentGatewayFactory?: IAgentGatewayFactory;
+  workmodeAdmissionGuard?: IWorkmodeAdmissionGuard;
   now?: () => string;
   nowMs?: () => number;
   idFactory?: () => string;
@@ -129,12 +131,14 @@ export interface GatewayBackedTurnExecutorDeps {
 
 export class GatewayBackedTurnExecutor implements ICoreExecutor {
   private readonly gatewayFactory: IAgentGatewayFactory;
+  private readonly workmodeAdmissionGuard: IWorkmodeAdmissionGuard;
   private readonly traceRecorder: GatewayTraceRecorder;
   private readonly now: () => string;
   private readonly idFactory: () => string;
 
   constructor(private readonly deps: GatewayBackedTurnExecutorDeps) {
     this.gatewayFactory = deps.agentGatewayFactory ?? new AgentGatewayFactory();
+    this.workmodeAdmissionGuard = deps.workmodeAdmissionGuard ?? new WorkmodeAdmissionGuard();
     this.traceRecorder = new GatewayTraceRecorder(deps.documentStore);
     this.now = deps.now ?? (() => new Date().toISOString());
     this.idFactory = deps.idFactory ?? randomUUID;
@@ -262,8 +266,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
         runtime: this.deps.runtime,
         instanceRoot: this.deps.instanceRoot,
         outputSchemaValidator: this.deps.outputSchemaValidator,
-        // TODO(Phase 1.3): Wire admission guard from runtime deps
-        workmodeAdmissionGuard: new WorkmodeAdmissionGuard(),
+        workmodeAdmissionGuard: this.workmodeAdmissionGuard,
         now: this.now,
         idFactory: this.idFactory,
       },

--- a/self/cortex/core/src/gateway-runtime/public-mcp-runtime-adapter.ts
+++ b/self/cortex/core/src/gateway-runtime/public-mcp-runtime-adapter.ts
@@ -15,7 +15,6 @@ import type {
 import { AgentGatewayFactory } from '../agent-gateway/index.js';
 import { createInternalMcpSurfaceBundle } from '../internal-mcp/index.js';
 import type { InternalMcpRuntimeDeps } from '../internal-mcp/types.js';
-import { WorkmodeAdmissionGuard } from '../workmode/admission-guard.js';
 import { parseModelOutput } from '../output-parser.js';
 import { ORCHESTRATOR_SYSTEM_PROMPT } from '../prompts/index.js';
 
@@ -92,8 +91,7 @@ export class PublicMcpRuntimeAdapter {
       agentId,
       deps: {
         ...this.deps,
-        // TODO(Phase 1.3): Wire admission guard from runtime deps
-        workmodeAdmissionGuard: this.deps.workmodeAdmissionGuard ?? new WorkmodeAdmissionGuard(),
+        workmodeAdmissionGuard: this.deps.workmodeAdmissionGuard,
         now: this.now,
         nowMs: this.deps.nowMs,
         idFactory: this.idFactory,


### PR DESCRIPTION
## Summary

- Replace compile-compat admission guard stubs in `GatewayTurnExecutor` and `PublicMcpRuntimeAdapter` with real wiring
- Extend `GatewayBackedTurnExecutorDeps` with optional `workmodeAdmissionGuard` field
- Add 8 integration tests covering the complete dispatch authority enforcement chain:
  - Worker dispatch blocked at tool-surface AND admission-guard levels
  - Orchestrator nesting blocked
  - Authority widening blocked
  - Scope guard fail-close with evidence refs
  - Provenance field in completion packets
  - All valid dispatch edges succeed
  - Denied dispatch produces witness evidence (START-005)

## Test plan

- [x] 179 cortex-core tests pass (46 files, including 8 new integration tests)
- [x] All valid dispatch edges verified (cortex→orch, cortex→worker, orch→worker)
- [x] All invalid dispatch edges blocked with correct reason codes
- [x] `pnpm build` succeeds
- [x] Zero `TODO(Phase 1.3)` markers remaining in `@nous/cortex-core`

## Sprint

`feat/kernel-dispatch-authority` — WR-052 + WR-053 (final sub-phase)

## Sub-phase spec

`.architecture/roadmap/features/kernel-dispatch-authority/phase-1.3.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>