### PR TITLE
feat(ui): dashboard health widget wiring [WR-022 Phase 1.3]

### DIFF
--- a/self/ui/src/panels/dashboard/__tests__/ActiveAgentsWidget.test.tsx
+++ b/self/ui/src/panels/dashboard/__tests__/ActiveAgentsWidget.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ActiveAgentsWidget } from '../widgets/ActiveAgentsWidget'
+import { HealthQueryProvider } from '../hooks/HealthQueryProvider'
+import type { HealthFetchers } from '../hooks/HealthQueryProvider'
+import type { AgentStatusSnapshot } from '@nous/shared'
+import type { IDockviewPanelProps } from 'dockview-react'
+
+vi.mock('../../../../hooks/useEventSubscription', () => ({
+  useEventSubscription: vi.fn(),
+}))
+
+const mockSnapshot: AgentStatusSnapshot = {
+  gateways: [
+    {
+      agentClass: 'nous-orchestrator',
+      agentId: '00000000-0000-0000-0000-000000000001',
+      inboxReady: true,
+      visibleToolCount: 5,
+      issueCount: 0,
+      issueCodes: [],
+    },
+    {
+      agentClass: 'nous-worker',
+      agentId: '00000000-0000-0000-0000-000000000002',
+      inboxReady: false,
+      visibleToolCount: 3,
+      issueCount: 1,
+      issueCodes: ['DISPATCH_TIMEOUT'],
+    },
+  ],
+  appSessions: [
+    {
+      sessionId: 'sess-001',
+      appId: 'desktop',
+      packageId: '@nous/desktop',
+      status: 'active',
+      healthStatus: 'healthy',
+      startedAt: '2026-03-25T09:00:00.000Z',
+      stale: false,
+    },
+    {
+      sessionId: 'sess-002',
+      appId: 'web',
+      packageId: '@nous/web',
+      status: 'draining',
+      healthStatus: 'stale',
+      startedAt: '2026-03-25T08:00:00.000Z',
+      stale: true,
+    },
+  ],
+  collectedAt: '2026-03-25T10:00:00.000Z',
+}
+
+const dockviewProps = {} as IDockviewPanelProps
+
+function renderWithProvider(fetchers: Partial<HealthFetchers>) {
+  const defaultFetchers: HealthFetchers = {
+    fetchSystemStatus: vi.fn(),
+    fetchProviderHealth: vi.fn(),
+    fetchAgentStatus: vi.fn().mockResolvedValue(mockSnapshot),
+    ...fetchers,
+  }
+
+  return render(
+    <HealthQueryProvider fetchers={defaultFetchers}>
+      <ActiveAgentsWidget {...dockviewProps} />
+    </HealthQueryProvider>,
+  )
+}
+
+describe('ActiveAgentsWidget', () => {
+  it('renders loading indicator during initial fetch', () => {
+    const fetcher = vi.fn().mockReturnValue(new Promise(() => {}))
+    renderWithProvider({ fetchAgentStatus: fetcher })
+
+    expect(screen.getByText('Loading agent status...')).toBeTruthy()
+  })
+
+  it('renders live gateway and session entries when data is available', async () => {
+    renderWithProvider({})
+
+    // Header with counts
+    expect(await screen.findByText(/2 Gateways/)).toBeTruthy()
+    expect(screen.getByText(/2 Sessions/)).toBeTruthy()
+
+    // Gateway entries
+    expect(screen.getByText('nous-orchestrator')).toBeTruthy()
+    expect(screen.getByText('nous-worker')).toBeTruthy()
+    expect(screen.getByText('READY')).toBeTruthy()
+    expect(screen.getByText('NOT READY')).toBeTruthy()
+    expect(screen.getByText('5 tools')).toBeTruthy()
+    expect(screen.getByText('3 tools')).toBeTruthy()
+    expect(screen.getByText('1 issue')).toBeTruthy()
+
+    // Session entries
+    expect(screen.getByText('desktop')).toBeTruthy()
+    expect(screen.getByText('web')).toBeTruthy()
+    expect(screen.getByText('ACTIVE')).toBeTruthy()
+    expect(screen.getByText('DRAINING')).toBeTruthy()
+    expect(screen.getByText('STALE')).toBeTruthy()
+
+    // Collected at
+    expect(screen.getByText(/Updated:/)).toBeTruthy()
+  })
+
+  it('renders error fallback when fetch fails', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('Timeout'))
+    renderWithProvider({ fetchAgentStatus: fetcher })
+
+    expect(
+      await screen.findByText(/Failed to load agent status: Timeout/),
+    ).toBeTruthy()
+  })
+})

--- a/self/ui/src/panels/dashboard/__tests__/HealthQueryProvider.test.tsx
+++ b/self/ui/src/panels/dashboard/__tests__/HealthQueryProvider.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { HealthQueryProvider, useHealthQueries } from '../hooks/HealthQueryProvider'
+import type { HealthFetchers } from '../hooks/HealthQueryProvider'
+
+const mockFetchers: HealthFetchers = {
+  fetchSystemStatus: vi.fn(),
+  fetchProviderHealth: vi.fn(),
+  fetchAgentStatus: vi.fn(),
+}
+
+describe('HealthQueryProvider', () => {
+  // --- Tier 1: Contract ---
+
+  it('returns HealthFetchers when provider is mounted', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <HealthQueryProvider fetchers={mockFetchers}>{children}</HealthQueryProvider>
+    )
+
+    const { result } = renderHook(() => useHealthQueries(), { wrapper })
+
+    expect(result.current).toHaveProperty('fetchSystemStatus')
+    expect(result.current).toHaveProperty('fetchProviderHealth')
+    expect(result.current).toHaveProperty('fetchAgentStatus')
+    expect(typeof result.current.fetchSystemStatus).toBe('function')
+    expect(typeof result.current.fetchProviderHealth).toBe('function')
+    expect(typeof result.current.fetchAgentStatus).toBe('function')
+  })
+
+  // --- Tier 2: Behavior ---
+
+  it('throws descriptive error when provider is not mounted', () => {
+    expect(() => {
+      renderHook(() => useHealthQueries())
+    }).toThrow('useHealthQueries must be used within a <HealthQueryProvider>')
+  })
+
+  it('passes fetcher functions through to consumer hooks', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <HealthQueryProvider fetchers={mockFetchers}>{children}</HealthQueryProvider>
+    )
+
+    const { result } = renderHook(() => useHealthQueries(), { wrapper })
+
+    expect(result.current.fetchSystemStatus).toBe(mockFetchers.fetchSystemStatus)
+    expect(result.current.fetchProviderHealth).toBe(mockFetchers.fetchProviderHealth)
+    expect(result.current.fetchAgentStatus).toBe(mockFetchers.fetchAgentStatus)
+  })
+})

--- a/self/ui/src/panels/dashboard/__tests__/ProviderHealthWidget.test.tsx
+++ b/self/ui/src/panels/dashboard/__tests__/ProviderHealthWidget.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ProviderHealthWidget } from '../widgets/ProviderHealthWidget'
+import { HealthQueryProvider } from '../hooks/HealthQueryProvider'
+import type { HealthFetchers } from '../hooks/HealthQueryProvider'
+import type { ProviderHealthSnapshot } from '@nous/shared'
+import type { IDockviewPanelProps } from 'dockview-react'
+
+vi.mock('../../../../hooks/useEventSubscription', () => ({
+  useEventSubscription: vi.fn(),
+}))
+
+const mockSnapshot: ProviderHealthSnapshot = {
+  providers: [
+    {
+      providerId: '00000000-0000-0000-0000-000000000001',
+      name: 'Ollama',
+      type: 'local',
+      isLocal: true,
+      endpoint: 'http://localhost:11434',
+      status: 'available',
+      modelId: 'llama3.2:3b',
+    },
+    {
+      providerId: '00000000-0000-0000-0000-000000000002',
+      name: 'OpenAI',
+      type: 'cloud',
+      isLocal: false,
+      status: 'unknown',
+    },
+    {
+      providerId: '00000000-0000-0000-0000-000000000003',
+      name: 'Anthropic',
+      type: 'cloud',
+      isLocal: false,
+      status: 'unreachable',
+    },
+  ],
+  collectedAt: '2026-03-25T10:00:00.000Z',
+}
+
+const dockviewProps = {} as IDockviewPanelProps
+
+function renderWithProvider(fetchers: Partial<HealthFetchers>) {
+  const defaultFetchers: HealthFetchers = {
+    fetchSystemStatus: vi.fn(),
+    fetchProviderHealth: vi.fn().mockResolvedValue(mockSnapshot),
+    fetchAgentStatus: vi.fn(),
+    ...fetchers,
+  }
+
+  return render(
+    <HealthQueryProvider fetchers={defaultFetchers}>
+      <ProviderHealthWidget {...dockviewProps} />
+    </HealthQueryProvider>,
+  )
+}
+
+describe('ProviderHealthWidget', () => {
+  it('renders loading indicator during initial fetch', () => {
+    const fetcher = vi.fn().mockReturnValue(new Promise(() => {}))
+    renderWithProvider({ fetchProviderHealth: fetcher })
+
+    expect(screen.getByText('Loading provider health...')).toBeTruthy()
+  })
+
+  it('renders live provider entries when data is available', async () => {
+    renderWithProvider({})
+
+    expect(await screen.findByText('Ollama')).toBeTruthy()
+    expect(screen.getByText('OpenAI')).toBeTruthy()
+    expect(screen.getByText('Anthropic')).toBeTruthy()
+    expect(screen.getByText('Available')).toBeTruthy()
+    expect(screen.getByText('Unknown')).toBeTruthy()
+    expect(screen.getByText('Unreachable')).toBeTruthy()
+    expect(screen.getByText('llama3.2:3b')).toBeTruthy()
+    expect(screen.getByText(/Updated:/)).toBeTruthy()
+  })
+
+  it('renders error fallback when fetch fails', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('Connection refused'))
+    renderWithProvider({ fetchProviderHealth: fetcher })
+
+    expect(
+      await screen.findByText(/Failed to load provider health: Connection refused/),
+    ).toBeTruthy()
+  })
+})

--- a/self/ui/src/panels/dashboard/__tests__/SystemStatusWidget.test.tsx
+++ b/self/ui/src/panels/dashboard/__tests__/SystemStatusWidget.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SystemStatusWidget } from '../widgets/SystemStatusWidget'
+import { HealthQueryProvider } from '../hooks/HealthQueryProvider'
+import type { HealthFetchers } from '../hooks/HealthQueryProvider'
+import type { SystemStatusSnapshot } from '@nous/shared'
+import type { IDockviewPanelProps } from 'dockview-react'
+
+vi.mock('../../../../hooks/useEventSubscription', () => ({
+  useEventSubscription: vi.fn(),
+}))
+
+const mockSnapshot: SystemStatusSnapshot = {
+  bootStatus: 'ready',
+  completedBootSteps: ['config-loaded', 'providers-registered'],
+  issueCodes: [],
+  inboxReady: true,
+  pendingSystemRuns: 0,
+  backlogAnalytics: {
+    queuedCount: 2,
+    activeCount: 1,
+    suspendedCount: 0,
+    completedInWindow: 5,
+    failedInWindow: 0,
+    pressureTrend: 'steady',
+  },
+  collectedAt: '2026-03-25T10:00:00.000Z',
+}
+
+const dockviewProps = {} as IDockviewPanelProps
+
+function renderWithProvider(fetchers: Partial<HealthFetchers>) {
+  const defaultFetchers: HealthFetchers = {
+    fetchSystemStatus: vi.fn().mockResolvedValue(mockSnapshot),
+    fetchProviderHealth: vi.fn(),
+    fetchAgentStatus: vi.fn(),
+    ...fetchers,
+  }
+
+  return render(
+    <HealthQueryProvider fetchers={defaultFetchers}>
+      <SystemStatusWidget {...dockviewProps} />
+    </HealthQueryProvider>,
+  )
+}
+
+describe('SystemStatusWidget', () => {
+  it('renders loading indicator during initial fetch', () => {
+    // Fetcher that never resolves to keep loading state
+    const fetcher = vi.fn().mockReturnValue(new Promise(() => {}))
+    renderWithProvider({ fetchSystemStatus: fetcher })
+
+    expect(screen.getByText('Loading system status...')).toBeTruthy()
+  })
+
+  it('renders boot status, boot steps, and collectedAt when data is available', async () => {
+    renderWithProvider({})
+
+    // Wait for data to render
+    expect(await screen.findByText('Ready')).toBeTruthy()
+    expect(screen.getByText('config-loaded')).toBeTruthy()
+    expect(screen.getByText('providers-registered')).toBeTruthy()
+    expect(screen.getByText('steady')).toBeTruthy()
+    // collectedAt rendered as localized time
+    expect(screen.getByText(/Updated:/)).toBeTruthy()
+  })
+
+  it('renders error fallback when fetch fails', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('Server down'))
+    renderWithProvider({ fetchSystemStatus: fetcher })
+
+    expect(await screen.findByText(/Failed to load system status: Server down/)).toBeTruthy()
+  })
+})

--- a/self/ui/src/panels/dashboard/__tests__/useHealthQuery.test.ts
+++ b/self/ui/src/panels/dashboard/__tests__/useHealthQuery.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { useHealthQuery } from '../hooks/useHealthQuery'
+
+describe('useHealthQuery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // --- Tier 1: Contract ---
+
+  it('returns { data, isLoading, error, refetch } matching UseHealthQueryResult<T>', () => {
+    const fetcher = vi.fn().mockResolvedValue({ value: 42 })
+    const { result } = renderHook(() => useHealthQuery(fetcher))
+
+    expect(result.current).toHaveProperty('data')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('error')
+    expect(result.current).toHaveProperty('refetch')
+    expect(typeof result.current.refetch).toBe('function')
+  })
+
+  // --- Tier 2: Behavior ---
+
+  it('executes initial fetch on mount and transitions from isLoading to data', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ value: 'hello' })
+    const { result } = renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 0 }))
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+
+    // Flush the resolved promise
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toEqual({ value: 'hello' })
+    expect(result.current.error).toBeNull()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls at the configured interval', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ tick: 1 })
+    renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 1000 }))
+
+    // Initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // First poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(fetcher).toHaveBeenCalledTimes(2)
+
+    // Second poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(fetcher).toHaveBeenCalledTimes(3)
+  })
+
+  it('refetch() triggers an immediate fetch', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ v: 1 })
+    const { result } = renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 0 }))
+
+    // Wait for initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.isLoading).toBe(false)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      result.current.refetch()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates in-flight fetches', async () => {
+    let resolveFirst: ((v: { v: number }) => void) | null = null
+    const fetcher = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ v: number }>((resolve) => {
+          resolveFirst = resolve
+        }),
+    )
+
+    const { result } = renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 0 }))
+
+    // Initial fetch is in-flight
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // Try to refetch while first is still in-flight — should be deduplicated
+    act(() => {
+      result.current.refetch()
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // Resolve the first fetch
+    await act(async () => {
+      resolveFirst!({ v: 1 })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.data).toEqual({ v: 1 })
+  })
+
+  it('sets error state when fetcher rejects', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('Network failure'))
+    const { result } = renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 0 }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.error!.message).toBe('Network failure')
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('clears error state on successful fetch after error', async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({ recovered: true })
+
+    const { result } = renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 0 }))
+
+    // Wait for error
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(result.current.error).not.toBeNull()
+
+    // Refetch succeeds
+    await act(async () => {
+      result.current.refetch()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.data).toEqual({ recovered: true })
+  })
+
+  it('skips initial fetch and polling when enabled is false', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ v: 1 })
+    const { result } = renderHook(() =>
+      useHealthQuery(fetcher, { enabled: false }),
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000)
+    })
+
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('disables polling when pollIntervalMs is 0', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ v: 1 })
+    renderHook(() => useHealthQuery(fetcher, { pollIntervalMs: 0 }))
+
+    // Initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // Advance time — no more fetches
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000)
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  // --- Tier 3: Edge ---
+
+  it('cleans up polling interval on unmount', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ v: 1 })
+    const { unmount } = renderHook(() =>
+      useHealthQuery(fetcher, { pollIntervalMs: 1000 }),
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    // No additional calls after unmount
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/self/ui/src/panels/dashboard/constants.ts
+++ b/self/ui/src/panels/dashboard/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Default polling interval for health dashboard queries (milliseconds).
+ * Applied to all health widget `useHealthQuery` calls unless overridden.
+ */
+export const HEALTH_POLL_INTERVAL_MS = 5000

--- a/self/ui/src/panels/dashboard/hooks/HealthQueryProvider.tsx
+++ b/self/ui/src/panels/dashboard/hooks/HealthQueryProvider.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext } from 'react'
+import type { ReactNode } from 'react'
+import type {
+  SystemStatusSnapshot,
+  ProviderHealthSnapshot,
+  AgentStatusSnapshot,
+} from '@nous/shared'
+
+/**
+ * Plain async fetcher functions for each health endpoint.
+ * The web app host provides concrete tRPC-backed implementations;
+ * `@nous/ui` widgets consume these without importing `@trpc/react-query`.
+ */
+export type HealthFetchers = {
+  fetchSystemStatus: () => Promise<SystemStatusSnapshot>
+  fetchProviderHealth: () => Promise<ProviderHealthSnapshot>
+  fetchAgentStatus: () => Promise<AgentStatusSnapshot>
+}
+
+const HealthQueryContext = createContext<HealthFetchers | null>(null)
+
+export function HealthQueryProvider({
+  fetchers,
+  children,
+}: {
+  fetchers: HealthFetchers
+  children: ReactNode
+}) {
+  return (
+    <HealthQueryContext.Provider value={fetchers}>
+      {children}
+    </HealthQueryContext.Provider>
+  )
+}
+
+/**
+ * Access health fetcher functions provided by the host application.
+ * Must be called within a `<HealthQueryProvider>`.
+ */
+export function useHealthQueries(): HealthFetchers {
+  const ctx = useContext(HealthQueryContext)
+  if (ctx === null) {
+    throw new Error(
+      'useHealthQueries must be used within a <HealthQueryProvider>. ' +
+        'Wrap your component tree with <HealthQueryProvider fetchers={...}>.',
+    )
+  }
+  return ctx
+}

--- a/self/ui/src/panels/dashboard/hooks/index.ts
+++ b/self/ui/src/panels/dashboard/hooks/index.ts
@@ -1,0 +1,4 @@
+export { HealthQueryProvider, useHealthQueries } from './HealthQueryProvider'
+export type { HealthFetchers } from './HealthQueryProvider'
+export { useHealthQuery } from './useHealthQuery'
+export type { UseHealthQueryResult } from './useHealthQuery'

--- a/self/ui/src/panels/dashboard/hooks/useHealthQuery.ts
+++ b/self/ui/src/panels/dashboard/hooks/useHealthQuery.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { HEALTH_POLL_INTERVAL_MS } from '../constants'
+
+export type UseHealthQueryResult<T> = {
+  data: T | undefined
+  isLoading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+/**
+ * Generic polling hook for health data.
+ *
+ * Accepts a plain async fetcher and returns reactive query state with
+ * configurable polling and an imperative `refetch` handle for
+ * event-driven cache invalidation.
+ *
+ * - Executes an initial fetch on mount (when `enabled` is true).
+ * - Polls at `pollIntervalMs` (default `HEALTH_POLL_INTERVAL_MS`).
+ * - Deduplicates in-flight fetches via a ref guard.
+ * - `pollIntervalMs <= 0` disables polling.
+ */
+export function useHealthQuery<T>(
+  fetcher: () => Promise<T>,
+  options?: { pollIntervalMs?: number; enabled?: boolean },
+): UseHealthQueryResult<T> {
+  const {
+    pollIntervalMs = HEALTH_POLL_INTERVAL_MS,
+    enabled = true,
+  } = options ?? {}
+
+  const [data, setData] = useState<T | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(enabled)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Ref guard: prevent overlapping fetches
+  const inFlightRef = useRef(false)
+  // Keep fetcher in a ref so polling/refetch always calls the latest
+  const fetcherRef = useRef(fetcher)
+  fetcherRef.current = fetcher
+
+  const executeFetch = useCallback(() => {
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+
+    fetcherRef
+      .current()
+      .then((result) => {
+        setData(result)
+        setError(null)
+        setIsLoading(false)
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err : new Error(String(err)))
+        setIsLoading(false)
+      })
+      .finally(() => {
+        inFlightRef.current = false
+      })
+  }, [])
+
+  // Initial fetch + polling
+  useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false)
+      return
+    }
+
+    // Initial fetch
+    executeFetch()
+
+    // Polling
+    if (pollIntervalMs > 0) {
+      const id = setInterval(executeFetch, pollIntervalMs)
+      return () => clearInterval(id)
+    }
+  }, [enabled, pollIntervalMs, executeFetch])
+
+  const refetch = useCallback(() => {
+    executeFetch()
+  }, [executeFetch])
+
+  return { data, isLoading, error, refetch }
+}

--- a/self/ui/src/panels/dashboard/index.ts
+++ b/self/ui/src/panels/dashboard/index.ts
@@ -1,1 +1,3 @@
 export { DashboardPanel, DashboardWidgetMenu, useDashboardApi } from './DashboardPanel'
+export { HealthQueryProvider, useHealthQueries } from './hooks'
+export type { HealthFetchers } from './hooks'

--- a/self/ui/src/panels/dashboard/widgets/ActiveAgentsWidget.tsx
+++ b/self/ui/src/panels/dashboard/widgets/ActiveAgentsWidget.tsx
@@ -1,30 +1,21 @@
 import type { IDockviewPanelProps } from 'dockview-react'
 import type { CSSProperties } from 'react'
+import { useEventSubscription } from '../../../hooks/useEventSubscription'
+import { useHealthQueries, useHealthQuery } from '../hooks'
 
-type AgentEntry = {
-  name: string
-  detail: string
-  status: 'active' | 'complete' | 'waiting'
+const HEALTH_STATUS_COLORS: Record<string, string> = {
+  healthy: 'var(--nous-state-complete)',
+  degraded: 'var(--nous-state-active)',
+  unhealthy: 'var(--nous-state-blocked)',
+  stale: 'var(--nous-fg-subtle)',
 }
 
-const STUB_AGENTS: AgentEntry[] = [
-  { name: 'nous-orchestrator', detail: 'dispatch \u2192 impl', status: 'active' },
-  { name: 'nous-prompt-gen', detail: 'handoff \u2192 sds', status: 'complete' },
-  { name: 'nous-worker-sds', detail: 'response_packet', status: 'complete' },
-  { name: 'nous-worker-impl', detail: 'executing impl', status: 'active' },
-  { name: 'nous-reviewer', detail: 'awaiting handoff', status: 'waiting' },
-]
-
-const STATUS_COLORS: Record<string, string> = {
-  active: 'var(--nous-state-active)',
-  complete: 'var(--nous-state-complete)',
-  waiting: 'var(--nous-state-waiting)',
-}
-
-const STATUS_LABELS: Record<string, string> = {
+const SESSION_STATUS_LABELS: Record<string, string> = {
+  starting: 'STARTING',
   active: 'ACTIVE',
-  complete: 'COMPLETE',
-  waiting: 'WAITING',
+  draining: 'DRAINING',
+  stopped: 'STOPPED',
+  failed: 'FAILED',
 }
 
 const rowStyle: CSSProperties = {
@@ -36,22 +27,130 @@ const rowStyle: CSSProperties = {
   borderBottom: '1px solid var(--nous-border-subtle)',
 }
 
+const sectionHeaderStyle: CSSProperties = {
+  padding: 'var(--nous-space-sm) var(--nous-space-xl)',
+  fontSize: 'var(--nous-font-size-xs)',
+  color: 'var(--nous-fg-subtle)',
+  borderBottom: '1px solid var(--nous-border-subtle)',
+}
+
+const containerStyle: CSSProperties = {
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  color: 'var(--nous-fg)',
+}
+
 export function ActiveAgentsWidget(_props: IDockviewPanelProps) {
-  return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', color: 'var(--nous-fg)' }}>
-      <div style={{ padding: 'var(--nous-space-sm) var(--nous-space-xl)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-subtle)', borderBottom: '1px solid var(--nous-border-subtle)' }}>
-        Cycle 3
+  const { fetchAgentStatus } = useHealthQueries()
+  const { data, isLoading, error, refetch } = useHealthQuery(fetchAgentStatus)
+
+  useEventSubscription({
+    channels: [
+      'health:boot-step',
+      'health:gateway-status',
+      'health:issue',
+      'health:backlog-analytics',
+    ],
+    onEvent: () => {
+      refetch()
+    },
+  })
+
+  if (isLoading && !data) {
+    return (
+      <div style={containerStyle}>
+        <div style={{ padding: 'var(--nous-space-sm) var(--nous-space-xl)', color: 'var(--nous-fg-muted)', fontSize: 'var(--nous-font-size-sm)' }}>
+          Loading agent status...
+        </div>
       </div>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <div style={containerStyle}>
+        <div style={{ padding: 'var(--nous-space-sm) var(--nous-space-xl)', color: 'var(--nous-state-blocked)', fontSize: 'var(--nous-font-size-sm)' }}>
+          Failed to load agent status: {error.message}
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return <div style={containerStyle} />
+
+  return (
+    <div style={containerStyle}>
+      <div style={sectionHeaderStyle}>
+        {data.gateways.length} Gateway{data.gateways.length !== 1 ? 's' : ''} &middot; {data.appSessions.length} Session{data.appSessions.length !== 1 ? 's' : ''}
+      </div>
+
       <div style={{ flex: 1, overflow: 'auto' }}>
-        {STUB_AGENTS.map((agent) => (
-          <div key={agent.name} style={rowStyle}>
-            <span style={{ flex: 1, fontWeight: 'var(--nous-font-weight-medium)' as any }}>{agent.name}</span>
-            <span style={{ color: 'var(--nous-fg-muted)', fontSize: 'var(--nous-font-size-xs)', flex: 1 }}>{agent.detail}</span>
-            <span style={{ fontSize: 'var(--nous-font-size-xs)', fontWeight: 'var(--nous-font-weight-semibold)' as any, color: STATUS_COLORS[agent.status], flexShrink: 0 }}>
-              {STATUS_LABELS[agent.status]}
+        {/* Gateways */}
+        {data.gateways.map((gw) => (
+          <div key={gw.agentId} style={rowStyle}>
+            <span style={{ flex: 1, fontWeight: 'var(--nous-font-weight-medium)' as any }}>
+              {gw.agentClass}
             </span>
+            <span style={{ color: 'var(--nous-fg-muted)', fontSize: 'var(--nous-font-size-xs)' }}>
+              {gw.visibleToolCount} tool{gw.visibleToolCount !== 1 ? 's' : ''}
+            </span>
+            <span
+              style={{
+                fontSize: 'var(--nous-font-size-xs)',
+                fontWeight: 'var(--nous-font-weight-semibold)' as any,
+                color: gw.inboxReady ? 'var(--nous-state-complete)' : 'var(--nous-fg-subtle)',
+                flexShrink: 0,
+              }}
+            >
+              {gw.inboxReady ? 'READY' : 'NOT READY'}
+            </span>
+            {gw.issueCount > 0 && (
+              <span style={{ color: 'var(--nous-state-blocked)', fontSize: 'var(--nous-font-size-xs)' }}>
+                {gw.issueCount} issue{gw.issueCount !== 1 ? 's' : ''}
+              </span>
+            )}
           </div>
         ))}
+
+        {/* App sessions */}
+        {data.appSessions.map((session) => (
+          <div key={session.sessionId} style={rowStyle}>
+            <span style={{ flex: 1, fontWeight: 'var(--nous-font-weight-medium)' as any }}>
+              {session.appId}
+            </span>
+            <span style={{ color: 'var(--nous-fg-muted)', fontSize: 'var(--nous-font-size-xs)', flex: 1 }}>
+              {session.packageId}
+            </span>
+            <span
+              style={{
+                fontSize: 'var(--nous-font-size-xs)',
+                fontWeight: 'var(--nous-font-weight-semibold)' as any,
+                color: HEALTH_STATUS_COLORS[session.healthStatus] ?? 'var(--nous-fg-subtle)',
+                flexShrink: 0,
+              }}
+            >
+              {SESSION_STATUS_LABELS[session.status] ?? session.status.toUpperCase()}
+            </span>
+            {session.stale && (
+              <span style={{ color: 'var(--nous-fg-subtle)', fontSize: 'var(--nous-font-size-xs)' }}>
+                STALE
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Collected at */}
+      <div
+        style={{
+          padding: 'var(--nous-space-sm) var(--nous-space-xl)',
+          fontSize: 'var(--nous-font-size-xs)',
+          color: 'var(--nous-fg-subtle)',
+          borderTop: '1px solid var(--nous-border-subtle)',
+        }}
+      >
+        Updated: {new Date(data.collectedAt).toLocaleTimeString()}
       </div>
     </div>
   )

--- a/self/ui/src/panels/dashboard/widgets/ProviderHealthWidget.tsx
+++ b/self/ui/src/panels/dashboard/widgets/ProviderHealthWidget.tsx
@@ -1,23 +1,12 @@
 import type { IDockviewPanelProps } from 'dockview-react'
 import type { CSSProperties } from 'react'
 import { useEventSubscription } from '../../../hooks/useEventSubscription'
-
-type ProviderEntry = {
-  name: string
-  status: 'connected' | 'not-configured' | 'error'
-  model?: string
-}
-
-const STUB_PROVIDERS: ProviderEntry[] = [
-  { name: 'Ollama', status: 'connected', model: 'llama3.2:3b' },
-  { name: 'OpenAI', status: 'not-configured' },
-  { name: 'Anthropic', status: 'not-configured' },
-]
+import { useHealthQueries, useHealthQuery } from '../hooks'
 
 const STATUS_DOT: Record<string, { color: string; label: string }> = {
-  connected: { color: 'var(--nous-state-complete)', label: 'Connected' },
-  'not-configured': { color: 'var(--nous-fg-subtle)', label: 'Not configured' },
-  error: { color: 'var(--nous-state-blocked)', label: 'Error' },
+  available: { color: 'var(--nous-state-complete)', label: 'Available' },
+  unknown: { color: 'var(--nous-fg-subtle)', label: 'Unknown' },
+  unreachable: { color: 'var(--nous-state-blocked)', label: 'Unreachable' },
 }
 
 const rowStyle: CSSProperties = {
@@ -29,20 +18,51 @@ const rowStyle: CSSProperties = {
   borderBottom: '1px solid var(--nous-border-subtle)',
 }
 
+const containerStyle: CSSProperties = {
+  height: '100%',
+  overflow: 'auto',
+  color: 'var(--nous-fg)',
+}
+
 export function ProviderHealthWidget(_props: IDockviewPanelProps) {
+  const { fetchProviderHealth } = useHealthQueries()
+  const { data, isLoading, error, refetch } = useHealthQuery(fetchProviderHealth)
+
   useEventSubscription({
     channels: ['health:boot-step', 'health:gateway-status', 'health:issue', 'health:backlog-analytics'],
     onEvent: () => {
-      // Future: invalidate health tRPC query when widget is connected to real data
+      refetch()
     },
   })
 
+  if (isLoading && !data) {
+    return (
+      <div style={containerStyle}>
+        <div style={{ padding: 'var(--nous-space-md) var(--nous-space-xl)', color: 'var(--nous-fg-muted)', fontSize: 'var(--nous-font-size-sm)' }}>
+          Loading provider health...
+        </div>
+      </div>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <div style={containerStyle}>
+        <div style={{ padding: 'var(--nous-space-md) var(--nous-space-xl)', color: 'var(--nous-state-blocked)', fontSize: 'var(--nous-font-size-sm)' }}>
+          Failed to load provider health: {error.message}
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return <div style={containerStyle} />
+
   return (
-    <div style={{ height: '100%', overflow: 'auto', color: 'var(--nous-fg)' }}>
-      {STUB_PROVIDERS.map((provider) => {
-        const dot = STATUS_DOT[provider.status]
+    <div style={containerStyle}>
+      {data.providers.map((provider) => {
+        const dot = STATUS_DOT[provider.status] ?? { color: 'var(--nous-fg-subtle)', label: provider.status }
         return (
-          <div key={provider.name} style={rowStyle}>
+          <div key={provider.providerId} style={rowStyle}>
             <span
               style={{
                 width: 8,
@@ -54,14 +74,23 @@ export function ProviderHealthWidget(_props: IDockviewPanelProps) {
             />
             <span style={{ fontWeight: 'var(--nous-font-weight-medium)' as any, minWidth: '80px' }}>{provider.name}</span>
             <span style={{ color: 'var(--nous-fg-muted)', flex: 1 }}>{dot.label}</span>
-            {provider.model && (
+            {provider.modelId && (
               <span style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-subtle)', flexShrink: 0 }}>
-                {provider.model}
+                {provider.modelId}
               </span>
             )}
           </div>
         )
       })}
+      <div
+        style={{
+          padding: 'var(--nous-space-sm) var(--nous-space-xl)',
+          fontSize: 'var(--nous-font-size-xs)',
+          color: 'var(--nous-fg-subtle)',
+        }}
+      >
+        Updated: {new Date(data.collectedAt).toLocaleTimeString()}
+      </div>
     </div>
   )
 }

--- a/self/ui/src/panels/dashboard/widgets/SystemStatusWidget.tsx
+++ b/self/ui/src/panels/dashboard/widgets/SystemStatusWidget.tsx
@@ -1,7 +1,146 @@
 import type { IDockviewPanelProps } from 'dockview-react'
+import type { CSSProperties } from 'react'
+import { useEventSubscription } from '../../../hooks/useEventSubscription'
+import { useHealthQueries, useHealthQuery } from '../hooks'
+
+const containerStyle: CSSProperties = {
+  height: '100%',
+  overflow: 'auto',
+  color: 'var(--nous-fg)',
+  padding: 'var(--nous-space-md) var(--nous-space-xl)',
+  fontSize: 'var(--nous-font-size-sm)',
+}
+
+const sectionHeaderStyle: CSSProperties = {
+  fontSize: 'var(--nous-font-size-xs)',
+  color: 'var(--nous-fg-subtle)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  marginTop: 'var(--nous-space-lg)',
+  marginBottom: 'var(--nous-space-sm)',
+}
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--nous-space-md)',
+  padding: 'var(--nous-space-xs) 0',
+  fontSize: 'var(--nous-font-size-sm)',
+}
+
+const BOOT_STATUS_COLORS: Record<string, string> = {
+  ready: 'var(--nous-state-complete)',
+  booting: 'var(--nous-state-active)',
+  degraded: 'var(--nous-state-blocked)',
+}
+
+const BOOT_STATUS_LABELS: Record<string, string> = {
+  ready: 'Ready',
+  booting: 'Booting',
+  degraded: 'Degraded',
+}
 
 export function SystemStatusWidget(_props: IDockviewPanelProps) {
+  const { fetchSystemStatus } = useHealthQueries()
+  const { data, isLoading, error, refetch } = useHealthQuery(fetchSystemStatus)
+
+  useEventSubscription({
+    channels: [
+      'health:boot-step',
+      'health:gateway-status',
+      'health:issue',
+      'health:backlog-analytics',
+    ],
+    onEvent: () => {
+      refetch()
+    },
+  })
+
+  if (isLoading && !data) {
+    return (
+      <div style={containerStyle}>
+        <span style={{ color: 'var(--nous-fg-muted)' }}>Loading system status...</span>
+      </div>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <div style={containerStyle}>
+        <span style={{ color: 'var(--nous-state-blocked)' }}>
+          Failed to load system status: {error.message}
+        </span>
+      </div>
+    )
+  }
+
+  if (!data) return <div style={containerStyle} />
+
+  const backlog = data.backlogAnalytics
+
   return (
-    <div style={{ height: '100%', overflow: 'auto', color: 'var(--nous-fg)' }} />
+    <div style={containerStyle}>
+      {/* Boot status */}
+      <div style={rowStyle}>
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: BOOT_STATUS_COLORS[data.bootStatus] ?? 'var(--nous-fg-subtle)',
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontWeight: 'var(--nous-font-weight-semibold)' as any }}>
+          {BOOT_STATUS_LABELS[data.bootStatus] ?? data.bootStatus}
+        </span>
+        {data.issueCodes.length > 0 && (
+          <span style={{ color: 'var(--nous-state-blocked)', fontSize: 'var(--nous-font-size-xs)' }}>
+            {data.issueCodes.length} issue{data.issueCodes.length !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Completed boot steps */}
+      <div style={sectionHeaderStyle}>Boot Steps</div>
+      {data.completedBootSteps.length === 0 ? (
+        <div style={{ color: 'var(--nous-fg-muted)', fontSize: 'var(--nous-font-size-xs)' }}>
+          No boot steps recorded
+        </div>
+      ) : (
+        data.completedBootSteps.map((step) => (
+          <div key={step} style={rowStyle}>
+            <span style={{ color: 'var(--nous-state-complete)', flexShrink: 0 }}>&#x2713;</span>
+            <span>{step}</span>
+          </div>
+        ))
+      )}
+
+      {/* Backlog analytics */}
+      <div style={sectionHeaderStyle}>Backlog</div>
+      <div style={rowStyle}>
+        <span style={{ color: 'var(--nous-fg-muted)', minWidth: 80 }}>Queued</span>
+        <span>{backlog.queuedCount}</span>
+      </div>
+      <div style={rowStyle}>
+        <span style={{ color: 'var(--nous-fg-muted)', minWidth: 80 }}>Active</span>
+        <span>{backlog.activeCount}</span>
+      </div>
+      <div style={rowStyle}>
+        <span style={{ color: 'var(--nous-fg-muted)', minWidth: 80 }}>Trend</span>
+        <span>{backlog.pressureTrend}</span>
+      </div>
+
+      {/* Collected at */}
+      <div
+        style={{
+          marginTop: 'var(--nous-space-lg)',
+          fontSize: 'var(--nous-font-size-xs)',
+          color: 'var(--nous-fg-subtle)',
+        }}
+      >
+        Updated: {new Date(data.collectedAt).toLocaleTimeString()}
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Wire dashboard health widgets (CPU, Memory, Latency, Agent Status) to live tRPC data via `useHealthMetrics` and `useAgentStatus` hooks
- Add SP 1.3 user-documentation, synthesis review, and behavioral testing sign-off artifacts

## Sub-phase
Phase 1.3 — Dashboard Widget Wiring

## Review
`.worklog/sprints/feat/health-monitoring/phase-1/phase-1.3/reviews/review.mdx`