### PR TITLE
fix(cortex-core): export BacklogEntryStatusSchema from barrel

### DIFF
--- a/self/cortex/core/src/index.ts
+++ b/self/cortex/core/src/index.ts
@@ -141,6 +141,7 @@ export {
   SUBMIT_TASK_TO_SYSTEM_TOOL_NAME,
   SystemContextReplicaProvider,
   GatewayRuntimeHealthSink,
+  BacklogEntryStatusSchema,
 } from './gateway-runtime/index.js';
 export type {
   GatewayAppSessionHealthProjection,


### PR DESCRIPTION
## Summary
- Adds missing `BacklogEntryStatusSchema` to `@nous/cortex-core` package-level barrel export
- Fixes CI Gate #311 — Rollup desktop build failure (symbol unresolvable)
- Root cause: SP 1.1 `system-activity.ts` imports `BacklogEntryStatusSchema` from `@nous/cortex-core`, but the schema was only re-exported from the `gateway-runtime` sub-barrel, not the package entry point

## Change
1 line added to `self/cortex/core/src/index.ts` — value export block.

## Test plan
- [ ] Desktop build (Rollup) resolves `BacklogEntryStatusSchema` without error
- [ ] No barrel import test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)