### PR TITLE
Merge SP 2.4.1 context-menu BT fixes into Phase 2.4

### DIFF
--- a/self/ui/src/panels/workflow-builder/context-menu/CanvasContextMenu.tsx
+++ b/self/ui/src/panels/workflow-builder/context-menu/CanvasContextMenu.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { getAllRegistryEntries } from '../nodes/node-registry'
 import type { NodeCategory } from '../../../types/workflow-builder'
 
@@ -142,7 +143,7 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
     return { category, entries }
   }).filter((g) => g.entries.length > 0)
 
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       style={{ ...menuStyle, left: clampedPosition.x, top: clampedPosition.y }}
@@ -157,6 +158,7 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
       >
         <button
           type="button"
+          className="context-menu-item"
           style={menuItemStyle}
           aria-label="Add node"
           role="menuitem"
@@ -187,6 +189,7 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
                   <button
                     key={nousType}
                     type="button"
+                    className="context-menu-item"
                     style={menuItemStyle}
                     onClick={() => handleAddNode(nousType)}
                     aria-label={`Add ${entry.defaultLabel}`}
@@ -208,6 +211,7 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
       {/* Paste — placeholder */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemDisabledStyle}
         disabled
         aria-label="Paste"
@@ -221,6 +225,7 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
       {/* Select all */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleSelectAll}
         aria-label="Select all"
@@ -236,6 +241,7 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
       {/* Auto-layout — placeholder */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemDisabledStyle}
         disabled
         aria-label="Auto-layout"
@@ -245,7 +251,8 @@ function CanvasContextMenuInner({ position, onClose, onAddNode, onSelectAll }: C
         <i className="codicon codicon-layout" style={{ fontSize: 14 }} />
         <span>Auto-layout</span>
       </button>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/self/ui/src/panels/workflow-builder/context-menu/EdgeContextMenu.tsx
+++ b/self/ui/src/panels/workflow-builder/context-menu/EdgeContextMenu.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -112,7 +113,7 @@ function EdgeContextMenuInner({
     onClose()
   }, [onChangeEdgeType, edgeId, onClose])
 
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       style={{ ...menuStyle, left: clampedPosition.x, top: clampedPosition.y }}
@@ -122,6 +123,7 @@ function EdgeContextMenuInner({
       {/* Delete */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleDelete}
         aria-label="Delete edge"
@@ -135,6 +137,7 @@ function EdgeContextMenuInner({
       {/* Change type */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleChangeType}
         aria-label="Change edge type"
@@ -150,6 +153,7 @@ function EdgeContextMenuInner({
       {/* Set condition — placeholder */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemDisabledStyle}
         disabled
         aria-label="Set condition"
@@ -159,7 +163,8 @@ function EdgeContextMenuInner({
         <i className="codicon codicon-filter" style={{ fontSize: 14 }} />
         <span>Set condition</span>
       </button>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/self/ui/src/panels/workflow-builder/context-menu/NodeContextMenu.tsx
+++ b/self/ui/src/panels/workflow-builder/context-menu/NodeContextMenu.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -114,7 +115,7 @@ function NodeContextMenuInner({
     onClose()
   }, [onOpenInspector, nodeId, onClose])
 
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       style={{ ...menuStyle, left: clampedPosition.x, top: clampedPosition.y }}
@@ -124,6 +125,7 @@ function NodeContextMenuInner({
       {/* Delete */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleDelete}
         aria-label="Delete node"
@@ -137,6 +139,7 @@ function NodeContextMenuInner({
       {/* Duplicate */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleDuplicate}
         aria-label="Duplicate node"
@@ -152,6 +155,7 @@ function NodeContextMenuInner({
       {/* Bind skill */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleOpenInspector}
         aria-label="Bind skill"
@@ -165,6 +169,7 @@ function NodeContextMenuInner({
       {/* Bind contract */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleOpenInspector}
         aria-label="Bind contract"
@@ -178,6 +183,7 @@ function NodeContextMenuInner({
       {/* Bind template */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleOpenInspector}
         aria-label="Bind template"
@@ -193,6 +199,7 @@ function NodeContextMenuInner({
       {/* View node.md */}
       <button
         type="button"
+        className="context-menu-item"
         style={menuItemStyle}
         onClick={handleOpenInspector}
         aria-label="View node.md"
@@ -202,7 +209,8 @@ function NodeContextMenuInner({
         <i className="codicon codicon-file-code" style={{ fontSize: 14 }} />
         <span>View node.md</span>
       </button>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/self/ui/src/styles/components.css
+++ b/self/ui/src/styles/components.css
@@ -213,3 +213,8 @@
   --nous-builder-panel-header-bg:   var(--nous-canvas-panel-header-bg);
   --nous-builder-panel-header-text: var(--nous-canvas-panel-header-text);
 }
+
+/* ── Context menu item hover ─────────────────────────────────────── */
+.context-menu-item:hover {
+  background: var(--nous-bg-hover);
+}


### PR DESCRIPTION
## Summary
- Fixes context menu portal positioning and hover feedback issues found during behavioral testing
- Adds SP 2.4 and SP 2.4.1 review and user-documentation worklog artifacts
- Completes sub-phase 2.4.1 close sequence

## Merge direction
`feat/workflow-projection-builder.2.4.1/context-menu-bt-fixes` -> `feat/workflow-projection-builder.2.4/context-menus-node-search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)