### PR TITLE
fix(typecheck): correct invalid pressureTrend enum values — WR-081

### DIFF
--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -1522,7 +1522,7 @@ ipcMain.handle('health:systemStatus', async () => {
       issueCodes: [],
       inboxReady: false,
       pendingSystemRuns: 0,
-      backlogAnalytics: { queuedCount: 0, activeCount: 0, suspendedCount: 0, completedInWindow: 0, failedInWindow: 0, pressureTrend: 'idle' },
+      backlogAnalytics: { queuedCount: 0, activeCount: 0, suspendedCount: 0, completedInWindow: 0, failedInWindow: 0, pressureTrend: 'stable' },
       collectedAt: new Date().toISOString(),
     }
   }

--- a/self/apps/desktop/src/renderer/src/test-setup.ts
+++ b/self/apps/desktop/src/renderer/src/test-setup.ts
@@ -190,7 +190,7 @@ export function createElectronAPIMock() {
         issueCodes: [],
         inboxReady: false,
         pendingSystemRuns: 0,
-        backlogAnalytics: { queuedCount: 0, activeCount: 0, suspendedCount: 0, completedInWindow: 0, failedInWindow: 0, pressureTrend: 'idle' as const },
+        backlogAnalytics: { queuedCount: 0, activeCount: 0, suspendedCount: 0, completedInWindow: 0, failedInWindow: 0, pressureTrend: 'stable' as const },
         collectedAt: new Date().toISOString(),
       })),
       providerHealth: vi.fn(async () => ({ providers: [], collectedAt: new Date().toISOString() })),

--- a/self/apps/shared-server/__tests__/gateway-health-source-adapter.test.ts
+++ b/self/apps/shared-server/__tests__/gateway-health-source-adapter.test.ts
@@ -40,7 +40,7 @@ function createMockRuntime(): IPrincipalSystemGatewayRuntime {
         suspendedCount: 0,
         completedInWindow: 10,
         failedInWindow: 1,
-        pressureTrend: 'steady',
+        pressureTrend: 'stable',
       },
       issueCodes: [],
       appSessions: [
@@ -70,7 +70,7 @@ function createMockRuntime(): IPrincipalSystemGatewayRuntime {
         suspendedCount: 0,
         completedInWindow: 8,
         failedInWindow: 0,
-        pressureTrend: 'rising',
+        pressureTrend: 'increasing',
       },
       issueCodes: ['ISSUE_1'],
       visibleTools: ['sys-tool-a'],
@@ -180,7 +180,7 @@ describe('GatewayHealthSourceAdapter', () => {
           suspendedCount: 0,
           completedInWindow: 8,
           failedInWindow: 0,
-          pressureTrend: 'rising',
+          pressureTrend: 'increasing',
         },
         issueCodes: ['ISSUE_1'],
       });

--- a/self/apps/shared-server/__tests__/health-router.test.ts
+++ b/self/apps/shared-server/__tests__/health-router.test.ts
@@ -62,7 +62,7 @@ function createMockSystemStatus(): SystemStatusSnapshot {
       suspendedCount: 0,
       completedInWindow: 5,
       failedInWindow: 0,
-      pressureTrend: 'idle',
+      pressureTrend: 'stable',
     },
     collectedAt: NOW,
   };

--- a/self/subcortex/mao/src/__tests__/mao-projection-degraded-health.test.ts
+++ b/self/subcortex/mao/src/__tests__/mao-projection-degraded-health.test.ts
@@ -297,7 +297,7 @@ function createMockHealthAggregator(bootStatus: 'booting' | 'ready' | 'degraded'
         suspendedCount: 0,
         completedInWindow: 0,
         failedInWindow: 0,
-        pressureTrend: 'idle',
+        pressureTrend: 'stable',
       },
       collectedAt: NOW,
     }),

--- a/self/ui/src/panels/dashboard/__tests__/SystemStatusWidget.test.tsx
+++ b/self/ui/src/panels/dashboard/__tests__/SystemStatusWidget.test.tsx
@@ -25,7 +25,7 @@ const mockSnapshot: SystemStatusSnapshot = {
     suspendedCount: 0,
     completedInWindow: 5,
     failedInWindow: 0,
-    pressureTrend: 'steady',
+    pressureTrend: 'stable',
   },
   collectedAt: '2026-03-25T10:00:00.000Z',
 }
@@ -63,7 +63,7 @@ describe('SystemStatusWidget', () => {
     expect(await screen.findByText('Ready')).toBeTruthy()
     expect(screen.getByText('config-loaded')).toBeTruthy()
     expect(screen.getByText('providers-registered')).toBeTruthy()
-    expect(screen.getByText('steady')).toBeTruthy()
+    expect(screen.getByText('stable')).toBeTruthy()
     // collectedAt rendered as localized time
     expect(screen.getByText(/Updated:/)).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

- Fixes CI typecheck failures on `dev` that have been red for 4 consecutive runs
- Corrects 9 invalid `pressureTrend` enum values across 8 files in 5 packages
- Maps stale 4-state enum variants to canonical 3-state values per ADR Decision 5:
  - `'steady'` → `'stable'`
  - `'rising'` → `'increasing'`
  - `'idle'` → `'stable'`

## Affected Files

| File | Package | Change |
|------|---------|--------|
| `SystemStatusWidget.test.tsx:28,66` | `@nous/ui` | `steady` → `stable` (mock + assertion) |
| `gateway-health-source-adapter.test.ts:43,73,183` | `@nous/shared-server` | `steady` → `stable`, `rising` → `increasing` |
| `health-router.test.ts:65` | `@nous/shared-server` | `idle` → `stable` |
| `mao-projection-degraded-health.test.ts:300` | `@nous/subcortex-mao` | `idle` → `stable` |
| `test-setup.ts:193` | `@nous/desktop` | `idle` → `stable` |
| `index.ts:1525` | `@nous/desktop` | `idle` → `stable` |

## Root Cause

Sprint agents (WR-022, WR-031, WR-054+072) independently used stale 4-state enum values from the pre-ADR-5 design instead of the canonical 3-state enum (`'increasing' | 'stable' | 'decreasing'`).

## Test Plan

- [x] All 9 string literal replacements applied
- [x] `@nous/ui` SystemStatusWidget tests pass (308 tests)
- [x] `@nous/subcortex-mao` mao-projection tests pass (9 tests)
- [ ] CI typecheck gate passes (primary acceptance criterion)

Discovery: `.worklog/sprints/fix/ci-red-typecheck-failures/discovery/root-cause-manifest.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)