### PR TITLE
Merge feat/workflow-projection-builder.2.5/keyboard-nav-validation-toolbar into feat/workflow-projection-builder — Phase 2.5 complete

### DIFF
--- a/self/ui/src/panels/workflow-builder/BuilderToolbar.tsx
+++ b/self/ui/src/panels/workflow-builder/BuilderToolbar.tsx
@@ -10,6 +10,16 @@ export interface BuilderToolbarProps {
   onRedo?: () => void
   canUndo?: boolean
   canRedo?: boolean
+  /** SP 2.5 — Save handler (serialization only, persistence in Phase 3). */
+  onSave?: () => void
+  /** SP 2.5 — Toggle validation panel and trigger re-validation. */
+  onValidate?: () => void
+  /** SP 2.5 — Whether builder state has unsaved changes. */
+  isDirty?: boolean
+  /** SP 2.5 — Number of current validation errors. */
+  validationErrorCount?: number
+  /** SP 2.5 — Whether the validation panel is currently open. */
+  isValidationPanelOpen?: boolean
 }
 
 const MODES: { value: BuilderMode; label: string; icon: string }[] = [
@@ -71,6 +81,22 @@ const separatorStyle: React.CSSProperties = {
   flexShrink: 0,
 }
 
+const badgeStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'var(--nous-node-trigger, #e06c75)',
+  color: '#fff',
+  fontSize: '10px',
+  fontWeight: 700,
+  borderRadius: '9px',
+  minWidth: 18,
+  height: 18,
+  padding: '0 5px',
+  lineHeight: 1,
+  marginLeft: '-4px',
+}
+
 export function BuilderToolbar({
   mode,
   onModeChange,
@@ -78,6 +104,11 @@ export function BuilderToolbar({
   onRedo,
   canUndo = false,
   canRedo = false,
+  onSave,
+  onValidate,
+  isDirty = false,
+  validationErrorCount = 0,
+  isValidationPanelOpen = false,
 }: BuilderToolbarProps) {
   const { zoomIn, zoomOut, fitView } = useReactFlow()
 
@@ -89,6 +120,7 @@ export function BuilderToolbar({
           key={m.value}
           type="button"
           title={m.label}
+          aria-label={`${m.label} mode`}
           style={mode === m.value ? activeButtonStyle : buttonBaseStyle}
           onClick={() => onModeChange(m.value)}
         >
@@ -103,6 +135,7 @@ export function BuilderToolbar({
       <button
         type="button"
         title="Zoom In"
+        aria-label="Zoom in"
         style={buttonBaseStyle}
         onClick={() => zoomIn()}
       >
@@ -111,6 +144,7 @@ export function BuilderToolbar({
       <button
         type="button"
         title="Zoom Out"
+        aria-label="Zoom out"
         style={buttonBaseStyle}
         onClick={() => zoomOut()}
       >
@@ -119,6 +153,7 @@ export function BuilderToolbar({
       <button
         type="button"
         title="Fit View"
+        aria-label="Fit view"
         style={buttonBaseStyle}
         onClick={() => fitView()}
       >
@@ -131,6 +166,7 @@ export function BuilderToolbar({
       <button
         type="button"
         title="Undo (Ctrl+Z)"
+        aria-label="Undo"
         style={canUndo ? buttonBaseStyle : disabledButtonStyle}
         disabled={!canUndo}
         onClick={onUndo}
@@ -140,6 +176,7 @@ export function BuilderToolbar({
       <button
         type="button"
         title="Redo (Ctrl+Shift+Z)"
+        aria-label="Redo"
         style={canRedo ? buttonBaseStyle : disabledButtonStyle}
         disabled={!canRedo}
         onClick={onRedo}
@@ -147,14 +184,44 @@ export function BuilderToolbar({
         <i className="codicon codicon-redo" style={{ fontSize: 14 }} />
       </button>
 
-      {/* ── Placeholder actions (non-functional stubs) ── */}
-      <button type="button" title="Save" style={disabledButtonStyle} disabled>
+      {/* ── Save (SP 2.5) ── */}
+      <button
+        type="button"
+        title="Serialize workflow (persistence coming in Phase 3)"
+        aria-label="Save workflow"
+        data-testid="toolbar-save"
+        style={isDirty ? buttonBaseStyle : disabledButtonStyle}
+        disabled={!isDirty || !onSave}
+        onClick={onSave}
+      >
         <i className="codicon codicon-save" style={{ fontSize: 14 }} />
       </button>
-      <button type="button" title="Validate" style={disabledButtonStyle} disabled>
+
+      {/* ── Validate (SP 2.5) ── */}
+      <button
+        type="button"
+        title="Toggle Validation Panel"
+        aria-label="Toggle validation panel"
+        data-testid="toolbar-validate"
+        style={isValidationPanelOpen ? activeButtonStyle : buttonBaseStyle}
+        disabled={!onValidate}
+        onClick={onValidate}
+      >
         <i className="codicon codicon-check-all" style={{ fontSize: 14 }} />
       </button>
-      <button type="button" title="Auto Layout" style={disabledButtonStyle} disabled>
+      {validationErrorCount > 0 && (
+        <span
+          data-testid="toolbar-validation-badge"
+          role="status"
+          aria-label={`${validationErrorCount} validation error${validationErrorCount !== 1 ? 's' : ''}`}
+          style={badgeStyle}
+        >
+          {validationErrorCount}
+        </span>
+      )}
+
+      {/* ── Auto Layout (disabled stub — Phase 4 scope) ── */}
+      <button type="button" title="Auto Layout" aria-label="Auto layout" style={disabledButtonStyle} disabled>
         <i className="codicon codicon-layout" style={{ fontSize: 14 }} />
       </button>
     </div>

--- a/self/ui/src/panels/workflow-builder/ValidationPanel.tsx
+++ b/self/ui/src/panels/workflow-builder/ValidationPanel.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import type { WorkflowSpecValidationError } from '@nous/shared'
+import type { WorkflowBuilderNode, WorkflowBuilderEdge, ValidationPanelItem } from '../../types/workflow-builder'
+import { FloatingPanel } from './floating-panel/FloatingPanel'
+import { useFloatingPanel } from './floating-panel/useFloatingPanel'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface ValidationPanelProps {
+  /** Validation errors from useBuilderState. */
+  validationErrors: WorkflowSpecValidationError[]
+  /** Current nodes for element ID resolution. */
+  nodes: WorkflowBuilderNode[]
+  /** Current edges for element ID resolution. */
+  edges: WorkflowBuilderEdge[]
+  /** Whether the panel is visible (controlled by toolbar toggle). */
+  isVisible: boolean
+  /** Close the panel. */
+  onClose: () => void
+  /** Called when user clicks an error — pans to and selects affected element. */
+  onErrorClick: (errorPath: string) => void
+  /** Ref to the canvas wrapper for FloatingPanel boundary clamping. */
+  containerRef: React.RefObject<HTMLDivElement | null>
+}
+
+// ─── Error path resolution ───────────────────────────────────────────────────
+
+function resolveElementId(
+  path: string,
+  nodes: WorkflowBuilderNode[],
+  edges: WorkflowBuilderEdge[],
+): { elementId: string | null; elementType: 'node' | 'edge' | 'spec' | null } {
+  const nodeMatch = path.match(/^nodes\[(\d+)\]/)
+  if (nodeMatch) {
+    const index = parseInt(nodeMatch[1], 10)
+    return {
+      elementId: nodes[index]?.id ?? null,
+      elementType: 'node',
+    }
+  }
+  const connMatch = path.match(/^connections\[(\d+)\]/)
+  if (connMatch) {
+    const index = parseInt(connMatch[1], 10)
+    return {
+      elementId: edges[index]?.id ?? null,
+      elementType: 'edge',
+    }
+  }
+  return { elementId: null, elementType: 'spec' }
+}
+
+function deriveValidationItems(
+  errors: WorkflowSpecValidationError[],
+  nodes: WorkflowBuilderNode[],
+  edges: WorkflowBuilderEdge[],
+): ValidationPanelItem[] {
+  return errors.map((error) => {
+    const { elementId, elementType } = resolveElementId(error.path, nodes, edges)
+    return {
+      path: error.path,
+      message: error.message,
+      severity: 'error' as const,
+      elementId,
+      elementType,
+    }
+  })
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const errorListStyle: React.CSSProperties = {
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+}
+
+const errorItemStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: 'var(--nous-space-sm)' as unknown as string,
+  padding: 'var(--nous-space-xs) var(--nous-space-sm)' as unknown as string,
+  background: 'transparent',
+  border: 'none',
+  borderBottom: '1px solid var(--nous-border)',
+  color: 'var(--nous-fg)',
+  cursor: 'pointer',
+  width: '100%',
+  textAlign: 'left' as const,
+  fontSize: 'var(--nous-font-size-xs)' as unknown as string,
+  lineHeight: 1.4,
+}
+
+const errorIconStyle: React.CSSProperties = {
+  fontSize: 14,
+  flexShrink: 0,
+  marginTop: 1,
+}
+
+const emptyStateStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--nous-space-sm)' as unknown as string,
+  padding: 'var(--nous-space-md)' as unknown as string,
+  color: 'var(--nous-fg-muted)',
+  fontSize: 'var(--nous-font-size-sm)' as unknown as string,
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+function ValidationPanelInner({
+  validationErrors,
+  nodes,
+  edges,
+  isVisible,
+  onClose,
+  onErrorClick,
+  containerRef,
+}: ValidationPanelProps) {
+  const { state, panelRef, onCollapse, onPin, onClose: floatingOnClose, onShow, onDragStart } =
+    useFloatingPanel({
+      initialPosition: 'right',
+      containerRef,
+    })
+
+  // Sync visibility with isVisible prop
+  React.useEffect(() => {
+    if (isVisible) {
+      onShow()
+    }
+  }, [isVisible, onShow])
+
+  const items = useMemo(
+    () => deriveValidationItems(validationErrors, nodes, edges),
+    [validationErrors, nodes, edges],
+  )
+
+  if (!isVisible) return null
+
+  const handleClose = () => {
+    floatingOnClose()
+    onClose()
+  }
+
+  const severityIcon = (severity: 'error' | 'warning') =>
+    severity === 'error' ? 'codicon-error' : 'codicon-warning'
+
+  const severityColor = (severity: 'error' | 'warning') =>
+    severity === 'error' ? 'var(--nous-node-trigger, #e06c75)' : 'var(--nous-fg-muted)'
+
+  return (
+    <div data-testid="validation-panel">
+      <FloatingPanel
+        title="Validation"
+        state={state}
+        panelRef={panelRef}
+        onCollapse={onCollapse}
+        onPin={onPin}
+        onClose={handleClose}
+        onDragStart={onDragStart}
+      >
+        {items.length === 0 ? (
+          <div data-testid="validation-panel-empty" style={emptyStateStyle}>
+            <i
+              className="codicon codicon-check"
+              style={{ fontSize: 16, color: 'var(--nous-node-governance, #98c379)' }}
+            />
+            <span>No issues found</span>
+          </div>
+        ) : (
+          <ul style={errorListStyle} aria-live="polite" role="list">
+            {items.map((item, index) => (
+              <li key={`${item.path}-${index}`}>
+                <button
+                  type="button"
+                  style={errorItemStyle}
+                  data-testid="validation-panel-error-item"
+                  onClick={() => onErrorClick(item.path)}
+                  aria-label={`${item.severity}: ${item.message}`}
+                >
+                  <i
+                    className={`codicon ${severityIcon(item.severity)}`}
+                    style={{ ...errorIconStyle, color: severityColor(item.severity) }}
+                  />
+                  <span>{item.message}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </FloatingPanel>
+    </div>
+  )
+}
+
+export const ValidationPanel = React.memo(ValidationPanelInner)

--- a/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
+++ b/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useCallback, useRef, useState, useEffect } from 'react'
+import { useMemo, useCallback, useRef, useState, useEffect, useImperativeHandle, forwardRef } from 'react'
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -13,6 +13,7 @@ import {
 import type { IDockviewPanelProps } from 'dockview-react'
 import type { WorkflowBuilderNode, WorkflowBuilderEdge, ContextMenuState } from '../../types/workflow-builder'
 import { useBuilderState } from './hooks/useBuilderState'
+import { useKeyboardNav } from './hooks/useKeyboardNav'
 import { BuilderToolbar } from './BuilderToolbar'
 import { NodePalette } from './NodePalette'
 import { NodeInspector } from './inspectors/NodeInspector'
@@ -20,6 +21,7 @@ import { EdgeInspector } from './inspectors/EdgeInspector'
 import { WorkflowInspector } from './inspectors/WorkflowInspector'
 import { CanvasContextMenu, NodeContextMenu, EdgeContextMenu } from './context-menu'
 import { NodeSearch } from './NodeSearch'
+import { ValidationPanel } from './ValidationPanel'
 import { nodeTypes } from './nodes'
 import { edgeTypes } from './edges'
 
@@ -37,14 +39,24 @@ interface WorkflowBuilderDockviewProps extends IDockviewPanelProps {
 
 // ─── Inner canvas (runtime-agnostic — no dockview imports) ──────────────────
 
+// Imperative handle exposed by CanvasDropTarget to parent for keyboard nav wiring
+interface CanvasDropTargetHandle {
+  handleKeyDown: (e: React.KeyboardEvent) => void
+}
+
 // Inner drop-target component — must be inside ReactFlowProvider for useReactFlow()
-function CanvasDropTarget({
-  className,
+const CanvasDropTarget = forwardRef<
+  CanvasDropTargetHandle,
+  {
+    canvasRef: React.RefObject<HTMLDivElement | null>
+    canvasHasFocus: boolean
+    onFocusedNodeChange: (nodeId: string | null) => void
+  }
+>(function CanvasDropTarget({
   canvasRef,
-}: {
-  className?: string
-  canvasRef: React.RefObject<HTMLDivElement | null>
-}) {
+  canvasHasFocus,
+  onFocusedNodeChange,
+}, ref) {
   const {
     nodes,
     edges,
@@ -65,22 +77,100 @@ function CanvasDropTarget({
     updateNodeData,
     getCurrentSpec,
     validationErrors,
+    isDirty,
+    markClean,
+    moveNode,
     undo,
     redo,
     canUndo,
     canRedo,
   } = useBuilderState()
 
-  const { screenToFlowPosition, fitView, setCenter } = useReactFlow()
+  const { screenToFlowPosition, fitView } = useReactFlow()
 
   // ─── Context menu state ─────────────────────────────────────────────────
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const [nodeSearchOpen, setNodeSearchOpen] = useState(false)
+  const [isValidationPanelOpen, setIsValidationPanelOpen] = useState(false)
 
   const closeContextMenu = useCallback(() => {
     setContextMenu(null)
   }, [])
+
+  // ─── Keyboard navigation ───────────────────────────────────────────────
+
+  const { focusedNodeId, handleKeyDown: keyboardNavHandleKeyDown } = useKeyboardNav({
+    nodes,
+    edges,
+    selectedNodeId,
+    selectedEdgeId,
+    onSelectNode: (nodeId: string) => {
+      const node = nodes.find((n) => n.id === nodeId)
+      if (node) onNodeClick({} as React.MouseEvent, node)
+    },
+    onDeselectAll: () => onPaneClick({} as React.MouseEvent),
+    removeNode,
+    removeEdge,
+    moveNode,
+    onEscape: () => {
+      setContextMenu(null)
+      setNodeSearchOpen(false)
+      setIsValidationPanelOpen(false)
+    },
+    canvasHasFocus,
+  })
+
+  // ─── Expose keyboard nav handler to parent via imperative handle ────────
+
+  useImperativeHandle(ref, () => ({
+    handleKeyDown: keyboardNavHandleKeyDown,
+  }), [keyboardNavHandleKeyDown])
+
+  // Propagate focusedNodeId changes to parent for visual focus ring
+  useEffect(() => {
+    onFocusedNodeChange(focusedNodeId)
+  }, [focusedNodeId, onFocusedNodeChange])
+
+  // ─── Save handler (SP 2.5) ─────────────────────────────────────────────
+
+  const handleSave = useCallback(() => {
+    getCurrentSpec()
+    markClean()
+  }, [getCurrentSpec, markClean])
+
+  // ─── Validate toggle handler (SP 2.5) ──────────────────────────────────
+
+  const handleValidate = useCallback(() => {
+    setIsValidationPanelOpen((prev) => !prev)
+  }, [])
+
+  // ─── Error click handler (SP 2.5) ─────────────────────────────────────
+
+  const handleErrorClick = useCallback(
+    (errorPath: string) => {
+      // Parse path to find affected node/edge
+      const nodeMatch = errorPath.match(/^nodes\[(\d+)\]/)
+      if (nodeMatch) {
+        const index = parseInt(nodeMatch[1], 10)
+        const node = nodes[index]
+        if (node) {
+          onNodeClick({} as React.MouseEvent, node)
+          fitView({ nodes: [{ id: node.id }], duration: 300 })
+        }
+        return
+      }
+      const connMatch = errorPath.match(/^connections\[(\d+)\]/)
+      if (connMatch) {
+        const index = parseInt(connMatch[1], 10)
+        const edge = edges[index]
+        if (edge) {
+          onEdgeClick({} as React.MouseEvent, edge)
+        }
+      }
+    },
+    [nodes, edges, onNodeClick, onEdgeClick, fitView],
+  )
 
   // ─── Context menu event handlers ────────────────────────────────────────
 
@@ -331,6 +421,11 @@ function CanvasDropTarget({
         onRedo={redo}
         canUndo={canUndo}
         canRedo={canRedo}
+        onSave={handleSave}
+        onValidate={handleValidate}
+        isDirty={isDirty}
+        validationErrorCount={validationErrors.length}
+        isValidationPanelOpen={isValidationPanelOpen}
       />
       <NodePalette containerRef={canvasRef} />
       <NodeInspector
@@ -394,25 +489,58 @@ function CanvasDropTarget({
         onAddNode={handleSearchAddNode}
         onFocusNode={handleSearchFocusNode}
       />
+
+      {/* Validation Panel (SP 2.5) */}
+      <ValidationPanel
+        validationErrors={validationErrors}
+        nodes={nodes}
+        edges={edges}
+        isVisible={isValidationPanelOpen}
+        onClose={() => setIsValidationPanelOpen(false)}
+        onErrorClick={handleErrorClick}
+        containerRef={canvasRef}
+      />
     </>
   )
-}
+})
 
 function WorkflowBuilderCanvas({ className }: { className?: string }) {
   const canvasRef = useRef<HTMLDivElement | null>(null)
+  const dropTargetRef = useRef<CanvasDropTargetHandle>(null)
+  const [canvasHasFocus, setCanvasHasFocus] = useState(false)
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null)
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    dropTargetRef.current?.handleKeyDown(e)
+  }, [])
+
+  const handleFocusedNodeChange = useCallback((nodeId: string | null) => {
+    setFocusedNodeId(nodeId)
+  }, [])
 
   return (
     <div
       ref={canvasRef}
       className={className}
+      tabIndex={0}
+      onFocus={() => setCanvasHasFocus(true)}
+      onBlur={() => setCanvasHasFocus(false)}
+      onKeyDown={handleKeyDown}
+      data-focused-node-id={focusedNodeId ?? undefined}
       style={{
         width: '100%',
         height: '100%',
         position: 'relative',
+        outline: 'none',
       }}
     >
       <ReactFlowProvider>
-        <CanvasDropTarget className={className} canvasRef={canvasRef} />
+        <CanvasDropTarget
+          ref={dropTargetRef}
+          canvasRef={canvasRef}
+          canvasHasFocus={canvasHasFocus}
+          onFocusedNodeChange={handleFocusedNodeChange}
+        />
       </ReactFlowProvider>
     </div>
   )

--- a/self/ui/src/panels/workflow-builder/__tests__/ValidationPanel.test.tsx
+++ b/self/ui/src/panels/workflow-builder/__tests__/ValidationPanel.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { reactFlowMock } from './react-flow-mock'
+
+vi.mock('@xyflow/react', () => reactFlowMock)
+
+import { ValidationPanel } from '../ValidationPanel'
+import type { ValidationPanelProps } from '../ValidationPanel'
+import type { WorkflowBuilderNode, WorkflowBuilderEdge } from '../../../types/workflow-builder'
+import type { WorkflowSpecValidationError } from '@nous/shared'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createNode(id: string, index: number): WorkflowBuilderNode {
+  return {
+    id,
+    type: 'builderNode',
+    position: { x: index * 100, y: 0 },
+    data: {
+      label: `Node ${id}`,
+      category: 'agent',
+      nousType: `nous.agent.${id}`,
+    },
+  }
+}
+
+function createEdge(id: string, source: string, target: string): WorkflowBuilderEdge {
+  return {
+    id,
+    source,
+    target,
+    data: { edgeType: 'execution' },
+  }
+}
+
+const defaultNodes = [createNode('n1', 0), createNode('n2', 1)]
+const defaultEdges = [createEdge('e1', 'n1', 'n2')]
+
+function renderPanel(overrides: Partial<ValidationPanelProps> = {}) {
+  const containerRef = React.createRef<HTMLDivElement>()
+  const props: ValidationPanelProps = {
+    validationErrors: [],
+    nodes: defaultNodes,
+    edges: defaultEdges,
+    isVisible: true,
+    onClose: vi.fn(),
+    onErrorClick: vi.fn(),
+    containerRef,
+    ...overrides,
+  }
+  return {
+    ...render(<ValidationPanel {...props} />),
+    props,
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ValidationPanel', () => {
+  // ─── Tier 1 — Contract ──────────────────────────────────────────────────
+
+  describe('Tier 1 — Contract', () => {
+    it('renders without crashing with empty validationErrors', () => {
+      expect(() => renderPanel()).not.toThrow()
+    })
+
+    it('exports ValidationPanelProps type', () => {
+      const _props: ValidationPanelProps | undefined = undefined
+      expect(_props).toBeUndefined()
+    })
+  })
+
+  // ─── Tier 2 — Behavior ─────────────────────────────────────────────────
+
+  describe('Tier 2 — Behavior', () => {
+    it('renders error list items with data-testid when errors are present', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'nodes[0].type', message: 'Missing node type' },
+        { path: 'nodes[1].type', message: 'Invalid node type' },
+      ]
+      renderPanel({ validationErrors: errors })
+      const items = screen.getAllByTestId('validation-panel-error-item')
+      expect(items).toHaveLength(2)
+    })
+
+    it('renders empty state with "No issues found" when no errors', () => {
+      renderPanel({ validationErrors: [] })
+      expect(screen.getByTestId('validation-panel-empty')).toBeTruthy()
+      expect(screen.getByText('No issues found')).toBeTruthy()
+    })
+
+    it('returns null when isVisible=false', () => {
+      const { container } = renderPanel({ isVisible: false })
+      expect(container.querySelector('[data-testid="validation-panel"]')).toBeNull()
+    })
+
+    it('clicking an error item calls onErrorClick with the error path', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'nodes[0].type', message: 'Missing node type' },
+      ]
+      const { props } = renderPanel({ validationErrors: errors })
+      const item = screen.getByTestId('validation-panel-error-item')
+      fireEvent.click(item)
+      expect(props.onErrorClick).toHaveBeenCalledWith('nodes[0].type')
+    })
+
+    it('error count matches number of validation-panel-error-item elements', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'nodes[0].type', message: 'Error 1' },
+        { path: 'nodes[1].type', message: 'Error 2' },
+        { path: 'connections[0].from', message: 'Error 3' },
+      ]
+      renderPanel({ validationErrors: errors })
+      const items = screen.getAllByTestId('validation-panel-error-item')
+      expect(items).toHaveLength(3)
+    })
+
+    it('panel has data-testid="validation-panel"', () => {
+      renderPanel()
+      expect(screen.getByTestId('validation-panel')).toBeTruthy()
+    })
+
+    it('error list has aria-live="polite" attribute', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'nodes[0].type', message: 'Error' },
+      ]
+      renderPanel({ validationErrors: errors })
+      const list = screen.getByRole('list')
+      expect(list.getAttribute('aria-live')).toBe('polite')
+    })
+  })
+
+  // ─── Tier 3 — Edge Cases ───────────────────────────────────────────────
+
+  describe('Tier 3 — Edge Cases', () => {
+    it('error with node path renders error item', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'nodes[0].type', message: 'Node error' },
+      ]
+      renderPanel({ validationErrors: errors })
+      expect(screen.getByText('Node error')).toBeTruthy()
+    })
+
+    it('error with connection path renders error item', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'connections[0].from', message: 'Connection error' },
+      ]
+      renderPanel({ validationErrors: errors })
+      expect(screen.getByText('Connection error')).toBeTruthy()
+    })
+
+    it('error with structural path renders error item', () => {
+      const errors: WorkflowSpecValidationError[] = [
+        { path: 'name', message: 'Name is required' },
+      ]
+      renderPanel({ validationErrors: errors })
+      expect(screen.getByText('Name is required')).toBeTruthy()
+    })
+  })
+})

--- a/self/ui/src/panels/workflow-builder/__tests__/WorkflowBuilderPanel.test.tsx
+++ b/self/ui/src/panels/workflow-builder/__tests__/WorkflowBuilderPanel.test.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { reactFlowMock } from './react-flow-mock'
 
 vi.mock('@xyflow/react', () => reactFlowMock)
@@ -38,6 +38,82 @@ describe('WorkflowBuilderPanel', () => {
       expect(screen.getByText('Author')).toBeTruthy()
       expect(screen.getByText('Monitor')).toBeTruthy()
       expect(screen.getByText('Inspect')).toBeTruthy()
+    })
+
+    it('renders Validate button with data-testid="toolbar-validate"', () => {
+      render(<WorkflowBuilderPanel />)
+      expect(screen.getByTestId('toolbar-validate')).toBeTruthy()
+    })
+
+    it('renders Save button with data-testid="toolbar-save"', () => {
+      render(<WorkflowBuilderPanel />)
+      expect(screen.getByTestId('toolbar-save')).toBeTruthy()
+    })
+  })
+
+  // ─── Tier 2 — Phase 2 Integration ────────────────────────────────────────
+
+  describe('Tier 2 — Phase 2 Integration', () => {
+    it('renders toolbar Validate button', () => {
+      render(<WorkflowBuilderPanel />)
+      const validateBtn = screen.getByTestId('toolbar-validate')
+      expect(validateBtn).toBeTruthy()
+      expect(validateBtn.getAttribute('aria-label')).toBe('Toggle validation panel')
+    })
+
+    it('renders toolbar Save button', () => {
+      render(<WorkflowBuilderPanel />)
+      const saveBtn = screen.getByTestId('toolbar-save')
+      expect(saveBtn).toBeTruthy()
+      expect(saveBtn.getAttribute('aria-label')).toBe('Save workflow')
+    })
+
+    it('Save button is disabled when not dirty', () => {
+      render(<WorkflowBuilderPanel />)
+      const saveBtn = screen.getByTestId('toolbar-save') as HTMLButtonElement
+      expect(saveBtn.disabled).toBe(true)
+    })
+
+    it('canvas wrapper div has tabIndex for keyboard focus', () => {
+      const { container } = render(<WorkflowBuilderPanel />)
+      const wrapper = container.querySelector('[tabindex="0"]')
+      expect(wrapper).toBeTruthy()
+    })
+  })
+
+  // ─── Tier 3 — Phase 2 Authoring Flow ─────────────────────────────────────
+
+  describe('Tier 3 — Phase 2 Authoring Flow', () => {
+    it('toolbar validate button toggles validation panel visibility', () => {
+      render(<WorkflowBuilderPanel />)
+      const validateBtn = screen.getByTestId('toolbar-validate')
+
+      // Click to open
+      fireEvent.click(validateBtn)
+      expect(screen.getByTestId('validation-panel')).toBeTruthy()
+
+      // Click to close
+      fireEvent.click(validateBtn)
+      expect(screen.queryByTestId('validation-panel')).toBeNull()
+    })
+
+    it('all toolbar buttons have aria-label attributes', () => {
+      render(<WorkflowBuilderPanel />)
+      // Mode buttons
+      expect(screen.getByLabelText('Author mode')).toBeTruthy()
+      expect(screen.getByLabelText('Monitor mode')).toBeTruthy()
+      expect(screen.getByLabelText('Inspect mode')).toBeTruthy()
+      // Zoom buttons
+      expect(screen.getByLabelText('Zoom in')).toBeTruthy()
+      expect(screen.getByLabelText('Zoom out')).toBeTruthy()
+      expect(screen.getByLabelText('Fit view')).toBeTruthy()
+      // Undo/Redo
+      expect(screen.getByLabelText('Undo')).toBeTruthy()
+      expect(screen.getByLabelText('Redo')).toBeTruthy()
+      // Save/Validate/AutoLayout
+      expect(screen.getByLabelText('Save workflow')).toBeTruthy()
+      expect(screen.getByLabelText('Toggle validation panel')).toBeTruthy()
+      expect(screen.getByLabelText('Auto layout')).toBeTruthy()
     })
   })
 })

--- a/self/ui/src/panels/workflow-builder/__tests__/useKeyboardNav.test.ts
+++ b/self/ui/src/panels/workflow-builder/__tests__/useKeyboardNav.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useKeyboardNav } from '../hooks/useKeyboardNav'
+import type { UseKeyboardNavOptions } from '../hooks/useKeyboardNav'
+import type { WorkflowBuilderNode, WorkflowBuilderEdge } from '../../../types/workflow-builder'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createNode(id: string, x: number, y: number): WorkflowBuilderNode {
+  return {
+    id,
+    type: 'builderNode',
+    position: { x, y },
+    data: {
+      label: `Node ${id}`,
+      category: 'agent',
+      nousType: `nous.agent.${id}`,
+    },
+  }
+}
+
+function createEdge(id: string, source: string, target: string): WorkflowBuilderEdge {
+  return {
+    id,
+    source,
+    target,
+    data: { edgeType: 'execution' },
+  }
+}
+
+function makeKeyEvent(key: string, overrides: Partial<React.KeyboardEvent> = {}): React.KeyboardEvent {
+  return {
+    key,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...overrides,
+  } as unknown as React.KeyboardEvent
+}
+
+function createOptions(overrides: Partial<UseKeyboardNavOptions> = {}): UseKeyboardNavOptions {
+  return {
+    nodes: [
+      createNode('a', 0, 0),
+      createNode('b', 100, 0),
+      createNode('c', 0, 100),
+    ],
+    edges: [createEdge('e1', 'a', 'b')],
+    selectedNodeId: null,
+    selectedEdgeId: null,
+    onSelectNode: vi.fn(),
+    onDeselectAll: vi.fn(),
+    removeNode: vi.fn(),
+    removeEdge: vi.fn(),
+    moveNode: vi.fn(),
+    onEscape: vi.fn(),
+    canvasHasFocus: true,
+    ...overrides,
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useKeyboardNav', () => {
+  // ─── Tier 1 — Contract ──────────────────────────────────────────────────
+
+  describe('Tier 1 — Contract', () => {
+    it('returns focusedNodeIndex, focusedNodeId, and handleKeyDown', () => {
+      const { result } = renderHook(() => useKeyboardNav(createOptions()))
+      expect(result.current).toHaveProperty('focusedNodeIndex')
+      expect(result.current).toHaveProperty('focusedNodeId')
+      expect(result.current).toHaveProperty('handleKeyDown')
+    })
+
+    it('focusedNodeIndex is -1 initially', () => {
+      const { result } = renderHook(() => useKeyboardNav(createOptions()))
+      expect(result.current.focusedNodeIndex).toBe(-1)
+    })
+
+    it('focusedNodeId is null initially', () => {
+      const { result } = renderHook(() => useKeyboardNav(createOptions()))
+      expect(result.current.focusedNodeId).toBeNull()
+    })
+  })
+
+  // ─── Tier 2 — Behavior ─────────────────────────────────────────────────
+
+  describe('Tier 2 — Behavior', () => {
+    it('Tab cycles through nodes in position-sorted order (top-to-bottom, left-to-right)', () => {
+      // Nodes: a(0,0), b(100,0), c(0,100)
+      // Sorted: a(0,0), b(100,0), c(0,100) — y primary, x secondary
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('Tab'))
+      })
+      expect(result.current.focusedNodeIndex).toBe(0)
+      expect(opts.onSelectNode).toHaveBeenCalledWith('a')
+    })
+
+    it('Shift+Tab cycles in reverse order', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      // First Tab to get to index 0
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('Tab'))
+      })
+      // Shift+Tab should wrap to last
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('Tab', { shiftKey: true }))
+      })
+      // Should wrap to index 2 (last node: c)
+      expect(result.current.focusedNodeIndex).toBe(2)
+    })
+
+    it('Tab wraps from last node to first', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      // Tab 3 times to reach last, then one more to wrap
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      // Now at index 2 (last)
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      // Should wrap to 0
+      expect(result.current.focusedNodeIndex).toBe(0)
+    })
+
+    it('Shift+Tab wraps from first node to last', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      // Shift+Tab from initial (-1) should go to last
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('Tab', { shiftKey: true }))
+      })
+      expect(result.current.focusedNodeIndex).toBe(2)
+    })
+
+    it('Enter on focused node calls onSelectNode with the focused node ID', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      // First Tab to focus a node
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      ;(opts.onSelectNode as ReturnType<typeof vi.fn>).mockClear()
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Enter')) })
+      expect(opts.onSelectNode).toHaveBeenCalledWith('a')
+    })
+
+    it('Delete removes the currently selected node via removeNode', () => {
+      const opts = createOptions({ selectedNodeId: 'b' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Delete')) })
+      expect(opts.removeNode).toHaveBeenCalledWith('b')
+    })
+
+    it('Backspace removes the currently selected node via removeNode', () => {
+      const opts = createOptions({ selectedNodeId: 'a' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Backspace')) })
+      expect(opts.removeNode).toHaveBeenCalledWith('a')
+    })
+
+    it('Delete removes the currently selected edge via removeEdge when no node is selected', () => {
+      const opts = createOptions({ selectedEdgeId: 'e1' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Delete')) })
+      expect(opts.removeEdge).toHaveBeenCalledWith('e1')
+      expect(opts.removeNode).not.toHaveBeenCalled()
+    })
+
+    it('Arrow Up nudges selected node position by -20px on y axis', () => {
+      const nodes = [createNode('a', 100, 100)]
+      const opts = createOptions({ nodes, selectedNodeId: 'a' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowUp')) })
+      expect(opts.moveNode).toHaveBeenCalledWith('a', { x: 100, y: 80 })
+    })
+
+    it('Arrow Down nudges selected node position by +20px on y axis', () => {
+      const nodes = [createNode('a', 100, 100)]
+      const opts = createOptions({ nodes, selectedNodeId: 'a' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowDown')) })
+      expect(opts.moveNode).toHaveBeenCalledWith('a', { x: 100, y: 120 })
+    })
+
+    it('Arrow Left nudges selected node position by -20px on x axis', () => {
+      const nodes = [createNode('a', 100, 100)]
+      const opts = createOptions({ nodes, selectedNodeId: 'a' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowLeft')) })
+      expect(opts.moveNode).toHaveBeenCalledWith('a', { x: 80, y: 100 })
+    })
+
+    it('Arrow Right nudges selected node position by +20px on x axis', () => {
+      const nodes = [createNode('a', 100, 100)]
+      const opts = createOptions({ nodes, selectedNodeId: 'a' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowRight')) })
+      expect(opts.moveNode).toHaveBeenCalledWith('a', { x: 120, y: 100 })
+    })
+
+    it('Arrow key nudge clamps position to Math.max(0, value) (no negative coordinates)', () => {
+      const nodes = [createNode('a', 10, 10)]
+      const opts = createOptions({ nodes, selectedNodeId: 'a' })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowUp')) })
+      expect(opts.moveNode).toHaveBeenCalledWith('a', { x: 10, y: 0 })
+
+      ;(opts.moveNode as ReturnType<typeof vi.fn>).mockClear()
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowLeft')) })
+      expect(opts.moveNode).toHaveBeenCalledWith('a', { x: 0, y: 10 })
+    })
+
+    it('Escape calls onDeselectAll and onEscape, resets focused index', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      // First Tab to set a focused index
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      expect(result.current.focusedNodeIndex).toBe(0)
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Escape')) })
+      expect(opts.onDeselectAll).toHaveBeenCalled()
+      expect(opts.onEscape).toHaveBeenCalled()
+      expect(result.current.focusedNodeIndex).toBe(-1)
+    })
+  })
+
+  // ─── Tier 3 — Edge Cases ───────────────────────────────────────────────
+
+  describe('Tier 3 — Edge Cases', () => {
+    it('canvasHasFocus=false suppresses all key bindings (no callbacks called)', () => {
+      const opts = createOptions({ canvasHasFocus: false })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Enter')) })
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Delete')) })
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Escape')) })
+
+      expect(opts.onSelectNode).not.toHaveBeenCalled()
+      expect(opts.onDeselectAll).not.toHaveBeenCalled()
+      expect(opts.removeNode).not.toHaveBeenCalled()
+      expect(opts.onEscape).not.toHaveBeenCalled()
+    })
+
+    it('Modifier keys (Ctrl+key) are not intercepted', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab', { ctrlKey: true })) })
+      expect(opts.onSelectNode).not.toHaveBeenCalled()
+    })
+
+    it('Modifier keys (Meta+key) are not intercepted', () => {
+      const opts = createOptions()
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab', { metaKey: true })) })
+      expect(opts.onSelectNode).not.toHaveBeenCalled()
+    })
+
+    it('Tab on empty nodes array is a no-op', () => {
+      const opts = createOptions({ nodes: [] })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Tab')) })
+      expect(opts.onSelectNode).not.toHaveBeenCalled()
+      expect(result.current.focusedNodeIndex).toBe(-1)
+    })
+
+    it('Delete with no selection (neither node nor edge selected) is a no-op', () => {
+      const opts = createOptions({ selectedNodeId: null, selectedEdgeId: null })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('Delete')) })
+      expect(opts.removeNode).not.toHaveBeenCalled()
+      expect(opts.removeEdge).not.toHaveBeenCalled()
+    })
+
+    it('Arrow nudge with no selected node is a no-op', () => {
+      const opts = createOptions({ selectedNodeId: null })
+      const { result } = renderHook(() => useKeyboardNav(opts))
+
+      act(() => { result.current.handleKeyDown(makeKeyEvent('ArrowUp')) })
+      expect(opts.moveNode).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/self/ui/src/panels/workflow-builder/hooks/index.ts
+++ b/self/ui/src/panels/workflow-builder/hooks/index.ts
@@ -14,3 +14,6 @@ export {
   createMoveNodeCommand,
   createUpdateNodeDataCommand,
 } from './useUndoRedo'
+
+export { useKeyboardNav } from './useKeyboardNav'
+export type { UseKeyboardNavReturn } from './useKeyboardNav'

--- a/self/ui/src/panels/workflow-builder/hooks/useKeyboardNav.ts
+++ b/self/ui/src/panels/workflow-builder/hooks/useKeyboardNav.ts
@@ -1,0 +1,184 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import type { XYPosition } from '@xyflow/react'
+import type { WorkflowBuilderNode, WorkflowBuilderEdge } from '../../../types/workflow-builder'
+
+// ─── Options and return type ──────────────────────────────────────────────────
+
+export interface UseKeyboardNavOptions {
+  /** Current nodes array from useBuilderState. */
+  nodes: WorkflowBuilderNode[]
+  /** Current edges array from useBuilderState. */
+  edges: WorkflowBuilderEdge[]
+  /** Selected node ID from useBuilderState. */
+  selectedNodeId: string | null
+  /** Selected edge ID from useBuilderState. */
+  selectedEdgeId: string | null
+  /** Callbacks into useBuilderState mutations. */
+  onSelectNode: (nodeId: string) => void
+  onDeselectAll: () => void
+  removeNode: (nodeId: string) => void
+  removeEdge: (edgeId: string) => void
+  moveNode: (nodeId: string, position: XYPosition) => void
+  /** Callback to close open floating panels/context menus. */
+  onEscape: () => void
+  /** Whether the canvas wrapper element has focus. */
+  canvasHasFocus: boolean
+}
+
+export interface UseKeyboardNavReturn {
+  /** Index of the currently focused node in the sorted node list (-1 = none). */
+  focusedNodeIndex: number
+  /** ID of the currently focused node (null = none). */
+  focusedNodeId: string | null
+  /** Attach to the canvas wrapper element's onKeyDown. */
+  handleKeyDown: (e: React.KeyboardEvent) => void
+}
+
+// ─── Grid increment for arrow key nudge ─────────────────────────────────────
+
+const GRID_SIZE = 20
+
+// ─── Sort nodes by spatial position (top-to-bottom, left-to-right) ──────────
+
+function sortNodesByPosition(nodes: WorkflowBuilderNode[]): WorkflowBuilderNode[] {
+  return [...nodes].sort((a, b) => {
+    const dy = a.position.y - b.position.y
+    if (dy !== 0) return dy
+    return a.position.x - b.position.x
+  })
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useKeyboardNav(options: UseKeyboardNavOptions): UseKeyboardNavReturn {
+  const {
+    nodes,
+    edges: _edges,
+    selectedNodeId,
+    selectedEdgeId,
+    onSelectNode,
+    onDeselectAll,
+    removeNode,
+    removeEdge,
+    moveNode,
+    onEscape,
+    canvasHasFocus,
+  } = options
+
+  const [focusedNodeIndex, setFocusedNodeIndex] = useState(-1)
+
+  // Derive focusedNodeId from current index and sorted nodes
+  const sortedNodes = sortNodesByPosition(nodes)
+  const focusedNodeId =
+    focusedNodeIndex >= 0 && focusedNodeIndex < sortedNodes.length
+      ? sortedNodes[focusedNodeIndex].id
+      : null
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Guard: inactive when canvas does not have focus
+      if (!canvasHasFocus) return
+
+      // Guard: do not intercept modifier key combos (Ctrl+Z, Ctrl+K, etc.)
+      if (e.ctrlKey || e.metaKey) return
+
+      const key = e.key
+
+      switch (key) {
+        case 'Tab': {
+          e.preventDefault()
+          if (nodes.length === 0) return
+          const sorted = sortNodesByPosition(nodes)
+          setFocusedNodeIndex((prev) => {
+            let next: number
+            if (e.shiftKey) {
+              // Shift+Tab: reverse cycle
+              next = prev <= 0 ? sorted.length - 1 : prev - 1
+            } else {
+              // Tab: forward cycle
+              next = prev >= sorted.length - 1 ? 0 : prev + 1
+            }
+            const nodeId = sorted[next].id
+            onSelectNode(nodeId)
+            return next
+          })
+          break
+        }
+
+        case 'Enter': {
+          e.preventDefault()
+          if (focusedNodeId) {
+            onSelectNode(focusedNodeId)
+          }
+          break
+        }
+
+        case 'Delete':
+        case 'Backspace': {
+          e.preventDefault()
+          if (selectedNodeId) {
+            removeNode(selectedNodeId)
+            setFocusedNodeIndex(-1)
+          } else if (selectedEdgeId) {
+            removeEdge(selectedEdgeId)
+            setFocusedNodeIndex(-1)
+          }
+          break
+        }
+
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight': {
+          if (!selectedNodeId) return
+          e.preventDefault()
+          const node = nodes.find((n) => n.id === selectedNodeId)
+          if (!node) return
+          let newX = node.position.x
+          let newY = node.position.y
+          if (key === 'ArrowUp') newY -= GRID_SIZE
+          if (key === 'ArrowDown') newY += GRID_SIZE
+          if (key === 'ArrowLeft') newX -= GRID_SIZE
+          if (key === 'ArrowRight') newX += GRID_SIZE
+          // Clamp to non-negative
+          newX = Math.max(0, newX)
+          newY = Math.max(0, newY)
+          moveNode(selectedNodeId, { x: newX, y: newY })
+          break
+        }
+
+        case 'Escape': {
+          e.preventDefault()
+          onDeselectAll()
+          onEscape()
+          setFocusedNodeIndex(-1)
+          break
+        }
+
+        default:
+          break
+      }
+    },
+    [
+      canvasHasFocus,
+      nodes,
+      focusedNodeId,
+      selectedNodeId,
+      selectedEdgeId,
+      onSelectNode,
+      onDeselectAll,
+      removeNode,
+      removeEdge,
+      moveNode,
+      onEscape,
+    ],
+  )
+
+  return {
+    focusedNodeIndex,
+    focusedNodeId,
+    handleKeyDown,
+  }
+}

--- a/self/ui/src/panels/workflow-builder/index.ts
+++ b/self/ui/src/panels/workflow-builder/index.ts
@@ -25,6 +25,14 @@ export type { CanvasContextMenuProps, NodeContextMenuProps, EdgeContextMenuProps
 export { NodeSearch } from './NodeSearch'
 export type { NodeSearchProps } from './NodeSearch'
 
+// Validation Panel (SP 2.5)
+export { ValidationPanel } from './ValidationPanel'
+export type { ValidationPanelProps } from './ValidationPanel'
+
+// Keyboard Navigation hook (SP 2.5)
+export { useKeyboardNav } from './hooks/useKeyboardNav'
+export type { UseKeyboardNavReturn } from './hooks/useKeyboardNav'
+
 // Type re-exports for Phase 2
 export type {
   FloatingPanelState,
@@ -45,4 +53,6 @@ export type {
   ContextMenuAction,
   NodeSearchState,
   NodeSearchResult,
+  KeyboardNavState,
+  ValidationPanelItem,
 } from '../../types/workflow-builder'

--- a/self/ui/src/types/workflow-builder.ts
+++ b/self/ui/src/types/workflow-builder.ts
@@ -292,3 +292,27 @@ export interface NodeSearchResult {
   /** The nousType string (for add-node) or node ID (for existing-node). */
   value: string
 }
+
+// ─── Keyboard Navigation Types (SP 2.5) ─────────────────────────────────────
+
+/** State tracked by useKeyboardNav. */
+export interface KeyboardNavState {
+  /** Index into the position-sorted node array. -1 = no focus. */
+  focusedIndex: number
+  /** Whether keyboard nav is actively intercepting keys (canvas has focus). */
+  isActive: boolean
+}
+
+/** A renderable validation error item for the ValidationPanel. */
+export interface ValidationPanelItem {
+  /** Original error path from WorkflowSpecValidationError. */
+  path: string
+  /** Human-readable error message. */
+  message: string
+  /** Severity level derived from error path analysis. */
+  severity: 'error' | 'warning'
+  /** Affected element ID extracted from the error path. Null if structural. */
+  elementId: string | null
+  /** Element type for icon rendering. */
+  elementType: 'node' | 'edge' | 'spec' | null
+}


### PR DESCRIPTION
## Summary
- Phase 2.5: Keyboard navigation, validation panel, and toolbar wiring for the workflow projection builder
- Implements keyboard shortcuts, node/edge validation display, and toolbar actions
- All gates passed: implementation, completion report, behavioral testing, user documentation, synthesis review

## Merge direction
`feat/workflow-projection-builder.2.5/keyboard-nav-validation-toolbar` -> `feat/workflow-projection-builder`