### PR TITLE
fix(web,ui): wire HealthQueryProvider + guard ChatSurface SSR

### DIFF
--- a/self/apps/web/app/(shell)/layout.tsx
+++ b/self/apps/web/app/(shell)/layout.tsx
@@ -14,6 +14,8 @@ import {
   CommandPalette,
 } from '@nous/ui/components'
 import type { ShellMode, NavigationState } from '@nous/ui/components'
+import { HealthQueryProvider } from '@nous/ui/panels'
+import type { HealthFetchers } from '@nous/ui/panels'
 import { WebChromeShell } from '@/components/shell/web-chrome-shell'
 import { webRailSections } from '@/components/shell/web-rail-config'
 import { webShellRoutes } from '@/components/shell/web-shell-routes'
@@ -171,6 +173,12 @@ function ShellLayoutContent({
     [projectsData],
   )
 
+  const healthFetchers: HealthFetchers = useMemo(() => ({
+    fetchSystemStatus: () => utils.health.systemStatus.fetch(),
+    fetchProviderHealth: () => utils.health.providerHealth.fetch(),
+    fetchAgentStatus: () => utils.health.agentStatus.fetch(),
+  }), [utils])
+
   return (
     <WebChromeShell mode={mode} onModeToggle={handleModeToggle}>
       <ShellProvider
@@ -181,6 +189,7 @@ function ShellLayoutContent({
         goBack={handleGoBack}
         activeProjectId={projectId}
       >
+        <HealthQueryProvider fetchers={healthFetchers}>
         <ProjectProvider value={{ projectId, setProjectId }}>
           <CommandPalette
             isOpen={commandPaletteOpen}
@@ -213,6 +222,7 @@ function ShellLayoutContent({
           )}
           {children}
         </ProjectProvider>
+        </HealthQueryProvider>
       </ShellProvider>
     </WebChromeShell>
   )

--- a/self/ui/src/components/shell/ChatSurface.tsx
+++ b/self/ui/src/components/shell/ChatSurface.tsx
@@ -9,7 +9,7 @@ export function ChatSurface(props: ChatSurfaceProps) {
   const { conversation } = useShellContext()
 
   const chatApi: ChatAPI | undefined =
-    props.chatApi ?? (window as any).electronAPI?.chat ?? undefined
+    props.chatApi ?? (typeof window !== 'undefined' ? (window as any).electronAPI?.chat : undefined) ?? undefined
 
   return (
     <ChatPanel


### PR DESCRIPTION
## Summary
- Adds `HealthQueryProvider` with tRPC health fetchers to the web shell layout provider tree, fixing the runtime crash from WR-022 health monitoring merge
- Guards `window` access in `ChatSurface.tsx` with `typeof` check to prevent SSR `ReferenceError`

## Context
After WR-022 (health monitoring) merged to `dev`, the web app crashes on load because `SystemStatusWidget` calls `useHealthQueries` without a `HealthQueryProvider` in the web provider tree. The desktop app had this wired but the web app did not.

The `ChatSurface` SSR error is a pre-existing issue where `window.electronAPI` is accessed during server-side rendering.

## Test plan
- [ ] `pnpm dev:web` starts without console errors
- [ ] Dashboard renders with health widgets functional
- [ ] Navigation between shell routes works
- [ ] Chat page loads without SSR crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)