### PR TITLE
feat(mao): UI conformance overhaul — spec-to-code gap remediation — WR-106

### DIFF
--- a/self/shared/src/__tests__/types/mao.test.ts
+++ b/self/shared/src/__tests__/types/mao.test.ts
@@ -59,6 +59,15 @@ describe('MaoAgentLifecycleStateSchema', () => {
     expect(MaoAgentLifecycleStateSchema.parse('waiting_pfc')).toBe('waiting_pfc');
     expect(MaoAgentLifecycleStateSchema.parse('resuming')).toBe('resuming');
   });
+
+  it('accepts canceled and hard_stopped lifecycle states', () => {
+    expect(MaoAgentLifecycleStateSchema.parse('canceled')).toBe('canceled');
+    expect(MaoAgentLifecycleStateSchema.parse('hard_stopped')).toBe('hard_stopped');
+  });
+
+  it('has exactly 12 enum members', () => {
+    expect(MaoAgentLifecycleStateSchema.options).toHaveLength(12);
+  });
 });
 
 describe('MaoReasoningLogPreviewSchema', () => {
@@ -586,6 +595,42 @@ describe('WorkflowNodeMetadataSchema — displayName', () => {
       WorkflowNodeMetadataSchema.parse({
         specNodeId: 'node-1',
         displayName: '',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('WorkflowNodeMetadataSchema — agentClass', () => {
+  it('accepts agentClass when provided', () => {
+    const result = WorkflowNodeMetadataSchema.parse({
+      specNodeId: 'node-1',
+      agentClass: 'Worker',
+    });
+    expect(result.agentClass).toBe('Worker');
+  });
+
+  it('accepts all valid agentClass values', () => {
+    for (const cls of ['Cortex::Principal', 'Cortex::System', 'Orchestrator', 'Worker'] as const) {
+      const result = WorkflowNodeMetadataSchema.parse({
+        specNodeId: 'node-1',
+        agentClass: cls,
+      });
+      expect(result.agentClass).toBe(cls);
+    }
+  });
+
+  it('allows agentClass to be omitted (backward compat)', () => {
+    const result = WorkflowNodeMetadataSchema.parse({
+      specNodeId: 'node-1',
+    });
+    expect(result.agentClass).toBeUndefined();
+  });
+
+  it('rejects invalid agentClass values', () => {
+    expect(() =>
+      WorkflowNodeMetadataSchema.parse({
+        specNodeId: 'node-1',
+        agentClass: 'InvalidClass',
       }),
     ).toThrow();
   });

--- a/self/shared/src/types/mao.ts
+++ b/self/shared/src/types/mao.ts
@@ -54,6 +54,8 @@ export const MaoAgentLifecycleStateSchema = z.enum([
   'completed',
   'paused',
   'resuming',
+  'canceled',
+  'hard_stopped',
 ]);
 export type MaoAgentLifecycleState = z.infer<
   typeof MaoAgentLifecycleStateSchema

--- a/self/shared/src/types/opctl.ts
+++ b/self/shared/src/types/opctl.ts
@@ -60,6 +60,20 @@ export type ControlAction = z.infer<typeof ControlActionSchema>;
 export const ConfirmationTierSchema = z.enum(['T0', 'T1', 'T2', 'T3']);
 export type ConfirmationTier = z.infer<typeof ConfirmationTierSchema>;
 
+export const ACTION_TIER_MAP: Record<ControlAction, ConfirmationTier> = {
+  pause: 'T0',
+  resume: 'T0',
+  cancel: 'T1',
+  hard_stop: 'T3',
+  revert: 'T2',
+  retry: 'T1',
+  edit: 'T0',
+  stop_response: 'T0',
+  retry_step: 'T1',
+  revert_to_previous_state: 'T2',
+  edit_submitted_prompt: 'T0',
+} satisfies Record<ControlAction, ConfirmationTier>;
+
 // --- Control Command Envelope ---
 
 export const ControlCommandEnvelopeSchema = z.object({

--- a/self/shared/src/types/workflow.ts
+++ b/self/shared/src/types/workflow.ts
@@ -21,6 +21,7 @@ import {
   ModelRoleSchema,
 } from './enums.js';
 import { WorkmodeIdSchema } from './workmode.js';
+import { AgentClassSchema } from './agent-gateway.js';
 import { ProjectControlStateSchema, type ProjectControlState } from './mao.js';
 import { IngressTriggerTypeSchema } from './ingress-trigger.js';
 import {
@@ -173,6 +174,7 @@ export const WorkflowNodeMetadataSchema = z.object({
   contracts: z.array(z.string().min(1)).optional(),
   templates: z.array(z.string().min(1)).optional(),
   displayName: z.string().min(1).optional(),
+  agentClass: AgentClassSchema.optional(),
 });
 export type WorkflowNodeMetadata = z.infer<typeof WorkflowNodeMetadataSchema>;
 

--- a/self/subcortex/mao/src/__tests__/mao-projection-service.test.ts
+++ b/self/subcortex/mao/src/__tests__/mao-projection-service.test.ts
@@ -945,15 +945,185 @@ describe('MaoProjectionService', () => {
       expect(draftAgent?.display_name).toBe('Draft');
     });
 
-    it('sets agent_class to undefined in SP 1.1', async () => {
+    it('derives agent_class from node kind for workflow-derived projections', async () => {
       const { service, setControlState } = createService(createWorkflowRun());
       setControlState('running');
 
       const projections = await service.getAgentProjections(PROJECT_ID);
 
+      // Node A is type 'model-call' -> Worker
+      const draftAgent = projections.find(
+        (a) => a.workflow_node_definition_id === NODE_A,
+      );
+      expect(draftAgent?.agent_class).toBe('Worker');
+
+      // Node B is type 'human-decision' -> undefined (structural node kind)
+      const reviewAgent = projections.find(
+        (a) => a.workflow_node_definition_id === NODE_B,
+      );
+      expect(reviewAgent?.agent_class).toBeUndefined();
+    });
+
+    it('reads agent_class from node metadata when present, overriding node-kind fallback', async () => {
+      const runState = createWorkflowRun();
+      // We need a custom engine with metadata.agentClass on Node A
+      const graphWithMetadata = {
+        workflowDefinitionId: runState.workflowDefinitionId,
+        projectId: PROJECT_ID,
+        version: '1.0.0',
+        graphDigest: runState.graphDigest,
+        entryNodeIds: [NODE_A],
+        topologicalOrder: [NODE_A, NODE_B],
+        nodes: {
+          [NODE_A]: {
+            definition: {
+              id: NODE_A,
+              name: 'Draft',
+              type: 'model-call',
+              governance: 'must',
+              executionModel: 'synchronous',
+              config: {
+                type: 'model-call',
+                modelRole: 'reasoner',
+                promptRef: 'prompt://draft',
+              },
+              metadata: {
+                specNodeId: 'spec-a',
+                agentClass: 'Orchestrator', // Override: model-call would normally be Worker
+              },
+            },
+            inboundEdgeIds: [],
+            outboundEdgeIds: ['edge-1'],
+            topologicalIndex: 0,
+          },
+          [NODE_B]: {
+            definition: {
+              id: NODE_B,
+              name: 'Review',
+              type: 'human-decision',
+              governance: 'must',
+              executionModel: 'synchronous',
+              config: {
+                type: 'human-decision',
+                decisionRef: 'decision://review',
+              },
+            },
+            inboundEdgeIds: ['edge-1'],
+            outboundEdgeIds: [],
+            topologicalIndex: 1,
+          },
+        },
+        edges: {
+          'edge-1': {
+            id: 'edge-1',
+            from: NODE_A,
+            to: NODE_B,
+            priority: 0,
+          },
+        },
+      } as any;
+
+      const { opctlService, setControlState } = createOpctlServiceMock();
+      setControlState('running');
+
+      const engine: IWorkflowEngine = {
+        resolveDefinition: async () => ({}) as any,
+        resolveDefinitionSource: async () => ({}) as any,
+        deriveGraph: async () => graphWithMetadata,
+        evaluateAdmission: async () => ({}) as any,
+        start: async () => ({}) as any,
+        resume: async () => runState,
+        pause: async () => runState,
+        cancel: async () => runState,
+        completeNode: async () => runState,
+        executeReadyNode: async () => runState,
+        continueNode: async () => runState,
+        getState: async () => runState,
+        listProjectRuns: async () => [runState],
+        getRunGraph: async () => graphWithMetadata,
+      };
+
+      const service = new MaoProjectionService({
+        opctlService,
+        workflowEngine: engine,
+        escalationService: createEscalationService(),
+        schedulerService: createSchedulerService(),
+        witnessService: mockWitnessService(),
+      });
+
+      const projections = await service.getAgentProjections(PROJECT_ID);
+
+      const draftAgent = projections.find(
+        (a) => a.workflow_node_definition_id === NODE_A,
+      );
+      // metadata.agentClass ('Orchestrator') overrides node-kind fallback ('Worker')
+      expect(draftAgent?.agent_class).toBe('Orchestrator');
+    });
+  });
+
+  describe('lifecycle state mapping — canceled and hard_stopped', () => {
+    it('maps all agents to canceled when workflow run status is canceled', async () => {
+      const { service, setControlState } = createService(createWorkflowRun('canceled'));
+      setControlState('running');
+
+      const projections = await service.getAgentProjections(PROJECT_ID);
+
       for (const proj of projections) {
-        expect(proj.agent_class).toBeUndefined();
+        expect(proj.state).toBe('canceled');
       }
+    });
+
+    it('maps all agents to hard_stopped when control state is hard_stopped', async () => {
+      const { service, setControlState } = createService(createWorkflowRun());
+      setControlState('hard_stopped');
+
+      const projections = await service.getAgentProjections(PROJECT_ID);
+
+      for (const proj of projections) {
+        expect(proj.state).toBe('hard_stopped');
+      }
+    });
+
+    it('canceled (run-level) takes precedence over hard_stopped (project-level)', async () => {
+      const { service, setControlState } = createService(createWorkflowRun('canceled'));
+      setControlState('hard_stopped');
+
+      const projections = await service.getAgentProjections(PROJECT_ID);
+
+      for (const proj of projections) {
+        expect(proj.state).toBe('canceled');
+      }
+    });
+
+    it('preserves existing paused_review overlay when neither canceled nor hard_stopped', async () => {
+      const { service, setControlState } = createService(createWorkflowRun());
+      setControlState('paused_review');
+
+      const projections = await service.getAgentProjections(PROJECT_ID);
+      // Node A is completed, so paused overlay does not apply
+      // Node B is blocked/waiting (active), so paused overlay applies
+      const reviewAgent = projections.find(
+        (a) => a.workflow_node_definition_id === NODE_B,
+      );
+      // Node B status is 'blocked' which is in the ['ready', 'running'] check?
+      // Actually per the existing logic, 'blocked' is NOT in ['ready', 'running'],
+      // so paused overlay does not apply; it returns 'waiting_pfc' from the wait state.
+      // This preserves existing behavior correctly.
+      expect(reviewAgent?.state).toBe('waiting_pfc');
+    });
+
+    it('omitting runStatus preserves existing behavior (no regression)', async () => {
+      // When runStatus is undefined (default), mapLifecycleState behaves as before
+      const { service, setControlState } = createService(createWorkflowRun('running'));
+      setControlState('running');
+
+      const projections = await service.getAgentProjections(PROJECT_ID);
+
+      const draftAgent = projections.find(
+        (a) => a.workflow_node_definition_id === NODE_A,
+      );
+      // Node A is 'completed' -> should map to 'completed'
+      expect(draftAgent?.state).toBe('completed');
     });
   });
 

--- a/self/subcortex/mao/src/mao-projection-service.ts
+++ b/self/subcortex/mao/src/mao-projection-service.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import type {
+  AgentClass,
   AgentGatewayEntry,
   ConfirmationProof,
   ControlActorType,
@@ -27,8 +28,10 @@ import type {
   MaoSystemSnapshotInput,
   ProjectControlState,
   ProjectId,
+  WorkflowNodeDefinition,
   WorkflowNodeRunState,
   WorkflowRunState,
+  WorkflowRunStatus,
   IHealthAggregator,
   MaoControlAuditHistoryEntry,
 } from '@nous/shared';
@@ -163,10 +166,32 @@ function isPfcWait(nodeState: WorkflowNodeRunState): boolean {
   );
 }
 
+function deriveClassFromNodeKind(
+  nodeDefinition: WorkflowNodeDefinition | undefined,
+): AgentClass | undefined {
+  if (!nodeDefinition) return undefined;
+  switch (nodeDefinition.type) {
+    case 'model-call':
+    case 'tool-execution':
+      return 'Worker';
+    case 'subworkflow':
+      return 'Orchestrator';
+    default:
+      return undefined;
+  }
+}
+
 function mapLifecycleState(
   nodeState: WorkflowNodeRunState,
   controlState: ProjectControlState,
+  runStatus?: WorkflowRunStatus,
 ): MaoAgentProjection['state'] {
+  if (runStatus === 'canceled') {
+    return 'canceled';
+  }
+  if (controlState === 'hard_stopped') {
+    return 'hard_stopped';
+  }
   if (
     controlState === 'paused_review' &&
     ['ready', 'running'].includes(nodeState.status)
@@ -1089,7 +1114,7 @@ export class MaoProjectionService {
     nodeState: WorkflowNodeRunState,
     controlState: ProjectControlState,
   ): MaoAgentProjection {
-    const lifecycleState = mapLifecycleState(nodeState, controlState);
+    const lifecycleState = mapLifecycleState(nodeState, controlState, run.status);
     const urgencyLevel = deriveUrgencyLevel(lifecycleState);
     const latestAttempt = nodeState.attempts[nodeState.attempts.length - 1];
     const parentNodeDefinitionId = run.dispatchLineage.find(
@@ -1115,7 +1140,7 @@ export class MaoProjectionService {
       workflow_node_definition_id: nodeDefinitionId as import('@nous/shared').WorkflowNodeDefinitionId,
       dispatching_task_agent_id: dispatchingTaskAgentId,
       dispatch_origin_ref: nodeState.lastDispatchLineageId ?? `workflow-run:${run.runId}`,
-      agent_class: undefined,
+      agent_class: nodeDefinition?.metadata?.agentClass ?? deriveClassFromNodeKind(nodeDefinition),
       display_name: nodeDefinition?.metadata?.displayName ?? nodeDefinition?.name,
       state: lifecycleState,
       state_reason: nodeState.reasonCode ?? nodeState.activeWaitState?.reasonCode,

--- a/self/ui/src/components/mao/__tests__/mao-audit-trail-panel.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-audit-trail-panel.test.tsx
@@ -95,6 +95,30 @@ describe('MaoAuditTrailPanel', () => {
     ).toBeTruthy();
   });
 
+  it('shows system-level indicator when projectId is sentinel UUID', () => {
+    const SENTINEL_PROJECT_ID = '00000000-0000-0000-0000-000000000000' as any;
+
+    render(<MaoAuditTrailPanel projectId={SENTINEL_PROJECT_ID} />);
+
+    expect(screen.getByTestId('sentinel-indicator')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'System-level agent — audit trail scoped to project context.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('does not fire query when projectId is sentinel UUID', () => {
+    const SENTINEL_PROJECT_ID = '00000000-0000-0000-0000-000000000000' as any;
+
+    render(<MaoAuditTrailPanel projectId={SENTINEL_PROJECT_ID} />);
+
+    // The query should have been called with enabled: false
+    expect(mockUseQuery).toHaveBeenCalled();
+    const queryCall = mockUseQuery.mock.calls[0];
+    expect(queryCall[1]?.enabled).toBe(false);
+  });
+
   it('expands entry details on click showing commandId, resumeReadinessStatus, and decisionRef', () => {
     mockUseQuery = vi.fn().mockReturnValue({
       data: MOCK_ENTRIES,

--- a/self/ui/src/components/mao/__tests__/mao-density-grid.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-density-grid.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import * as React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { MaoDensityGrid } from '../mao-density-grid'
 import type { MaoDensityMode, MaoGridTileProjection, MaoProjectSnapshot } from '@nous/shared'
@@ -23,6 +23,7 @@ function createTile(
       urgency_level: 'normal',
       workflow_run_id: 'run-001',
       workflow_node_definition_id: 'node-001',
+      last_update_at: '2026-03-28T10:00:00Z',
       deepLinks: [],
       evidenceRefs: [],
       ...overrides,
@@ -34,6 +35,7 @@ function createTile(
 function createSnapshot(
   densityMode: MaoDensityMode,
   tiles: MaoGridTileProjection[],
+  overrides?: Partial<MaoProjectSnapshot>,
 ): MaoProjectSnapshot {
   return {
     projectId: 'project-001',
@@ -54,6 +56,7 @@ function createSnapshot(
     },
     diagnostics: { runtimePosture: 'single_process_local' },
     generatedAt: '2026-03-28T10:00:00Z',
+    ...overrides,
   } as unknown as MaoProjectSnapshot
 }
 
@@ -210,5 +213,263 @@ describe('MaoDensityGrid inference rendering', () => {
     )
 
     expect(screen.queryByTestId('streaming-pulse')).toBeNull()
+  })
+})
+
+describe('MaoDensityGrid D3 compact tile', () => {
+  it('renders compact tile at D3 with state dot and truncated label, no full card markup', () => {
+    const tile = createTile({
+      agent_id: 'agent-d3',
+      current_step: 'Execute long task name here',
+      state: 'running',
+      display_name: 'My Agent With Long Name',
+    })
+    const snapshot = createSnapshot('D3', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const d3Tile = screen.getByTestId('density-tile-d3')
+    expect(d3Tile).toBeTruthy()
+    // Should not render full card elements
+    expect(screen.queryByText('dispatched')).toBeNull()
+    expect(screen.queryByText('50% complete')).toBeNull()
+    expect(screen.queryByText('2 review cycles')).toBeNull()
+  })
+
+  it('fires onSelectTile when D3 tile is clicked', () => {
+    const handler = vi.fn()
+    const tile = createTile({ agent_id: 'agent-d3-click' })
+    const snapshot = createSnapshot('D3', [tile])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={handler} />,
+    )
+
+    fireEvent.click(screen.getByTestId('density-tile-d3'))
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({ agent_id: 'agent-d3-click' }),
+      }),
+    )
+  })
+})
+
+describe('MaoDensityGrid D4 tiny square', () => {
+  it('renders tiny square at D4 with no text', () => {
+    const tile = createTile({
+      agent_id: 'agent-d4',
+      state: 'running',
+      display_name: 'Visible Name',
+    })
+    const snapshot = createSnapshot('D4', [tile])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const d4Tile = screen.getByTestId('density-tile-d4')
+    expect(d4Tile).toBeTruthy()
+    expect(d4Tile.className).toContain('w-6')
+    expect(d4Tile.className).toContain('h-6')
+    // No text content at D4
+    expect(screen.queryByText('Visible Name')).toBeNull()
+    expect(screen.queryByText('dispatched')).toBeNull()
+  })
+
+  it('fires onSelectTile when D4 tile is clicked', () => {
+    const handler = vi.fn()
+    const tile = createTile({ agent_id: 'agent-d4-click' })
+    const snapshot = createSnapshot('D4', [tile])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={handler} />,
+    )
+
+    fireEvent.click(screen.getByTestId('density-tile-d4'))
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({ agent_id: 'agent-d4-click' }),
+      }),
+    )
+  })
+})
+
+describe('MaoDensityGrid D4 clustering', () => {
+  it('groups tiles by lifecycle state with state-group headers at D4', () => {
+    const runningTile = createTile({ agent_id: 'a1', state: 'running' })
+    const blockedTile = createTile({ agent_id: 'a2', state: 'blocked' })
+    const completedTile = createTile({ agent_id: 'a3', state: 'completed' })
+    const snapshot = createSnapshot('D4', [runningTile, blockedTile, completedTile])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    expect(screen.getByTestId('cluster-running')).toBeTruthy()
+    expect(screen.getByTestId('cluster-blocked')).toBeTruthy()
+    expect(screen.getByTestId('cluster-completed')).toBeTruthy()
+    // Headers show state name and count
+    expect(screen.getByText('running (1)')).toBeTruthy()
+    expect(screen.getByText('blocked (1)')).toBeTruthy()
+    expect(screen.getByText('completed (1)')).toBeTruthy()
+  })
+
+  it('renders empty state when grid is empty at D4', () => {
+    const snapshot = createSnapshot('D4', [])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    expect(screen.getByText('No MAO agent projections are available for the selected project.')).toBeTruthy()
+  })
+})
+
+describe('MaoDensityGrid motion pulse', () => {
+  it('applies nous-state-pulse-subtle class on running agent tile', () => {
+    const tile = createTile({ agent_id: 'running-agent', state: 'running' })
+    const snapshot = createSnapshot('D2', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const button = container.querySelector('[aria-label="Inspect Execute task"]')
+    expect(button?.className).toContain('nous-state-pulse-subtle')
+  })
+
+  it('applies nous-state-pulse-strong class on blocked agent tile', () => {
+    const tile = createTile({ agent_id: 'blocked-agent', state: 'blocked' })
+    const snapshot = createSnapshot('D2', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const button = container.querySelector('[aria-label="Inspect Execute task"]')
+    expect(button?.className).toContain('nous-state-pulse-strong')
+  })
+
+  it('does not apply pulse class on completed agent tile', () => {
+    const tile = createTile({ agent_id: 'completed-agent', state: 'completed' })
+    const snapshot = createSnapshot('D2', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const button = container.querySelector('[aria-label="Inspect Execute task"]')
+    expect(button?.className).not.toContain('nous-state-pulse-subtle')
+    expect(button?.className).not.toContain('nous-state-pulse-strong')
+  })
+
+  it('does not apply pulse class on canceled agent tile', () => {
+    const tile = createTile({ agent_id: 'canceled-agent', state: 'canceled' })
+    const snapshot = createSnapshot('D2', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const button = container.querySelector('[aria-label="Inspect Execute task"]')
+    expect(button?.className).not.toContain('nous-state-pulse-subtle')
+    expect(button?.className).not.toContain('nous-state-pulse-strong')
+  })
+})
+
+describe('MaoDensityGrid urgent indicators', () => {
+  it('renders URGENT badge, critical border, and timer at D0-D2 for urgent agent', () => {
+    const tile = createTile({
+      agent_id: 'urgent-agent',
+      urgency_level: 'urgent',
+      last_update_at: new Date(Date.now() - 5 * 60000).toISOString(),
+    })
+    const snapshot = createSnapshot('D2', [tile])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    expect(screen.getByTestId('urgent-indicator')).toBeTruthy()
+    expect(screen.getByText('URGENT')).toBeTruthy()
+    expect(screen.getByTestId('urgent-timer')).toBeTruthy()
+  })
+
+  it('renders critical border and urgent icon at D3 for urgent agent', () => {
+    const tile = createTile({
+      agent_id: 'urgent-d3',
+      urgency_level: 'urgent',
+    })
+    const snapshot = createSnapshot('D3', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const d3Tile = screen.getByTestId('density-tile-d3')
+    expect(d3Tile.className).toContain('border-red-500')
+    expect(screen.getByTestId('urgent-icon')).toBeTruthy()
+  })
+
+  it('renders ring-red-500 at D4 for urgent agent', () => {
+    const tile = createTile({
+      agent_id: 'urgent-d4',
+      urgency_level: 'urgent',
+    })
+    const snapshot = createSnapshot('D4', [tile])
+
+    render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const d4Tile = screen.getByTestId('density-tile-d4')
+    expect(d4Tile.className).toContain('ring-red-500')
+  })
+
+  it('pins urgent agents to top of grid at D0-D3', () => {
+    const normalTile = createTile({ agent_id: 'normal-agent', state: 'running', urgency_level: 'normal' })
+    const urgentTile = createTile({ agent_id: 'urgent-agent', state: 'running', urgency_level: 'urgent' })
+    const snapshot = createSnapshot('D2', [normalTile, urgentTile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const buttons = container.querySelectorAll('button[type="button"]')
+    // Urgent agent should be rendered first
+    expect(buttons[0].getAttribute('aria-label')).toContain('Inspect')
+    // Check that the first button has the urgent indicator
+    const firstTileText = buttons[0].textContent
+    expect(firstTileText).toContain('URGENT')
+  })
+})
+
+describe('MaoDensityGrid state color handling', () => {
+  it('renders appropriate tone classes for canceled state (not default)', () => {
+    const tile = createTile({ agent_id: 'canceled-agent', state: 'canceled' })
+    const snapshot = createSnapshot('D2', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const button = container.querySelector('[aria-label="Inspect Execute task"]')
+    expect(button?.className).toContain('border-slate-500/40')
+    expect(button?.className).toContain('bg-slate-500/10')
+  })
+
+  it('renders appropriate tone classes for hard_stopped state (not default)', () => {
+    const tile = createTile({ agent_id: 'stopped-agent', state: 'hard_stopped' })
+    const snapshot = createSnapshot('D2', [tile])
+
+    const { container } = render(
+      <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
+    )
+
+    const button = container.querySelector('[aria-label="Inspect Execute task"]')
+    expect(button?.className).toContain('border-red-700/40')
+    expect(button?.className).toContain('bg-red-700/10')
   })
 })

--- a/self/ui/src/components/mao/__tests__/mao-inspect-panel.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-inspect-panel.test.tsx
@@ -62,6 +62,174 @@ afterEach(() => {
   cleanup()
 })
 
+describe('MaoInspectPanel label, lineage, and badge', () => {
+  it('uses display_name as primary label when present', () => {
+    const inspect = createInspect({
+      agent: {
+        agent_id: 'agent-001',
+        current_step: 'Process data',
+        display_name: 'Custom Agent Name',
+        dispatch_state: 'dispatched',
+        state: 'running',
+        risk_level: 'low',
+        attention_level: 'normal',
+        progress_percent: 75,
+        reflection_cycle_count: 1,
+        reasoning_log_preview: null,
+        urgency_level: 'normal',
+        workflow_run_id: 'run-001',
+        workflow_node_definition_id: 'node-001',
+        deepLinks: [],
+        evidenceRefs: [],
+      } as any,
+    })
+
+    render(<MaoInspectPanel inspect={inspect} isLoading={false} />, {
+      wrapper: Wrapper,
+    })
+
+    const label = screen.getByTestId('inspect-primary-label')
+    expect(label.textContent).toBe('Custom Agent Name')
+  })
+
+  it('falls back to current_step when display_name is absent', () => {
+    const inspect = createInspect()
+
+    render(<MaoInspectPanel inspect={inspect} isLoading={false} />, {
+      wrapper: Wrapper,
+    })
+
+    const label = screen.getByTestId('inspect-primary-label')
+    expect(label.textContent).toBe('Process data')
+  })
+
+  it('renders dispatch lineage with resolved agent label when dispatching_task_agent_id is present', () => {
+    const resolverFn = vi.fn().mockReturnValue('Parent Orchestrator')
+    const inspect = createInspect({
+      agent: {
+        agent_id: 'agent-001',
+        current_step: 'Process data',
+        dispatching_task_agent_id: 'parent-agent-uuid',
+        dispatch_state: 'dispatched',
+        state: 'running',
+        risk_level: 'low',
+        attention_level: 'normal',
+        progress_percent: 75,
+        reflection_cycle_count: 1,
+        reasoning_log_preview: null,
+        urgency_level: 'normal',
+        workflow_run_id: 'run-001',
+        workflow_node_definition_id: 'node-001',
+        deepLinks: [],
+        evidenceRefs: [],
+      } as any,
+    })
+
+    render(
+      <MaoInspectPanel
+        inspect={inspect}
+        isLoading={false}
+        resolveAgentLabel={resolverFn}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    const lineage = screen.getByTestId('inspect-dispatch-lineage')
+    expect(lineage).toBeTruthy()
+    expect(lineage.textContent).toContain('Parent Orchestrator')
+    expect(resolverFn).toHaveBeenCalledWith('parent-agent-uuid')
+  })
+
+  it('omits dispatch lineage when dispatching_task_agent_id is null', () => {
+    const inspect = createInspect({
+      agent: {
+        agent_id: 'agent-001',
+        current_step: 'Process data',
+        dispatching_task_agent_id: null,
+        dispatch_state: 'dispatched',
+        state: 'running',
+        risk_level: 'low',
+        attention_level: 'normal',
+        progress_percent: 75,
+        reflection_cycle_count: 1,
+        reasoning_log_preview: null,
+        urgency_level: 'normal',
+        workflow_run_id: 'run-001',
+        workflow_node_definition_id: 'node-001',
+        deepLinks: [],
+        evidenceRefs: [],
+      } as any,
+    })
+
+    render(<MaoInspectPanel inspect={inspect} isLoading={false} />, {
+      wrapper: Wrapper,
+    })
+
+    expect(screen.queryByTestId('inspect-dispatch-lineage')).toBeNull()
+  })
+
+  it('renders agent class badge when agent_class is present', () => {
+    const inspect = createInspect({
+      agent: {
+        agent_id: 'agent-001',
+        current_step: 'Process data',
+        agent_class: 'Worker',
+        dispatch_state: 'dispatched',
+        state: 'running',
+        risk_level: 'low',
+        attention_level: 'normal',
+        progress_percent: 75,
+        reflection_cycle_count: 1,
+        reasoning_log_preview: null,
+        urgency_level: 'normal',
+        workflow_run_id: 'run-001',
+        workflow_node_definition_id: 'node-001',
+        deepLinks: [],
+        evidenceRefs: [],
+      } as any,
+    })
+
+    render(<MaoInspectPanel inspect={inspect} isLoading={false} />, {
+      wrapper: Wrapper,
+    })
+
+    const badge = screen.getByTestId('inspect-agent-class-badge')
+    expect(badge).toBeTruthy()
+    expect(badge.textContent).toBe('Worker')
+  })
+
+  it('renders formatShortId fallback when resolveAgentLabel is not provided', () => {
+    const inspect = createInspect({
+      agent: {
+        agent_id: 'agent-001',
+        current_step: 'Process data',
+        dispatching_task_agent_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        dispatch_state: 'dispatched',
+        state: 'running',
+        risk_level: 'low',
+        attention_level: 'normal',
+        progress_percent: 75,
+        reflection_cycle_count: 1,
+        reasoning_log_preview: null,
+        urgency_level: 'normal',
+        workflow_run_id: 'run-001',
+        workflow_node_definition_id: 'node-001',
+        deepLinks: [],
+        evidenceRefs: [],
+      } as any,
+    })
+
+    render(<MaoInspectPanel inspect={inspect} isLoading={false} />, {
+      wrapper: Wrapper,
+    })
+
+    const lineage = screen.getByTestId('inspect-dispatch-lineage')
+    expect(lineage).toBeTruthy()
+    // Should show short UUID format (first 8 chars)
+    expect(lineage.textContent).toContain('aaaaaaaa')
+  })
+})
+
 describe('MaoInspectPanel inference history', () => {
   it('renders with inference history section collapsed by default', () => {
     const inspect = createInspect({

--- a/self/ui/src/components/mao/__tests__/mao-lease-tree.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-lease-tree.test.tsx
@@ -288,3 +288,197 @@ describe('MaoLeaseTree', () => {
     expect(screen.getByTestId('edge-connector-svg')).toBeTruthy();
   });
 });
+
+describe('MaoLeaseTree motion pulse', () => {
+  it('applies nous-state-pulse-subtle on running root tile at D2', () => {
+    const root = createAgent({ agent_id: 'root-1', display_name: 'Root Agent', state: 'running' });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    const { container } = render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const rootButton = container.querySelector('[data-agent-id="root-1"]');
+    expect(rootButton?.className).toContain('nous-state-pulse-subtle');
+  });
+});
+
+describe('MaoLeaseTree urgent indicators', () => {
+  it('renders urgent indicator on root tile at D3', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      urgency_level: 'urgent',
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D3"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    expect(screen.getByTestId('urgent-indicator')).toBeTruthy();
+  });
+
+  it('renders ring-red-500 on urgent root tile at D4', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      urgency_level: 'urgent',
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    const { container } = render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D4"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const rootButton = container.querySelector('[data-agent-id="root-1"]');
+    expect(rootButton?.className).toContain('ring-red-500');
+  });
+});
+
+describe('MaoLeaseTree agent class badge', () => {
+  it('renders agent class badge at D2 when agent_class is set', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      agent_class: 'Orchestrator' as any,
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const badge = screen.getByTestId('agent-class-badge');
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('Orchestrator');
+  });
+
+  it('does not render agent class badge at D3', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      agent_class: 'Worker' as any,
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D3"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    expect(screen.queryByTestId('agent-class-badge')).toBeNull();
+  });
+
+  it('does not render agent class badge when agent_class is undefined', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      agent_class: undefined,
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    expect(screen.queryByTestId('agent-class-badge')).toBeNull();
+  });
+});
+
+describe('MaoLeaseTree state color handling', () => {
+  it('renders appropriate dot color for canceled state', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      state: 'canceled',
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    const { container } = render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const dots = container.querySelectorAll('.bg-slate-500');
+    expect(dots.length).toBeGreaterThan(0);
+  });
+
+  it('renders appropriate dot color for hard_stopped state', () => {
+    const root = createAgent({
+      agent_id: 'root-1',
+      display_name: 'Root Agent',
+      state: 'hard_stopped',
+    });
+    const snapshot = createSystemSnapshot({
+      agents: [root],
+      leaseRoots: ['root-1'],
+    });
+
+    const { container } = render(
+      <MaoLeaseTree
+        snapshot={snapshot}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const dots = container.querySelectorAll('.bg-red-700');
+    expect(dots.length).toBeGreaterThan(0);
+  });
+});

--- a/self/ui/src/components/mao/__tests__/mao-operating-surface-tabs.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-operating-surface-tabs.test.tsx
@@ -303,6 +303,123 @@ describe('MaoOperatingSurface tab behavior', () => {
     expect(screen.getByTestId('tab-projects')).toBeTruthy();
   });
 
+  it('system tab inspect popup passes projectControlProjection for non-sentinel agents', () => {
+    const controlProjection = {
+      project_id: 'real-project-001',
+      project_control_state: 'running',
+      active_agent_count: 2,
+      blocked_agent_count: 0,
+      urgent_agent_count: 0,
+      pfc_project_review_status: 'none',
+      pfc_project_recommendation: 'continue',
+      resume_readiness_status: 'not_applicable',
+      resume_readiness_evidence_refs: [],
+    };
+
+    mockGetSystemSnapshotQuery = vi.fn().mockReturnValue({
+      data: createSystemSnapshot({
+        agents: [
+          {
+            agent_id: 'agent-sys-001',
+            project_id: 'real-project-001',
+            current_step: 'Processing',
+            state: 'running',
+            risk_level: 'low',
+            urgency_level: 'normal',
+            attention_level: 'normal',
+            progress_percent: 50,
+            reflection_cycle_count: 0,
+            dispatch_state: 'dispatched',
+            pfc_alert_status: 'none',
+            pfc_mitigation_status: 'none',
+            dispatching_task_agent_id: null,
+            dispatch_origin_ref: 'origin',
+            reasoning_log_preview: null,
+            reasoning_log_redaction_state: 'none',
+            deepLinks: [],
+            evidenceRefs: [],
+          },
+        ] as any,
+        projectControls: {
+          'real-project-001': controlProjection,
+        } as any,
+      }),
+      isLoading: false,
+    });
+
+    // Mock the inspect query to return data for popup rendering
+    mockGetAgentInspectProjectionQuery = vi.fn().mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+
+    const Wrapper = createWrapper(null);
+
+    render(
+      <Wrapper>
+        <MaoOperatingSurface />
+      </Wrapper>,
+    );
+
+    // Verify we're on system tab and snapshot was queried
+    expect(screen.getByTestId('system-tab-content')).toBeTruthy();
+    expect(mockGetSystemSnapshotQuery).toHaveBeenCalled();
+
+    // The system snapshot has agents with non-sentinel project IDs,
+    // and projectControls with matching entries. The operating surface
+    // should derive the projectControlProjection for system-tab agents.
+    // We verify the snapshot contains the control projection entry.
+    const systemData = mockGetSystemSnapshotQuery.mock.results[0]?.value?.data;
+    expect(systemData?.projectControls['real-project-001']).toBeTruthy();
+  });
+
+  it('system tab inspect popup does not pass projectControlProjection for sentinel agents', () => {
+    mockGetSystemSnapshotQuery = vi.fn().mockReturnValue({
+      data: createSystemSnapshot({
+        agents: [
+          {
+            agent_id: 'agent-sentinel-001',
+            project_id: '00000000-0000-0000-0000-000000000000',
+            current_step: 'System task',
+            state: 'running',
+            risk_level: 'low',
+            urgency_level: 'normal',
+            attention_level: 'normal',
+            progress_percent: 50,
+            reflection_cycle_count: 0,
+            dispatch_state: 'dispatched',
+            pfc_alert_status: 'none',
+            pfc_mitigation_status: 'none',
+            dispatching_task_agent_id: null,
+            dispatch_origin_ref: 'origin',
+            reasoning_log_preview: null,
+            reasoning_log_redaction_state: 'none',
+            deepLinks: [],
+            evidenceRefs: [],
+          },
+        ] as any,
+        projectControls: {},
+      }),
+      isLoading: false,
+    });
+
+    const Wrapper = createWrapper(null);
+
+    render(
+      <Wrapper>
+        <MaoOperatingSurface />
+      </Wrapper>,
+    );
+
+    // Verify we're on system tab
+    expect(screen.getByTestId('system-tab-content')).toBeTruthy();
+
+    // For sentinel-scoped agents, projectControls should be empty
+    const systemData = mockGetSystemSnapshotQuery.mock.results[0]?.value?.data;
+    const sentinelId = '00000000-0000-0000-0000-000000000000';
+    expect(systemData?.projectControls[sentinelId]).toBeUndefined();
+  });
+
   it('system tab shows system health strip when snapshot is loaded', () => {
     mockGetSystemSnapshotQuery = vi.fn().mockReturnValue({
       data: createSystemSnapshot({

--- a/self/ui/src/components/mao/__tests__/mao-project-controls.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-project-controls.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MaoProjectControls } from '../mao-project-controls';
+import type { MaoProjectSnapshot } from '@nous/shared';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function createSnapshot(): MaoProjectSnapshot {
+  return {
+    projectId: '11111111-1111-1111-1111-111111111111',
+    densityMode: 'D2',
+    workflowRunId: '22222222-2222-2222-2222-222222222222',
+    controlProjection: {
+      project_id: '11111111-1111-1111-1111-111111111111',
+      project_control_state: 'running',
+      active_agent_count: 1,
+      blocked_agent_count: 0,
+      urgent_agent_count: 0,
+      pfc_project_review_status: 'none',
+      pfc_project_recommendation: 'continue',
+      resume_readiness_status: 'not_applicable',
+      resume_readiness_evidence_refs: [],
+    },
+    grid: [],
+    graph: { projectId: '11111111-1111-1111-1111-111111111111', nodes: [], edges: [], generatedAt: '2026-03-10T01:00:00.000Z' },
+    urgentOverlay: { urgentAgentIds: [], blockedAgentIds: [], generatedAt: '2026-03-10T01:00:00.000Z' },
+    summary: {
+      activeAgentCount: 1,
+      blockedAgentCount: 0,
+      failedAgentCount: 0,
+      waitingPfcAgentCount: 0,
+      urgentAgentCount: 0,
+    },
+    diagnostics: { runtimePosture: 'single_process_local' },
+    generatedAt: '2026-03-10T01:00:00.000Z',
+  } as unknown as MaoProjectSnapshot;
+}
+
+describe('MaoProjectControls', () => {
+  it('generates a unique commandId on each button click', () => {
+    const onRequestControl = vi.fn();
+
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={onRequestControl}
+      />,
+    );
+
+    // Fill in the reason (required to enable buttons)
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Test reason' } });
+
+    // Click the "Hard Stop Project" button (always enabled when running)
+    const hardStopButton = screen.getByText('Hard Stop Project');
+    fireEvent.click(hardStopButton);
+    fireEvent.click(hardStopButton);
+
+    expect(onRequestControl).toHaveBeenCalledTimes(2);
+
+    const firstCommandId = onRequestControl.mock.calls[0][0].commandId;
+    const secondCommandId = onRequestControl.mock.calls[1][0].commandId;
+
+    // Both should be valid UUIDs
+    expect(firstCommandId).toMatch(UUID_REGEX);
+    expect(secondCommandId).toMatch(UUID_REGEX);
+
+    // They should be different (not static)
+    expect(firstCommandId).not.toBe(secondCommandId);
+  });
+
+  it('generates different commandIds for different button types', () => {
+    const onRequestControl = vi.fn();
+
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={onRequestControl}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Test reason' } });
+
+    // Click Pause then Hard Stop
+    const pauseButton = screen.getByText('Pause Project');
+    fireEvent.click(pauseButton);
+
+    const hardStopButton = screen.getByText('Hard Stop Project');
+    fireEvent.click(hardStopButton);
+
+    expect(onRequestControl).toHaveBeenCalledTimes(2);
+
+    const pauseCommandId = onRequestControl.mock.calls[0][0].commandId;
+    const hardStopCommandId = onRequestControl.mock.calls[1][0].commandId;
+
+    expect(pauseCommandId).toMatch(UUID_REGEX);
+    expect(hardStopCommandId).toMatch(UUID_REGEX);
+    expect(pauseCommandId).not.toBe(hardStopCommandId);
+  });
+
+  it('passes the correct action to onRequestControl', () => {
+    const onRequestControl = vi.fn();
+
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={onRequestControl}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Test reason' } });
+
+    const pauseButton = screen.getByText('Pause Project');
+    fireEvent.click(pauseButton);
+
+    expect(onRequestControl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'pause_project',
+        reason: 'Test reason',
+        commandId: expect.stringMatching(UUID_REGEX),
+      }),
+    );
+  });
+});

--- a/self/ui/src/components/mao/__tests__/mao-project-controls.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-project-controls.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
 import * as React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MaoProjectControls } from '../mao-project-controls';
-import type { MaoProjectSnapshot } from '@nous/shared';
+import type { MaoProjectControlResult, MaoProjectSnapshot } from '@nous/shared';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -38,6 +38,145 @@ function createSnapshot(): MaoProjectSnapshot {
     generatedAt: '2026-03-10T01:00:00.000Z',
   } as unknown as MaoProjectSnapshot;
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MaoProjectControls Cortex and evidence surfaces', () => {
+  it('renders Cortex review status in body', () => {
+    const snapshot = createSnapshot();
+    (snapshot.controlProjection as any).pfc_project_review_status = 'active';
+
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+
+    const section = screen.getByTestId('cortex-review-section');
+    expect(section).toBeTruthy();
+    expect(section.textContent).toContain('active');
+  });
+
+  it('shows "No active Cortex review" when pfc_project_review_status is "none"', () => {
+    const snapshot = createSnapshot();
+
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+
+    const section = screen.getByTestId('cortex-review-section');
+    expect(section.textContent).toContain('No active Cortex review');
+  });
+
+  it('renders clickable evidence links from resume_readiness_evidence_refs', () => {
+    const snapshot = createSnapshot();
+    (snapshot.controlProjection as any).resume_readiness_evidence_refs = [
+      'evidence://ref-1',
+      'evidence://ref-2',
+    ];
+
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+
+    const section = screen.getByTestId('resume-readiness-evidence');
+    expect(section).toBeTruthy();
+
+    const links = section.querySelectorAll('[data-evidence-ref]');
+    expect(links.length).toBe(2);
+    expect(links[0]!.getAttribute('data-evidence-ref')).toBe('evidence://ref-1');
+    expect(links[1]!.getAttribute('data-evidence-ref')).toBe('evidence://ref-2');
+  });
+
+  it('renders clickable evidence links from lastResult.evidenceRefs', () => {
+    const snapshot = createSnapshot();
+    const lastResult: MaoProjectControlResult = {
+      command_id: 'cmd-001',
+      project_id: '11111111-1111-1111-1111-111111111111',
+      accepted: true,
+      status: 'applied',
+      from_state: 'paused_review',
+      to_state: 'running',
+      reason_code: 'mao_project_control_applied',
+      decision_ref: 'mao-control:cmd-001',
+      impactSummary: {
+        activeRunCount: 1,
+        activeAgentCount: 1,
+        blockedAgentCount: 0,
+        urgentAgentCount: 0,
+        affectedScheduleCount: 0,
+        evidenceRefs: [],
+      },
+      evidenceRefs: ['evidence://result-ref-1'],
+      readiness_status: 'passed',
+    } as unknown as MaoProjectControlResult;
+
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={lastResult}
+        onRequestControl={vi.fn()}
+      />,
+    );
+
+    const section = screen.getByTestId('last-result-evidence');
+    expect(section).toBeTruthy();
+
+    const links = section.querySelectorAll('[data-evidence-ref]');
+    expect(links.length).toBe(1);
+    expect(links[0]!.getAttribute('data-evidence-ref')).toBe('evidence://result-ref-1');
+  });
+
+  it('renders no evidence section when evidence refs are empty', () => {
+    const snapshot = createSnapshot();
+
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('resume-readiness-evidence')).toBeNull();
+  });
+
+  it('START-005 placeholder element is present', () => {
+    const snapshot = createSnapshot();
+
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('start-005-stub')).toBeTruthy();
+  });
+});
 
 describe('MaoProjectControls', () => {
   it('generates a unique commandId on each button click', () => {

--- a/self/ui/src/components/mao/__tests__/mao-run-graph.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-run-graph.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MaoRunGraphSnapshot, MaoRunGraphNode, MaoRunGraphEdge } from '@nous/shared';
+import { MaoRunGraph } from '../mao-run-graph';
+
+function createNode(overrides?: Partial<MaoRunGraphNode>): MaoRunGraphNode {
+  return {
+    id: overrides?.id ?? crypto.randomUUID(),
+    kind: 'agent',
+    label: 'Test Node',
+    evidenceRefs: ['ref-001'],
+    ...overrides,
+  } as MaoRunGraphNode;
+}
+
+function createEdge(overrides?: Partial<MaoRunGraphEdge>): MaoRunGraphEdge {
+  return {
+    id: overrides?.id ?? crypto.randomUUID(),
+    kind: 'dispatch',
+    fromNodeId: 'node-a',
+    toNodeId: 'node-b',
+    reasonCode: 'test-reason',
+    evidenceRefs: ['ref-001'],
+    occurredAt: '2026-03-29T00:00:00Z',
+    ...overrides,
+  } as MaoRunGraphEdge;
+}
+
+function createGraph(
+  nodes: MaoRunGraphNode[],
+  edges: MaoRunGraphEdge[],
+): MaoRunGraphSnapshot {
+  return {
+    projectId: 'project-001',
+    nodes,
+    edges,
+    generatedAt: '2026-03-29T00:00:00Z',
+  } as MaoRunGraphSnapshot;
+}
+
+const noop = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MaoRunGraph node color-coding', () => {
+  it('renders running node with emerald border', () => {
+    const node = createNode({ id: 'n1', label: 'Running Node', state: 'running' });
+    const graph = createGraph([node], []);
+
+    const { container } = render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    const nodeEl = screen.getByTestId('run-graph-node');
+    expect(nodeEl.className).toContain('border-emerald-500/40');
+    expect(nodeEl.className).toContain('bg-emerald-500/10');
+  });
+
+  it('renders blocked node with amber border', () => {
+    const node = createNode({ id: 'n1', label: 'Blocked Node', state: 'blocked' });
+    const graph = createGraph([node], []);
+
+    const { container } = render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    const nodeEl = screen.getByTestId('run-graph-node');
+    expect(nodeEl.className).toContain('border-amber-500/40');
+    expect(nodeEl.className).toContain('bg-amber-500/10');
+  });
+
+  it('renders failed node with red border', () => {
+    const node = createNode({ id: 'n1', label: 'Failed Node', state: 'failed' });
+    const graph = createGraph([node], []);
+
+    const { container } = render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    const nodeEl = screen.getByTestId('run-graph-node');
+    expect(nodeEl.className).toContain('border-red-500/40');
+    expect(nodeEl.className).toContain('bg-red-500/10');
+  });
+
+  it('renders completed node with slate border', () => {
+    const node = createNode({ id: 'n1', label: 'Done Node', state: 'completed' });
+    const graph = createGraph([node], []);
+
+    const { container } = render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    const nodeEl = screen.getByTestId('run-graph-node');
+    expect(nodeEl.className).toContain('border-slate-500/40');
+  });
+
+  it('renders neutral styling when node state is undefined', () => {
+    const node = createNode({ id: 'n1', label: 'No State Node' });
+    const graph = createGraph([node], []);
+
+    const { container } = render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    const nodeEl = screen.getByTestId('run-graph-node');
+    expect(nodeEl.className).toContain('border-border');
+  });
+
+  it('selected node overrides state color with border-primary', () => {
+    const node = createNode({
+      id: 'n1',
+      label: 'Selected Node',
+      state: 'running',
+      workflowNodeDefinitionId: 'wnd-1' as any,
+    });
+    const graph = createGraph([node], []);
+
+    const { container } = render(
+      <MaoRunGraph graph={graph} selectedNodeId="wnd-1" onSelectNode={noop} />,
+    );
+
+    const nodeEl = screen.getByTestId('run-graph-node');
+    expect(nodeEl.className).toContain('border-primary');
+    expect(nodeEl.className).toContain('bg-primary/10');
+  });
+});
+
+describe('MaoRunGraph corrective arc emphasis', () => {
+  it('renders dispatch arc with neutral border-border', () => {
+    const edge = createEdge({ id: 'e1', kind: 'dispatch' });
+    const graph = createGraph([], [edge]);
+
+    render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    expect(screen.queryByTestId('corrective-arc')).toBeNull();
+  });
+
+  it('renders rollback arc with corrective emphasis', () => {
+    const edge = createEdge({ id: 'e1', kind: 'rollback' });
+    const graph = createGraph([], [edge]);
+
+    render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    const correctiveArc = screen.getByTestId('corrective-arc');
+    expect(correctiveArc).toBeTruthy();
+    expect(correctiveArc.className).toContain('border-amber-500/60');
+    expect(correctiveArc.className).toContain('bg-amber-500/5');
+    expect(correctiveArc.className).toContain('border-l-amber-500');
+  });
+
+  it.each([
+    'reflection_review',
+    'retry',
+    'rollback',
+    'reprompt',
+    'resume',
+  ] as const)('renders %s edge with corrective-arc test id', (kind) => {
+    const edge = createEdge({ id: `e-${kind}`, kind });
+    const graph = createGraph([], [edge]);
+
+    render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
+    );
+
+    expect(screen.getByTestId('corrective-arc')).toBeTruthy();
+    cleanup();
+  });
+});
+
+describe('MaoRunGraph click handler', () => {
+  it('fires onSelectNode with correct payload when node is clicked', () => {
+    const handler = vi.fn();
+    const node = createNode({
+      id: 'n1',
+      label: 'Clickable Node',
+      workflowRunId: 'run-001' as any,
+      workflowNodeDefinitionId: 'wnd-001' as any,
+      agentId: 'agent-001',
+    });
+    const graph = createGraph([node], []);
+
+    render(
+      <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={handler} />,
+    );
+
+    fireEvent.click(screen.getByTestId('run-graph-node'));
+    expect(handler).toHaveBeenCalledWith({
+      workflowRunId: 'run-001',
+      nodeDefinitionId: 'wnd-001',
+      agentId: 'agent-001',
+    });
+  });
+});

--- a/self/ui/src/components/mao/__tests__/mao-t3-confirmation-dialog.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-t3-confirmation-dialog.test.tsx
@@ -65,7 +65,7 @@ describe('MaoT3ConfirmationDialog', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
   });
 
-  it('calls requestConfirmationProof mutation on confirm and invokes onConfirm with proof', async () => {
+  it('calls requestConfirmationProof mutation on confirm and invokes onConfirm with proof after Done click', async () => {
     const onConfirm = vi.fn();
 
     // Simulate mutation that calls onSuccess
@@ -96,7 +96,20 @@ describe('MaoT3ConfirmationDialog', () => {
       />,
     );
 
+    // Click Confirm to obtain proof
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    // Proof details should be displayed before onConfirm is called
+    await waitFor(() => {
+      expect(screen.getByTestId('proof-details')).toBeTruthy();
+      expect(screen.getByTestId('proof-id').textContent).toBe(MOCK_PROOF.proof_id);
+    });
+
+    // onConfirm should NOT have been called yet
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    // Click Done to execute
+    fireEvent.click(screen.getByTestId('proof-done-button'));
 
     await waitFor(() => {
       expect(onConfirm).toHaveBeenCalledWith(MOCK_PROOF);
@@ -174,5 +187,131 @@ describe('MaoT3ConfirmationDialog', () => {
     const confirmButton = screen.getByRole('button', { name: 'Confirming...' });
     expect(confirmButton).toBeTruthy();
     expect((confirmButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('displays proof details after mutation success before calling onConfirm', async () => {
+    const onConfirm = vi.fn();
+
+    mockUseMutation = vi.fn().mockImplementation(
+      (opts?: { onSuccess?: (proof: any) => void }) => ({
+        mutate: () => {
+          opts?.onSuccess?.(MOCK_PROOF);
+        },
+        isPending: false,
+        isError: false,
+      }),
+    );
+
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="hard_stop_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Proof confirmed')).toBeTruthy();
+      expect(screen.getByTestId('proof-id').textContent).toBe(MOCK_PROOF.proof_id);
+    });
+
+    // onConfirm should not have been called yet
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm with proof when Done button is clicked after proof display', async () => {
+    const onConfirm = vi.fn();
+
+    mockUseMutation = vi.fn().mockImplementation(
+      (opts?: { onSuccess?: (proof: any) => void }) => ({
+        mutate: () => {
+          opts?.onSuccess?.(MOCK_PROOF);
+        },
+        isPending: false,
+        isError: false,
+      }),
+    );
+
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('proof-done-button')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('proof-done-button'));
+
+    expect(onConfirm).toHaveBeenCalledWith(MOCK_PROOF);
+  });
+
+  it('resets proof display state when dialog re-opens', async () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    mockUseMutation = vi.fn().mockImplementation(
+      (opts?: { onSuccess?: (proof: any) => void }) => ({
+        mutate: () => {
+          opts?.onSuccess?.(MOCK_PROOF);
+        },
+        isPending: false,
+        isError: false,
+      }),
+    );
+
+    const { rerender } = render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    // Trigger confirm to show proof
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Proof confirmed')).toBeTruthy();
+    });
+
+    // Close the dialog
+    rerender(
+      <MaoT3ConfirmationDialog
+        open={false}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    // Re-open the dialog
+    rerender(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    // Should show the confirmation view, not the proof display
+    expect(screen.getByText('Confirm T3 action')).toBeTruthy();
+    expect(screen.queryByText('Proof confirmed')).toBeNull();
   });
 });

--- a/self/ui/src/components/mao/__tests__/mao-workflow-group-card.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-workflow-group-card.test.tsx
@@ -199,3 +199,175 @@ describe('MaoWorkflowGroupCard', () => {
     expect(selectedButton?.className).toContain('border-primary');
   });
 });
+
+describe('MaoWorkflowGroupCard motion pulse', () => {
+  it('applies nous-state-pulse-subtle on running worker tile at D2', () => {
+    const orch = createAgent({ agent_id: 'orch-1', display_name: 'Orch', state: 'running' });
+    const worker = createAgent({ agent_id: 'w1', display_name: 'Worker', state: 'running' });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[worker]}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const workerButton = container.querySelector('[data-agent-id="w1"]');
+    expect(workerButton?.className).toContain('nous-state-pulse-subtle');
+  });
+
+  it('applies pulse class on orchestrator tile at D2', () => {
+    const orch = createAgent({ agent_id: 'orch-1', display_name: 'Orch', state: 'blocked' });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const orchButton = container.querySelector('[data-agent-id="orch-1"]');
+    expect(orchButton?.className).toContain('nous-state-pulse-strong');
+  });
+});
+
+describe('MaoWorkflowGroupCard urgent indicators', () => {
+  it('renders urgent indicator at D3 for urgent agent', () => {
+    const orch = createAgent({
+      agent_id: 'orch-1',
+      display_name: 'Orch',
+      urgency_level: 'urgent',
+    });
+
+    render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D3"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    expect(screen.getByTestId('urgent-indicator')).toBeTruthy();
+  });
+
+  it('renders ring-red-500 on urgent agent tile at D4', () => {
+    const orch = createAgent({
+      agent_id: 'orch-1',
+      display_name: 'Orch',
+      urgency_level: 'urgent',
+    });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D4"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const orchButton = container.querySelector('[data-agent-id="orch-1"]');
+    expect(orchButton?.className).toContain('ring-red-500');
+  });
+});
+
+describe('MaoWorkflowGroupCard D4 hover-expand', () => {
+  it('expands D4 tile to D3 on hover with state dot and label visible', () => {
+    const orch = createAgent({ agent_id: 'orch-1', display_name: 'Orchestrator' });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D4"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    const orchButton = container.querySelector('[data-agent-id="orch-1"]');
+    expect(orchButton).toBeTruthy();
+
+    // Before hover: should be w-6 h-6 (D4)
+    expect(orchButton?.className).toContain('w-6');
+
+    // Simulate hover
+    fireEvent.mouseEnter(orchButton!);
+
+    // After hover: should expand to D3 with label visible
+    const expandedTile = screen.getByTestId('hover-expand-tile');
+    expect(expandedTile).toBeTruthy();
+    expect(screen.getByText('Orchestrator')).toBeTruthy();
+  });
+
+  it('fires click after hover-expand in D4', () => {
+    const handler = vi.fn();
+    const orch = createAgent({ agent_id: 'orch-1', display_name: 'Orch' });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D4"
+        selectedAgentId={null}
+        onSelectAgent={handler}
+      />,
+    );
+
+    const orchButton = container.querySelector('[data-agent-id="orch-1"]');
+    fireEvent.mouseEnter(orchButton!);
+
+    const expandedTile = screen.getByTestId('hover-expand-tile');
+    fireEvent.click(expandedTile);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: 'orch-1' }),
+    );
+  });
+});
+
+describe('MaoWorkflowGroupCard state color handling', () => {
+  it('renders appropriate dot color for canceled state (not default)', () => {
+    const orch = createAgent({ agent_id: 'orch-1', display_name: 'Orch', state: 'canceled' });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    // The dot span should have bg-slate-500 (not default bg-slate-400)
+    const dots = container.querySelectorAll('.bg-slate-500');
+    expect(dots.length).toBeGreaterThan(0);
+  });
+
+  it('renders appropriate dot color for hard_stopped state', () => {
+    const orch = createAgent({ agent_id: 'orch-1', display_name: 'Orch', state: 'hard_stopped' });
+
+    const { container } = render(
+      <MaoWorkflowGroupCard
+        orchestrator={orch}
+        workers={[]}
+        densityMode="D2"
+        selectedAgentId={null}
+        onSelectAgent={noop}
+      />,
+    );
+
+    // The dot span should have bg-red-700
+    const dots = container.querySelectorAll('.bg-red-700');
+    expect(dots.length).toBeGreaterThan(0);
+  });
+});

--- a/self/ui/src/components/mao/mao-audit-trail-panel.tsx
+++ b/self/ui/src/components/mao/mao-audit-trail-panel.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import type { ProjectId } from '@nous/shared';
+import { SYSTEM_SCOPE_SENTINEL_PROJECT_ID } from '@nous/shared';
 import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 import { trpc, useEventSubscription } from '@nous/transport';
@@ -14,9 +15,11 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
   const utils = trpc.useUtils();
   const [expandedId, setExpandedId] = React.useState<string | null>(null);
 
+  const isSentinel = projectId === SYSTEM_SCOPE_SENTINEL_PROJECT_ID;
+
   const auditQuery = trpc.mao.getControlAuditHistory.useQuery(
     { projectId: projectId as string },
-    { enabled: !!projectId },
+    { enabled: !!projectId && !isSentinel },
   );
 
   useEventSubscription({
@@ -24,7 +27,7 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
     onEvent: () => {
       void utils.mao.getControlAuditHistory.invalidate();
     },
-    enabled: !!projectId,
+    enabled: !!projectId && !isSentinel,
   });
 
   const entries = auditQuery.data ?? [];
@@ -40,7 +43,11 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3 pt-4 text-sm">
-        {auditQuery.isLoading ? (
+        {isSentinel ? (
+          <p className="text-muted-foreground" data-testid="sentinel-indicator">
+            System-level agent — audit trail scoped to project context.
+          </p>
+        ) : auditQuery.isLoading ? (
           <p className="text-muted-foreground">Loading audit history...</p>
         ) : auditQuery.isError ? (
           <p className="text-muted-foreground">

--- a/self/ui/src/components/mao/mao-density-grid.tsx
+++ b/self/ui/src/components/mao/mao-density-grid.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import type { MaoDensityMode, MaoGridTileProjection, MaoProjectSnapshot } from '@nous/shared';
 import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
+import { resolveAgentLabel } from './mao-workflow-group-card';
+import { getStateVisuals, CLUSTER_STATE_ORDER } from './mao-state-utils';
 
 function gridColumnsForDensity(
   densityMode: MaoProjectSnapshot['densityMode'],
@@ -22,22 +24,6 @@ function gridColumnsForDensity(
     default:
       return 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3';
   }
-}
-
-function toneClasses(tile: MaoGridTileProjection): string {
-  if (tile.agent.state === 'failed') {
-    return 'border-red-500/40 bg-red-500/10';
-  }
-  if (tile.agent.state === 'blocked' || tile.agent.state === 'waiting_pfc') {
-    return 'border-amber-500/40 bg-amber-500/10';
-  }
-  if (tile.agent.state === 'running' || tile.agent.state === 'resuming') {
-    return 'border-emerald-500/40 bg-emerald-500/10';
-  }
-  if (tile.agent.state === 'completed') {
-    return 'border-slate-500/40 bg-slate-500/10';
-  }
-  return 'border-border bg-background';
 }
 
 const streamingPulseStyle: React.CSSProperties = {
@@ -89,6 +75,45 @@ function renderInferenceInfo(
   );
 }
 
+/** Small SVG exclamation icon for urgent indicators at D3 */
+function UrgentIcon() {
+  return (
+    <svg
+      width="8"
+      height="8"
+      viewBox="0 0 8 8"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="text-red-500 shrink-0"
+      data-testid="urgent-icon"
+      aria-hidden="true"
+    >
+      <circle cx="4" cy="4" r="4" fill="currentColor" />
+      <text x="4" y="6" textAnchor="middle" fontSize="6" fill="white" fontWeight="bold">!</text>
+    </svg>
+  );
+}
+
+/** Elapsed-since-urgent timer for D0-D2 */
+function UrgentTimer({ lastUpdateAt }: { lastUpdateAt: string }) {
+  const [minutes, setMinutes] = React.useState(() =>
+    Math.floor((Date.now() - new Date(lastUpdateAt).getTime()) / 60000),
+  );
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setMinutes(Math.floor((Date.now() - new Date(lastUpdateAt).getTime()) / 60000));
+    }, 60000);
+    return () => clearInterval(interval);
+  }, [lastUpdateAt]);
+
+  return (
+    <span className="text-[10px] text-red-500" data-testid="urgent-timer">
+      {minutes}m
+    </span>
+  );
+}
+
 export interface MaoDensityGridProps {
   snapshot: MaoProjectSnapshot;
   selectedAgentId: string | null;
@@ -100,6 +125,62 @@ export function MaoDensityGrid({
   selectedAgentId,
   onSelectTile,
 }: MaoDensityGridProps) {
+  const { densityMode } = snapshot;
+
+  // Sort tiles: urgent first, blocked second, then original order (D0-D3)
+  const sortedTiles = React.useMemo(() => {
+    return Array.from(snapshot.grid).sort((a, b) => {
+      const aUrgent =
+        snapshot.urgentOverlay.urgentAgentIds.includes(a.agent.agent_id) ||
+        a.agent.urgency_level === 'urgent';
+      const bUrgent =
+        snapshot.urgentOverlay.urgentAgentIds.includes(b.agent.agent_id) ||
+        b.agent.urgency_level === 'urgent';
+      const aBlocked = snapshot.urgentOverlay.blockedAgentIds.includes(a.agent.agent_id);
+      const bBlocked = snapshot.urgentOverlay.blockedAgentIds.includes(b.agent.agent_id);
+
+      if (aUrgent && !bUrgent) return -1;
+      if (!aUrgent && bUrgent) return 1;
+      if (aBlocked && !bBlocked) return -1;
+      if (!aBlocked && bBlocked) return 1;
+      return 0;
+    });
+  }, [snapshot.grid, snapshot.urgentOverlay]);
+
+  // D4 clustering: group tiles by lifecycle state
+  const clusterMap = React.useMemo(() => {
+    if (densityMode !== 'D4') return null;
+    const map = new Map<string, MaoGridTileProjection[]>();
+    for (const tile of snapshot.grid) {
+      const state = tile.agent.state;
+      if (!map.has(state)) map.set(state, []);
+      map.get(state)!.push(tile);
+    }
+    // Sort urgent to front within each cluster
+    for (const tiles of map.values()) {
+      tiles.sort((a, b) => {
+        const aUrgent =
+          snapshot.urgentOverlay.urgentAgentIds.includes(a.agent.agent_id) ||
+          a.agent.urgency_level === 'urgent';
+        const bUrgent =
+          snapshot.urgentOverlay.urgentAgentIds.includes(b.agent.agent_id) ||
+          b.agent.urgency_level === 'urgent';
+        if (aUrgent && !bUrgent) return -1;
+        if (!aUrgent && bUrgent) return 1;
+        return 0;
+      });
+    }
+    return map;
+  }, [snapshot.grid, snapshot.urgentOverlay, densityMode]);
+
+  // Ordered cluster entries for D4
+  const orderedClusters = React.useMemo(() => {
+    if (!clusterMap) return null;
+    return CLUSTER_STATE_ORDER
+      .filter((state) => clusterMap.has(state))
+      .map((state) => ({ state, tiles: clusterMap.get(state)! }));
+  }, [clusterMap]);
+
   return (
     <Card>
       <CardHeader className="border-b border-border">
@@ -121,11 +202,45 @@ export function MaoDensityGrid({
           <p className="text-sm text-muted-foreground">
             No MAO agent projections are available for the selected project.
           </p>
+        ) : densityMode === 'D4' && orderedClusters ? (
+          /* D4 clustered rendering */
+          <div className="space-y-3">
+            {orderedClusters.map(({ state, tiles }) => (
+              <div key={state} data-testid={`cluster-${state}`}>
+                <div className="text-[10px] text-muted-foreground font-medium mb-1 uppercase tracking-wider">
+                  {state} ({tiles.length})
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {tiles.map((tile) => {
+                    const isSelected = selectedAgentId === tile.agent.agent_id;
+                    const urgent =
+                      snapshot.urgentOverlay.urgentAgentIds.includes(tile.agent.agent_id) ||
+                      tile.agent.urgency_level === 'urgent';
+                    const visuals = getStateVisuals(tile.agent.state);
+
+                    return (
+                      <button
+                        key={tile.agent.agent_id}
+                        type="button"
+                        aria-label={`Inspect ${resolveAgentLabel(tile.agent)}`}
+                        onClick={() => onSelectTile(tile)}
+                        data-testid="density-tile-d4"
+                        className={`w-6 h-6 rounded ${visuals.dot} ${
+                          isSelected ? 'ring-2 ring-primary' : ''
+                        } ${urgent ? 'ring-2 ring-red-500' : ''} ${visuals.pulse}`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
         ) : (
+          /* D0-D3 flat rendering */
           <div
-            className={`grid gap-3 ${gridColumnsForDensity(snapshot.densityMode)}`}
+            className={`grid gap-3 ${gridColumnsForDensity(densityMode)}`}
           >
-            {snapshot.grid.map((tile) => {
+            {sortedTiles.map((tile) => {
               const isSelected = selectedAgentId === tile.agent.agent_id;
               const urgent =
                 snapshot.urgentOverlay.urgentAgentIds.includes(tile.agent.agent_id) ||
@@ -133,7 +248,29 @@ export function MaoDensityGrid({
               const blocked = snapshot.urgentOverlay.blockedAgentIds.includes(
                 tile.agent.agent_id,
               );
+              const visuals = getStateVisuals(tile.agent.state);
 
+              /* D3 compact tile */
+              if (densityMode === 'D3') {
+                return (
+                  <button
+                    key={tile.agent.agent_id}
+                    type="button"
+                    aria-label={`Inspect ${resolveAgentLabel(tile.agent)}`}
+                    onClick={() => onSelectTile(tile)}
+                    data-testid="density-tile-d3"
+                    className={`inline-flex items-center gap-1 rounded border px-1.5 py-1 text-xs transition-colors hover:bg-muted/30 ${
+                      isSelected ? 'border-primary bg-primary/10' : visuals.tone
+                    } ${urgent ? 'border-red-500 border-2' : ''} ${visuals.pulse}`}
+                  >
+                    <span className={`inline-block w-2 h-2 rounded-full ${visuals.dot}`} />
+                    <span className="truncate max-w-16">{resolveAgentLabel(tile.agent).slice(0, 16)}</span>
+                    {urgent && <UrgentIcon />}
+                  </button>
+                );
+              }
+
+              /* D0-D2 full card */
               return (
                 <button
                   key={tile.agent.agent_id}
@@ -141,8 +278,8 @@ export function MaoDensityGrid({
                   aria-label={`Inspect ${tile.agent.current_step}`}
                   onClick={() => onSelectTile(tile)}
                   className={`rounded-lg border p-3 text-left transition-colors hover:bg-muted/20 ${
-                    isSelected ? 'border-primary bg-primary/10' : toneClasses(tile)
-                  }`}
+                    isSelected ? 'border-primary bg-primary/10' : visuals.tone
+                  } ${urgent ? 'border-red-500 border-2' : ''} ${visuals.pulse}`}
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
@@ -162,9 +299,23 @@ export function MaoDensityGrid({
                     {tile.inspectOnly ? (
                       <Badge variant="outline">inspect-first</Badge>
                     ) : null}
-                    {urgent ? <Badge variant="outline">urgent</Badge> : null}
+                    {urgent ? (
+                      <Badge
+                        variant="outline"
+                        className="border-red-500 text-red-500 bg-red-500/10"
+                        data-testid="urgent-indicator"
+                      >
+                        URGENT
+                      </Badge>
+                    ) : null}
                     {blocked ? <Badge variant="outline">blocked</Badge> : null}
                   </div>
+
+                  {urgent && tile.agent.last_update_at && (
+                    <div className="mt-1">
+                      <UrgentTimer lastUpdateAt={tile.agent.last_update_at} />
+                    </div>
+                  )}
 
                   <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
                     <span>{tile.agent.progress_percent}% complete</span>

--- a/self/ui/src/components/mao/mao-inspect-panel.tsx
+++ b/self/ui/src/components/mao/mao-inspect-panel.tsx
@@ -6,13 +6,20 @@ import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 import { buildMaoSurfaceHref, formatShortId } from './mao-links';
 import { useMaoServices } from './mao-services-context';
+import {
+  resolveAgentLabel as resolveAgentLabelFromProjection,
+  AGENT_CLASS_COLORS,
+  FALLBACK_CLASS_COLOR,
+} from './mao-workflow-group-card';
 
 interface MaoInspectPanelProps {
   inspect: MaoAgentInspectProjection | null | undefined;
   isLoading: boolean;
+  /** Resolve a dispatching agent UUID to a human-readable label */
+  resolveAgentLabel?: (agentId: string) => string;
 }
 
-export function MaoInspectPanel({ inspect, isLoading }: MaoInspectPanelProps) {
+export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoInspectPanelProps) {
   const { Link } = useMaoServices();
   const [inferenceHistoryOpen, setInferenceHistoryOpen] = React.useState(false);
 
@@ -66,13 +73,36 @@ export function MaoInspectPanel({ inspect, isLoading }: MaoInspectPanelProps) {
           <>
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-base font-semibold">
-                  {inspect.agent.current_step}
+                <span className="text-base font-semibold" data-testid="inspect-primary-label">
+                  {resolveAgentLabelFromProjection(inspect.agent as any)}
                 </span>
+                {(() => {
+                  const classKey = (inspect.agent as any).agent_class ?? '';
+                  const classColor = AGENT_CLASS_COLORS[classKey] ?? FALLBACK_CLASS_COLOR;
+                  return classKey ? (
+                    <Badge
+                      variant="outline"
+                      className={classColor.fill}
+                      data-testid="inspect-agent-class-badge"
+                    >
+                      {classColor.label}
+                    </Badge>
+                  ) : null;
+                })()}
                 <Badge variant="outline">{inspect.agent.state}</Badge>
                 <Badge variant="outline">{inspect.agent.urgency_level}</Badge>
                 <Badge variant="outline">{inspect.projectControlState}</Badge>
               </div>
+              {inspect.agent.dispatching_task_agent_id ? (
+                <div className="text-xs text-muted-foreground" data-testid="inspect-dispatch-lineage">
+                  Dispatched by:{' '}
+                  <span className="font-medium">
+                    {resolveAgentLabel
+                      ? resolveAgentLabel(inspect.agent.dispatching_task_agent_id)
+                      : formatShortId(inspect.agent.dispatching_task_agent_id)}
+                  </span>
+                </div>
+              ) : null}
               <div className="grid gap-2 md:grid-cols-2">
                 <div className="rounded-md border border-border px-3 py-2">
                   <div className="text-xs uppercase tracking-wide text-muted-foreground">

--- a/self/ui/src/components/mao/mao-inspect-popup.tsx
+++ b/self/ui/src/components/mao/mao-inspect-popup.tsx
@@ -3,11 +3,13 @@
 import * as React from 'react';
 import type {
   MaoAgentProjection,
+  MaoProjectControlProjection,
   MaoProjectSnapshot,
   MaoProjectControlAction,
   MaoProjectControlResult,
   ProjectId,
 } from '@nous/shared';
+import { SYSTEM_SCOPE_SENTINEL_PROJECT_ID } from '@nous/shared';
 import { trpc } from '@nous/transport';
 import { MaoInspectPanel } from './mao-inspect-panel';
 import { MaoProjectControls } from './mao-project-controls';
@@ -20,6 +22,8 @@ export interface MaoInspectPopupProps {
   agent: MaoAgentProjection | null;
   /** Project snapshot for project controls (if available for the agent's project) */
   projectSnapshot: MaoProjectSnapshot | null;
+  /** Optional project control projection for system-tab agents */
+  projectControlProjection?: MaoProjectControlProjection | null;
   /** Control mutation pending state */
   controlPending?: boolean;
   /** Last control result */
@@ -30,6 +34,8 @@ export interface MaoInspectPopupProps {
     reason: string;
     commandId: string;
   }) => void;
+  /** Resolve dispatching agent UUID to human-readable label */
+  resolveAgentLabel?: (agentId: string) => string;
 }
 
 export function MaoInspectPopup({
@@ -37,9 +43,11 @@ export function MaoInspectPopup({
   onClose,
   agent,
   projectSnapshot,
+  projectControlProjection,
   controlPending = false,
   lastControlResult = null,
   onRequestControl,
+  resolveAgentLabel,
 }: MaoInspectPopupProps) {
   // Escape key handler
   React.useEffect(() => {
@@ -69,6 +77,45 @@ export function MaoInspectPopup({
     inspectInput as any,
     { enabled: open && agent != null },
   );
+
+  // Derive effective project snapshot: use provided snapshot or construct minimal from control projection
+  const effectiveProjectSnapshot = React.useMemo<MaoProjectSnapshot | null>(() => {
+    if (projectSnapshot) return projectSnapshot;
+    if (
+      !projectControlProjection ||
+      !agent ||
+      agent.project_id === SYSTEM_SCOPE_SENTINEL_PROJECT_ID
+    ) {
+      return null;
+    }
+    // Construct minimal snapshot from control projection (SDS D2)
+    return {
+      projectId: agent.project_id,
+      densityMode: 'D2',
+      controlProjection: projectControlProjection,
+      grid: [],
+      graph: {
+        projectId: agent.project_id,
+        nodes: [],
+        edges: [],
+        generatedAt: new Date().toISOString(),
+      },
+      urgentOverlay: {
+        urgentAgentIds: [],
+        blockedAgentIds: [],
+        generatedAt: new Date().toISOString(),
+      },
+      summary: {
+        activeAgentCount: projectControlProjection.active_agent_count,
+        blockedAgentCount: projectControlProjection.blocked_agent_count,
+        failedAgentCount: 0,
+        waitingPfcAgentCount: 0,
+        urgentAgentCount: projectControlProjection.urgent_agent_count,
+      },
+      diagnostics: { runtimePosture: 'single_process_local' as const },
+      generatedAt: new Date().toISOString(),
+    } as MaoProjectSnapshot;
+  }, [projectSnapshot, projectControlProjection, agent]);
 
   if (!open) return null;
 
@@ -156,11 +203,12 @@ export function MaoInspectPopup({
           <MaoInspectPanel
             inspect={inspectQuery.data}
             isLoading={inspectQuery.isLoading}
+            resolveAgentLabel={resolveAgentLabel}
           />
 
-          {projectSnapshot && onRequestControl ? (
+          {effectiveProjectSnapshot && onRequestControl ? (
             <MaoProjectControls
-              snapshot={projectSnapshot}
+              snapshot={effectiveProjectSnapshot}
               pending={controlPending}
               lastResult={lastControlResult ?? null}
               onRequestControl={onRequestControl}

--- a/self/ui/src/components/mao/mao-lease-tree.tsx
+++ b/self/ui/src/components/mao/mao-lease-tree.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import type { MaoAgentProjection, MaoDensityMode, MaoSystemSnapshot } from '@nous/shared';
 import { MaoWorkflowGroupCard, resolveAgentLabel, AGENT_CLASS_COLORS, FALLBACK_CLASS_COLOR } from './mao-workflow-group-card';
 import { MaoEdgeConnector, type EdgeDef } from './mao-edge-connector';
+import { getStateVisuals } from './mao-state-utils';
 
 // ---------------------------------------------------------------------------
 // Lease Tree Derivation
@@ -167,25 +168,26 @@ function rootTileSizeClasses(densityMode: MaoDensityMode): string {
   }
 }
 
-function stateColorDot(state: string): string {
-  switch (state) {
-    case 'running':
-    case 'resuming':
-      return 'bg-emerald-500';
-    case 'blocked':
-    case 'waiting_pfc':
-      return 'bg-amber-500';
-    case 'failed':
-      return 'bg-red-500';
-    case 'completed':
-      return 'bg-slate-400';
-    default:
-      return 'bg-slate-400';
-  }
-}
-
 function getClassFill(agent: MaoAgentProjection): string {
   return (AGENT_CLASS_COLORS[agent.agent_class ?? ''] ?? FALLBACK_CLASS_COLOR).fill;
+}
+
+/** Small SVG exclamation icon for urgent indicators at D3 */
+function UrgentIcon() {
+  return (
+    <svg
+      width="8"
+      height="8"
+      viewBox="0 0 8 8"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="text-red-500 shrink-0"
+      aria-hidden="true"
+    >
+      <circle cx="4" cy="4" r="4" fill="currentColor" />
+      <text x="4" y="6" textAnchor="middle" fontSize="6" fill="white" fontWeight="bold">!</text>
+    </svg>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -248,6 +250,8 @@ export function MaoLeaseTree({
                           ? 'D3'
                           : 'D2'
                         : densityMode;
+                    const visuals = getStateVisuals(agent.state);
+                    const isUrgent = agent.urgency_level === 'urgent';
 
                     if (effectiveDensity === 'D4') {
                       return (
@@ -256,14 +260,15 @@ export function MaoLeaseTree({
                           type="button"
                           data-agent-id={agent.agent_id}
                           onClick={() => onSelectAgent(agent)}
-                          className={`w-6 h-6 rounded ${stateColorDot(agent.state)} ${
+                          className={`w-6 h-6 rounded ${visuals.dot} ${
                             selectedAgentId === agent.agent_id
                               ? 'ring-2 ring-primary'
                               : ''
-                          } ${getClassFill(agent)}`}
+                          } ${isUrgent ? 'ring-2 ring-red-500' : ''} ${getClassFill(agent)} ${visuals.pulse}`}
                           aria-label={resolveAgentLabel(agent)}
                           onMouseEnter={() => setHoveredId(agent.agent_id)}
                           onMouseLeave={() => setHoveredId(null)}
+                          data-testid="urgent-indicator-wrapper"
                         />
                       );
                     }
@@ -279,21 +284,25 @@ export function MaoLeaseTree({
                             selectedAgentId === agent.agent_id
                               ? 'border-primary bg-primary/10'
                               : getClassFill(agent)
-                          }`}
+                          } ${isUrgent ? 'border-2 border-red-500' : ''} ${visuals.pulse}`}
                           aria-label={resolveAgentLabel(agent)}
                           onMouseEnter={() => setHoveredId(agent.agent_id)}
                           onMouseLeave={() => setHoveredId(null)}
                         >
                           <span
-                            className={`inline-block w-2 h-2 rounded-full ${stateColorDot(agent.state)}`}
+                            className={`inline-block w-2 h-2 rounded-full ${visuals.dot}`}
                           />
                           <span className="truncate max-w-24">
                             {resolveAgentLabel(agent)}
                           </span>
+                          {isUrgent && (
+                            <span data-testid="urgent-indicator"><UrgentIcon /></span>
+                          )}
                         </button>
                       );
                     }
 
+                    // D0-D2: full root tile with agent class badge
                     return (
                       <button
                         key={agent.agent_id}
@@ -304,22 +313,30 @@ export function MaoLeaseTree({
                           selectedAgentId === agent.agent_id
                             ? 'border-primary bg-primary/10'
                             : `border-border bg-background`
-                        }`}
+                        } ${visuals.pulse}`}
                         aria-label={resolveAgentLabel(agent)}
                         onMouseEnter={() => setHoveredId(agent.agent_id)}
                         onMouseLeave={() => setHoveredId(null)}
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
-                            <div className="truncate text-sm font-medium">
+                            <div className="flex items-center gap-1.5 truncate text-sm font-medium">
                               {resolveAgentLabel(agent)}
+                              {agent.agent_class && (
+                                <span
+                                  className={`inline-flex items-center rounded-sm px-1 py-0.5 text-[10px] font-medium leading-none ${(AGENT_CLASS_COLORS[agent.agent_class] ?? FALLBACK_CLASS_COLOR).fill}`}
+                                  data-testid="agent-class-badge"
+                                >
+                                  {(AGENT_CLASS_COLORS[agent.agent_class] ?? FALLBACK_CLASS_COLOR).label}
+                                </span>
+                              )}
                             </div>
                             <div className="mt-1 text-xs text-muted-foreground">
                               {agent.state}
                             </div>
                           </div>
                           <span
-                            className={`inline-block w-2.5 h-2.5 rounded-full mt-1 ${stateColorDot(agent.state)}`}
+                            className={`inline-block w-2.5 h-2.5 rounded-full mt-1 ${visuals.dot}`}
                           />
                         </div>
                       </button>

--- a/self/ui/src/components/mao/mao-operating-surface.tsx
+++ b/self/ui/src/components/mao/mao-operating-surface.tsx
@@ -10,6 +10,7 @@ import type {
   MaoProjectControlResult,
   ProjectId,
 } from '@nous/shared';
+import { SYSTEM_SCOPE_SENTINEL_PROJECT_ID } from '@nous/shared';
 import { Badge } from '../badge';
 import { Button } from '../button';
 import { MaoAuditTrailPanel } from './mao-audit-trail-panel';
@@ -20,6 +21,7 @@ import { MaoInspectPopup } from './mao-inspect-popup';
 import { MaoLeaseTree } from './mao-lease-tree';
 import { MaoProjectControls } from './mao-project-controls';
 import { MaoRunGraph } from './mao-run-graph';
+import { resolveAgentLabel } from './mao-workflow-group-card';
 import { MaoSystemHealthStrip } from './mao-system-health-strip';
 import {
   MaoT3ConfirmationDialog,
@@ -184,6 +186,34 @@ export function MaoOperatingSurface() {
   }, [activeTab, activeTabState.selectedTarget, systemSnapshotQuery.data, snapshotQuery.data]);
 
   const popupOpen = selectedAgent != null;
+
+  // B1-e: Build a resolver function that looks up agent ID in the current snapshots
+  const resolveAgentLabelFn = React.useCallback(
+    (agentId: string): string => {
+      if (systemSnapshotQuery.data) {
+        const found = systemSnapshotQuery.data.agents.find(
+          (a) => a.agent_id === agentId,
+        );
+        if (found) return resolveAgentLabel(found);
+      }
+      if (snapshotQuery.data) {
+        const tile = snapshotQuery.data.grid.find(
+          (t) => t.agent.agent_id === agentId,
+        );
+        if (tile) return resolveAgentLabel(tile.agent);
+      }
+      return formatShortId(agentId);
+    },
+    [systemSnapshotQuery.data, snapshotQuery.data],
+  );
+
+  // B3-b: Derive project control projection for system tab agents
+  const systemTabProjectControlProjection = React.useMemo(() => {
+    if (activeTab !== 'system') return null;
+    if (!selectedAgent) return null;
+    if (selectedAgent.project_id === SYSTEM_SCOPE_SENTINEL_PROJECT_ID) return null;
+    return systemSnapshotQuery.data?.projectControls[selectedAgent.project_id as ProjectId] ?? null;
+  }, [activeTab, selectedAgent, systemSnapshotQuery.data]);
 
   const handleClosePopup = React.useCallback(() => {
     activeTabState.setSelectedTarget(null);
@@ -430,6 +460,14 @@ export function MaoOperatingSurface() {
       </div>
 
       {/* Tab content */}
+      {/*
+        * @todo START-005 — Unauthorized start attempt alert surface (system-level).
+        * This placeholder reserves the location for a future system-wide alert
+        * banner that surfaces unauthorized start attempt events from the backend.
+        * No runtime behavior. Deferred to follow-on WR.
+        */}
+      <div data-testid="start-005-stub-system" aria-hidden="true" style={{ display: 'none' }} />
+
       {activeTab === 'system' ? (
         <div data-testid="system-tab-content">
           {systemSnapshotQuery.isLoading || !systemSnapshot ? (
@@ -506,9 +544,11 @@ export function MaoOperatingSurface() {
         projectSnapshot={
           activeTab === 'projects' && snapshot ? snapshot : null
         }
+        projectControlProjection={systemTabProjectControlProjection}
         controlPending={controlMutation.isPending}
         lastControlResult={lastResult}
         onRequestControl={handleRequestControl}
+        resolveAgentLabel={resolveAgentLabelFn}
       />
 
       {/* T3 confirmation dialog */}

--- a/self/ui/src/components/mao/mao-project-controls.tsx
+++ b/self/ui/src/components/mao/mao-project-controls.tsx
@@ -10,12 +10,6 @@ import { Badge } from '../badge';
 import { Button } from '../button';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 
-const COMMAND_IDS: Record<MaoProjectControlAction, string> = {
-  pause_project: '6f139b92-f4fc-49b9-a1df-2d6b8149b001',
-  resume_project: '6f139b92-f4fc-49b9-a1df-2d6b8149b002',
-  hard_stop_project: '6f139b92-f4fc-49b9-a1df-2d6b8149b003',
-};
-
 export interface MaoProjectControlsProps {
   snapshot: MaoProjectSnapshot;
   pending: boolean;
@@ -136,7 +130,7 @@ export function MaoProjectControls({
                 onRequestControl({
                   action: button.action,
                   reason: reasonTrimmed,
-                  commandId: COMMAND_IDS[button.action],
+                  commandId: crypto.randomUUID(),
                 })
               }
             >

--- a/self/ui/src/components/mao/mao-project-controls.tsx
+++ b/self/ui/src/components/mao/mao-project-controls.tsx
@@ -96,6 +96,43 @@ export function MaoProjectControls({
           </div>
         </div>
 
+        {/* B2-a: Cortex review status surface */}
+        <div className="rounded-md border border-border px-3 py-2" data-testid="cortex-review-section">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            Cortex review
+          </div>
+          <div className="mt-1">
+            {control.pfc_project_review_status === 'none'
+              ? 'No active Cortex review'
+              : control.pfc_project_review_status}
+          </div>
+        </div>
+
+        {/* B2-b: Evidence links from resume_readiness_evidence_refs */}
+        {control.resume_readiness_evidence_refs &&
+        control.resume_readiness_evidence_refs.length > 0 ? (
+          <div className="space-y-1" data-testid="resume-readiness-evidence">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">
+              Resume readiness evidence
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {control.resume_readiness_evidence_refs.map((ref) => (
+                <button
+                  key={ref}
+                  type="button"
+                  className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted/20"
+                  data-evidence-ref={ref}
+                  onClick={() => {
+                    /* V1: in-app evidence link placeholder */
+                  }}
+                >
+                  {ref}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         <div className="rounded-md border border-border p-3">
           <div className="text-xs uppercase tracking-wide text-muted-foreground">
             Impact summary
@@ -149,8 +186,34 @@ export function MaoProjectControls({
             <div className="mt-1 text-xs text-muted-foreground">
               {lastResult.reason_code} • {lastResult.decision_ref}
             </div>
+            {/* B2-b: Evidence links from lastResult.evidenceRefs */}
+            {lastResult.evidenceRefs && lastResult.evidenceRefs.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1" data-testid="last-result-evidence">
+                {lastResult.evidenceRefs.map((ref) => (
+                  <button
+                    key={ref}
+                    type="button"
+                    className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted/20"
+                    data-evidence-ref={ref}
+                    onClick={() => {
+                      /* V1: in-app evidence link placeholder */
+                    }}
+                  >
+                    {ref}
+                  </button>
+                ))}
+              </div>
+            ) : null}
           </div>
         ) : null}
+
+        {/*
+          * @todo START-005 — Unauthorized start attempt alert surface (project-level).
+          * This placeholder reserves the location for a future per-project alert
+          * surface that renders unauthorized start attempt events.
+          * No runtime behavior. Deferred to follow-on WR.
+          */}
+        <div data-testid="start-005-stub" aria-hidden="true" style={{ display: 'none' }} />
       </CardContent>
     </Card>
   );

--- a/self/ui/src/components/mao/mao-run-graph.tsx
+++ b/self/ui/src/components/mao/mao-run-graph.tsx
@@ -5,6 +5,7 @@ import type { MaoRunGraphSnapshot } from '@nous/shared';
 import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 import { formatShortId } from './mao-links';
+import { getStateVisuals } from './mao-state-utils';
 
 export interface MaoRunGraphProps {
   graph: MaoRunGraphSnapshot;
@@ -46,10 +47,21 @@ export function MaoRunGraph({
                 (selectedNodeId === node.workflowNodeDefinitionId ||
                   selectedNodeId === node.id);
 
+              // State-based color coding for nodes
+              const stateClasses = node.state
+                ? getStateVisuals(node.state)
+                : null;
+              const nodeClasses = active
+                ? 'border-primary bg-primary/10'
+                : stateClasses
+                  ? `${stateClasses.tone} hover:bg-muted/20`
+                  : 'border-border hover:bg-muted/20';
+
               return (
                 <button
                   key={node.id}
                   type="button"
+                  data-testid="run-graph-node"
                   onClick={() =>
                     onSelectNode({
                       workflowRunId: node.workflowRunId,
@@ -57,11 +69,7 @@ export function MaoRunGraph({
                       agentId: node.agentId,
                     })
                   }
-                  className={`w-full rounded-md border px-3 py-2 text-left ${
-                    active
-                      ? 'border-primary bg-primary/10'
-                      : 'border-border hover:bg-muted/20'
-                  }`}
+                  className={`w-full rounded-md border px-3 py-2 text-left ${nodeClasses}`}
                 >
                   <div className="flex items-center justify-between gap-2">
                     <span className="font-medium">{node.label}</span>
@@ -87,23 +95,37 @@ export function MaoRunGraph({
               No dispatch or corrective arcs are available.
             </p>
           ) : (
-            graph.edges.map((edge) => (
-              <div
-                key={edge.id}
-                className="rounded-md border border-border px-3 py-2 text-sm"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-medium">
-                    {formatShortId(edge.fromNodeId)} {'->'}{' '}
-                    {formatShortId(edge.toNodeId)}
-                  </span>
-                  <Badge variant="outline">{edge.kind}</Badge>
+            graph.edges.map((edge) => {
+              const isCorrective = edge.kind !== 'dispatch';
+
+              return (
+                <div
+                  key={edge.id}
+                  data-testid={isCorrective ? 'corrective-arc' : undefined}
+                  className={`rounded-md border px-3 py-2 text-sm ${
+                    isCorrective
+                      ? 'border-amber-500/60 bg-amber-500/5 border-l-2 border-l-amber-500'
+                      : 'border-border'
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">
+                      {formatShortId(edge.fromNodeId)} {'->'}{' '}
+                      {formatShortId(edge.toNodeId)}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className={isCorrective ? 'border-amber-500 text-amber-500' : ''}
+                    >
+                      {edge.kind}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {edge.reasonCode} • {edge.evidenceRefs[0]}
+                  </div>
                 </div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  {edge.reasonCode} • {edge.evidenceRefs[0]}
-                </div>
-              </div>
-            ))
+              );
+            })
           )}
         </div>
       </CardContent>

--- a/self/ui/src/components/mao/mao-state-utils.ts
+++ b/self/ui/src/components/mao/mao-state-utils.ts
@@ -1,0 +1,93 @@
+import type { MaoAgentLifecycleState } from '@nous/shared';
+
+export interface StateColorResult {
+  /** Tailwind bg class for dot/square */
+  dot: string;
+  /** Tailwind border + bg classes for tile tone */
+  tone: string;
+  /** CSS utility class for motion pulse (empty string = no pulse) */
+  pulse: string;
+  /** true for completed, canceled, hard_stopped */
+  isTerminal: boolean;
+}
+
+/**
+ * Centralized state-to-visual mapping for all MAO agent tile surfaces.
+ * Eliminates the triplicated stateColorDot/toneClasses logic across
+ * mao-density-grid, mao-workflow-group-card, and mao-lease-tree.
+ */
+export function getStateVisuals(state: MaoAgentLifecycleState): StateColorResult {
+  switch (state) {
+    case 'running':
+    case 'resuming':
+      return {
+        dot: 'bg-emerald-500',
+        tone: 'border-emerald-500/40 bg-emerald-500/10',
+        pulse: 'nous-state-pulse-subtle',
+        isTerminal: false,
+      };
+    case 'blocked':
+    case 'waiting_pfc':
+      return {
+        dot: 'bg-amber-500',
+        tone: 'border-amber-500/40 bg-amber-500/10',
+        pulse: 'nous-state-pulse-strong',
+        isTerminal: false,
+      };
+    case 'failed':
+      return {
+        dot: 'bg-red-500',
+        tone: 'border-red-500/40 bg-red-500/10',
+        pulse: 'nous-state-pulse-strong',
+        isTerminal: false,
+      };
+    case 'completed':
+      return {
+        dot: 'bg-slate-400',
+        tone: 'border-slate-500/40 bg-slate-500/10',
+        pulse: '',
+        isTerminal: true,
+      };
+    case 'canceled':
+      return {
+        dot: 'bg-slate-500',
+        tone: 'border-slate-500/40 bg-slate-500/10',
+        pulse: '',
+        isTerminal: true,
+      };
+    case 'hard_stopped':
+      return {
+        dot: 'bg-red-700',
+        tone: 'border-red-700/40 bg-red-700/10',
+        pulse: '',
+        isTerminal: true,
+      };
+    default:
+      // paused, queued, ready, waiting_async
+      return {
+        dot: 'bg-slate-400',
+        tone: 'border-border bg-background',
+        pulse: '',
+        isTerminal: false,
+      };
+  }
+}
+
+/**
+ * Cluster rendering order for D4 density mode.
+ * Active states first, then passive, then terminal.
+ */
+export const CLUSTER_STATE_ORDER: MaoAgentLifecycleState[] = [
+  'running',
+  'resuming',
+  'blocked',
+  'waiting_pfc',
+  'failed',
+  'queued',
+  'ready',
+  'waiting_async',
+  'paused',
+  'completed',
+  'canceled',
+  'hard_stopped',
+];

--- a/self/ui/src/components/mao/mao-t3-confirmation-dialog.tsx
+++ b/self/ui/src/components/mao/mao-t3-confirmation-dialog.tsx
@@ -61,11 +61,21 @@ export function MaoT3ConfirmationDialog({
   onConfirm,
   onCancel,
 }: MaoT3ConfirmationDialogProps) {
+  const [confirmedProof, setConfirmedProof] =
+    React.useState<ConfirmationProof | null>(null);
+
   const proofMutation = trpc.opctl.requestConfirmationProof.useMutation({
     onSuccess: (proof) => {
-      onConfirm(proof);
+      setConfirmedProof(proof);
     },
   });
+
+  // Reset proof display state when dialog opens/closes
+  React.useEffect(() => {
+    if (!open) {
+      setConfirmedProof(null);
+    }
+  }, [open]);
 
   // Escape key handler
   React.useEffect(() => {
@@ -73,13 +83,18 @@ export function MaoT3ConfirmationDialog({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        onCancel();
+        if (confirmedProof) {
+          // If proof is displayed, Escape dismisses without executing
+          onCancel();
+        } else {
+          onCancel();
+        }
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, onCancel]);
+  }, [open, onCancel, confirmedProof]);
 
   if (!open) return null;
 
@@ -98,6 +113,108 @@ export function MaoT3ConfirmationDialog({
       tier: 'T3',
     });
   };
+
+  const handleDone = () => {
+    if (confirmedProof) {
+      onConfirm(confirmedProof);
+      setConfirmedProof(null);
+    }
+  };
+
+  // Proof display view — shown after confirmation proof is obtained
+  if (confirmedProof) {
+    return (
+      <div
+        className="fixed inset-0 flex items-center justify-center"
+        style={{
+          zIndex: 300,
+          animation: 'var(--nous-modal-enter)',
+        }}
+        data-testid="t3-confirmation-dialog"
+      >
+        <div
+          className="absolute inset-0 bg-black/50"
+          onClick={onCancel}
+          aria-hidden="true"
+        />
+        <div className="relative mx-4 w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg">
+          <h2 className="text-lg font-semibold">
+            Proof confirmed
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Confirmation proof obtained. Review details below, then click Done to
+            execute the control action.
+          </p>
+
+          <div className="mt-4 space-y-2" data-testid="proof-details">
+            <div className="rounded-md border border-border px-3 py-2">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                Proof ID
+              </div>
+              <div className="mt-1 font-mono text-xs" data-testid="proof-id">
+                {confirmedProof.proof_id}
+              </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="rounded-md border border-border px-3 py-2">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Issued at
+                </div>
+                <div className="mt-1 text-xs">
+                  {new Date(confirmedProof.issued_at).toLocaleString()}
+                </div>
+              </div>
+              <div className="rounded-md border border-border px-3 py-2">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Expires at
+                </div>
+                <div className="mt-1 text-xs">
+                  {new Date(confirmedProof.expires_at).toLocaleString()}
+                </div>
+              </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="rounded-md border border-border px-3 py-2">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Tier
+                </div>
+                <div className="mt-1">{confirmedProof.tier}</div>
+              </div>
+              <div className="rounded-md border border-border px-3 py-2">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Action
+                </div>
+                <div className="mt-1">{confirmedProof.action}</div>
+              </div>
+            </div>
+            <div className="rounded-md border border-border px-3 py-2">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                Scope hash
+              </div>
+              <div className="mt-1 truncate font-mono text-xs">
+                {confirmedProof.scope_hash}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <Button
+              variant="outline"
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDone}
+              data-testid="proof-done-button"
+            >
+              Done
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/self/ui/src/components/mao/mao-workflow-group-card.tsx
+++ b/self/ui/src/components/mao/mao-workflow-group-card.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import type { MaoAgentProjection, MaoDensityMode } from '@nous/shared';
+import { getStateVisuals } from './mao-state-utils';
 
 /** Agent class color mapping for edge connectors and tile accents */
 export interface AgentClassColor {
@@ -69,21 +70,22 @@ function tileSizeClasses(densityMode: MaoDensityMode): string {
   }
 }
 
-function stateColorDot(state: string): string {
-  switch (state) {
-    case 'running':
-    case 'resuming':
-      return 'bg-emerald-500';
-    case 'blocked':
-    case 'waiting_pfc':
-      return 'bg-amber-500';
-    case 'failed':
-      return 'bg-red-500';
-    case 'completed':
-      return 'bg-slate-400';
-    default:
-      return 'bg-slate-400';
-  }
+/** Small SVG exclamation icon for urgent indicators at D3 */
+function UrgentIcon() {
+  return (
+    <svg
+      width="8"
+      height="8"
+      viewBox="0 0 8 8"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="text-red-500 shrink-0"
+      aria-hidden="true"
+    >
+      <circle cx="4" cy="4" r="4" fill="currentColor" />
+      <text x="4" y="6" textAnchor="middle" fontSize="6" fill="white" fontWeight="bold">!</text>
+    </svg>
+  );
 }
 
 export interface MaoWorkflowGroupCardProps {
@@ -110,43 +112,97 @@ export function MaoWorkflowGroupCard({
         className={`relative rounded border ${classColor.fill} p-1`}
         data-testid="workflow-group-card"
       >
-        <button
-          type="button"
-          data-agent-id={orchestrator.agent_id}
-          onClick={() => onSelectAgent(orchestrator)}
-          className={`w-6 h-6 rounded ${stateColorDot(orchestrator.state)} ${
-            selectedAgentId === orchestrator.agent_id ? 'ring-2 ring-primary' : ''
-          }`}
-          aria-label={resolveAgentLabel(orchestrator)}
-          onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
-          onMouseLeave={() => setHoveredId(null)}
-        />
-        {hoveredId === orchestrator.agent_id && (
-          <div className="absolute z-10 -top-8 left-0 rounded bg-popover px-2 py-1 text-xs shadow-md border border-border whitespace-nowrap">
-            {resolveAgentLabel(orchestrator)}
-          </div>
-        )}
-        <div className="flex flex-wrap gap-0.5 mt-0.5">
-          {workers.map((w) => (
-            <div key={w.agent_id} className="relative">
+        {/* Orchestrator tile — D4 with hover-expand to D3 */}
+        {(() => {
+          const isHovered = hoveredId === orchestrator.agent_id;
+          const orchVisuals = getStateVisuals(orchestrator.state);
+          const orchUrgent = orchestrator.urgency_level === 'urgent';
+
+          if (isHovered) {
+            // Hover-expand: render D3 compact markup
+            return (
               <button
                 type="button"
-                data-agent-id={w.agent_id}
-                onClick={() => onSelectAgent(w)}
-                className={`w-6 h-6 rounded ${stateColorDot(w.state)} ${
-                  selectedAgentId === w.agent_id ? 'ring-2 ring-primary' : ''
-                }`}
-                aria-label={resolveAgentLabel(w)}
-                onMouseEnter={() => setHoveredId(w.agent_id)}
+                data-agent-id={orchestrator.agent_id}
+                onClick={() => onSelectAgent(orchestrator)}
+                className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium transition-colors hover:bg-muted/30 ${
+                  selectedAgentId === orchestrator.agent_id ? 'ring-1 ring-primary' : ''
+                } ${orchUrgent ? 'border-2 border-red-500' : ''} ${orchVisuals.pulse}`}
+                aria-label={resolveAgentLabel(orchestrator)}
+                onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
                 onMouseLeave={() => setHoveredId(null)}
-              />
-              {hoveredId === w.agent_id && (
-                <div className="absolute z-10 -top-8 left-0 rounded bg-popover px-2 py-1 text-xs shadow-md border border-border whitespace-nowrap">
-                  {resolveAgentLabel(w)}
+                data-testid="hover-expand-tile"
+              >
+                <span className={`inline-block w-2 h-2 rounded-full ${orchVisuals.dot}`} />
+                <span className="truncate max-w-24">
+                  {resolveAgentLabel(orchestrator)}
+                </span>
+                {orchUrgent && <UrgentIcon />}
+              </button>
+            );
+          }
+
+          return (
+            <button
+              type="button"
+              data-agent-id={orchestrator.agent_id}
+              onClick={() => onSelectAgent(orchestrator)}
+              className={`w-6 h-6 rounded ${orchVisuals.dot} ${
+                selectedAgentId === orchestrator.agent_id ? 'ring-2 ring-primary' : ''
+              } ${orchUrgent ? 'ring-2 ring-red-500' : ''} ${orchVisuals.pulse}`}
+              aria-label={resolveAgentLabel(orchestrator)}
+              onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
+              onMouseLeave={() => setHoveredId(null)}
+            />
+          );
+        })()}
+
+        <div className="flex flex-wrap gap-0.5 mt-0.5">
+          {workers.map((w) => {
+            const isHovered = hoveredId === w.agent_id;
+            const wVisuals = getStateVisuals(w.state);
+            const wUrgent = w.urgency_level === 'urgent';
+
+            if (isHovered) {
+              // Hover-expand: render D3 compact markup
+              return (
+                <div key={w.agent_id} className="relative">
+                  <button
+                    type="button"
+                    data-agent-id={w.agent_id}
+                    onClick={() => onSelectAgent(w)}
+                    className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors hover:bg-muted/30 ${
+                      selectedAgentId === w.agent_id ? 'ring-1 ring-primary' : ''
+                    } ${wUrgent ? 'border-2 border-red-500' : ''} ${wVisuals.pulse}`}
+                    aria-label={resolveAgentLabel(w)}
+                    onMouseEnter={() => setHoveredId(w.agent_id)}
+                    onMouseLeave={() => setHoveredId(null)}
+                    data-testid="hover-expand-tile"
+                  >
+                    <span className={`inline-block w-2 h-2 rounded-full ${wVisuals.dot}`} />
+                    <span className="truncate max-w-24 text-[10px]">{resolveAgentLabel(w)}</span>
+                    {wUrgent && <UrgentIcon />}
+                  </button>
                 </div>
-              )}
-            </div>
-          ))}
+              );
+            }
+
+            return (
+              <div key={w.agent_id} className="relative">
+                <button
+                  type="button"
+                  data-agent-id={w.agent_id}
+                  onClick={() => onSelectAgent(w)}
+                  className={`w-6 h-6 rounded ${wVisuals.dot} ${
+                    selectedAgentId === w.agent_id ? 'ring-2 ring-primary' : ''
+                  } ${wUrgent ? 'ring-2 ring-red-500' : ''} ${wVisuals.pulse}`}
+                  aria-label={resolveAgentLabel(w)}
+                  onMouseEnter={() => setHoveredId(w.agent_id)}
+                  onMouseLeave={() => setHoveredId(null)}
+                />
+              </div>
+            );
+          })}
         </div>
         <span className="text-[10px] text-muted-foreground">
           {workers.length + 1}
@@ -161,50 +217,66 @@ export function MaoWorkflowGroupCard({
         className={`rounded border ${classColor.fill} p-1.5`}
         data-testid="workflow-group-card"
       >
-        <button
-          type="button"
-          data-agent-id={orchestrator.agent_id}
-          onClick={() => onSelectAgent(orchestrator)}
-          className={`flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium transition-colors hover:bg-muted/30 ${
-            selectedAgentId === orchestrator.agent_id ? 'ring-1 ring-primary' : ''
-          }`}
-          aria-label={resolveAgentLabel(orchestrator)}
-          onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
-          onMouseLeave={() => setHoveredId(null)}
-        >
-          <span className={`inline-block w-2 h-2 rounded-full ${stateColorDot(orchestrator.state)}`} />
-          <span className="truncate max-w-24">
-            {hoveredId === orchestrator.agent_id
-              ? resolveAgentLabel(orchestrator)
-              : resolveAgentLabel(orchestrator).slice(0, 12)}
-          </span>
-        </button>
-        <div className="flex flex-wrap gap-1 mt-1">
-          {workers.map((w) => (
+        {(() => {
+          const orchVisuals = getStateVisuals(orchestrator.state);
+          const orchUrgent = orchestrator.urgency_level === 'urgent';
+          return (
             <button
-              key={w.agent_id}
               type="button"
-              data-agent-id={w.agent_id}
-              onClick={() => onSelectAgent(w)}
-              className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors hover:bg-muted/30 ${
-                selectedAgentId === w.agent_id ? 'ring-1 ring-primary' : ''
-              }`}
-              aria-label={resolveAgentLabel(w)}
-              onMouseEnter={() => setHoveredId(w.agent_id)}
+              data-agent-id={orchestrator.agent_id}
+              onClick={() => onSelectAgent(orchestrator)}
+              className={`flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium transition-colors hover:bg-muted/30 ${
+                selectedAgentId === orchestrator.agent_id ? 'ring-1 ring-primary' : ''
+              } ${orchUrgent ? 'border-2 border-red-500' : ''} ${orchVisuals.pulse}`}
+              aria-label={resolveAgentLabel(orchestrator)}
+              onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
               onMouseLeave={() => setHoveredId(null)}
             >
-              <span className={`inline-block w-2 h-2 rounded-full ${stateColorDot(w.state)}`} />
-              {hoveredId === w.agent_id && (
-                <span className="truncate max-w-24 text-[10px]">{resolveAgentLabel(w)}</span>
+              <span className={`inline-block w-2 h-2 rounded-full ${orchVisuals.dot}`} />
+              <span className="truncate max-w-24">
+                {hoveredId === orchestrator.agent_id
+                  ? resolveAgentLabel(orchestrator)
+                  : resolveAgentLabel(orchestrator).slice(0, 12)}
+              </span>
+              {orchUrgent && (
+                <span data-testid="urgent-indicator"><UrgentIcon /></span>
               )}
             </button>
-          ))}
+          );
+        })()}
+        <div className="flex flex-wrap gap-1 mt-1">
+          {workers.map((w) => {
+            const wVisuals = getStateVisuals(w.state);
+            const wUrgent = w.urgency_level === 'urgent';
+            return (
+              <button
+                key={w.agent_id}
+                type="button"
+                data-agent-id={w.agent_id}
+                onClick={() => onSelectAgent(w)}
+                className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors hover:bg-muted/30 ${
+                  selectedAgentId === w.agent_id ? 'ring-1 ring-primary' : ''
+                } ${wUrgent ? 'border-2 border-red-500' : ''} ${wVisuals.pulse}`}
+                aria-label={resolveAgentLabel(w)}
+                onMouseEnter={() => setHoveredId(w.agent_id)}
+                onMouseLeave={() => setHoveredId(null)}
+              >
+                <span className={`inline-block w-2 h-2 rounded-full ${wVisuals.dot}`} />
+                {hoveredId === w.agent_id && (
+                  <span className="truncate max-w-24 text-[10px]">{resolveAgentLabel(w)}</span>
+                )}
+                {wUrgent && (
+                  <span data-testid="urgent-indicator"><UrgentIcon /></span>
+                )}
+              </button>
+            );
+          })}
         </div>
       </div>
     );
   }
 
-  // D1 and D2 — full card rendering
+  // D0, D1, D2 — full card rendering
   const isLarge = densityMode === 'D1' || densityMode === 'D0';
   const tileSize = tileSizeClasses(densityMode);
 
@@ -214,59 +286,67 @@ export function MaoWorkflowGroupCard({
       data-testid="workflow-group-card"
     >
       {/* Orchestrator — header */}
-      <button
-        type="button"
-        data-agent-id={orchestrator.agent_id}
-        onClick={() => onSelectAgent(orchestrator)}
-        className={`w-full rounded-lg border p-3 text-left transition-colors hover:bg-muted/20 ${
-          selectedAgentId === orchestrator.agent_id
-            ? 'border-primary bg-primary/10'
-            : 'border-border bg-background'
-        } ${tileSize}`}
-        aria-label={resolveAgentLabel(orchestrator)}
-      >
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            <div className="truncate text-sm font-medium">
-              {resolveAgentLabel(orchestrator)}
+      {(() => {
+        const orchVisuals = getStateVisuals(orchestrator.state);
+        return (
+          <button
+            type="button"
+            data-agent-id={orchestrator.agent_id}
+            onClick={() => onSelectAgent(orchestrator)}
+            className={`w-full rounded-lg border p-3 text-left transition-colors hover:bg-muted/20 ${
+              selectedAgentId === orchestrator.agent_id
+                ? 'border-primary bg-primary/10'
+                : 'border-border bg-background'
+            } ${tileSize} ${orchVisuals.pulse}`}
+            aria-label={resolveAgentLabel(orchestrator)}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">
+                  {resolveAgentLabel(orchestrator)}
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {orchestrator.state}
+                </div>
+              </div>
+              <span className={`inline-block w-2.5 h-2.5 rounded-full mt-1 ${orchVisuals.dot}`} />
             </div>
-            <div className="mt-1 text-xs text-muted-foreground">
-              {orchestrator.state}
-            </div>
-          </div>
-          <span className={`inline-block w-2.5 h-2.5 rounded-full mt-1 ${stateColorDot(orchestrator.state)}`} />
-        </div>
-      </button>
+          </button>
+        );
+      })()}
 
       {/* Workers — horizontal flex-wrap */}
       {workers.length > 0 && (
         <div className="flex flex-wrap gap-2 mt-2" data-testid="workers-container">
-          {workers.map((w) => (
-            <button
-              key={w.agent_id}
-              type="button"
-              data-agent-id={w.agent_id}
-              onClick={() => onSelectAgent(w)}
-              className={`rounded-lg border p-2 text-left transition-colors hover:bg-muted/20 ${
-                selectedAgentId === w.agent_id
-                  ? 'border-primary bg-primary/10'
-                  : 'border-border bg-background'
-              } ${tileSize}`}
-              aria-label={resolveAgentLabel(w)}
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0">
-                  <div className="truncate text-sm font-medium">
-                    {resolveAgentLabel(w)}
+          {workers.map((w) => {
+            const wVisuals = getStateVisuals(w.state);
+            return (
+              <button
+                key={w.agent_id}
+                type="button"
+                data-agent-id={w.agent_id}
+                onClick={() => onSelectAgent(w)}
+                className={`rounded-lg border p-2 text-left transition-colors hover:bg-muted/20 ${
+                  selectedAgentId === w.agent_id
+                    ? 'border-primary bg-primary/10'
+                    : 'border-border bg-background'
+                } ${tileSize} ${wVisuals.pulse}`}
+                aria-label={resolveAgentLabel(w)}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {resolveAgentLabel(w)}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {w.state}
+                    </div>
                   </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    {w.state}
-                  </div>
+                  <span className={`inline-block w-2 h-2 rounded-full mt-1 ${wVisuals.dot}`} />
                 </div>
-                <span className={`inline-block w-2 h-2 rounded-full mt-1 ${stateColorDot(w.state)}`} />
-              </div>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/self/ui/src/styles/animations.css
+++ b/self/ui/src/styles/animations.css
@@ -146,6 +146,44 @@
     var(--nous-ease-out);
 }
 
+/* State-based motion pulse — subtle for running/resuming agents */
+@keyframes nous-state-pulse-subtle {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.85;
+    transform: scale(1.01);
+  }
+}
+
+/* State-based motion pulse — strong for blocked/waiting_pfc/failed agents */
+@keyframes nous-state-pulse-strong {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.7;
+    transform: scale(1.03);
+  }
+}
+
+.nous-state-pulse-subtle {
+  animation: nous-state-pulse-subtle 2s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.nous-state-pulse-strong {
+  animation: nous-state-pulse-strong 1.2s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .nous-animate-pulse,
   .nous-animate-shake,
@@ -153,7 +191,9 @@
   .nous-animate-flash-error,
   .nous-animate-slide-in-right,
   .nous-animate-fade-in-up,
-  .nous-animate-fade-in-scale {
+  .nous-animate-fade-in-scale,
+  .nous-state-pulse-subtle,
+  .nous-state-pulse-strong {
     animation: none !important;
     transition-duration: 0s !important;
   }


### PR DESCRIPTION
## Summary

MAO UI conformance overhaul closing 25 spec-to-code gaps across the full MAO operating surface. Implements all Phase 1 work (3 sub-phases) per the qualified WR-106 discovery report.

- **SP 1.1 — Runtime Infrastructure:** Fixed single-use command ID bug (`crypto.randomUUID()`), added `agentClass` to WorkflowNodeMetadataSchema, extended lifecycle states to 12 (+canceled, +hard_stopped), agent class propagation in MaoProjectionService with `deriveClassFromNodeKind` fallback, ACTION_TIER_MAP export
- **SP 1.2 — Visual Conformance:** D3/D4 compact tile rendering, state-based motion pulse CSS (GPU-composited, respects `prefers-reduced-motion`), urgent indicators at all densities with pinning, D4 clustering by lifecycle state, D4 hover-expand, agent class badge in MaoLeaseTree, color-coded nodes + corrective arc emphasis in MaoRunGraph
- **SP 1.3 — Control Surfaces:** `display_name` as primary label in MaoInspectPanel with dispatch lineage, Cortex reason/risk/mitigation/evidence surfaces in MaoProjectControls, system tab project controls wiring, T3 confirmation proof display, sentinel-aware audit trail, START-005 stubs

**29 files changed, 2,735 insertions(+), 220 deletions(-). 111 new tests across 8 test files.**

## Test plan

- [x] `pnpm --filter @nous/shared build` — pass
- [x] `pnpm --filter @nous/shared test --run` — pass
- [x] `pnpm --filter @nous/subcortex-mao build` — pass
- [x] `pnpm --filter @nous/subcortex-mao test --run` — 64 passed (3 files)
- [x] `pnpm --filter @nous/ui test --run` — 949 passed (80 files)
- [x] BT Round 1 — Principal runtime verification approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)