### PR TITLE
fix(desktop): data persistence + error visibility — WR-102

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -24,7 +24,7 @@ import {
   type ShellMode,
   type CommandGroup,
 } from '@nous/ui/components'
-import { TransportProvider, createDesktopTransport } from '@nous/transport'
+import { TransportProvider, createDesktopTransport, trpc } from '@nous/transport'
 import { FirstRunWizard } from './components/FirstRunWizard'
 import { TitleBar } from './components/TitleBar'
 import { StatusBar } from './components/StatusBar'
@@ -672,47 +672,53 @@ export function App() {
     return loadingShell
   }
 
+  const shellChildren = (
+    <>
+      <CommandPalette
+        isOpen={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+        commands={commands}
+      />
+      {mode === 'simple' ? (
+        <ShellLayout
+          rail={(
+            <NavigationRail
+              items={RAIL_SECTIONS}
+              activeItemId={activeRoute}
+              onItemSelect={handleNavigate}
+            />
+          )}
+          chat={<ConnectedChatSurface />}
+          content={(
+            <ContentRouter
+              activeRoute={activeRoute}
+              routes={simpleModeRoutes}
+              onNavigate={handleNavigate}
+            />
+          )}
+          observe={<ObservePanel />}
+        />
+      ) : (
+        <DockviewShell
+          savedLayout={savedLayout}
+          onApiReady={setDockviewApi}
+          activeAppPanelIds={new Set(appPanels.map((panel) => panel.dockview_panel_id))}
+          panelDefs={panelDefs}
+        />
+      )}
+    </>
+  )
+
   const mainContent = (
-    <ShellProvider
+    <DesktopShellWithProject
       mode={mode}
       activeRoute={activeRoute}
       navigation={navigation}
       navigate={handleNavigate}
       goBack={handleGoBack}
     >
-        <CommandPalette
-          isOpen={commandPaletteOpen}
-          onClose={() => setCommandPaletteOpen(false)}
-          commands={commands}
-        />
-        {mode === 'simple' ? (
-          <ShellLayout
-            rail={(
-              <NavigationRail
-                items={RAIL_SECTIONS}
-                activeItemId={activeRoute}
-                onItemSelect={handleNavigate}
-              />
-            )}
-            chat={<ConnectedChatSurface />}
-            content={(
-              <ContentRouter
-                activeRoute={activeRoute}
-                routes={simpleModeRoutes}
-                onNavigate={handleNavigate}
-              />
-            )}
-            observe={<ObservePanel />}
-          />
-        ) : (
-          <DockviewShell
-            savedLayout={savedLayout}
-            onApiReady={setDockviewApi}
-            activeAppPanelIds={new Set(appPanels.map((panel) => panel.dockview_panel_id))}
-            panelDefs={panelDefs}
-          />
-        )}
-    </ShellProvider>
+      {shellChildren}
+    </DesktopShellWithProject>
   )
 
   return (
@@ -730,6 +736,55 @@ export function App() {
         mainContent
       )}
     </ChromeShell>
+  )
+}
+
+// ─── Project boot wrapper ───────────────────────────────────────────────────
+// Renders inside TransportProvider so tRPC hooks are available.
+// Boots a default project on mount, then passes activeProjectId to ShellProvider.
+
+function DesktopShellWithProject({
+  children,
+  mode,
+  activeRoute,
+  navigation,
+  navigate,
+  goBack,
+}: {
+  children: React.ReactNode
+  mode: ShellMode
+  activeRoute: string
+  navigation: { activeRoute: string; history: string[]; canGoBack: boolean }
+  navigate: (routeId: string) => void
+  goBack: () => void
+}) {
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
+
+  const { data: projectList } = trpc.projects.list.useQuery()
+  const createProject = trpc.projects.create.useMutation()
+
+  useEffect(() => {
+    if (!projectList) return // still loading
+    if (projectList.length > 0) {
+      setActiveProjectId(projectList[0].id)
+    } else {
+      createProject.mutateAsync({ name: 'Default' }).then((created) => {
+        setActiveProjectId(created.id)
+      })
+    }
+  }, [projectList]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <ShellProvider
+      mode={mode}
+      activeRoute={activeRoute}
+      navigation={navigation}
+      navigate={navigate}
+      goBack={goBack}
+      activeProjectId={activeProjectId}
+    >
+      {children}
+    </ShellProvider>
   )
 }
 

--- a/self/apps/desktop/src/renderer/src/desktop-chat-wrappers.tsx
+++ b/self/apps/desktop/src/renderer/src/desktop-chat-wrappers.tsx
@@ -1,16 +1,18 @@
 import type { IDockviewPanelProps } from 'dockview-react'
 import { ChatPanel } from '@nous/ui/panels'
-import { ChatSurface } from '@nous/ui/components'
+import { ChatSurface, useShellContext } from '@nous/ui/components'
 import { useChatApi } from '@nous/transport'
 
 /** Wrapper that wires ChatPanel to tRPC via useChatApi (dockview). */
 export function DesktopChatPanel(props: IDockviewPanelProps) {
-  const chatApi = useChatApi()
+  const { activeProjectId } = useShellContext()
+  const chatApi = useChatApi({ projectId: activeProjectId ?? undefined })
   return <ChatPanel {...props} params={{ chatApi }} />
 }
 
 /** Wrapper that wires ChatSurface to tRPC via useChatApi (simple mode). */
 export function ConnectedChatSurface() {
-  const chatApi = useChatApi()
+  const { activeProjectId } = useShellContext()
+  const chatApi = useChatApi({ projectId: activeProjectId ?? undefined })
   return <ChatSurface chatApi={chatApi} />
 }

--- a/self/apps/shared-server/src/trpc/routers/preferences.ts
+++ b/self/apps/shared-server/src/trpc/routers/preferences.ts
@@ -671,13 +671,21 @@ export const preferencesRouter = router({
       // Ollama not reachable
     }
 
+    let credentialVaultHealthy = false
+    try {
+      await ctx.credentialVaultService.getMetadata(SYSTEM_APP_ID, 'health-check')
+      credentialVaultHealthy = true
+    } catch {
+      credentialVaultHealthy = false
+    }
+
     return {
       ollama: {
         running: ollamaRunning,
         models: ollamaModels,
       },
       configuredProviders,
-      credentialVaultHealthy: true,
+      credentialVaultHealthy,
     };
   }),
 });

--- a/self/apps/web/components/shell/web-chat-wrappers.tsx
+++ b/self/apps/web/components/shell/web-chat-wrappers.tsx
@@ -2,17 +2,19 @@
 
 import type { IDockviewPanelProps } from 'dockview-react'
 import { ChatPanel } from '@nous/ui/panels'
-import { ChatSurface } from '@nous/ui/components'
+import { ChatSurface, useShellContext } from '@nous/ui/components'
 import { useChatApi } from '@nous/transport'
 
 /** Wrapper that wires ChatPanel to tRPC via useChatApi (dockview). */
 export function WebChatPanel(props: IDockviewPanelProps) {
-  const chatApi = useChatApi()
+  const { activeProjectId } = useShellContext()
+  const chatApi = useChatApi({ projectId: activeProjectId ?? undefined })
   return <ChatPanel {...props} params={{ chatApi }} />
 }
 
 /** Wrapper that wires ChatSurface to tRPC via useChatApi (simple mode). */
 export function WebConnectedChatSurface() {
-  const chatApi = useChatApi()
+  const { activeProjectId } = useShellContext()
+  const chatApi = useChatApi({ projectId: activeProjectId ?? undefined })
   return <ChatSurface chatApi={chatApi} />
 }

--- a/self/transport/src/hooks/event-source-multiplexer.ts
+++ b/self/transport/src/hooks/event-source-multiplexer.ts
@@ -1,0 +1,196 @@
+/**
+ * EventSource multiplexer — shared SSE connection for all subscribers.
+ *
+ * Problem: Each EventSource consumes one HTTP/1.1 connection slot.
+ * Browsers limit to ~6 concurrent connections per host. Developer mode
+ * can easily exhaust this limit with multiple panels subscribing to
+ * different channels, starving tRPC HTTP requests.
+ *
+ * Solution: Maintain a single EventSource per events URL. When subscribers
+ * add/remove channels, tear down and reconnect with the full channel set.
+ * Route incoming events to the correct subscriber callbacks.
+ */
+
+type Listener = (channel: string, payload: unknown) => void;
+
+interface Subscription {
+  id: number;
+  channels: string[];
+  listener: Listener;
+}
+
+interface MuxState {
+  source: EventSource | null;
+  subscriptions: Map<number, Subscription>;
+  activeChannels: Set<string>;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  attempt: number;
+  disposed: boolean;
+}
+
+const MAX_BACKOFF_MS = 30_000;
+const BASE_BACKOFF_MS = 1_000;
+const JITTER_MAX_MS = 500;
+
+/** One multiplexer per events URL (module-level singleton map). */
+const muxes = new Map<string, MuxState>();
+let nextSubId = 1;
+
+function getOrCreateMux(eventsUrl: string): MuxState {
+  let mux = muxes.get(eventsUrl);
+  if (!mux) {
+    mux = {
+      source: null,
+      subscriptions: new Map(),
+      activeChannels: new Set(),
+      reconnectTimer: null,
+      attempt: 0,
+      disposed: false,
+    };
+    muxes.set(eventsUrl, mux);
+  }
+  return mux;
+}
+
+function computeChannels(mux: MuxState): Set<string> {
+  const channels = new Set<string>();
+  for (const sub of mux.subscriptions.values()) {
+    for (const ch of sub.channels) {
+      channels.add(ch);
+    }
+  }
+  return channels;
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+}
+
+function clearReconnectTimer(mux: MuxState): void {
+  if (mux.reconnectTimer != null) {
+    clearTimeout(mux.reconnectTimer);
+    mux.reconnectTimer = null;
+  }
+}
+
+function closeSource(mux: MuxState): void {
+  clearReconnectTimer(mux);
+  if (mux.source) {
+    mux.source.close();
+    mux.source = null;
+  }
+}
+
+function connectMux(mux: MuxState, eventsUrl: string): void {
+  if (mux.disposed) return;
+  if (typeof EventSource === 'undefined') return;
+
+  const channels = computeChannels(mux);
+  if (channels.size === 0) {
+    closeSource(mux);
+    mux.activeChannels = channels;
+    return;
+  }
+
+  // Close existing connection before opening new one
+  if (mux.source) {
+    mux.source.close();
+    mux.source = null;
+  }
+
+  const channelList = [...channels].sort();
+  const url = `${eventsUrl}?channels=${channelList.join(',')}`;
+  const source = new EventSource(url);
+
+  source.addEventListener('open', () => {
+    mux.attempt = 0;
+    console.log(
+      `[nous:event-bus:mux] connected channels=${channelList.join(',')} subscribers=${mux.subscriptions.size}`,
+    );
+  });
+
+  source.addEventListener('error', () => {
+    source.close();
+    if (mux.disposed || mux.subscriptions.size === 0) return;
+
+    mux.attempt += 1;
+    const backoff = Math.min(
+      BASE_BACKOFF_MS * Math.pow(2, mux.attempt - 1),
+      MAX_BACKOFF_MS,
+    );
+    const jitter = Math.floor(Math.random() * JITTER_MAX_MS);
+    const delay = backoff + jitter;
+
+    console.log(
+      `[nous:event-bus:mux] reconnecting attempt=${mux.attempt} delay=${delay}ms`,
+    );
+
+    mux.reconnectTimer = setTimeout(() => {
+      mux.reconnectTimer = null;
+      connectMux(mux, eventsUrl);
+    }, delay);
+  });
+
+  // Register a listener for EACH channel and fan out to subscribers
+  for (const channel of channelList) {
+    source.addEventListener(channel, (event: MessageEvent) => {
+      let payload: unknown;
+      try {
+        payload = JSON.parse(event.data);
+      } catch {
+        return; // malformed event
+      }
+
+      for (const sub of mux.subscriptions.values()) {
+        if (sub.channels.includes(channel)) {
+          try {
+            sub.listener(channel, payload);
+          } catch {
+            // subscriber error — don't crash the mux
+          }
+        }
+      }
+    });
+  }
+
+  mux.source = source;
+  mux.activeChannels = channels;
+}
+
+/**
+ * Subscribe to event channels via the shared multiplexer.
+ * Returns a dispose function that removes this subscription.
+ */
+export function subscribe(
+  eventsUrl: string,
+  channels: string[],
+  listener: Listener,
+): () => void {
+  const mux = getOrCreateMux(eventsUrl);
+  const id = nextSubId++;
+
+  mux.subscriptions.set(id, { id, channels, listener });
+
+  // Reconnect if the channel set changed
+  const needed = computeChannels(mux);
+  if (!setsEqual(needed, mux.activeChannels)) {
+    connectMux(mux, eventsUrl);
+  }
+
+  return () => {
+    mux.subscriptions.delete(id);
+
+    const remaining = computeChannels(mux);
+    if (remaining.size === 0) {
+      closeSource(mux);
+      mux.activeChannels = remaining;
+      muxes.delete(eventsUrl);
+    } else if (!setsEqual(remaining, mux.activeChannels)) {
+      connectMux(mux, eventsUrl);
+    }
+  };
+}

--- a/self/transport/src/hooks/useEventSubscription.ts
+++ b/self/transport/src/hooks/useEventSubscription.ts
@@ -4,12 +4,14 @@
  * Reads the events URL from TransportProvider context so it works on both
  * web (relative `/api/events`) and desktop (loopback `http://127.0.0.1:<port>/api/events`).
  *
- * Auto-reconnects with exponential backoff on connection drop.
- * Cleans up EventSource and timers on unmount or when disabled.
+ * Uses a shared EventSource multiplexer to avoid exhausting the browser's
+ * per-host connection limit (~6 for HTTP/1.1). All hooks share a single
+ * SSE connection per events URL.
  */
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import type { EventChannelMap } from '@nous/shared';
 import { useEventsUrl } from '../provider';
+import { subscribe } from './event-source-multiplexer';
 
 export interface UseEventSubscriptionOptions<C extends keyof EventChannelMap> {
   /** Channel or channels to subscribe to. Supports glob prefixes (e.g., 'health:*'). */
@@ -19,10 +21,6 @@ export interface UseEventSubscriptionOptions<C extends keyof EventChannelMap> {
   /** Whether the subscription is active. Defaults to true. */
   enabled?: boolean;
 }
-
-const MAX_BACKOFF_MS = 30_000;
-const BASE_BACKOFF_MS = 1_000;
-const JITTER_MAX_MS = 500;
 
 export function useEventSubscription<C extends keyof EventChannelMap>(
   options: UseEventSubscriptionOptions<C>,
@@ -37,15 +35,6 @@ export function useEventSubscription<C extends keyof EventChannelMap>(
   const onEventRef = useRef(onEvent);
   onEventRef.current = onEvent;
 
-  const connect = useCallback(
-    (channelList: string[]) => {
-      const url = `${eventsUrl}?channels=${channelList.join(',')}`;
-      const source = new EventSource(url);
-      return { source, channelList };
-    },
-    [eventsUrl],
-  );
-
   useEffect(() => {
     if (!enabled) {
       return;
@@ -56,81 +45,10 @@ export function useEventSubscription<C extends keyof EventChannelMap>(
       return;
     }
 
-    let eventSource: EventSource | null = null;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    let attempt = 0;
-    let disposed = false;
+    const dispose = subscribe(eventsUrl, parsedChannels, (channel, payload) => {
+      onEventRef.current(channel, payload as EventChannelMap[C]);
+    });
 
-    function clearReconnectTimer() {
-      if (reconnectTimer != null) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-    }
-
-    function createConnection() {
-      if (disposed) {
-        return;
-      }
-
-      if (typeof EventSource === 'undefined') {
-        return;
-      }
-
-      const url = `${eventsUrl}?channels=${parsedChannels.join(',')}`;
-      const source = new EventSource(url);
-
-      source.addEventListener('open', () => {
-        attempt = 0;
-        console.log(`[nous:event-bus:client] connected channels=${parsedChannels.join(',')}`);
-      });
-
-      source.addEventListener('error', () => {
-        source.close();
-
-        if (disposed) {
-          return;
-        }
-
-        attempt += 1;
-        const backoff = Math.min(BASE_BACKOFF_MS * Math.pow(2, attempt - 1), MAX_BACKOFF_MS);
-        const jitter = Math.floor(Math.random() * JITTER_MAX_MS);
-        const delay = backoff + jitter;
-
-        console.log(
-          `[nous:event-bus:client] reconnecting attempt=${attempt} delay=${delay}ms`,
-        );
-
-        reconnectTimer = setTimeout(() => {
-          reconnectTimer = null;
-          createConnection();
-        }, delay);
-      });
-
-      // Register listeners for each channel
-      for (const channel of parsedChannels) {
-        source.addEventListener(channel, (event: MessageEvent) => {
-          try {
-            const payload = JSON.parse(event.data);
-            onEventRef.current(channel, payload);
-          } catch {
-            // JSON.parse failure — do not crash the component
-          }
-        });
-      }
-
-      eventSource = source;
-    }
-
-    createConnection();
-
-    return () => {
-      disposed = true;
-      clearReconnectTimer();
-      if (eventSource) {
-        eventSource.close();
-        eventSource = null;
-      }
-    };
-  }, [channelsKey, enabled, connect, eventsUrl]);
+    return dispose;
+  }, [channelsKey, enabled, eventsUrl]);
 }

--- a/self/transport/src/provider.tsx
+++ b/self/transport/src/provider.tsx
@@ -76,7 +76,9 @@ export interface TransportProviderProps {
 }
 
 export function TransportProvider({ config, children }: TransportProviderProps) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: { queries: { retry: 1 } },
+  }));
   const [trpcClient] = useState(() =>
     trpc.createClient({
       links: [

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -60,6 +60,7 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
   const [isListening, setIsListening] = useState(false)
+  const [historyError, setHistoryError] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null)
 
@@ -78,7 +79,7 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
   useEffect(() => {
     if (chatApi?.getHistory) {
       chatApi.getHistory().then(setMessages).catch(() => {
-        // History fetch failed — start with empty conversation
+        setHistoryError('Could not load previous messages.')
       })
     }
   }, [chatApi])
@@ -205,6 +206,11 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
         {messages.length === 0 && (
           <div style={{ textAlign: 'center', color: 'var(--nous-fg-subtle)', fontSize: 'var(--nous-font-size-base)', marginTop: 'var(--nous-space-4xl)' }}>
             {chatApi?.send ? 'Start a conversation with Nous.' : 'Chat API not connected. Start the web backend with `pnpm dev:web`.'}
+          </div>
+        )}
+        {historyError && (
+          <div style={{ textAlign: 'center', color: 'var(--nous-state-blocked)', fontSize: 'var(--nous-font-size-sm)', padding: 'var(--nous-space-sm) 0' }}>
+            {historyError}
           </div>
         )}
         {messages.map((msg, i) => (

--- a/self/ui/src/panels/settings/pages/RoleAssignmentsPage.tsx
+++ b/self/ui/src/panels/settings/pages/RoleAssignmentsPage.tsx
@@ -77,8 +77,8 @@ export function RoleAssignmentsPage({ api }: RoleAssignmentsPageProps) {
       if (recommendationResult) {
         setHardwareRecommendations(recommendationResult)
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      setRoleAssignmentFeedback(formatFeedbackError(err))
     }
   }, [api])
 

--- a/self/ui/src/panels/settings/pages/SystemStatusPage.tsx
+++ b/self/ui/src/panels/settings/pages/SystemStatusPage.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import type { PreferencesApi, Provider, SystemStatus } from '../types'
-import { sectionStyle, sectionTitleStyle, cardStyle, rowStyle, badgeStyle, PROVIDER_LABELS } from '../styles'
+import type { PreferencesApi, Provider, SystemStatus, FeedbackState } from '../types'
+import { sectionStyle, sectionTitleStyle, cardStyle, rowStyle, badgeStyle, feedbackStyle, PROVIDER_LABELS } from '../styles'
+import { formatFeedbackError } from './helpers'
 
 export interface SystemStatusPageProps {
   api: Pick<PreferencesApi, 'getSystemStatus'>
@@ -10,6 +11,7 @@ export interface SystemStatusPageProps {
 
 export function SystemStatusPage({ api }: SystemStatusPageProps) {
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -17,8 +19,8 @@ export function SystemStatusPage({ api }: SystemStatusPageProps) {
       if (!cancelled) {
         setSystemStatus(status)
       }
-    }).catch(() => {
-      // ignore
+    }).catch((err) => {
+      if (!cancelled) setFeedback(formatFeedbackError(err))
     })
     return () => { cancelled = true }
   }, [api])
@@ -61,6 +63,12 @@ export function SystemStatusPage({ api }: SystemStatusPageProps) {
             </span>
           </div>
         </div>
+
+        {feedback && (
+          <div style={feedbackStyle(feedback.success)}>
+            {feedback.message}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **Multiplex SSE connections** via shared EventSource to prevent HTTP/1.1 connection starvation — Developer mode opened 6 SSE connections (chat, MAO, dashboard health), exhausting Chrome's per-host limit and blocking all tRPC requests indefinitely
- **Auto-create default project** + wire `activeProjectId` through ShellProvider so chat persistence works across mode switches
- **Surface transport errors** in SystemStatusPage, RoleAssignmentsPage, and ChatPanel instead of silently swallowing them (`catch { // ignore }` → `formatFeedbackError`)
- **Replace hardcoded `credentialVaultHealthy: true`** with actual vault metadata probe in `getSystemStatus`
- **Reduce QueryClient retry** from 3 → 1 so errors surface in ~2s instead of ~8s

## Root causes addressed

| # | Root cause | Fix |
|---|---|---|
| RC-1 | `catch { // ignore }` swallowed all transport errors | `formatFeedbackError` + inline feedback |
| RC-2 | `credentialVaultHealthy` hardcoded to `true` | Actual vault metadata probe |
| RC-3 | SSE connection exhaustion (6/6 HTTP slots consumed by EventSource) | Shared EventSource multiplexer in `@nous/transport` |
| RC-4 | No `projectId` passed to chat API — history empty, sends unscoped | `DesktopShellWithProject` auto-creates project, wires through context |
| RC-5 | Mode switch destroys component subtree, losing in-flight state | Server-side refetch with projectId on remount |

## Test plan

- [x] Simple mode: chat sends and receives
- [x] Developer mode: chat sends and receives
- [x] Developer mode: API keys load, Ollama status shows
- [x] Mode switch simple → dev → simple: messages persist
- [x] Console shows single `[nous:event-bus:mux]` log instead of 6 separate SSE connections
- [x] Unit tests pass (transport: 15, ui: 881)

🤖 Generated with [Claude Code](https://claude.com/claude-code)