### PR TITLE
fix(web): resilient predev cache cleanup (WR-080 P1.1)

### DIFF
--- a/self/apps/web/package.json
+++ b/self/apps/web/package.json
@@ -10,6 +10,7 @@
     "./server/trpc/root": "./server/trpc/root.ts"
   },
   "scripts": {
+    "predev": "node ./scripts/clean-dev-cache.mjs",
     "dev": "node ./scripts/dev.mjs",
     "build": "next build",
     "start": "next start",

--- a/self/apps/web/scripts/clean-dev-cache.mjs
+++ b/self/apps/web/scripts/clean-dev-cache.mjs
@@ -1,0 +1,30 @@
+/**
+ * Removes stale .next-{port} dev cache directories before dev server start.
+ * Runs via the `predev` npm lifecycle hook in package.json.
+ * Uses Node.js fs API for cross-platform compatibility.
+ */
+import { readdir, rm } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+let entries;
+try {
+  entries = await readdir(webRoot);
+} catch (err) {
+  process.stderr.write(`[nous:web] warning: could not read web root for cache cleanup: ${err.message}\n`);
+  process.exit(0);
+}
+
+const stale = entries.filter((e) => /^\.next-\d+$/.test(e));
+
+for (const dir of stale) {
+  const target = resolve(webRoot, dir);
+  try {
+    await rm(target, { recursive: true, force: true, maxRetries: 3, retryDelay: 150 });
+    process.stderr.write(`[nous:web] removed stale dev cache: ${dir}\n`);
+  } catch (err) {
+    process.stderr.write(`[nous:web] warning: could not remove stale cache dir ${dir}: ${err.message}\n`);
+  }
+}


### PR DESCRIPTION
## Summary
- Make `clean-dev-cache.mjs` resilient to locked `.next-{port}` directories on Windows
- Add `maxRetries: 3, retryDelay: 150` to `fs.rm` for transient file lock recovery
- Wrap `rm` and `readdir` calls in try/catch — warn on failure, never crash
- Predev hook is now best-effort: dev server always starts regardless of cleanup success

## WR-080 — web-app-boot-failure
Root cause: parallel worktree dev servers hold file locks on stale `.next-{port}` cache dirs, causing `ENOTEMPTY` crash in the predev hook that blocks `pnpm dev:web`.

## Test plan
- [ ] Run `pnpm dev:web` — dev server starts without crash
- [ ] Run with locked `.next-*` dirs present — warning printed, dev server starts
- [ ] Run with no stale dirs — clean startup, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)