### PR TITLE
feat(ui): ambient thought stream UX — WR-093 Phase 1

### DIFF
--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -1197,6 +1197,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     instanceRoot,
     outputSchemaValidator: new DefaultSchemaRefValidator(),
     thoughtEmitter,
+    pfcEngine: Cortex,
   });
 
   // Recovery component instantiation (Phase 1.2 — WR-072)

--- a/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
+++ b/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
@@ -126,6 +126,7 @@ export interface GatewayBackedTurnExecutorDeps {
   agentGatewayFactory?: IAgentGatewayFactory;
   workmodeAdmissionGuard?: IWorkmodeAdmissionGuard;
   thoughtEmitter?: IThoughtEmitter;
+  pfcEngine?: { setTraceId(traceId: string): void };
   now?: () => string;
   nowMs?: () => number;
   idFactory?: () => string;
@@ -159,6 +160,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
     const traceId = validInput.traceId;
 
     this.deps.thoughtEmitter?.resetSequence();
+    this.deps.pfcEngine?.setTraceId(traceId);
     this.emitLifecycle(traceId, 'turn-start', 'started');
 
     this.emitLifecycle(traceId, 'opctl-check', 'started');
@@ -246,6 +248,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
     });
     this.emitLifecycle(traceId, 'trace-record', 'completed');
 
+    this.deps.pfcEngine?.setTraceId('');
     this.emitLifecycle(traceId, 'turn-complete', 'completed');
     return {
       response,

--- a/self/cortex/pfc/src/__tests__/pfc-engine.test.ts
+++ b/self/cortex/pfc/src/__tests__/pfc-engine.test.ts
@@ -501,5 +501,133 @@ describe('PfcEngine', () => {
       });
       expect(emitter.emitPfcDecision).toHaveBeenCalledTimes(1);
     });
+
+    it('setTraceId sets traceId on emitted PFC decisions', async () => {
+      const emitter = mockThoughtEmitter();
+      const pfc = new PfcEngine(mockConfig(3), mockToolExecutor(['echo']), undefined, emitter);
+
+      pfc.setTraceId('test-trace-uuid');
+      await pfc.evaluateToolExecution('echo', {}, undefined);
+
+      expect(emitter.pfcCalls[0]!.traceId).toBe('test-trace-uuid');
+    });
+
+    it('traceId defaults to empty string when setTraceId not called', async () => {
+      const emitter = mockThoughtEmitter();
+      const pfc = new PfcEngine(mockConfig(3), mockToolExecutor(['echo']), undefined, emitter);
+
+      await pfc.evaluateToolExecution('echo', {}, undefined);
+
+      expect(emitter.pfcCalls[0]!.traceId).toBe('');
+    });
+
+    it('setTraceId can be called multiple times (per-turn reset)', async () => {
+      const emitter = mockThoughtEmitter();
+      const pfc = new PfcEngine(mockConfig(3), mockToolExecutor(['echo']), undefined, emitter);
+
+      pfc.setTraceId('trace-1');
+      await pfc.evaluateToolExecution('echo', {}, undefined);
+      expect(emitter.pfcCalls[0]!.traceId).toBe('trace-1');
+
+      pfc.setTraceId('trace-2');
+      await pfc.evaluateToolExecution('echo', {}, undefined);
+      expect(emitter.pfcCalls[1]!.traceId).toBe('trace-2');
+    });
+
+    it('setTraceId propagates to all 9 emission sites', async () => {
+      const emitter = mockThoughtEmitter();
+      const pfc = new PfcEngine(mockConfig(3), mockToolExecutor(['echo']), undefined, emitter);
+
+      pfc.setTraceId('propagation-test-id');
+
+      // 1. evaluateConfidenceGovernance (1 site)
+      await pfc.evaluateConfidenceGovernance(
+        createEvaluationInput({
+          governance: 'may',
+          actionCategory: 'model-invoke',
+          confidenceSignal: {
+            tier: 'high',
+            confidence: 0.95,
+            supportingSignals: 22,
+            decayState: 'stable',
+          },
+        }),
+      );
+
+      // 2-3. evaluateMemoryWrite deny + approve (2 sites)
+      await pfc.evaluateMemoryWrite(
+        {
+          content: 'test',
+          type: 'fact',
+          scope: 'project',
+          confidence: 0.3,
+          sensitivity: [],
+          retention: 'permanent',
+          provenance: {
+            traceId: '00000000-0000-0000-0000-000000000001' as never,
+            source: 'test',
+            timestamp: new Date().toISOString(),
+          },
+          tags: [],
+        },
+        undefined,
+      );
+      await pfc.evaluateMemoryWrite(
+        {
+          content: 'test',
+          type: 'fact',
+          scope: 'project',
+          confidence: 0.8,
+          sensitivity: [],
+          retention: 'permanent',
+          provenance: {
+            traceId: '00000000-0000-0000-0000-000000000001' as never,
+            source: 'test',
+            timestamp: new Date().toISOString(),
+          },
+          tags: [],
+        },
+        undefined,
+      );
+
+      // 4. emitMemoryMutationThought (1 site, via evaluateMemoryMutation)
+      await pfc.evaluateMemoryMutation({
+        action: 'soft-delete',
+        actor: 'core',
+        targetEntryId: '00000000-0000-0000-0000-000000000002' as never,
+        reason: 'test',
+        traceId: '00000000-0000-0000-0000-000000000001' as never,
+        evidenceRefs: [],
+      });
+
+      // 5-6. evaluateToolExecution deny + approve (2 sites)
+      await pfc.evaluateToolExecution('unknown_tool', {}, undefined);
+      await pfc.evaluateToolExecution('echo', {}, undefined);
+
+      // 7. reflect (1 site)
+      await pfc.reflect('output', {
+        output: 'test',
+        traceId: '00000000-0000-0000-0000-000000000001' as never,
+        tier: 3,
+      });
+
+      // 8-9. evaluateEscalation escalate + no-escalate (2 sites)
+      await pfc.evaluateEscalation({
+        trigger: 'low_confidence',
+        context: 'test',
+        confidence: 0.2,
+      });
+      await pfc.evaluateEscalation({
+        trigger: 'test',
+        context: 'test',
+        confidence: 0.8,
+      });
+
+      // All 9 emission sites should carry the trace ID
+      expect(emitter.pfcCalls).toHaveLength(9);
+      for (const call of emitter.pfcCalls) {
+        expect(call.traceId).toBe('propagation-test-id');
+      }
+    });
   });
 });

--- a/self/cortex/pfc/src/pfc-engine.ts
+++ b/self/cortex/pfc/src/pfc-engine.ts
@@ -28,6 +28,7 @@ import {
 
 export class PfcEngine implements IPfcEngine {
   private thoughtEmitter?: IThoughtEmitter;
+  private currentTraceId: string = '';
 
   constructor(
     private readonly config: IConfig,
@@ -42,6 +43,10 @@ export class PfcEngine implements IPfcEngine {
     this.thoughtEmitter = emitter;
   }
 
+  setTraceId(traceId: string): void {
+    this.currentTraceId = traceId;
+  }
+
   async evaluateConfidenceGovernance(
     input: ConfidenceGovernanceEvaluationInput,
   ): Promise<ConfidenceGovernanceEvaluationResult> {
@@ -54,7 +59,7 @@ export class PfcEngine implements IPfcEngine {
       `[nous:pfc] confidence_governance patternId=${decision.patternId} outcome=${decision.outcome} reasonCode=${decision.reasonCode} governance=${decision.governance} tier=${decision.confidenceTier} actionCategory=${decision.actionCategory}`,
     );
     this.thoughtEmitter?.emitPfcDecision({
-      traceId: '',
+      traceId: this.currentTraceId,
       thoughtType: 'confidence-governance',
       decision: decision.outcome === 'deny' ? 'denied' : 'approved',
       confidence: undefined,
@@ -80,7 +85,7 @@ export class PfcEngine implements IPfcEngine {
         `[nous:pfc] memory_write approved=false reason=${decision.reason}`,
       );
       this.thoughtEmitter?.emitPfcDecision({
-        traceId: '',
+        traceId: this.currentTraceId,
         thoughtType: 'memory-write',
         decision: 'denied',
         confidence: decision.confidence,
@@ -100,7 +105,7 @@ export class PfcEngine implements IPfcEngine {
       `[nous:pfc] memory_write approved=true reason=${decision.reason}`,
     );
     this.thoughtEmitter?.emitPfcDecision({
-      traceId: '',
+      traceId: this.currentTraceId,
       thoughtType: 'memory-write',
       decision: 'approved',
       confidence: decision.confidence,
@@ -199,7 +204,7 @@ export class PfcEngine implements IPfcEngine {
 
   private emitMemoryMutationThought(decision: PfcDecision): void {
     this.thoughtEmitter?.emitPfcDecision({
-      traceId: '',
+      traceId: this.currentTraceId,
       thoughtType: 'memory-mutation',
       decision: decision.approved ? 'approved' : 'denied',
       confidence: decision.confidence,
@@ -227,7 +232,7 @@ export class PfcEngine implements IPfcEngine {
         `[nous:pfc] tool_auth toolName=${toolName} approved=false reason=${decision.reason}`,
       );
       this.thoughtEmitter?.emitPfcDecision({
-        traceId: '',
+        traceId: this.currentTraceId,
         thoughtType: 'tool-execution',
         decision: 'denied',
         confidence: decision.confidence,
@@ -247,7 +252,7 @@ export class PfcEngine implements IPfcEngine {
       `[nous:pfc] tool_auth toolName=${toolName} approved=true reason=${decision.reason}`,
     );
     this.thoughtEmitter?.emitPfcDecision({
-      traceId: '',
+      traceId: this.currentTraceId,
       thoughtType: 'tool-execution',
       decision: 'approved',
       confidence: decision.confidence,
@@ -265,7 +270,7 @@ export class PfcEngine implements IPfcEngine {
   ): Promise<ReflectionResult> {
     console.debug('[nous:pfc] reflect confidence=0.8 qualityScore=0.8');
     this.thoughtEmitter?.emitPfcDecision({
-      traceId: '',
+      traceId: this.currentTraceId,
       thoughtType: 'reflection',
       decision: 'neutral',
       confidence: 0.8,
@@ -290,7 +295,7 @@ export class PfcEngine implements IPfcEngine {
         `[nous:pfc] escalation trigger=${situation.trigger} context=${situation.context}`,
       );
       this.thoughtEmitter?.emitPfcDecision({
-        traceId: '',
+        traceId: this.currentTraceId,
         thoughtType: 'escalation',
         decision: 'neutral',
         confidence: situation.confidence,
@@ -305,7 +310,7 @@ export class PfcEngine implements IPfcEngine {
       };
     }
     this.thoughtEmitter?.emitPfcDecision({
-      traceId: '',
+      traceId: this.currentTraceId,
       thoughtType: 'escalation',
       decision: 'neutral',
       confidence: situation.confidence,

--- a/self/ui/src/components/thought/ThoughtCard.tsx
+++ b/self/ui/src/components/thought/ThoughtCard.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from 'clsx'
 import type { ThoughtPfcDecisionPayload } from '@nous/shared'
+import { getThoughtLabel } from './thought-labels'
 
 export interface ThoughtCardProps {
   payload: ThoughtPfcDecisionPayload
@@ -46,7 +47,7 @@ export function ThoughtCard({ payload, compact }: ThoughtCardProps) {
             fontWeight: 'var(--nous-font-weight-medium)' as any,
           }}
         >
-          [{payload.thoughtType}]
+          [{getThoughtLabel('thoughtType', payload.thoughtType)}]
         </span>
         <span
           style={{

--- a/self/ui/src/components/thought/ThoughtCard.tsx
+++ b/self/ui/src/components/thought/ThoughtCard.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { clsx } from 'clsx'
+import type { ThoughtPfcDecisionPayload } from '@nous/shared'
+
+export interface ThoughtCardProps {
+  payload: ThoughtPfcDecisionPayload
+  compact: boolean
+}
+
+const BORDER_COLOR_BY_DECISION: Record<
+  ThoughtPfcDecisionPayload['decision'],
+  string
+> = {
+  approved: 'var(--nous-state-approved)',
+  denied: 'var(--nous-alert-error)',
+  neutral: 'var(--nous-fg-subtle)',
+}
+
+export function ThoughtCard({ payload, compact }: ThoughtCardProps) {
+  const borderColor = BORDER_COLOR_BY_DECISION[payload.decision]
+
+  return (
+    <div
+      role="status"
+      aria-label={`${payload.decision} ${payload.thoughtType}: ${payload.content}`}
+      data-testid="thought-event"
+      className={clsx('nous-animate-fade-in-up')}
+      style={{
+        borderLeft: `3px solid ${borderColor}`,
+        padding: compact
+          ? 'var(--nous-space-xs) var(--nous-space-sm)'
+          : 'var(--nous-space-sm) var(--nous-space-md)',
+        fontFamily: 'var(--nous-font-mono)',
+        fontSize: 'var(--nous-font-size-xs)',
+        lineHeight: 1.4,
+        color: 'var(--nous-ambient-fg)',
+        background: 'var(--nous-ambient-event-bg)',
+        borderRadius: 'var(--nous-radius-sm)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--nous-space-xs)' }}>
+        <span
+          style={{
+            color: borderColor,
+            fontWeight: 'var(--nous-font-weight-medium)' as any,
+          }}
+        >
+          [{payload.thoughtType}]
+        </span>
+        <span
+          style={{
+            color: borderColor,
+            fontWeight: 'var(--nous-font-weight-medium)' as any,
+            fontSize: 'var(--nous-font-size-2xs)',
+            textTransform: 'uppercase',
+          }}
+        >
+          {payload.decision}
+        </span>
+      </div>
+      <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{payload.content}</div>
+      {payload.reason && !compact && (
+        <div
+          style={{
+            marginTop: 'var(--nous-space-2xs)',
+            color: 'var(--nous-fg-subtle)',
+            fontSize: 'var(--nous-font-size-2xs)',
+          }}
+        >
+          {payload.reason}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/self/ui/src/components/thought/ThoughtLifecycleEvent.tsx
+++ b/self/ui/src/components/thought/ThoughtLifecycleEvent.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from 'clsx'
 import type { ThoughtTurnLifecyclePayload } from '@nous/shared'
+import { getThoughtLabel } from './thought-labels'
 
 export interface ThoughtLifecycleEventProps {
   payload: ThoughtTurnLifecyclePayload
@@ -31,7 +32,7 @@ export function ThoughtLifecycleEvent({ payload }: ThoughtLifecycleEventProps) {
           fontWeight: 'var(--nous-font-weight-medium)' as any,
         }}
       >
-        [{payload.phase}]
+        [{getThoughtLabel('phase', payload.phase)}]
       </span>{' '}
       {displayContent}
     </div>

--- a/self/ui/src/components/thought/ThoughtLifecycleEvent.tsx
+++ b/self/ui/src/components/thought/ThoughtLifecycleEvent.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { clsx } from 'clsx'
+import type { ThoughtTurnLifecyclePayload } from '@nous/shared'
+
+export interface ThoughtLifecycleEventProps {
+  payload: ThoughtTurnLifecyclePayload
+}
+
+export function ThoughtLifecycleEvent({ payload }: ThoughtLifecycleEventProps) {
+  const displayContent = payload.content ?? payload.status
+
+  return (
+    <div
+      role="status"
+      aria-label={`${payload.phase} ${payload.status}`}
+      data-testid="thought-event"
+      className={clsx('nous-animate-fade-in-up')}
+      style={{
+        fontFamily: 'var(--nous-font-mono)',
+        fontSize: 'var(--nous-font-size-xs)',
+        lineHeight: 1.4,
+        color: 'var(--nous-fg-subtle)',
+        background: 'transparent',
+        padding: 'var(--nous-space-2xs) var(--nous-space-sm)',
+      }}
+    >
+      <span
+        style={{
+          color: 'var(--nous-accent)',
+          fontWeight: 'var(--nous-font-weight-medium)' as any,
+        }}
+      >
+        [{payload.phase}]
+      </span>{' '}
+      {displayContent}
+    </div>
+  )
+}

--- a/self/ui/src/components/thought/ThoughtStream.tsx
+++ b/self/ui/src/components/thought/ThoughtStream.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { clsx } from 'clsx'
+import type { ThoughtPfcDecisionPayload, ThoughtTurnLifecyclePayload } from '@nous/shared'
+import type { ThoughtMode } from './use-thought-mode'
+import { ThoughtCard } from './ThoughtCard'
+import { ThoughtLifecycleEvent } from './ThoughtLifecycleEvent'
+
+export type ThoughtEvent =
+  | { channel: 'thought:pfc-decision'; payload: ThoughtPfcDecisionPayload }
+  | { channel: 'thought:turn-lifecycle'; payload: ThoughtTurnLifecyclePayload }
+
+export interface ThoughtStreamProps {
+  thoughts: ThoughtEvent[]
+  mode: ThoughtMode
+  className?: string
+}
+
+export function ThoughtStream({ thoughts, mode, className }: ThoughtStreamProps) {
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const isCompact = mode === 'conversing:expanded'
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [thoughts.length])
+
+  return (
+    <div
+      role="log"
+      aria-live="polite"
+      aria-label="AI thought stream"
+      id="thought-stream"
+      data-testid="thought-stream"
+      className={clsx(className)}
+      style={{
+        padding: 'var(--nous-space-sm) var(--nous-space-md)',
+        background: 'var(--nous-bg-elevated)',
+        borderRadius: 'var(--nous-radius-sm)',
+        fontSize: 'var(--nous-font-size-xs)',
+        color: 'var(--nous-fg-subtle)',
+        maxHeight: isCompact ? '200px' : undefined,
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: isCompact
+          ? 'var(--nous-space-xs)'
+          : 'var(--nous-space-sm)',
+      }}
+    >
+      {thoughts.map((t, i) =>
+        t.channel === 'thought:pfc-decision' ? (
+          <ThoughtCard
+            key={i}
+            payload={t.payload as ThoughtPfcDecisionPayload}
+            compact={isCompact}
+          />
+        ) : (
+          <ThoughtLifecycleEvent
+            key={i}
+            payload={t.payload as ThoughtTurnLifecyclePayload}
+          />
+        ),
+      )}
+      <div ref={bottomRef} />
+    </div>
+  )
+}

--- a/self/ui/src/components/thought/ThoughtStream.tsx
+++ b/self/ui/src/components/thought/ThoughtStream.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, type CSSProperties } from 'react'
 import { clsx } from 'clsx'
 import type { ThoughtPfcDecisionPayload, ThoughtTurnLifecyclePayload } from '@nous/shared'
 import type { ThoughtMode } from './use-thought-mode'
@@ -15,9 +15,10 @@ export interface ThoughtStreamProps {
   thoughts: ThoughtEvent[]
   mode: ThoughtMode
   className?: string
+  style?: CSSProperties
 }
 
-export function ThoughtStream({ thoughts, mode, className }: ThoughtStreamProps) {
+export function ThoughtStream({ thoughts, mode, className, style: styleProp }: ThoughtStreamProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
   const isCompact = mode === 'conversing:expanded'
@@ -33,7 +34,7 @@ export function ThoughtStream({ thoughts, mode, className }: ThoughtStreamProps)
       aria-label="AI thought stream"
       id="thought-stream"
       data-testid="thought-stream"
-      className={clsx(className)}
+      className={clsx('nous-thought-transition', className)}
       style={{
         padding: 'var(--nous-space-sm) var(--nous-space-md)',
         background: 'var(--nous-bg-elevated)',
@@ -47,6 +48,8 @@ export function ThoughtStream({ thoughts, mode, className }: ThoughtStreamProps)
         gap: isCompact
           ? 'var(--nous-space-xs)'
           : 'var(--nous-space-sm)',
+        transition: 'max-height var(--nous-ambient-fade), opacity var(--nous-ambient-fade), gap var(--nous-ambient-fade)',
+        ...styleProp,
       }}
     >
       {thoughts.map((t, i) =>

--- a/self/ui/src/components/thought/ThoughtSummary.tsx
+++ b/self/ui/src/components/thought/ThoughtSummary.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useState } from 'react'
+import { trpc } from '@nous/transport'
+import type { ExecutionTrace } from '@nous/shared'
+import { TraceDetail } from './TraceDetail'
+
+export interface ThoughtSummaryCounts {
+  totalDecisions: number
+  approved: number
+  denied: number
+  memoryWrites: number
+  memoryDenials: number
+}
+
+export interface ThoughtSummaryProps {
+  traceId: string
+  className?: string
+}
+
+function projectCounts(trace: ExecutionTrace): ThoughtSummaryCounts {
+  const turn = trace.turns[0]
+  if (!turn) {
+    return { totalDecisions: 0, approved: 0, denied: 0, memoryWrites: 0, memoryDenials: 0 }
+  }
+  const pfcDecisions = turn.pfcDecisions ?? []
+  return {
+    totalDecisions: pfcDecisions.length,
+    approved: pfcDecisions.filter((d) => d.approved).length,
+    denied: pfcDecisions.filter((d) => !d.approved).length,
+    memoryWrites: (turn.memoryWrites ?? []).length,
+    memoryDenials: (turn.memoryDenials ?? []).length,
+  }
+}
+
+export function ThoughtSummary({ traceId, className }: ThoughtSummaryProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const { data: trace, isLoading, isError } = trpc.traces.get.useQuery(
+    { traceId },
+    { enabled: !!traceId },
+  )
+
+  if (!traceId) {
+    return null
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading thought summary"
+        data-testid="thought-summary-loading"
+        className={className}
+        style={{
+          fontFamily: 'var(--nous-font-mono)',
+          fontSize: 'var(--nous-font-size-xs)',
+          color: 'var(--nous-fg-subtle)',
+          padding: 'var(--nous-space-xs) 0',
+        }}
+      >
+        ...
+      </div>
+    )
+  }
+
+  if (isError || !trace) {
+    return null
+  }
+
+  const counts = projectCounts(trace)
+
+  const summaryText = `${counts.totalDecisions} decision${counts.totalDecisions !== 1 ? 's' : ''} \u00b7 ${counts.approved} approved \u00b7 ${counts.denied} denied \u00b7 ${counts.memoryWrites} memory write${counts.memoryWrites !== 1 ? 's' : ''}`
+
+  return (
+    <div
+      className={className}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--nous-space-xs)',
+      }}
+    >
+      <button
+        role="status"
+        aria-label={summaryText}
+        aria-expanded={expanded}
+        data-testid="thought-summary"
+        onClick={() => setExpanded((prev) => !prev)}
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: 'var(--nous-space-xs) 0',
+          fontFamily: 'var(--nous-font-mono)',
+          fontSize: 'var(--nous-font-size-xs)',
+          color: 'var(--nous-fg-subtle)',
+          textAlign: 'left',
+          lineHeight: 1.4,
+        }}
+      >
+        {summaryText}
+      </button>
+      {expanded && <TraceDetail trace={trace} />}
+    </div>
+  )
+}

--- a/self/ui/src/components/thought/ThoughtToggle.tsx
+++ b/self/ui/src/components/thought/ThoughtToggle.tsx
@@ -35,8 +35,14 @@ export function ThoughtToggle({
       }}
     >
       <i
-        className={`codicon codicon-chevron-${expanded ? 'down' : 'right'}`}
-        style={{ fontSize: 'var(--nous-font-size-xs)' }}
+        className="codicon codicon-chevron-right nous-thought-transition"
+        data-testid="thought-toggle-chevron"
+        style={{
+          fontSize: 'var(--nous-font-size-xs)',
+          transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+          transition: 'transform var(--nous-ambient-fade)',
+          display: 'inline-block',
+        }}
       />
       <span>
         {eventCount} thought{eventCount !== 1 ? 's' : ''}

--- a/self/ui/src/components/thought/ThoughtToggle.tsx
+++ b/self/ui/src/components/thought/ThoughtToggle.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+export interface ThoughtToggleProps {
+  expanded: boolean
+  eventCount: number
+  onToggle: () => void
+  sending: boolean
+}
+
+export function ThoughtToggle({
+  expanded,
+  eventCount,
+  onToggle,
+  sending,
+}: ThoughtToggleProps) {
+  const label = `AI thoughts, ${eventCount} event${eventCount !== 1 ? 's' : ''}`
+
+  return (
+    <button
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-controls="thought-stream"
+      aria-label={label}
+      data-testid="thought-toggle"
+      style={{
+        background: 'none',
+        border: 'none',
+        cursor: 'pointer',
+        color: 'var(--nous-fg-subtle)',
+        fontSize: 'var(--nous-font-size-xs)',
+        padding: 'var(--nous-space-xs) 0',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--nous-space-xs)',
+      }}
+    >
+      <i
+        className={`codicon codicon-chevron-${expanded ? 'down' : 'right'}`}
+        style={{ fontSize: 'var(--nous-font-size-xs)' }}
+      />
+      <span>
+        {eventCount} thought{eventCount !== 1 ? 's' : ''}
+      </span>
+      {sending && !expanded && (
+        <span
+          style={{
+            color: 'var(--nous-fg-subtle)',
+            fontSize: 'var(--nous-font-size-2xs)',
+            fontStyle: 'italic',
+          }}
+        >
+          Thinking...
+        </span>
+      )}
+    </button>
+  )
+}

--- a/self/ui/src/components/thought/TraceDetail.tsx
+++ b/self/ui/src/components/thought/TraceDetail.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import type { ExecutionTrace } from '@nous/shared'
+
+export interface TraceDetailProps {
+  trace: ExecutionTrace
+  className?: string
+}
+
+export function TraceDetail({ trace, className }: TraceDetailProps) {
+  const turn = trace.turns[0]
+  if (!turn) {
+    return (
+      <div
+        data-testid="trace-detail"
+        className={className}
+        style={{
+          fontFamily: 'var(--nous-font-mono)',
+          fontSize: 'var(--nous-font-size-xs)',
+          color: 'var(--nous-fg-subtle)',
+          padding: 'var(--nous-space-sm) var(--nous-space-md)',
+          background: 'var(--nous-bg-elevated)',
+          borderRadius: 'var(--nous-radius-sm)',
+        }}
+      >
+        No turn data available.
+      </div>
+    )
+  }
+
+  const pfcDecisions = turn.pfcDecisions ?? []
+  const toolDecisions = turn.toolDecisions ?? []
+  const memoryWrites = turn.memoryWrites ?? []
+  const memoryDenials = turn.memoryDenials ?? []
+
+  return (
+    <div
+      data-testid="trace-detail"
+      className={className}
+      style={{
+        fontFamily: 'var(--nous-font-mono)',
+        fontSize: 'var(--nous-font-size-xs)',
+        color: 'var(--nous-fg-subtle)',
+        padding: 'var(--nous-space-sm) var(--nous-space-md)',
+        background: 'var(--nous-bg-elevated)',
+        borderRadius: 'var(--nous-radius-sm)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--nous-space-sm)',
+      }}
+    >
+      {pfcDecisions.length > 0 && (
+        <div>
+          <div
+            style={{
+              fontWeight: 'var(--nous-font-weight-semibold)' as any,
+              marginBottom: 'var(--nous-space-2xs)',
+              color: 'var(--nous-fg-muted)',
+            }}
+          >
+            PFC Decisions
+          </div>
+          {pfcDecisions.map((d, i) => (
+            <div
+              key={i}
+              data-testid="trace-pfc-decision"
+              style={{
+                borderLeft: `2px solid ${d.approved ? 'var(--nous-state-approved)' : 'var(--nous-alert-error)'}`,
+                padding: 'var(--nous-space-2xs) var(--nous-space-xs)',
+                marginBottom: 'var(--nous-space-2xs)',
+              }}
+            >
+              <span style={{ color: d.approved ? 'var(--nous-state-approved)' : 'var(--nous-alert-error)' }}>
+                {d.approved ? 'approved' : 'denied'}
+              </span>
+              {d.reason && (
+                <span style={{ marginLeft: 'var(--nous-space-xs)' }}>{d.reason}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {toolDecisions.length > 0 && (
+        <div>
+          <div
+            style={{
+              fontWeight: 'var(--nous-font-weight-semibold)' as any,
+              marginBottom: 'var(--nous-space-2xs)',
+              color: 'var(--nous-fg-muted)',
+            }}
+          >
+            Tool Decisions
+          </div>
+          {toolDecisions.map((td, i) => (
+            <div
+              key={i}
+              data-testid="trace-tool-decision"
+              style={{
+                borderLeft: `2px solid ${td.approved ? 'var(--nous-state-approved)' : 'var(--nous-alert-error)'}`,
+                padding: 'var(--nous-space-2xs) var(--nous-space-xs)',
+                marginBottom: 'var(--nous-space-2xs)',
+              }}
+            >
+              <span>{td.toolName}</span>
+              <span
+                style={{
+                  marginLeft: 'var(--nous-space-xs)',
+                  color: td.approved ? 'var(--nous-state-approved)' : 'var(--nous-alert-error)',
+                }}
+              >
+                {td.approved ? 'approved' : 'denied'}
+              </span>
+              {td.reason && (
+                <span style={{ marginLeft: 'var(--nous-space-xs)' }}>{td.reason}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {memoryWrites.length > 0 && (
+        <div data-testid="trace-memory-writes">
+          <span style={{ fontWeight: 'var(--nous-font-weight-semibold)' as any, color: 'var(--nous-fg-muted)' }}>
+            Memory Writes:
+          </span>{' '}
+          {memoryWrites.length}
+        </div>
+      )}
+
+      {memoryDenials.length > 0 && (
+        <div data-testid="trace-memory-denials">
+          <div
+            style={{
+              fontWeight: 'var(--nous-font-weight-semibold)' as any,
+              marginBottom: 'var(--nous-space-2xs)',
+              color: 'var(--nous-fg-muted)',
+            }}
+          >
+            Memory Denials
+          </div>
+          {memoryDenials.map((md, i) => (
+            <div
+              key={i}
+              style={{
+                borderLeft: '2px solid var(--nous-alert-error)',
+                padding: 'var(--nous-space-2xs) var(--nous-space-xs)',
+                marginBottom: 'var(--nous-space-2xs)',
+              }}
+            >
+              {md.reason}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {pfcDecisions.length === 0 &&
+        toolDecisions.length === 0 &&
+        memoryWrites.length === 0 &&
+        memoryDenials.length === 0 && (
+          <div>No decision data in this turn.</div>
+        )}
+    </div>
+  )
+}

--- a/self/ui/src/components/thought/__tests__/ThoughtCard.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtCard.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ThoughtCard } from '../ThoughtCard'
+import type { ThoughtPfcDecisionPayload } from '@nous/shared'
+
+function makePayload(
+  overrides?: Partial<ThoughtPfcDecisionPayload>,
+): ThoughtPfcDecisionPayload {
+  return {
+    traceId: 'trace-1',
+    thoughtType: 'confidence-governance',
+    decision: 'approved',
+    reason: 'high confidence',
+    content: 'patternId=chat-response outcome=approved tier=3',
+    sequence: 1,
+    emittedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('ThoughtCard', () => {
+  it('renders thoughtType, decision, content from payload', () => {
+    render(<ThoughtCard payload={makePayload()} compact={false} />)
+
+    expect(screen.getByText('[confidence-governance]')).toBeTruthy()
+    // text-transform: uppercase is CSS-only; jsdom sees lowercase
+    expect(screen.getByText('approved')).toBeTruthy()
+    expect(
+      screen.getByText('patternId=chat-response outcome=approved tier=3'),
+    ).toBeTruthy()
+  })
+
+  it('renders reason when not compact', () => {
+    render(
+      <ThoughtCard payload={makePayload({ reason: 'high confidence' })} compact={false} />,
+    )
+    expect(screen.getByText('high confidence')).toBeTruthy()
+  })
+
+  it('hides reason when compact', () => {
+    render(
+      <ThoughtCard payload={makePayload({ reason: 'high confidence' })} compact={true} />,
+    )
+    // reason should not be rendered in compact mode
+    expect(screen.queryByText('high confidence')).toBeNull()
+  })
+
+  it('applies approved left border color', () => {
+    render(<ThoughtCard payload={makePayload({ decision: 'approved' })} compact={false} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.style.borderLeft).toContain('var(--nous-state-approved)')
+  })
+
+  it('applies denied left border color', () => {
+    render(<ThoughtCard payload={makePayload({ decision: 'denied' })} compact={false} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.style.borderLeft).toContain('var(--nous-alert-error)')
+  })
+
+  it('applies neutral left border color', () => {
+    render(<ThoughtCard payload={makePayload({ decision: 'neutral' })} compact={false} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.style.borderLeft).toContain('var(--nous-fg-subtle)')
+  })
+
+  it('has role="status" attribute', () => {
+    render(<ThoughtCard payload={makePayload()} compact={false} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.getAttribute('role')).toBe('status')
+  })
+
+  it('has composed aria-label containing decision type and content', () => {
+    render(
+      <ThoughtCard
+        payload={makePayload({
+          decision: 'approved',
+          thoughtType: 'memory-write',
+          content: 'wrote key=xyz',
+        })}
+        compact={false}
+      />,
+    )
+    const el = screen.getByTestId('thought-event')
+    const label = el.getAttribute('aria-label')!
+    expect(label).toContain('approved')
+    expect(label).toContain('memory-write')
+    expect(label).toContain('wrote key=xyz')
+  })
+
+  it('has data-testid="thought-event" attribute', () => {
+    render(<ThoughtCard payload={makePayload()} compact={false} />)
+    expect(screen.getByTestId('thought-event')).toBeTruthy()
+  })
+
+  it('applies nous-animate-fade-in-up CSS class', () => {
+    render(<ThoughtCard payload={makePayload()} compact={false} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.classList.contains('nous-animate-fade-in-up')).toBe(true)
+  })
+
+  it('compact mode applies compact padding', () => {
+    render(<ThoughtCard payload={makePayload()} compact={true} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.style.padding).toContain('var(--nous-space-xs)')
+  })
+
+  it('relaxed mode applies full-size padding', () => {
+    render(<ThoughtCard payload={makePayload()} compact={false} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.style.padding).toContain('var(--nous-space-sm)')
+  })
+})

--- a/self/ui/src/components/thought/__tests__/ThoughtCard.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtCard.test.tsx
@@ -25,7 +25,7 @@ describe('ThoughtCard', () => {
   it('renders thoughtType, decision, content from payload', () => {
     render(<ThoughtCard payload={makePayload()} compact={false} />)
 
-    expect(screen.getByText('[confidence-governance]')).toBeTruthy()
+    expect(screen.getByText('[Confidence Check]')).toBeTruthy()
     // text-transform: uppercase is CSS-only; jsdom sees lowercase
     expect(screen.getByText('approved')).toBeTruthy()
     expect(

--- a/self/ui/src/components/thought/__tests__/ThoughtLifecycleEvent.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtLifecycleEvent.test.tsx
@@ -22,7 +22,7 @@ function makePayload(
 describe('ThoughtLifecycleEvent', () => {
   it('renders phase and status from payload', () => {
     render(<ThoughtLifecycleEvent payload={makePayload({ phase: 'gateway-run', status: 'completed' })} />)
-    expect(screen.getByText('[gateway-run]')).toBeTruthy()
+    expect(screen.getByText('[Gateway Execution]')).toBeTruthy()
     expect(screen.getByText('completed')).toBeTruthy()
   })
 

--- a/self/ui/src/components/thought/__tests__/ThoughtLifecycleEvent.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtLifecycleEvent.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ThoughtLifecycleEvent } from '../ThoughtLifecycleEvent'
+import type { ThoughtTurnLifecyclePayload } from '@nous/shared'
+
+function makePayload(
+  overrides?: Partial<ThoughtTurnLifecyclePayload>,
+): ThoughtTurnLifecyclePayload {
+  return {
+    traceId: 'trace-1',
+    phase: 'turn-start',
+    status: 'started',
+    sequence: 0,
+    emittedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('ThoughtLifecycleEvent', () => {
+  it('renders phase and status from payload', () => {
+    render(<ThoughtLifecycleEvent payload={makePayload({ phase: 'gateway-run', status: 'completed' })} />)
+    expect(screen.getByText('[gateway-run]')).toBeTruthy()
+    expect(screen.getByText('completed')).toBeTruthy()
+  })
+
+  it('renders optional content when present', () => {
+    render(
+      <ThoughtLifecycleEvent
+        payload={makePayload({ content: 'gateway execution finished' })}
+      />,
+    )
+    expect(screen.getByText('gateway execution finished')).toBeTruthy()
+  })
+
+  it('falls back to status display when content is absent', () => {
+    render(
+      <ThoughtLifecycleEvent
+        payload={makePayload({ status: 'started', content: undefined })}
+      />,
+    )
+    expect(screen.getByText('started')).toBeTruthy()
+  })
+
+  it('has role="status" attribute', () => {
+    render(<ThoughtLifecycleEvent payload={makePayload()} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.getAttribute('role')).toBe('status')
+  })
+
+  it('has composed aria-label containing phase and status', () => {
+    render(
+      <ThoughtLifecycleEvent
+        payload={makePayload({ phase: 'opctl-check', status: 'completed' })}
+      />,
+    )
+    const el = screen.getByTestId('thought-event')
+    const label = el.getAttribute('aria-label')!
+    expect(label).toContain('opctl-check')
+    expect(label).toContain('completed')
+  })
+
+  it('has data-testid="thought-event" attribute', () => {
+    render(<ThoughtLifecycleEvent payload={makePayload()} />)
+    expect(screen.getByTestId('thought-event')).toBeTruthy()
+  })
+
+  it('applies nous-animate-fade-in-up CSS class', () => {
+    render(<ThoughtLifecycleEvent payload={makePayload()} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.classList.contains('nous-animate-fade-in-up')).toBe(true)
+  })
+
+  it('uses transparent background', () => {
+    render(<ThoughtLifecycleEvent payload={makePayload()} />)
+    const el = screen.getByTestId('thought-event')
+    expect(el.style.background).toBe('transparent')
+  })
+})

--- a/self/ui/src/components/thought/__tests__/ThoughtStream.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtStream.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, beforeAll } from 'vitest'
+import { ThoughtStream } from '../ThoughtStream'
+import type { ThoughtEvent } from '../ThoughtStream'
+import type { ThoughtPfcDecisionPayload, ThoughtTurnLifecyclePayload } from '@nous/shared'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+function makePfcEvent(
+  overrides?: Partial<ThoughtPfcDecisionPayload>,
+): ThoughtEvent {
+  return {
+    channel: 'thought:pfc-decision',
+    payload: {
+      traceId: 'trace-1',
+      thoughtType: 'confidence-governance',
+      decision: 'approved',
+      reason: 'high confidence',
+      content: 'patternId=chat-response outcome=approved',
+      sequence: 1,
+      emittedAt: new Date().toISOString(),
+      ...overrides,
+    },
+  }
+}
+
+function makeLifecycleEvent(
+  overrides?: Partial<ThoughtTurnLifecyclePayload>,
+): ThoughtEvent {
+  return {
+    channel: 'thought:turn-lifecycle',
+    payload: {
+      traceId: 'trace-1',
+      phase: 'turn-start',
+      status: 'started',
+      sequence: 0,
+      emittedAt: new Date().toISOString(),
+      ...overrides,
+    },
+  }
+}
+
+describe('ThoughtStream', () => {
+  it('renders role="log" on container', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.getAttribute('role')).toBe('log')
+  })
+
+  it('renders aria-live="polite" on container', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('renders aria-label="AI thought stream" on container', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.getAttribute('aria-label')).toBe('AI thought stream')
+  })
+
+  it('renders id="thought-stream" on container', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.getAttribute('id')).toBe('thought-stream')
+  })
+
+  it('has data-testid="thought-stream" attribute', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    expect(screen.getByTestId('thought-stream')).toBeTruthy()
+  })
+
+  it('renders ThoughtCard for thought:pfc-decision events', () => {
+    render(
+      <ThoughtStream
+        thoughts={[makePfcEvent({ thoughtType: 'memory-write' })]}
+        mode="conversing:expanded"
+      />,
+    )
+    expect(screen.getByText('[memory-write]')).toBeTruthy()
+  })
+
+  it('renders ThoughtLifecycleEvent for thought:turn-lifecycle events', () => {
+    render(
+      <ThoughtStream
+        thoughts={[makeLifecycleEvent({ phase: 'gateway-run' })]}
+        mode="conversing:expanded"
+      />,
+    )
+    expect(screen.getByText('[gateway-run]')).toBeTruthy()
+  })
+
+  it('in conversing:expanded mode applies compact layout (200px max height, xs gaps)', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.style.maxHeight).toBe('200px')
+    expect(el.style.gap).toContain('var(--nous-space-xs)')
+  })
+
+  it('in ambient:open mode applies relaxed layout (no max height, sm gaps)', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="ambient:open" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.style.maxHeight).toBe('')
+    expect(el.style.gap).toContain('var(--nous-space-sm)')
+  })
+
+  it('renders multiple events correctly', () => {
+    render(
+      <ThoughtStream
+        thoughts={[
+          makePfcEvent({ content: 'first-event' }),
+          makeLifecycleEvent({ phase: 'opctl-check', content: 'second-event' }),
+          makePfcEvent({ content: 'third-event', decision: 'denied' }),
+        ]}
+        mode="conversing:expanded"
+      />,
+    )
+    const events = screen.getAllByTestId('thought-event')
+    expect(events.length).toBe(3)
+    expect(screen.getByText('first-event')).toBeTruthy()
+    expect(screen.getByText('second-event')).toBeTruthy()
+    expect(screen.getByText('third-event')).toBeTruthy()
+  })
+})

--- a/self/ui/src/components/thought/__tests__/ThoughtStream.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtStream.test.tsx
@@ -82,7 +82,7 @@ describe('ThoughtStream', () => {
         mode="conversing:expanded"
       />,
     )
-    expect(screen.getByText('[memory-write]')).toBeTruthy()
+    expect(screen.getByText('[Memory Write]')).toBeTruthy()
   })
 
   it('renders ThoughtLifecycleEvent for thought:turn-lifecycle events', () => {
@@ -92,7 +92,7 @@ describe('ThoughtStream', () => {
         mode="conversing:expanded"
       />,
     )
-    expect(screen.getByText('[gateway-run]')).toBeTruthy()
+    expect(screen.getByText('[Gateway Execution]')).toBeTruthy()
   })
 
   it('in conversing:expanded mode applies compact layout (200px max height, xs gaps)', () => {
@@ -107,6 +107,32 @@ describe('ThoughtStream', () => {
     const el = screen.getByTestId('thought-stream')
     expect(el.style.maxHeight).toBe('')
     expect(el.style.gap).toContain('var(--nous-space-sm)')
+  })
+
+  it('container has CSS transition property using --nous-ambient-fade', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.style.transition).toContain('var(--nous-ambient-fade)')
+  })
+
+  it('applies nous-thought-transition CSS class', () => {
+    render(<ThoughtStream thoughts={[makePfcEvent()]} mode="conversing:expanded" />)
+    const el = screen.getByTestId('thought-stream')
+    expect(el.classList.contains('nous-thought-transition')).toBe(true)
+  })
+
+  it('merges external style prop onto container', () => {
+    render(
+      <ThoughtStream
+        thoughts={[makePfcEvent()]}
+        mode="conversing:expanded"
+        style={{ opacity: 0, maxHeight: '0px', overflow: 'hidden' }}
+      />,
+    )
+    const el = screen.getByTestId('thought-stream')
+    expect(el.style.opacity).toBe('0')
+    expect(el.style.maxHeight).toBe('0px')
+    expect(el.style.overflow).toBe('hidden')
   })
 
   it('renders multiple events correctly', () => {

--- a/self/ui/src/components/thought/__tests__/ThoughtSummary.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtSummary.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ThoughtSummary } from '../ThoughtSummary'
+import type { ExecutionTrace } from '@nous/shared'
+
+// Mock @nous/transport trpc client
+const mockUseQuery = vi.fn()
+
+vi.mock('@nous/transport', () => ({
+  trpc: {
+    traces: {
+      get: {
+        useQuery: (...args: unknown[]) => mockUseQuery(...args),
+      },
+    },
+  },
+}))
+
+function makeTrace(overrides?: Partial<ExecutionTrace>): ExecutionTrace {
+  return {
+    traceId: '00000000-0000-0000-0000-000000000001' as any,
+    startedAt: '2026-03-28T00:00:00.000Z',
+    turns: [
+      {
+        input: 'hello',
+        output: 'world',
+        modelCalls: [],
+        pfcDecisions: [
+          { approved: true, reason: 'passed', confidence: 1 },
+          { approved: true, reason: 'passed', confidence: 0.9 },
+          { approved: false, reason: 'denied', confidence: 0.3 },
+        ],
+        toolDecisions: [
+          { toolName: 'echo', approved: true },
+        ],
+        memoryWrites: ['00000000-0000-0000-0000-000000000002' as any],
+        memoryDenials: [],
+        evidenceRefs: [],
+        timestamp: '2026-03-28T00:00:01.000Z',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('ThoughtSummary', () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset()
+  })
+
+  // Tier 1 -- Contract
+  it('renders without crashing when given a valid traceId', () => {
+    mockUseQuery.mockReturnValue({
+      data: makeTrace(),
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+    expect(screen.getByTestId('thought-summary')).toBeTruthy()
+  })
+
+  it('renders nothing when traceId is empty string (graceful degradation)', () => {
+    mockUseQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    })
+
+    const { container } = render(<ThoughtSummary traceId="" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  // Tier 2 -- Behavior
+  it('displays correct counts from ExecutionTrace', () => {
+    mockUseQuery.mockReturnValue({
+      data: makeTrace(),
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+
+    const summary = screen.getByTestId('thought-summary')
+    expect(summary.textContent).toContain('3 decisions')
+    expect(summary.textContent).toContain('2 approved')
+    expect(summary.textContent).toContain('1 denied')
+    expect(summary.textContent).toContain('1 memory write')
+  })
+
+  it('click expands to show TraceDetail', () => {
+    mockUseQuery.mockReturnValue({
+      data: makeTrace(),
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+
+    expect(screen.queryByTestId('trace-detail')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('thought-summary'))
+
+    expect(screen.getByTestId('trace-detail')).toBeTruthy()
+  })
+
+  it('shows loading state while trace is being fetched', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+    expect(screen.getByTestId('thought-summary-loading')).toBeTruthy()
+  })
+
+  it('passes enabled: false when traceId is empty', () => {
+    mockUseQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="" />)
+    // useQuery was called with enabled: false
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      { traceId: '' },
+      { enabled: false },
+    )
+  })
+
+  // Tier 3 -- Edge cases
+  it('handles null trace response', () => {
+    mockUseQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    })
+
+    const { container } = render(
+      <ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />,
+    )
+    // No trace data -- renders nothing
+    expect(container.querySelector('[data-testid="thought-summary"]')).toBeNull()
+  })
+
+  it('handles ExecutionTrace with zero turns', () => {
+    mockUseQuery.mockReturnValue({
+      data: makeTrace({ turns: [] }),
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+
+    const summary = screen.getByTestId('thought-summary')
+    expect(summary.textContent).toContain('0 decisions')
+    expect(summary.textContent).toContain('0 approved')
+    expect(summary.textContent).toContain('0 denied')
+    expect(summary.textContent).toContain('0 memory writes')
+  })
+
+  it('handles ExecutionTrace with zero pfcDecisions', () => {
+    mockUseQuery.mockReturnValue({
+      data: makeTrace({
+        turns: [
+          {
+            input: 'hello',
+            output: 'world',
+            modelCalls: [],
+            pfcDecisions: [],
+            toolDecisions: [],
+            memoryWrites: [],
+            memoryDenials: [],
+            evidenceRefs: [],
+            timestamp: '2026-03-28T00:00:01.000Z',
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+
+    const summary = screen.getByTestId('thought-summary')
+    expect(summary.textContent).toContain('0 decisions')
+  })
+
+  it('handles error state by rendering nothing', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    })
+
+    const { container } = render(
+      <ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />,
+    )
+    expect(container.querySelector('[data-testid="thought-summary"]')).toBeNull()
+  })
+
+  it('has correct ARIA attributes', () => {
+    mockUseQuery.mockReturnValue({
+      data: makeTrace(),
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<ThoughtSummary traceId="00000000-0000-0000-0000-000000000001" />)
+
+    const summary = screen.getByTestId('thought-summary')
+    expect(summary.getAttribute('role')).toBe('status')
+    expect(summary.getAttribute('aria-label')).toContain('3 decisions')
+    expect(summary.getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/self/ui/src/components/thought/__tests__/ThoughtToggle.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtToggle.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ThoughtToggle } from '../ThoughtToggle'
+
+describe('ThoughtToggle', () => {
+  it('renders with aria-expanded={true} when expanded', () => {
+    render(
+      <ThoughtToggle expanded={true} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    expect(screen.getByTestId('thought-toggle').getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('renders with aria-expanded={false} when collapsed', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    expect(screen.getByTestId('thought-toggle').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('has aria-controls="thought-stream" attribute', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    expect(screen.getByTestId('thought-toggle').getAttribute('aria-controls')).toBe('thought-stream')
+  })
+
+  it('has aria-label containing event count', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    const label = screen.getByTestId('thought-toggle').getAttribute('aria-label')!
+    expect(label).toContain('3 events')
+  })
+
+  it('aria-label uses singular "event" for count of 1', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={1} onToggle={() => {}} sending={false} />,
+    )
+    const label = screen.getByTestId('thought-toggle').getAttribute('aria-label')!
+    expect(label).toContain('1 event')
+    expect(label).not.toContain('1 events')
+  })
+
+  it('displays event count badge text', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={5} onToggle={() => {}} sending={false} />,
+    )
+    expect(screen.getByText('5 thoughts')).toBeTruthy()
+  })
+
+  it('calls onToggle callback when clicked', () => {
+    const onToggle = vi.fn()
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={onToggle} sending={false} />,
+    )
+    fireEvent.click(screen.getByTestId('thought-toggle'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('has data-testid="thought-toggle" attribute', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    expect(screen.getByTestId('thought-toggle')).toBeTruthy()
+  })
+
+  it('shows "Thinking..." text when sending is true and collapsed', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={true} />,
+    )
+    expect(screen.getByText('Thinking...')).toBeTruthy()
+  })
+
+  it('hides "Thinking..." text when sending is false', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    expect(screen.queryByText('Thinking...')).toBeNull()
+  })
+
+  it('hides "Thinking..." text when sending is true and expanded', () => {
+    render(
+      <ThoughtToggle expanded={true} eventCount={3} onToggle={() => {}} sending={true} />,
+    )
+    expect(screen.queryByText('Thinking...')).toBeNull()
+  })
+})

--- a/self/ui/src/components/thought/__tests__/ThoughtToggle.test.tsx
+++ b/self/ui/src/components/thought/__tests__/ThoughtToggle.test.tsx
@@ -87,4 +87,36 @@ describe('ThoughtToggle', () => {
     )
     expect(screen.queryByText('Thinking...')).toBeNull()
   })
+
+  it('expanded chevron has transform rotate(90deg)', () => {
+    render(
+      <ThoughtToggle expanded={true} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    const chevron = screen.getByTestId('thought-toggle-chevron')
+    expect(chevron.style.transform).toBe('rotate(90deg)')
+  })
+
+  it('collapsed chevron has transform rotate(0deg)', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    const chevron = screen.getByTestId('thought-toggle-chevron')
+    expect(chevron.style.transform).toBe('rotate(0deg)')
+  })
+
+  it('chevron has transition property for transform', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    const chevron = screen.getByTestId('thought-toggle-chevron')
+    expect(chevron.style.transition).toContain('var(--nous-ambient-fade)')
+  })
+
+  it('chevron has nous-thought-transition CSS class', () => {
+    render(
+      <ThoughtToggle expanded={false} eventCount={3} onToggle={() => {}} sending={false} />,
+    )
+    const chevron = screen.getByTestId('thought-toggle-chevron')
+    expect(chevron.classList.contains('nous-thought-transition')).toBe(true)
+  })
 })

--- a/self/ui/src/components/thought/__tests__/TraceDetail.test.tsx
+++ b/self/ui/src/components/thought/__tests__/TraceDetail.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TraceDetail } from '../TraceDetail'
+import type { ExecutionTrace } from '@nous/shared'
+
+function makeTrace(overrides?: Partial<ExecutionTrace>): ExecutionTrace {
+  return {
+    traceId: '00000000-0000-0000-0000-000000000001' as any,
+    startedAt: '2026-03-28T00:00:00.000Z',
+    turns: [
+      {
+        input: 'hello',
+        output: 'world',
+        modelCalls: [],
+        pfcDecisions: [
+          { approved: true, reason: 'passed Phase 1 checks', confidence: 1 },
+          { approved: false, reason: 'tool not registered', confidence: 0 },
+        ],
+        toolDecisions: [
+          { toolName: 'echo', approved: true },
+          { toolName: 'danger', approved: false, reason: 'not registered' },
+        ],
+        memoryWrites: ['00000000-0000-0000-0000-000000000002' as any],
+        memoryDenials: [
+          {
+            candidate: {
+              content: 'test',
+              type: 'fact',
+              scope: 'project',
+              confidence: 0.3,
+              sensitivity: [],
+              retention: 'permanent',
+              provenance: {
+                traceId: '00000000-0000-0000-0000-000000000001' as any,
+                source: 'test',
+                timestamp: '2026-03-28T00:00:00.000Z',
+              },
+              tags: [],
+            },
+            reason: 'MEM-CONFIDENCE-BELOW-THRESHOLD',
+          },
+        ],
+        evidenceRefs: [],
+        timestamp: '2026-03-28T00:00:01.000Z',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('TraceDetail', () => {
+  // Tier 1 -- Contract
+  it('renders without crashing given a valid ExecutionTrace', () => {
+    render(<TraceDetail trace={makeTrace()} />)
+    expect(screen.getByTestId('trace-detail')).toBeTruthy()
+  })
+
+  // Tier 2 -- Behavior
+  it('lists pfcDecisions with decision status and reason', () => {
+    render(<TraceDetail trace={makeTrace()} />)
+
+    const decisions = screen.getAllByTestId('trace-pfc-decision')
+    expect(decisions).toHaveLength(2)
+    expect(decisions[0]!.textContent).toContain('approved')
+    expect(decisions[0]!.textContent).toContain('passed Phase 1 checks')
+    expect(decisions[1]!.textContent).toContain('denied')
+    expect(decisions[1]!.textContent).toContain('tool not registered')
+  })
+
+  it('lists tool decisions with tool name and approved status', () => {
+    render(<TraceDetail trace={makeTrace()} />)
+
+    const toolDecisions = screen.getAllByTestId('trace-tool-decision')
+    expect(toolDecisions).toHaveLength(2)
+    expect(toolDecisions[0]!.textContent).toContain('echo')
+    expect(toolDecisions[0]!.textContent).toContain('approved')
+    expect(toolDecisions[1]!.textContent).toContain('danger')
+    expect(toolDecisions[1]!.textContent).toContain('denied')
+  })
+
+  it('shows memory writes count', () => {
+    render(<TraceDetail trace={makeTrace()} />)
+
+    const memWrites = screen.getByTestId('trace-memory-writes')
+    expect(memWrites.textContent).toContain('1')
+  })
+
+  it('shows memory denials', () => {
+    render(<TraceDetail trace={makeTrace()} />)
+
+    const memDenials = screen.getByTestId('trace-memory-denials')
+    expect(memDenials.textContent).toContain('MEM-CONFIDENCE-BELOW-THRESHOLD')
+  })
+
+  // Tier 3 -- Edge cases
+  it('handles ExecutionTrace with zero turns', () => {
+    render(<TraceDetail trace={makeTrace({ turns: [] })} />)
+
+    expect(screen.getByTestId('trace-detail').textContent).toContain(
+      'No turn data available.',
+    )
+  })
+
+  it('handles turn with empty arrays (no decisions, no writes, no denials)', () => {
+    render(
+      <TraceDetail
+        trace={makeTrace({
+          turns: [
+            {
+              input: 'hello',
+              output: 'world',
+              modelCalls: [],
+              pfcDecisions: [],
+              toolDecisions: [],
+              memoryWrites: [],
+              memoryDenials: [],
+              evidenceRefs: [],
+              timestamp: '2026-03-28T00:00:01.000Z',
+            },
+          ],
+        })}
+      />,
+    )
+
+    const detail = screen.getByTestId('trace-detail')
+    expect(detail.textContent).toContain('No decision data in this turn.')
+  })
+})

--- a/self/ui/src/components/thought/__tests__/thought-labels.test.ts
+++ b/self/ui/src/components/thought/__tests__/thought-labels.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getThoughtLabel,
+  LIFECYCLE_PHASE_LABELS,
+  PFC_THOUGHT_TYPE_LABELS,
+} from '../thought-labels'
+
+describe('thought-labels', () => {
+  describe('LIFECYCLE_PHASE_LABELS', () => {
+    it('contains 7 entries', () => {
+      expect(Object.keys(LIFECYCLE_PHASE_LABELS).length).toBe(7)
+    })
+  })
+
+  describe('PFC_THOUGHT_TYPE_LABELS', () => {
+    it('contains 6 entries', () => {
+      expect(Object.keys(PFC_THOUGHT_TYPE_LABELS).length).toBe(6)
+    })
+  })
+
+  describe('getThoughtLabel — phase lookups', () => {
+    it('turn-start → Turn Started', () => {
+      expect(getThoughtLabel('phase', 'turn-start')).toBe('Turn Started')
+    })
+
+    it('opctl-check → Operations Check', () => {
+      expect(getThoughtLabel('phase', 'opctl-check')).toBe('Operations Check')
+    })
+
+    it('gateway-run → Gateway Execution', () => {
+      expect(getThoughtLabel('phase', 'gateway-run')).toBe('Gateway Execution')
+    })
+
+    it('response-resolved → Response Resolved', () => {
+      expect(getThoughtLabel('phase', 'response-resolved')).toBe('Response Resolved')
+    })
+
+    it('stm-finalize → Memory Finalized', () => {
+      expect(getThoughtLabel('phase', 'stm-finalize')).toBe('Memory Finalized')
+    })
+
+    it('trace-record → Trace Recorded', () => {
+      expect(getThoughtLabel('phase', 'trace-record')).toBe('Trace Recorded')
+    })
+
+    it('turn-complete → Turn Complete', () => {
+      expect(getThoughtLabel('phase', 'turn-complete')).toBe('Turn Complete')
+    })
+
+    it('unknown slug falls back to raw slug', () => {
+      expect(getThoughtLabel('phase', 'unknown-future-slug')).toBe('unknown-future-slug')
+    })
+  })
+
+  describe('getThoughtLabel — thoughtType lookups', () => {
+    it('confidence-governance → Confidence Check', () => {
+      expect(getThoughtLabel('thoughtType', 'confidence-governance')).toBe('Confidence Check')
+    })
+
+    it('memory-write → Memory Write', () => {
+      expect(getThoughtLabel('thoughtType', 'memory-write')).toBe('Memory Write')
+    })
+
+    it('memory-mutation → Memory Update', () => {
+      expect(getThoughtLabel('thoughtType', 'memory-mutation')).toBe('Memory Update')
+    })
+
+    it('tool-execution → Tool Execution', () => {
+      expect(getThoughtLabel('thoughtType', 'tool-execution')).toBe('Tool Execution')
+    })
+
+    it('reflection → Reflection', () => {
+      expect(getThoughtLabel('thoughtType', 'reflection')).toBe('Reflection')
+    })
+
+    it('escalation → Escalation', () => {
+      expect(getThoughtLabel('thoughtType', 'escalation')).toBe('Escalation')
+    })
+
+    it('unknown slug falls back to raw slug', () => {
+      expect(getThoughtLabel('thoughtType', 'unknown-future-slug')).toBe('unknown-future-slug')
+    })
+  })
+})

--- a/self/ui/src/components/thought/__tests__/use-thought-mode.test.ts
+++ b/self/ui/src/components/thought/__tests__/use-thought-mode.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  thoughtModeReducer,
+  useThoughtMode,
+  BUFFER_MAX,
+} from '../use-thought-mode'
+import type { ThoughtModeState, ThoughtModeAction } from '../use-thought-mode'
+
+// --- Pure reducer tests (Tier 1 — Contract) ---
+
+describe('thoughtModeReducer', () => {
+  const collapsed: ThoughtModeState = { mode: 'conversing:collapsed', toggledExpanded: false }
+  const expanded: ThoughtModeState = { mode: 'conversing:expanded', toggledExpanded: true }
+  const ambient: ThoughtModeState = { mode: 'ambient:open', toggledExpanded: false }
+  const ambientWithToggle: ThoughtModeState = { mode: 'ambient:open', toggledExpanded: true }
+
+  describe('FOCUS_INPUT', () => {
+    const action: ThoughtModeAction = { type: 'FOCUS_INPUT' }
+
+    it('from ambient:open transitions to conversing:collapsed when toggledExpanded is false', () => {
+      const result = thoughtModeReducer(ambient, action)
+      expect(result.mode).toBe('conversing:collapsed')
+    })
+
+    it('from ambient:open transitions to conversing:expanded when toggledExpanded is true', () => {
+      const result = thoughtModeReducer(ambientWithToggle, action)
+      expect(result.mode).toBe('conversing:expanded')
+    })
+
+    it('from conversing:collapsed is no-op', () => {
+      const result = thoughtModeReducer(collapsed, action)
+      expect(result).toBe(collapsed)
+    })
+
+    it('from conversing:expanded is no-op', () => {
+      const result = thoughtModeReducer(expanded, action)
+      expect(result).toBe(expanded)
+    })
+  })
+
+  describe('BLUR_INPUT', () => {
+    const action: ThoughtModeAction = { type: 'BLUR_INPUT' }
+
+    it('from conversing:collapsed transitions to ambient:open', () => {
+      const result = thoughtModeReducer(collapsed, action)
+      expect(result.mode).toBe('ambient:open')
+    })
+
+    it('from conversing:expanded transitions to ambient:open', () => {
+      const result = thoughtModeReducer(expanded, action)
+      expect(result.mode).toBe('ambient:open')
+    })
+
+    it('from ambient:open is no-op', () => {
+      const result = thoughtModeReducer(ambient, action)
+      expect(result).toBe(ambient)
+    })
+  })
+
+  describe('TOGGLE_EXPAND', () => {
+    const action: ThoughtModeAction = { type: 'TOGGLE_EXPAND' }
+
+    it('from conversing:collapsed transitions to conversing:expanded and sets toggledExpanded: true', () => {
+      const result = thoughtModeReducer(collapsed, action)
+      expect(result.mode).toBe('conversing:expanded')
+      expect(result.toggledExpanded).toBe(true)
+    })
+
+    it('from conversing:expanded transitions to conversing:collapsed and sets toggledExpanded: false', () => {
+      const result = thoughtModeReducer(expanded, action)
+      expect(result.mode).toBe('conversing:collapsed')
+      expect(result.toggledExpanded).toBe(false)
+    })
+
+    it('from ambient:open is no-op', () => {
+      const result = thoughtModeReducer(ambient, action)
+      expect(result).toBe(ambient)
+    })
+  })
+
+  describe('SEND_START', () => {
+    const action: ThoughtModeAction = { type: 'SEND_START' }
+
+    it('is no-op in all three states', () => {
+      expect(thoughtModeReducer(collapsed, action)).toBe(collapsed)
+      expect(thoughtModeReducer(expanded, action)).toBe(expanded)
+      expect(thoughtModeReducer(ambient, action)).toBe(ambient)
+    })
+  })
+
+  describe('SEND_END', () => {
+    const action: ThoughtModeAction = { type: 'SEND_END' }
+
+    it('is no-op in all three states', () => {
+      expect(thoughtModeReducer(collapsed, action)).toBe(collapsed)
+      expect(thoughtModeReducer(expanded, action)).toBe(expanded)
+      expect(thoughtModeReducer(ambient, action)).toBe(ambient)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('rapid FOCUS_INPUT/BLUR_INPUT cycling produces deterministic state', () => {
+      let state: ThoughtModeState = ambient
+      for (let i = 0; i < 100; i++) {
+        state = thoughtModeReducer(state, { type: 'FOCUS_INPUT' })
+        state = thoughtModeReducer(state, { type: 'BLUR_INPUT' })
+      }
+      // Should end in ambient:open after blur
+      expect(state.mode).toBe('ambient:open')
+    })
+
+    it('TOGGLE_EXPAND during rapid focus/blur does not produce invalid state', () => {
+      let state: ThoughtModeState = ambient
+      state = thoughtModeReducer(state, { type: 'FOCUS_INPUT' })
+      expect(state.mode).toBe('conversing:collapsed')
+      state = thoughtModeReducer(state, { type: 'TOGGLE_EXPAND' })
+      expect(state.mode).toBe('conversing:expanded')
+      state = thoughtModeReducer(state, { type: 'BLUR_INPUT' })
+      expect(state.mode).toBe('ambient:open')
+      state = thoughtModeReducer(state, { type: 'FOCUS_INPUT' })
+      // toggledExpanded was set true by TOGGLE_EXPAND, so should return to expanded
+      expect(state.mode).toBe('conversing:expanded')
+    })
+  })
+})
+
+// --- Hook tests (Tier 1 — Contract) ---
+
+describe('useThoughtMode', () => {
+  it('initializes to conversing:collapsed when detailsAlwaysOn is false', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: false, sending: false }),
+    )
+    expect(result.current.mode).toBe('conversing:collapsed')
+    expect(result.current.isExpanded).toBe(false)
+    expect(result.current.isAmbient).toBe(false)
+  })
+
+  it('initializes to conversing:expanded when detailsAlwaysOn is true', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: true, sending: false }),
+    )
+    expect(result.current.mode).toBe('conversing:expanded')
+    expect(result.current.isExpanded).toBe(true)
+    expect(result.current.isAmbient).toBe(false)
+  })
+
+  it('derived isExpanded is true for conversing:expanded', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: true, sending: false }),
+    )
+    expect(result.current.isExpanded).toBe(true)
+  })
+
+  it('derived isExpanded is true for ambient:open', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: false, sending: false }),
+    )
+    // Transition to ambient:open
+    act(() => {
+      result.current.dispatch({ type: 'BLUR_INPUT' })
+    })
+    expect(result.current.mode).toBe('ambient:open')
+    expect(result.current.isExpanded).toBe(true)
+  })
+
+  it('derived isExpanded is false for conversing:collapsed', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: false, sending: false }),
+    )
+    expect(result.current.isExpanded).toBe(false)
+  })
+
+  it('derived isAmbient is true only for ambient:open', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: false, sending: false }),
+    )
+    expect(result.current.isAmbient).toBe(false)
+    act(() => {
+      result.current.dispatch({ type: 'BLUR_INPUT' })
+    })
+    expect(result.current.isAmbient).toBe(true)
+    act(() => {
+      result.current.dispatch({ type: 'FOCUS_INPUT' })
+    })
+    expect(result.current.isAmbient).toBe(false)
+  })
+
+  it('dispatch transitions state correctly', () => {
+    const { result } = renderHook(() =>
+      useThoughtMode({ detailsAlwaysOn: false, sending: false }),
+    )
+    expect(result.current.mode).toBe('conversing:collapsed')
+
+    act(() => {
+      result.current.dispatch({ type: 'TOGGLE_EXPAND' })
+    })
+    expect(result.current.mode).toBe('conversing:expanded')
+
+    act(() => {
+      result.current.dispatch({ type: 'BLUR_INPUT' })
+    })
+    expect(result.current.mode).toBe('ambient:open')
+
+    act(() => {
+      result.current.dispatch({ type: 'FOCUS_INPUT' })
+    })
+    // toggledExpanded was set true by TOGGLE_EXPAND
+    expect(result.current.mode).toBe('conversing:expanded')
+  })
+})
+
+// --- Constants ---
+
+describe('BUFFER_MAX', () => {
+  it('equals 50', () => {
+    expect(BUFFER_MAX).toBe(50)
+  })
+})

--- a/self/ui/src/components/thought/index.ts
+++ b/self/ui/src/components/thought/index.ts
@@ -21,6 +21,3 @@ export type { ThoughtStreamProps, ThoughtEvent } from './ThoughtStream'
 
 export { ThoughtSummary } from './ThoughtSummary'
 export type { ThoughtSummaryProps, ThoughtSummaryCounts } from './ThoughtSummary'
-
-export { TraceDetail } from './TraceDetail'
-export type { TraceDetailProps } from './TraceDetail'

--- a/self/ui/src/components/thought/index.ts
+++ b/self/ui/src/components/thought/index.ts
@@ -1,0 +1,20 @@
+export { useThoughtMode, thoughtModeReducer, BUFFER_MAX } from './use-thought-mode'
+export type {
+  ThoughtMode,
+  ThoughtModeAction,
+  ThoughtModeState,
+  UseThoughtModeOptions,
+  UseThoughtModeReturn,
+} from './use-thought-mode'
+
+export { ThoughtCard } from './ThoughtCard'
+export type { ThoughtCardProps } from './ThoughtCard'
+
+export { ThoughtLifecycleEvent } from './ThoughtLifecycleEvent'
+export type { ThoughtLifecycleEventProps } from './ThoughtLifecycleEvent'
+
+export { ThoughtToggle } from './ThoughtToggle'
+export type { ThoughtToggleProps } from './ThoughtToggle'
+
+export { ThoughtStream } from './ThoughtStream'
+export type { ThoughtStreamProps, ThoughtEvent } from './ThoughtStream'

--- a/self/ui/src/components/thought/index.ts
+++ b/self/ui/src/components/thought/index.ts
@@ -24,3 +24,9 @@ export type { ThoughtSummaryProps, ThoughtSummaryCounts } from './ThoughtSummary
 
 export { TraceDetail } from './TraceDetail'
 export type { TraceDetailProps } from './TraceDetail'
+
+export {
+  getThoughtLabel,
+  LIFECYCLE_PHASE_LABELS,
+  PFC_THOUGHT_TYPE_LABELS,
+} from './thought-labels'

--- a/self/ui/src/components/thought/index.ts
+++ b/self/ui/src/components/thought/index.ts
@@ -21,3 +21,6 @@ export type { ThoughtStreamProps, ThoughtEvent } from './ThoughtStream'
 
 export { ThoughtSummary } from './ThoughtSummary'
 export type { ThoughtSummaryProps, ThoughtSummaryCounts } from './ThoughtSummary'
+
+export { TraceDetail } from './TraceDetail'
+export type { TraceDetailProps } from './TraceDetail'

--- a/self/ui/src/components/thought/index.ts
+++ b/self/ui/src/components/thought/index.ts
@@ -18,3 +18,9 @@ export type { ThoughtToggleProps } from './ThoughtToggle'
 
 export { ThoughtStream } from './ThoughtStream'
 export type { ThoughtStreamProps, ThoughtEvent } from './ThoughtStream'
+
+export { ThoughtSummary } from './ThoughtSummary'
+export type { ThoughtSummaryProps, ThoughtSummaryCounts } from './ThoughtSummary'
+
+export { TraceDetail } from './TraceDetail'
+export type { TraceDetailProps } from './TraceDetail'

--- a/self/ui/src/components/thought/thought-labels.ts
+++ b/self/ui/src/components/thought/thought-labels.ts
@@ -1,0 +1,26 @@
+export const LIFECYCLE_PHASE_LABELS: Record<string, string> = {
+  'turn-start': 'Turn Started',
+  'opctl-check': 'Operations Check',
+  'gateway-run': 'Gateway Execution',
+  'response-resolved': 'Response Resolved',
+  'stm-finalize': 'Memory Finalized',
+  'trace-record': 'Trace Recorded',
+  'turn-complete': 'Turn Complete',
+}
+
+export const PFC_THOUGHT_TYPE_LABELS: Record<string, string> = {
+  'confidence-governance': 'Confidence Check',
+  'memory-write': 'Memory Write',
+  'memory-mutation': 'Memory Update',
+  'tool-execution': 'Tool Execution',
+  'reflection': 'Reflection',
+  'escalation': 'Escalation',
+}
+
+export function getThoughtLabel(
+  type: 'phase' | 'thoughtType',
+  slug: string,
+): string {
+  const map = type === 'phase' ? LIFECYCLE_PHASE_LABELS : PFC_THOUGHT_TYPE_LABELS
+  return map[slug] ?? slug
+}

--- a/self/ui/src/components/thought/use-thought-mode.ts
+++ b/self/ui/src/components/thought/use-thought-mode.ts
@@ -1,0 +1,101 @@
+'use client'
+
+import { useReducer, useMemo } from 'react'
+
+/** Maximum number of thought events retained in the ring buffer. */
+export const BUFFER_MAX = 50
+
+export type ThoughtMode =
+  | 'conversing:collapsed'
+  | 'conversing:expanded'
+  | 'ambient:open'
+
+export type ThoughtModeAction =
+  | { type: 'FOCUS_INPUT' }
+  | { type: 'BLUR_INPUT' }
+  | { type: 'TOGGLE_EXPAND' }
+  | { type: 'SEND_START' }
+  | { type: 'SEND_END' }
+
+export interface ThoughtModeState {
+  mode: ThoughtMode
+  toggledExpanded: boolean
+}
+
+export function thoughtModeReducer(
+  state: ThoughtModeState,
+  action: ThoughtModeAction,
+): ThoughtModeState {
+  switch (action.type) {
+    case 'FOCUS_INPUT':
+      if (state.mode === 'ambient:open') {
+        return {
+          ...state,
+          mode: state.toggledExpanded
+            ? 'conversing:expanded'
+            : 'conversing:collapsed',
+        }
+      }
+      return state
+
+    case 'BLUR_INPUT':
+      if (state.mode.startsWith('conversing:')) {
+        return { ...state, mode: 'ambient:open' }
+      }
+      return state
+
+    case 'TOGGLE_EXPAND':
+      if (state.mode === 'conversing:collapsed') {
+        return { ...state, mode: 'conversing:expanded', toggledExpanded: true }
+      }
+      if (state.mode === 'conversing:expanded') {
+        return { ...state, mode: 'conversing:collapsed', toggledExpanded: false }
+      }
+      return state
+
+    case 'SEND_START':
+      return state
+
+    case 'SEND_END':
+      return state
+  }
+}
+
+export interface UseThoughtModeOptions {
+  detailsAlwaysOn: boolean
+  sending: boolean
+}
+
+export interface UseThoughtModeReturn {
+  mode: ThoughtMode
+  dispatch: React.Dispatch<ThoughtModeAction>
+  isExpanded: boolean
+  isAmbient: boolean
+}
+
+export function useThoughtMode(
+  options: UseThoughtModeOptions,
+): UseThoughtModeReturn {
+  const { detailsAlwaysOn } = options
+
+  const [state, dispatch] = useReducer(thoughtModeReducer, undefined, () => ({
+    mode: (detailsAlwaysOn
+      ? 'conversing:expanded'
+      : 'conversing:collapsed') as ThoughtMode,
+    toggledExpanded: detailsAlwaysOn,
+  }))
+
+  const derived = useMemo(
+    () => ({
+      isExpanded: state.mode !== 'conversing:collapsed',
+      isAmbient: state.mode === 'ambient:open',
+    }),
+    [state.mode],
+  )
+
+  return {
+    mode: state.mode,
+    dispatch,
+    ...derived,
+  }
+}

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -1,15 +1,17 @@
 'use client'
 
-import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import { useState, useEffect, useRef, useCallback, type KeyboardEvent } from 'react'
 import type { IDockviewPanelProps } from 'dockview-react'
 import { clsx } from 'clsx'
 import type { ConversationContext } from '../components/shell/types'
 import { useEventSubscription } from '@nous/transport'
-import type { ThoughtPfcDecisionPayload, ThoughtTurnLifecyclePayload } from '@nous/shared'
-
-type ThoughtEvent =
-  | { channel: 'thought:pfc-decision'; payload: ThoughtPfcDecisionPayload }
-  | { channel: 'thought:turn-lifecycle'; payload: ThoughtTurnLifecyclePayload }
+import {
+  ThoughtStream,
+  ThoughtToggle,
+  useThoughtMode,
+  BUFFER_MAX,
+} from '../components/thought'
+import type { ThoughtEvent } from '../components/thought'
 
 export interface ChatMessage {
   role: 'user' | 'assistant'
@@ -60,12 +62,12 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null)
 
   const [thoughts, setThoughts] = useState<ThoughtEvent[]>([])
-  const [thoughtsExpanded, setThoughtsExpanded] = useState(
+  const detailsAlwaysOn = useState(
     () => {
       try { return localStorage.getItem('nous:thoughts-expanded') === 'true' }
       catch { return false }
     }
-  )
+  )[0]
 
   const chatApi = 'params' in props ? props.params?.chatApi : props.chatApi
   const conversationContext = 'conversationContext' in props ? props.conversationContext : undefined
@@ -83,30 +85,39 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  const sendingRef = useRef(sending)
-  sendingRef.current = sending
+  const { mode, dispatch, isExpanded } = useThoughtMode({
+    detailsAlwaysOn,
+    sending,
+  })
 
   useEventSubscription({
     channels: ['thought:pfc-decision', 'thought:turn-lifecycle'],
     onEvent: (channel, payload) => {
-      if (sendingRef.current) {
-        setThoughts(prev => [...prev.slice(-19), { channel: channel as ThoughtEvent['channel'], payload: payload as any }])
-      }
+      setThoughts(prev => [
+        ...prev.slice(-(BUFFER_MAX - 1)),
+        { channel: channel as ThoughtEvent['channel'], payload: payload as any },
+      ])
     },
     enabled: true,
   })
 
-  useEffect(() => {
-    if (!sending) setThoughts([])
-  }, [sending])
+  const handleToggle = useCallback(() => {
+    dispatch({ type: 'TOGGLE_EXPAND' })
+    try {
+      const next = !isExpanded
+      localStorage.setItem('nous:thoughts-expanded', String(next))
+    } catch { /* localStorage unavailable */ }
+  }, [dispatch, isExpanded])
 
-  const toggleThoughts = () => {
-    setThoughtsExpanded(prev => {
-      const next = !prev
-      try { localStorage.setItem('nous:thoughts-expanded', String(next)) } catch {}
-      return next
-    })
-  }
+  const handleInputFocus = useCallback(() => {
+    dispatch({ type: 'FOCUS_INPUT' })
+  }, [dispatch])
+
+  const handleInputBlur = useCallback(() => {
+    if (!sending) {
+      dispatch({ type: 'BLUR_INPUT' })
+    }
+  }, [dispatch, sending])
 
   const send = async () => {
     if (!input.trim() || sending || !chatApi?.send) return
@@ -199,61 +210,18 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
             </div>
           </div>
         ))}
-        {sending && thoughts.length > 0 && (
+        {thoughts.length > 0 && (
           <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
             <div style={{ maxWidth: '80%' }}>
-              <button
-                onClick={toggleThoughts}
-                data-testid="thought-toggle"
-                style={{
-                  background: 'none', border: 'none', cursor: 'pointer',
-                  color: 'var(--nous-fg-subtle)', fontSize: 'var(--nous-font-size-xs)',
-                  padding: 'var(--nous-space-xs) 0', display: 'flex', alignItems: 'center',
-                  gap: 'var(--nous-space-xs)',
-                }}
-              >
-                <i className={`codicon codicon-chevron-${thoughtsExpanded ? 'down' : 'right'}`}
-                   style={{ fontSize: 'var(--nous-font-size-xs)' }} />
-                {thoughts.length} thought{thoughts.length !== 1 ? 's' : ''}
-              </button>
-              {thoughtsExpanded && (
-                <div data-testid="thought-stream" style={{
-                  padding: 'var(--nous-space-sm) var(--nous-space-md)',
-                  background: 'var(--nous-bg-elevated)',
-                  borderRadius: 'var(--nous-radius-sm)',
-                  fontSize: 'var(--nous-font-size-xs)',
-                  color: 'var(--nous-fg-subtle)',
-                  maxHeight: '200px',
-                  overflowY: 'auto',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 'var(--nous-space-2xs)',
-                }}>
-                  {thoughts.map((t, i) => {
-                    const label = t.channel === 'thought:pfc-decision'
-                      ? (t.payload as ThoughtPfcDecisionPayload).thoughtType
-                      : (t.payload as ThoughtTurnLifecyclePayload).phase
-                    const content = t.channel === 'thought:pfc-decision'
-                      ? (t.payload as ThoughtPfcDecisionPayload).content
-                      : (t.payload as ThoughtTurnLifecyclePayload).content ?? (t.payload as ThoughtTurnLifecyclePayload).status
-                    return (
-                      <div key={i} data-testid="thought-event" style={{ fontFamily: 'var(--nous-font-mono)', lineHeight: 1.4 }}>
-                        <span style={{ color: 'var(--nous-accent)', fontWeight: 'var(--nous-font-weight-medium)' as any }}>
-                          [{label}]
-                        </span>{' '}
-                        {content}
-                      </div>
-                    )
-                  })}
-                </div>
+              <ThoughtToggle
+                expanded={isExpanded}
+                eventCount={thoughts.length}
+                onToggle={handleToggle}
+                sending={sending}
+              />
+              {isExpanded && (
+                <ThoughtStream thoughts={thoughts} mode={mode} />
               )}
-            </div>
-          </div>
-        )}
-        {sending && (
-          <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
-            <div style={{ padding: 'var(--nous-space-md) var(--nous-space-xl)', borderRadius: 'var(--nous-radius-md)', background: 'var(--nous-bg-elevated)', color: 'var(--nous-fg-subtle)', fontSize: 'var(--nous-font-size-base)' }}>
-              Thinking...
             </div>
           </div>
         )}
@@ -265,6 +233,8 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
           value={input}
           onChange={e => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
           placeholder="Message Nous... (Enter to send, Shift+Enter for newline)"
           disabled={sending}
           style={{

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { useEventSubscription } from '@nous/transport'
 import {
   ThoughtStream,
   ThoughtToggle,
+  ThoughtSummary,
   useThoughtMode,
   BUFFER_MAX,
 } from '../components/thought'
@@ -17,6 +18,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
   timestamp: string
+  traceId?: string
 }
 
 export interface ChatAPI {
@@ -128,11 +130,17 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
     setMessages(prev => [...prev, userEntry])
     try {
       const result = await chatApi.send(userMsg)
-      setMessages(prev => [...prev, { role: 'assistant', content: result.response, timestamp: new Date().toISOString() }])
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: result.response,
+        timestamp: new Date().toISOString(),
+        traceId: result.traceId,
+      }])
     } catch (e) {
       setMessages(prev => [...prev, { role: 'assistant', content: 'Error: could not reach Nous.', timestamp: new Date().toISOString() }])
     } finally {
       setSending(false)
+      setThoughts([])
     }
   }
 
@@ -200,7 +208,7 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
           </div>
         )}
         {messages.map((msg, i) => (
-          <div key={i} style={{ display: 'flex', justifyContent: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
+          <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
             <div style={{
               maxWidth: '80%', padding: 'var(--nous-space-md) var(--nous-space-xl)', borderRadius: 'var(--nous-radius-md)', fontSize: 'var(--nous-font-size-base)', lineHeight: '1.5',
               background: msg.role === 'user' ? 'var(--nous-chat-user-bg)' : 'var(--nous-bg-elevated)',
@@ -208,6 +216,9 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
             }}>
               {msg.content}
             </div>
+            {msg.role === 'assistant' && msg.traceId && !sending && (
+              <ThoughtSummary traceId={msg.traceId} />
+            )}
           </div>
         ))}
         {thoughts.length > 0 && (

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -230,9 +230,17 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
                 onToggle={handleToggle}
                 sending={sending}
               />
-              {isExpanded && (
-                <ThoughtStream thoughts={thoughts} mode={mode} />
-              )}
+              <ThoughtStream
+                thoughts={thoughts}
+                mode={mode}
+                style={{
+                  opacity: isExpanded ? 1 : 0,
+                  maxHeight: isExpanded
+                    ? mode === 'conversing:expanded' ? '200px' : '2000px'
+                    : '0px',
+                  overflow: isExpanded ? undefined : 'hidden',
+                }}
+              />
             </div>
           </div>
         )}

--- a/self/ui/src/panels/__tests__/ChatPanel.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.test.tsx
@@ -92,4 +92,25 @@ describe('ChatPanel', () => {
     render(<ChatPanel />)
     expect(screen.getByText('Chat API not connected. Start the web backend with `pnpm dev:web`.')).toBeTruthy()
   })
+
+  // Tier 2 — Message binding
+  it('ChatMessage type includes optional traceId field', () => {
+    // Type-level verification — if this compiles, the traceId field exists
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: 'test',
+      timestamp: new Date().toISOString(),
+      traceId: 'trace-123',
+    }
+    expect(msg.traceId).toBe('trace-123')
+  })
+
+  it('ChatMessage type allows omitting traceId (optional field)', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: 'test',
+      timestamp: new Date().toISOString(),
+    }
+    expect(msg.traceId).toBeUndefined()
+  })
 })

--- a/self/ui/src/panels/__tests__/ChatPanel.thought-stream.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.thought-stream.test.tsx
@@ -14,6 +14,13 @@ vi.mock('@nous/transport', () => ({
   useEventSubscription: (options: { onEvent: (channel: string, payload: unknown) => void }) => {
     capturedOnEvent = options.onEvent
   },
+  trpc: {
+    traces: {
+      get: {
+        useQuery: () => ({ data: null, isLoading: false, isError: false }),
+      },
+    },
+  },
 }))
 
 beforeAll(() => {
@@ -121,7 +128,7 @@ describe('ChatPanel — Thought Stream', () => {
     expect(screen.getByText('2 thoughts')).toBeTruthy()
   })
 
-  it('thoughts persist when sending becomes false', async () => {
+  it('ephemeral thoughts clear when turn completes (post-turn transition)', async () => {
     const { resolveSend } = renderSendingPanel()
 
     act(() => {
@@ -135,8 +142,8 @@ describe('ChatPanel — Thought Stream', () => {
       resolveSend({ response: 'done', traceId: 'trace-1' })
     })
 
-    // Thoughts persist after sending completes (no longer cleared)
-    expect(screen.getByTestId('thought-toggle')).toBeTruthy()
+    // Ephemeral thoughts are cleared after turn completion
+    expect(screen.queryByTestId('thought-toggle')).toBeNull()
   })
 
   it('collapsed state shows thought count chip but not event details', async () => {

--- a/self/ui/src/panels/__tests__/ChatPanel.thought-stream.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.thought-stream.test.tsx
@@ -146,16 +146,19 @@ describe('ChatPanel — Thought Stream', () => {
     expect(screen.queryByTestId('thought-toggle')).toBeNull()
   })
 
-  it('collapsed state shows thought count chip but not event details', async () => {
+  it('collapsed state shows thought count chip and stream is in DOM but hidden', async () => {
     renderSendingPanel()
 
     act(() => {
       capturedOnEvent!('thought:pfc-decision', makePfcPayload())
     })
 
-    // Collapsed by default — toggle visible, stream not
+    // Collapsed by default — toggle visible, stream in DOM but hidden via CSS
     expect(screen.getByTestId('thought-toggle')).toBeTruthy()
-    expect(screen.queryByTestId('thought-stream')).toBeNull()
+    const stream = screen.getByTestId('thought-stream')
+    expect(stream.style.opacity).toBe('0')
+    expect(stream.style.maxHeight).toBe('0px')
+    expect(stream.style.overflow).toBe('hidden')
   })
 
   it('expanded state shows thought events with ThoughtCard components', async () => {
@@ -172,7 +175,7 @@ describe('ChatPanel — Thought Stream', () => {
     fireEvent.click(screen.getByTestId('thought-toggle'))
 
     expect(screen.getByTestId('thought-stream')).toBeTruthy()
-    expect(screen.getByText('[memory-write]')).toBeTruthy()
+    expect(screen.getByText('[Memory Write]')).toBeTruthy()
     expect(screen.getByText('MEM-WRITE-APPROVED confidence=0.85')).toBeTruthy()
   })
 
@@ -189,7 +192,7 @@ describe('ChatPanel — Thought Stream', () => {
 
     fireEvent.click(screen.getByTestId('thought-toggle'))
 
-    expect(screen.getByText('[gateway-run]')).toBeTruthy()
+    expect(screen.getByText('[Gateway Execution]')).toBeTruthy()
     expect(screen.getByText('gateway execution finished')).toBeTruthy()
   })
 
@@ -206,7 +209,7 @@ describe('ChatPanel — Thought Stream', () => {
 
     fireEvent.click(screen.getByTestId('thought-toggle'))
 
-    expect(screen.getByText('[turn-start]')).toBeTruthy()
+    expect(screen.getByText('[Turn Started]')).toBeTruthy()
     expect(screen.getByText('started')).toBeTruthy()
   })
 
@@ -236,7 +239,8 @@ describe('ChatPanel — Thought Stream', () => {
     })
 
     // Should be expanded on mount because localStorage says so (detailsAlwaysOn)
-    expect(screen.getByTestId('thought-stream')).toBeTruthy()
+    const stream = screen.getByTestId('thought-stream')
+    expect(stream.style.opacity).toBe('1')
   })
 
   it('caps at 50 events, truncating older ones', async () => {
@@ -307,5 +311,31 @@ describe('ChatPanel — Thought Stream', () => {
     // Expand and verify aria-expanded changes
     fireEvent.click(toggle)
     expect(toggle.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('ThoughtStream is always in DOM when thoughts exist (always-render pattern)', async () => {
+    renderSendingPanel()
+
+    act(() => {
+      capturedOnEvent!('thought:pfc-decision', makePfcPayload())
+    })
+
+    // Even when collapsed, ThoughtStream is in the DOM
+    expect(screen.getByTestId('thought-stream')).toBeTruthy()
+  })
+
+  it('expanded ThoughtStream has opacity 1 and non-zero maxHeight', async () => {
+    renderSendingPanel()
+
+    act(() => {
+      capturedOnEvent!('thought:pfc-decision', makePfcPayload())
+    })
+
+    // Expand
+    fireEvent.click(screen.getByTestId('thought-toggle'))
+
+    const stream = screen.getByTestId('thought-stream')
+    expect(stream.style.opacity).toBe('1')
+    expect(stream.style.maxHeight).not.toBe('0px')
   })
 })

--- a/self/ui/src/panels/__tests__/ChatPanel.thought-stream.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.thought-stream.test.tsx
@@ -70,6 +70,17 @@ function renderSendingPanel() {
   return { ...result, resolveSend: resolveSend! }
 }
 
+/**
+ * Creates a ChatPanel in idle state (not sending).
+ */
+function renderIdlePanel() {
+  const mockApi: ChatAPI = {
+    send: vi.fn().mockResolvedValue({ response: 'ok', traceId: 'trace-1' }),
+    getHistory: async () => [],
+  }
+  return render(<ChatPanel chatApi={mockApi} />)
+}
+
 describe('ChatPanel — Thought Stream', () => {
   beforeEach(() => {
     capturedOnEvent = null
@@ -86,14 +97,15 @@ describe('ChatPanel — Thought Stream', () => {
     expect(screen.queryByTestId('thought-stream')).toBeNull()
   })
 
-  it('accumulates thoughts during sending state', async () => {
-    renderSendingPanel()
+  it('accumulates thoughts regardless of sending state', async () => {
+    renderIdlePanel()
 
-    // Emit a thought event
+    // Emit a thought event while NOT sending
     act(() => {
       capturedOnEvent!('thought:pfc-decision', makePfcPayload())
     })
 
+    // Thought should accumulate even when not sending (sendingRef gate removed)
     expect(screen.getByTestId('thought-toggle')).toBeTruthy()
     expect(screen.getByText('1 thought')).toBeTruthy()
   })
@@ -109,7 +121,7 @@ describe('ChatPanel — Thought Stream', () => {
     expect(screen.getByText('2 thoughts')).toBeTruthy()
   })
 
-  it('clears thoughts when sending becomes false (response arrives)', async () => {
+  it('thoughts persist when sending becomes false', async () => {
     const { resolveSend } = renderSendingPanel()
 
     act(() => {
@@ -123,7 +135,8 @@ describe('ChatPanel — Thought Stream', () => {
       resolveSend({ response: 'done', traceId: 'trace-1' })
     })
 
-    expect(screen.queryByTestId('thought-toggle')).toBeNull()
+    // Thoughts persist after sending completes (no longer cleared)
+    expect(screen.getByTestId('thought-toggle')).toBeTruthy()
   })
 
   it('collapsed state shows thought count chip but not event details', async () => {
@@ -138,7 +151,7 @@ describe('ChatPanel — Thought Stream', () => {
     expect(screen.queryByTestId('thought-stream')).toBeNull()
   })
 
-  it('expanded state shows thought events', async () => {
+  it('expanded state shows thought events with ThoughtCard components', async () => {
     renderSendingPanel()
 
     act(() => {
@@ -215,18 +228,18 @@ describe('ChatPanel — Thought Stream', () => {
       capturedOnEvent!('thought:pfc-decision', makePfcPayload())
     })
 
-    // Should be expanded on mount because localStorage says so
+    // Should be expanded on mount because localStorage says so (detailsAlwaysOn)
     expect(screen.getByTestId('thought-stream')).toBeTruthy()
   })
 
-  it('caps at 20 events, truncating older ones', async () => {
+  it('caps at 50 events, truncating older ones', async () => {
     localStorage.setItem('nous:thoughts-expanded', 'true')
 
     renderSendingPanel()
 
-    // Emit 25 events
+    // Emit 55 events
     act(() => {
-      for (let i = 0; i < 25; i++) {
+      for (let i = 0; i < 55; i++) {
         capturedOnEvent!('thought:pfc-decision', makePfcPayload({
           sequence: i,
           content: `event-${i}`,
@@ -235,13 +248,57 @@ describe('ChatPanel — Thought Stream', () => {
     })
 
     const events = screen.getAllByTestId('thought-event')
-    expect(events.length).toBe(20)
+    expect(events.length).toBe(50)
 
-    // The last event should be event-24 (most recent)
-    expect(screen.getByText('event-24')).toBeTruthy()
-    // The first retained event should be event-5 (25 - 20 = 5)
+    // The last event should be event-54 (most recent)
+    expect(screen.getByText('event-54')).toBeTruthy()
+    // The first retained event should be event-5 (55 - 50 = 5)
     expect(screen.getByText('event-5')).toBeTruthy()
     // event-4 should be truncated
     expect(screen.queryByText('event-4')).toBeNull()
+  })
+
+  it('ThoughtToggle shows "Thinking..." when sending and collapsed', async () => {
+    renderSendingPanel()
+
+    act(() => {
+      capturedOnEvent!('thought:pfc-decision', makePfcPayload())
+    })
+
+    // Collapsed by default + sending=true: should show "Thinking..."
+    expect(screen.getByText('Thinking...')).toBeTruthy()
+  })
+
+  it('ThoughtStream container has correct ARIA attributes', async () => {
+    localStorage.setItem('nous:thoughts-expanded', 'true')
+
+    renderSendingPanel()
+
+    act(() => {
+      capturedOnEvent!('thought:pfc-decision', makePfcPayload())
+    })
+
+    const stream = screen.getByTestId('thought-stream')
+    expect(stream.getAttribute('role')).toBe('log')
+    expect(stream.getAttribute('aria-live')).toBe('polite')
+    expect(stream.getAttribute('aria-label')).toBe('AI thought stream')
+    expect(stream.getAttribute('id')).toBe('thought-stream')
+  })
+
+  it('ThoughtToggle has correct ARIA attributes', async () => {
+    renderSendingPanel()
+
+    act(() => {
+      capturedOnEvent!('thought:pfc-decision', makePfcPayload())
+    })
+
+    const toggle = screen.getByTestId('thought-toggle')
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.getAttribute('aria-controls')).toBe('thought-stream')
+    expect(toggle.getAttribute('aria-label')).toContain('1 event')
+
+    // Expand and verify aria-expanded changes
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
   })
 })


### PR DESCRIPTION
## Summary

- **Three-state thought stream model** — conversing:collapsed / conversing:expanded / ambient:open, driven by chat input focus, mode-independent
- **5 new components** in `@nous/ui`: ThoughtStream, ThoughtCard, ThoughtLifecycleEvent, ThoughtToggle, ThoughtSummary + TraceDetail
- **Trace-backed message binding** — PFC traceId wiring (9 sites), ThoughtSummary under assistant messages, expand fetches ExecutionTrace via tRPC
- **Crossfade animations** using `--nous-ambient-fade` (200ms), prefers-reduced-motion respected
- **Human-readable labels** for all lifecycle phases and PFC thought types
- **ARIA accessibility contract** — role="log", aria-live="polite", aria-expanded, aria-controls
- **Platform-agnostic** — all in `@nous/ui`, works on both desktop and web via `@nous/transport`

**3 sub-phases delivered:**
1. 1.1 — Thought stream components and state machine (11 new files)
2. 1.2 — Message binding and trace integration (ThoughtSummary, traceId wiring)
3. 1.3 — BT fix: transition animation and display labels

**Test coverage:** 3,282 tests passing (788 in @nous/ui, ~100 thought-specific)

## Test plan

- [x] Build passes (all packages including desktop Electron)
- [x] 3,282/3,282 tests pass
- [x] CI green on remote
- [x] Behavioral testing: 2 rounds, Principal approved
- [x] All design gates approved (Goals, SDS, Impl Plan, CR, User Docs × 3 sub-phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)