### PR TITLE
feat: OpenUI generative chat cards — WR-110

### DIFF
--- a/self/apps/shared-server/__tests__/chat-router.test.ts
+++ b/self/apps/shared-server/__tests__/chat-router.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock all heavy dependencies to avoid worktree resolution issues
+// Provide BacklogEntryStatusSchema inline to avoid worktree resolution issues
+vi.mock('@nous/cortex-core', async () => {
+  const { z } = await import('zod');
+  return {
+    BacklogEntryStatusSchema: z.enum(['queued', 'active', 'suspended', 'completed', 'failed']),
+  };
+});
+vi.mock('@nous/cortex-pfc', () => ({}));
+vi.mock('@nous/subcortex-apps', () => ({}));
+vi.mock('@nous/subcortex-artifacts', () => ({}));
+vi.mock('@nous/subcortex-coding-agents', () => ({}));
+vi.mock('@nous/subcortex-communication-gateway', () => ({}));
+vi.mock('@nous/subcortex-endpoint-trust', () => ({}));
+vi.mock('@nous/subcortex-escalation', () => ({}));
+vi.mock('@nous/subcortex-gtm', () => ({}));
+vi.mock('@nous/subcortex-mao', () => ({}));
+vi.mock('@nous/subcortex-nudges', () => ({}));
+vi.mock('@nous/subcortex-opctl', () => ({}));
+vi.mock('@nous/subcortex-projects', () => ({}));
+vi.mock('@nous/subcortex-providers', () => ({}));
+vi.mock('@nous/subcortex-public-mcp', () => ({}));
+vi.mock('@nous/subcortex-registry', () => ({}));
+vi.mock('@nous/subcortex-router', () => ({}));
+vi.mock('@nous/subcortex-scheduler', () => ({}));
+vi.mock('@nous/subcortex-tools', () => ({}));
+vi.mock('@nous/subcortex-voice-control', () => ({}));
+vi.mock('@nous/subcortex-witnessd', () => ({}));
+vi.mock('@nous/subcortex-workflows', () => ({}));
+vi.mock('@nous/memory-access', () => ({}));
+vi.mock('@nous/memory-knowledge-index', () => ({}));
+vi.mock('@nous/memory-mwc', () => ({}));
+vi.mock('@nous/memory-stm', () => ({}));
+vi.mock('@nous/memory-distillation', () => ({}));
+vi.mock('@nous/autonomic-config', () => ({}));
+vi.mock('@nous/autonomic-credentials', () => ({}));
+vi.mock('@nous/autonomic-embeddings', () => ({}));
+vi.mock('@nous/autonomic-health', () => ({}));
+vi.mock('@nous/autonomic-runtime', () => ({}));
+vi.mock('@nous/autonomic-storage', () => ({}));
+
+function createMockContext() {
+  return {
+    coreExecutor: {
+      executeTurn: vi.fn().mockResolvedValue({
+        response: 'Follow-up response',
+        traceId: 'trace-123',
+        memoryCandidates: [],
+        pfcDecisions: [],
+        contentType: 'text',
+      }),
+      superviseProject: vi.fn(),
+      getTrace: vi.fn(),
+    },
+    gatewayRuntime: {
+      submitTaskToSystem: vi.fn().mockResolvedValue({
+        runId: 'run-abc',
+        dispatchRef: 'ref-xyz',
+        acceptedAt: '2026-03-27T00:00:00Z',
+        source: 'card-action',
+      }),
+      boot: vi.fn(),
+      getStatus: vi.fn(),
+      getAgentStatus: vi.fn(),
+      getBacklog: vi.fn(),
+      getSystemRunActivity: vi.fn(),
+      getActiveSystemRunSummaries: vi.fn(),
+    },
+    stmStore: { getContext: vi.fn().mockResolvedValue({ entries: [], summary: undefined, tokenCount: 0 }) },
+  } as any;
+}
+
+describe('chat.sendAction', () => {
+  async function getCaller(ctx: any) {
+    const { chatRouter } = await import('../src/trpc/routers/chat.js');
+    const { router: createRouter } = await import('../src/trpc/trpc.js');
+    const testRouter = createRouter({ chat: chatRouter });
+    return testRouter.createCaller(ctx);
+  }
+
+  // ── Tier 2: Behavior Tests ──────────────────────────────────────────────
+
+  it('followup action calls coreExecutor.executeTurn with correct args', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+
+    const result = await caller.chat.sendAction({
+      action: { actionType: 'followup', cardId: 'card-1', payload: { prompt: 'Tell me more' } },
+    });
+
+    expect(ctx.coreExecutor.executeTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Tell me more',
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe('Follow-up response');
+    expect(result.traceId).toBe('trace-123');
+    expect(result.contentType).toBe('text');
+  });
+
+  it('followup action returns normalized ActionResult', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+
+    const result = await caller.chat.sendAction({
+      action: { actionType: 'followup', cardId: 'card-1', payload: { prompt: 'Details' } },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: 'Follow-up response',
+      traceId: 'trace-123',
+      contentType: 'text',
+    });
+  });
+
+  it('approve action calls gatewayRuntime.submitTaskToSystem', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+    const action = { actionType: 'approve' as const, cardId: 'card-2', payload: { reason: 'ok' } };
+
+    const result = await caller.chat.sendAction({ action });
+
+    expect(ctx.gatewayRuntime.submitTaskToSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: 'Card action: approve',
+        detail: { cardAction: action },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe('Action submitted');
+    expect(result.traceId).toBe('run-abc');
+  });
+
+  it('reject action calls gatewayRuntime.submitTaskToSystem', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+    const action = { actionType: 'reject' as const, cardId: 'card-3', payload: { reason: 'no' } };
+
+    const result = await caller.chat.sendAction({ action });
+
+    expect(ctx.gatewayRuntime.submitTaskToSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: 'Card action: reject',
+        detail: { cardAction: action },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe('Action submitted');
+  });
+
+  it('submit action calls gatewayRuntime.submitTaskToSystem with form payload in detail', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+    const action = { actionType: 'submit' as const, cardId: 'card-4', payload: { name: 'test', value: 42 } };
+
+    const result = await caller.chat.sendAction({ action });
+
+    expect(ctx.gatewayRuntime.submitTaskToSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: 'Card action: submit',
+        detail: { cardAction: action },
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('navigate action throws TRPCError with BAD_REQUEST', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+
+    await expect(
+      caller.chat.sendAction({
+        action: { actionType: 'navigate', cardId: 'card-5', payload: { panel: 'settings' } },
+      }),
+    ).rejects.toThrow('Navigate actions must be handled client-side');
+  });
+
+  it('invalid actionType rejected by Zod validation', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+
+    await expect(
+      caller.chat.sendAction({
+        action: { actionType: 'invalid' as any, cardId: 'card-6', payload: {} },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('missing cardId rejected by Zod validation', async () => {
+    const ctx = createMockContext();
+    const caller = await getCaller(ctx);
+
+    await expect(
+      caller.chat.sendAction({
+        action: { actionType: 'approve', payload: {} } as any,
+      }),
+    ).rejects.toThrow();
+  });
+
+  // ── Tier 3: Edge Case Tests ─────────────────────────────────────────────
+
+  it('followup action propagates executeTurn error', async () => {
+    const ctx = createMockContext();
+    ctx.coreExecutor.executeTurn.mockRejectedValueOnce(new Error('Gateway failure'));
+    const caller = await getCaller(ctx);
+
+    await expect(
+      caller.chat.sendAction({
+        action: { actionType: 'followup', cardId: 'card-1', payload: { prompt: 'Test' } },
+      }),
+    ).rejects.toThrow('Gateway failure');
+  });
+
+  it('approve action propagates submitTaskToSystem error', async () => {
+    const ctx = createMockContext();
+    ctx.gatewayRuntime.submitTaskToSystem.mockRejectedValueOnce(new Error('System inbox full'));
+    const caller = await getCaller(ctx);
+
+    await expect(
+      caller.chat.sendAction({
+        action: { actionType: 'approve', cardId: 'card-2', payload: {} },
+      }),
+    ).rejects.toThrow('System inbox full');
+  });
+});

--- a/self/apps/shared-server/src/trpc/routers/chat.ts
+++ b/self/apps/shared-server/src/trpc/routers/chat.ts
@@ -3,8 +3,10 @@
  */
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
+import { TRPCError } from '@trpc/server';
 import { router, publicProcedure } from '../trpc';
-import { ProjectIdSchema } from '@nous/shared';
+import { ProjectIdSchema, CardActionSchema } from '@nous/shared';
+import type { TraceId } from '@nous/shared';
 
 export const chatRouter = router({
   sendMessage: publicProcedure
@@ -15,7 +17,7 @@ export const chatRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const traceId = randomUUID() as import('@nous/shared').TraceId;
+      const traceId = randomUUID() as TraceId;
       const result = await ctx.coreExecutor.executeTurn({
         message: input.message,
         projectId: input.projectId,
@@ -32,5 +34,54 @@ export const chatRouter = router({
         return { entries: [], summary: undefined, tokenCount: 0 };
       }
       return ctx.stmStore.getContext(input.projectId);
+    }),
+
+  sendAction: publicProcedure
+    .input(
+      z.object({
+        action: CardActionSchema,
+        projectId: ProjectIdSchema.optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { action, projectId } = input;
+
+      switch (action.actionType) {
+        case 'followup': {
+          const traceId = randomUUID() as TraceId;
+          const result = await ctx.coreExecutor.executeTurn({
+            message: String(action.payload.prompt),
+            projectId,
+            traceId,
+          });
+          return {
+            ok: true as const,
+            message: result.response,
+            traceId: result.traceId,
+            contentType: result.contentType,
+          };
+        }
+
+        case 'approve':
+        case 'reject':
+        case 'submit': {
+          const receipt = await ctx.gatewayRuntime.submitTaskToSystem({
+            task: `Card action: ${action.actionType}`,
+            projectId,
+            detail: { cardAction: action },
+          });
+          return {
+            ok: true as const,
+            message: 'Action submitted',
+            traceId: receipt.runId,
+          };
+        }
+
+        case 'navigate':
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Navigate actions must be handled client-side',
+          });
+      }
     }),
 });

--- a/self/apps/shared-server/src/trpc/routers/chat.ts
+++ b/self/apps/shared-server/src/trpc/routers/chat.ts
@@ -22,7 +22,7 @@ export const chatRouter = router({
         traceId,
       });
 
-      return { response: result.response, traceId: result.traceId };
+      return { response: result.response, traceId: result.traceId, contentType: result.contentType };
     }),
 
   getHistory: publicProcedure

--- a/self/cortex/core/src/__tests__/gateway-runtime/card-prompt-injection.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/card-prompt-injection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { CARD_PROMPT_FRAGMENT } from '../../gateway-runtime/card-prompt-fragment.js';
+
+describe('CARD_PROMPT_FRAGMENT — content contract', () => {
+  // ── Tier 1: Contract Tests ─────────────────────────────────────────────
+
+  it('contains %%openui format instructions', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('%%openui');
+  });
+
+  it('contains all 5 card type names', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('StatusCard');
+    expect(CARD_PROMPT_FRAGMENT).toContain('ActionCard');
+    expect(CARD_PROMPT_FRAGMENT).toContain('ApprovalCard');
+    expect(CARD_PROMPT_FRAGMENT).toContain('WorkflowCard');
+    expect(CARD_PROMPT_FRAGMENT).toContain('FollowUpBlock');
+  });
+
+  it('contains "when to use" guidance', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('When to use cards');
+  });
+
+  it('contains "when NOT to use" guidance', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('When NOT to use cards');
+  });
+
+  it('contains card type reference section', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('Card type reference');
+  });
+
+  it('contains format section', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('Format:');
+    expect(CARD_PROMPT_FRAGMENT).toContain('Prefix card responses with %%openui');
+  });
+
+  it('is a non-empty string', () => {
+    expect(typeof CARD_PROMPT_FRAGMENT).toBe('string');
+    expect(CARD_PROMPT_FRAGMENT.length).toBeGreaterThan(100);
+  });
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/gateway-turn-executor.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/gateway-turn-executor.test.ts
@@ -205,4 +205,134 @@ describe('GatewayBackedTurnExecutor', () => {
 
     expect(result.response).toBe('[suspended: Lane lease held.]');
   });
+
+  it('propagates contentType through the pipeline for OpenUI-prefixed output', async () => {
+    const stmEntries: Array<{ role: string; content: string; timestamp: string; metadata?: Record<string, unknown> }> = [];
+    const provider = {
+      invoke: vi.fn().mockResolvedValue({
+        output: JSON.stringify({
+          response: '%%openui\n<StatusCard title="Test" status="active" message="Hi" />',
+          toolCalls: [],
+          memoryCandidates: [],
+        }),
+        providerId: '00000000-0000-0000-0000-000000000001',
+        usage: {},
+        traceId: '550e8400-e29b-41d4-a716-446655440199',
+      }),
+      stream: async function* () {},
+      getConfig: () => ({
+        id: '00000000-0000-0000-0000-000000000001',
+        name: 'mock',
+        type: 'text' as const,
+        modelId: 'mock',
+        isLocal: true,
+        capabilities: [],
+      }),
+    };
+
+    const executor = new GatewayBackedTurnExecutor({
+      modelRouter: {
+        routeWithEvidence: vi.fn().mockResolvedValue({
+          providerId: '00000000-0000-0000-0000-000000000001',
+          evidence: {},
+        }),
+      } as any,
+      getProvider: vi.fn().mockReturnValue(provider as any),
+      documentStore: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn(),
+      } as any,
+      stmStore: {
+        getContext: vi.fn().mockResolvedValue({ entries: [], tokenCount: 0 }),
+        append: vi.fn(async (_projectId, entry) => {
+          stmEntries.push(entry);
+        }),
+      } as any,
+      mwcPipeline: {
+        submit: vi.fn(),
+        mutate: vi.fn().mockResolvedValue({ applied: true, reason: 'ok', reasonCode: 'ok' }),
+      },
+    });
+
+    const result = await executor.executeTurn({
+      message: 'Show status',
+      projectId: '00000000-0000-0000-0000-000000000099' as import('@nous/shared').ProjectId,
+      traceId: '550e8400-e29b-41d4-a716-446655440188' as import('@nous/shared').TraceId,
+    });
+
+    // contentType should be propagated in the return value
+    expect(result.contentType).toBe('openui');
+    // Prefix should be stripped from response
+    expect(result.response).toBe('<StatusCard title="Test" status="active" message="Hi" />');
+    expect(result.response).not.toContain('%%openui');
+
+    // STM assistant entry should have contentType in metadata
+    const assistantEntry = stmEntries.find(e => e.role === 'assistant');
+    expect(assistantEntry).toBeDefined();
+    expect(assistantEntry?.metadata).toEqual({ contentType: 'openui' });
+    expect(assistantEntry?.content).not.toContain('%%openui');
+  });
+
+  it('does not include contentType metadata for plain text output', async () => {
+    const stmEntries: Array<{ role: string; content: string; timestamp: string; metadata?: Record<string, unknown> }> = [];
+    const provider = {
+      invoke: vi.fn().mockResolvedValue({
+        output: JSON.stringify({
+          response: 'Just a normal reply',
+          toolCalls: [],
+          memoryCandidates: [],
+        }),
+        providerId: '00000000-0000-0000-0000-000000000001',
+        usage: {},
+        traceId: '550e8400-e29b-41d4-a716-446655440199',
+      }),
+      stream: async function* () {},
+      getConfig: () => ({
+        id: '00000000-0000-0000-0000-000000000001',
+        name: 'mock',
+        type: 'text' as const,
+        modelId: 'mock',
+        isLocal: true,
+        capabilities: [],
+      }),
+    };
+
+    const executor = new GatewayBackedTurnExecutor({
+      modelRouter: {
+        routeWithEvidence: vi.fn().mockResolvedValue({
+          providerId: '00000000-0000-0000-0000-000000000001',
+          evidence: {},
+        }),
+      } as any,
+      getProvider: vi.fn().mockReturnValue(provider as any),
+      documentStore: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn(),
+      } as any,
+      stmStore: {
+        getContext: vi.fn().mockResolvedValue({ entries: [], tokenCount: 0 }),
+        append: vi.fn(async (_projectId, entry) => {
+          stmEntries.push(entry);
+        }),
+      } as any,
+      mwcPipeline: {
+        submit: vi.fn(),
+        mutate: vi.fn().mockResolvedValue({ applied: true, reason: 'ok', reasonCode: 'ok' }),
+      },
+    });
+
+    const result = await executor.executeTurn({
+      message: 'Hello',
+      projectId: '00000000-0000-0000-0000-000000000099' as import('@nous/shared').ProjectId,
+      traceId: '550e8400-e29b-41d4-a716-446655440188' as import('@nous/shared').TraceId,
+    });
+
+    // Plain text should have contentType text (or undefined)
+    expect(result.contentType).toBe('text');
+
+    // STM assistant entry should NOT have metadata with contentType
+    const assistantEntry = stmEntries.find(e => e.role === 'assistant');
+    expect(assistantEntry).toBeDefined();
+    expect(assistantEntry?.metadata).toBeUndefined();
+  });
 });

--- a/self/cortex/core/src/__tests__/output-parser.test.ts
+++ b/self/cortex/core/src/__tests__/output-parser.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { parseModelOutput, type ParsedModelOutput } from '../output-parser.js';
+import type { TraceId } from '@nous/shared';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440000' as TraceId;
+
+describe('parseModelOutput — contentType detection', () => {
+  // ---------------------------------------------------------------------------
+  // Tier 1 — Contract
+  // ---------------------------------------------------------------------------
+
+  it('ParsedModelOutput includes optional contentType field', () => {
+    const result: ParsedModelOutput = parseModelOutput('hello', TRACE_ID);
+    // Type-level: if this compiles, the field exists
+    expect(typeof result.contentType === 'string' || result.contentType === undefined).toBe(true);
+  });
+
+  it('returns object with contentType property', () => {
+    const result = parseModelOutput('test', TRACE_ID);
+    expect(result).toHaveProperty('contentType');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 2 — Behavior
+  // ---------------------------------------------------------------------------
+
+  it('plain text input: no prefix, response unchanged, contentType text', () => {
+    const result = parseModelOutput('Hello, world!', TRACE_ID);
+    expect(result.response).toBe('Hello, world!');
+    expect(result.contentType).toBe('text');
+  });
+
+  it('%%openui\\n prefixed input: prefix stripped, contentType openui', () => {
+    const input = '%%openui\n<StatusCard title="Test" status="active" message="Hello" />';
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.response).toBe('<StatusCard title="Test" status="active" message="Hello" />');
+    expect(result.contentType).toBe('openui');
+  });
+
+  it('JSON envelope with %%openui\\n in response field: prefix stripped, contentType openui', () => {
+    const input = JSON.stringify({
+      response: '%%openui\n<StatusCard title="Test" status="active" message="Hi" />',
+      toolCalls: [],
+      memoryCandidates: [],
+    });
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.response).toBe('<StatusCard title="Test" status="active" message="Hi" />');
+    expect(result.contentType).toBe('openui');
+  });
+
+  it('object input with %%openui\\n in response field: prefix stripped, contentType openui', () => {
+    const input = {
+      response: '%%openui\n<ActionCard title="Act" description="Do" actions={[]} />',
+      toolCalls: [],
+    };
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.response).toBe('<ActionCard title="Act" description="Do" actions={[]} />');
+    expect(result.contentType).toBe('openui');
+  });
+
+  it('empty string: contentType text, empty response', () => {
+    const result = parseModelOutput('', TRACE_ID);
+    expect(result.response).toBe('');
+    expect(result.contentType).toBe('text');
+  });
+
+  it('null input: no crash, contentType text', () => {
+    const result = parseModelOutput(null, TRACE_ID);
+    expect(result.contentType).toBe('text');
+  });
+
+  it('undefined input: no crash, contentType text', () => {
+    const result = parseModelOutput(undefined, TRACE_ID);
+    expect(result.contentType).toBe('text');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 3 — Edge Cases
+  // ---------------------------------------------------------------------------
+
+  it('%%openui without trailing \\n: treated as plain text', () => {
+    const result = parseModelOutput('%%openui<StatusCard />', TRACE_ID);
+    expect(result.response).toBe('%%openui<StatusCard />');
+    expect(result.contentType).toBe('text');
+  });
+
+  it('%%openui\\n prefix but no content after: contentType openui, empty response', () => {
+    const result = parseModelOutput('%%openui\n', TRACE_ID);
+    expect(result.response).toBe('');
+    expect(result.contentType).toBe('openui');
+  });
+
+  it('multiple %%openui\\n prefixes: only first stripped', () => {
+    const result = parseModelOutput('%%openui\n%%openui\n<Card />', TRACE_ID);
+    expect(result.response).toBe('%%openui\n<Card />');
+    expect(result.contentType).toBe('openui');
+  });
+
+  it('JSON envelope with plain text response: contentType text', () => {
+    const input = JSON.stringify({
+      response: 'Just plain text response.',
+      toolCalls: [],
+      memoryCandidates: [],
+    });
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.response).toBe('Just plain text response.');
+    expect(result.contentType).toBe('text');
+  });
+
+  it('object input with plain text response: contentType text', () => {
+    const result = parseModelOutput({ response: 'Plain text.' }, TRACE_ID);
+    expect(result.response).toBe('Plain text.');
+    expect(result.contentType).toBe('text');
+  });
+});

--- a/self/cortex/core/src/gateway-runtime/card-prompt-fragment.ts
+++ b/self/cortex/core/src/gateway-runtime/card-prompt-fragment.ts
@@ -1,0 +1,34 @@
+/**
+ * Card prompt fragment — teaches Worker agents how to produce OpenUI card output.
+ * Canonical human-readable reference: self/ui/src/components/chat/cards/card-prompt-fragment.md
+ *
+ * This is extracted to its own file so that:
+ * 1. Tests can import it without resolving the full gateway-turn-executor dependency tree.
+ * 2. The constant is co-located with the gateway runtime but independently testable.
+ */
+export const CARD_PROMPT_FRAGMENT = `## Structured Response Cards
+
+You can respond with interactive cards using OpenUI markup when the situation calls for structured interaction. Use the %%openui prefix to indicate card content.
+
+### When to use cards:
+- Presenting a decision that requires user approval or choice (ActionCard or ApprovalCard)
+- Reporting operation status with progress (StatusCard)
+- Summarizing a workflow with actionable options (WorkflowCard)
+- Suggesting follow-up actions after completing a task (FollowUpBlock)
+
+### When NOT to use cards:
+- Simple conversational replies, explanations, or discussions
+- Responses that are purely informational with no actionable component
+- When the user asked a question that deserves a direct text answer
+- Error messages or apologies -- use plain text
+
+### Card type reference:
+- StatusCard: { title, status: active|complete|error|waiting, message, detail?, progress? }
+- ActionCard: { title, description, actions: [{ label, actionType, payload?, variant? }] }
+- ApprovalCard: { title, description, tier: t1|t2|t3, command, context? }
+- WorkflowCard: { title, workflowId, nodeCount?, status?, summary? }
+- FollowUpBlock: { suggestions: [{ label, prompt?, actionType?, payload? }] }
+
+### Format:
+Prefix card responses with %%openui on its own line, then the card markup.
+You may mix plain text and cards in a single response -- text before %%openui is rendered normally.`;

--- a/self/cortex/core/src/gateway-runtime/card-prompt-fragment.ts
+++ b/self/cortex/core/src/gateway-runtime/card-prompt-fragment.ts
@@ -23,12 +23,43 @@ You can respond with interactive cards using OpenUI markup when the situation ca
 - Error messages or apologies -- use plain text
 
 ### Card type reference:
-- StatusCard: { title, status: active|complete|error|waiting, message, detail?, progress? }
-- ActionCard: { title, description, actions: [{ label, actionType, payload?, variant? }] }
-- ApprovalCard: { title, description, tier: t1|t2|t3, command, context? }
-- WorkflowCard: { title, workflowId, nodeCount?, status?, summary? }
-- FollowUpBlock: { suggestions: [{ label, prompt?, actionType?, payload? }] }
+
+Each card is written as a self-closing XML-style tag with PascalCase name and props.
+String props use key="value". Non-string props (numbers, arrays, objects) use key={json}.
+
+**StatusCard** -- report operation status with optional progress
+Required: title, status (active|complete|error|waiting), message
+Optional: detail, progress (0-100)
+<StatusCard title="Indexing complete" status="complete" message="Processed 142 files" progress={100} />
+
+**ActionCard** -- present action buttons for user choice
+Required: title, description, actions (array of {label, actionType: approve|reject|navigate|followup})
+Optional per action: payload, variant (primary|secondary|ghost, default: secondary)
+<ActionCard title="Deploy options" description="Choose a deployment target" actions={[{"label":"Production","actionType":"approve","variant":"primary"},{"label":"Staging","actionType":"approve","variant":"secondary"}]} />
+
+**ApprovalCard** -- request user approval with tier-based controls
+Required: title, description, tier (t1|t2|t3), command
+Optional: context (object)
+<ApprovalCard title="Run migration" description="Apply database schema changes" tier="t2" command="pnpm db:migrate --production" />
+
+**WorkflowCard** -- show workflow status and controls
+Required: title, workflowId
+Optional: nodeCount, status (draft|ready|running|completed|failed), summary
+<WorkflowCard title="CI Pipeline" workflowId="ci-main-branch" status="running" nodeCount={5} summary="Running lint and test stages" />
+
+**FollowUpBlock** -- suggest follow-up actions as pill buttons
+Required: suggestions (array of {label}, 1-6 items)
+Optional per suggestion: prompt, actionType (followup|navigate|submit, default: followup), payload
+<FollowUpBlock suggestions={[{"label":"Show details"},{"label":"Run again","prompt":"Re-run the last operation"},{"label":"Open logs","actionType":"navigate"}]} />
 
 ### Format:
 Prefix card responses with %%openui on its own line, then the card markup.
-You may mix plain text and cards in a single response -- text before %%openui is rendered normally.`;
+You may mix plain text and cards in a single response -- text before %%openui is rendered normally.
+
+Example complete response:
+I've finished analyzing the repository. Here are the results:
+
+%%openui
+<StatusCard title="Analysis complete" status="complete" message="Found 3 issues across 12 files" detail="2 warnings, 1 error" progress={100} />
+
+<FollowUpBlock suggestions={[{"label":"Show issues"},{"label":"Auto-fix warnings","prompt":"Fix the 2 warnings automatically"},{"label":"View full report","actionType":"navigate"}]} />`;

--- a/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
+++ b/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
@@ -38,6 +38,8 @@ import { WorkmodeAdmissionGuard } from '../workmode/admission-guard.js';
 import { parseModelOutput } from '../output-parser.js';
 import { GatewayTraceRecorder } from './trace-recorder.js';
 
+import { CARD_PROMPT_FRAGMENT } from './card-prompt-fragment.js';
+
 const DEFAULT_CHAT_BUDGET = {
   maxTurns: 4,
   maxTokens: 1200,
@@ -315,6 +317,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
         'You are the gateway-backed compatibility executor for direct chat turns.',
         'You cannot dispatch child agents.',
         'Always finish with task_complete.',
+        CARD_PROMPT_FRAGMENT,
       ].join('\n'),
       modelRouter: this.deps.modelRouter,
       getProvider: (providerId) =>

--- a/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
+++ b/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
@@ -212,7 +212,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
     });
     this.emitLifecycle(traceId, 'gateway-run', 'completed');
 
-    const response = this.resolveResponse(result);
+    const resolved = this.resolveResponse(result);
     this.emitLifecycle(traceId, 'response-resolved', 'completed');
 
     const pfcDecisions =
@@ -230,9 +230,10 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
     await this.finalizeStmTurn(
       validInput.projectId,
       validInput.message,
-      response,
+      resolved.response,
       validInput.traceId,
       result.evidenceRefs,
+      resolved.contentType,
     );
     this.emitLifecycle(traceId, 'stm-finalize', 'completed');
 
@@ -242,7 +243,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
       startedAt,
       completedAt: this.now(),
       input: validInput.message,
-      output: response,
+      output: resolved.response,
       pfcDecisions,
       evidenceRefs: result.evidenceRefs,
     });
@@ -251,10 +252,11 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
     this.deps.pfcEngine?.setTraceId('');
     this.emitLifecycle(traceId, 'turn-complete', 'completed');
     return {
-      response,
+      response: resolved.response,
       traceId: validInput.traceId,
       memoryCandidates: [],
       pfcDecisions,
+      contentType: resolved.contentType,
     };
   }
 
@@ -358,7 +360,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
               {
                 name: 'task_complete',
                 params: {
-                  output: { response: finalResponse },
+                  output: { response: finalResponse, contentType: parsedOutput.contentType },
                   summary: 'chat turn completed',
                 },
               },
@@ -400,31 +402,32 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
 
   private resolveResponse(
     result: Awaited<ReturnType<ReturnType<GatewayBackedTurnExecutor['createGateway']>['run']>>,
-  ): string {
+  ): { response: string; contentType?: 'text' | 'openui' } {
     if (result.status === 'completed') {
-      const output = result.output as { response?: unknown } | string;
+      const output = result.output as { response?: unknown; contentType?: unknown } | string;
       if (typeof output === 'string') {
-        return output;
+        return { response: output };
       }
       if (typeof output?.response === 'string') {
-        return output.response;
+        const contentType = output.contentType === 'openui' ? 'openui' as const : output.contentType === 'text' ? 'text' as const : undefined;
+        return { response: output.response, contentType };
       }
-      return JSON.stringify(output);
+      return { response: JSON.stringify(output) };
     }
 
     if (result.status === 'escalated') {
-      return `[escalated: ${result.reason}]`;
+      return { response: `[escalated: ${result.reason}]` };
     }
     if (result.status === 'budget_exhausted') {
-      return '[budget exhausted]';
+      return { response: '[budget exhausted]' };
     }
     if (result.status === 'aborted') {
-      return `[aborted: ${result.reason}]`;
+      return { response: `[aborted: ${result.reason}]` };
     }
     if (result.status === 'suspended') {
-      return `[suspended: ${result.reason}]`;
+      return { response: `[suspended: ${result.reason}]` };
     }
-    return `[error: ${result.reason}]`;
+    return { response: `[error: ${result.reason}]` };
   }
 
   private async finalizeStmTurn(
@@ -433,6 +436,7 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
     assistantResponse: string,
     traceId: TraceId,
     evidenceRefs: TraceEvidenceReference[],
+    contentType?: 'text' | 'openui',
   ): Promise<void> {
     if (!projectId) {
       return;
@@ -445,11 +449,15 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
         content: userMessage,
         timestamp,
       });
-      await this.deps.stmStore.append(projectId, {
+      const assistantEntry: { role: 'assistant'; content: string; timestamp: string; metadata?: Record<string, unknown> } = {
         role: 'assistant',
         content: assistantResponse,
         timestamp,
-      });
+      };
+      if (contentType && contentType !== 'text') {
+        assistantEntry.metadata = { contentType };
+      }
+      await this.deps.stmStore.append(projectId, assistantEntry);
 
       const stmContext = await this.deps.stmStore.getContext(projectId);
       if (!stmContext.compactionState?.requiresCompaction) {

--- a/self/cortex/core/src/output-parser.ts
+++ b/self/cortex/core/src/output-parser.ts
@@ -13,10 +13,25 @@ export interface ParsedModelOutput {
   response: string;
   toolCalls: Array<{ name: string; params: unknown }>;
   memoryCandidates: MemoryWriteCandidate[];
+  contentType?: 'text' | 'openui';
+}
+
+const OPENUI_PREFIX = '%%openui\n';
+
+/**
+ * Detect and strip the `%%openui\n` prefix from a response string.
+ * Returns the stripped response and contentType.
+ */
+function detectContentType(response: string): { response: string; contentType: 'text' | 'openui' } {
+  if (response.startsWith(OPENUI_PREFIX)) {
+    return { response: response.slice(OPENUI_PREFIX.length), contentType: 'openui' };
+  }
+  return { response, contentType: 'text' };
 }
 
 /**
  * Parses model output. Supports plain text or JSON envelope.
+ * Detects `%%openui\n` prefix and sets `contentType` accordingly.
  */
 export function parseModelOutput(
   output: unknown,
@@ -27,43 +42,52 @@ export function parseModelOutput(
     try {
       const parsed = JSON.parse(output) as Record<string, unknown>;
       if (parsed && typeof parsed.response === 'string') {
+        const detected = detectContentType(parsed.response);
         return {
-          response: parsed.response,
+          response: detected.response,
           toolCalls: parseToolCalls(parsed.toolCalls),
           memoryCandidates: parseMemoryCandidates(
             parsed.memoryCandidates,
             traceId,
             fallbackInput,
           ),
+          contentType: detected.contentType,
         };
       }
     } catch {
       // Not JSON, treat as plain text
     }
+    const detected = detectContentType(output);
     return {
-      response: output,
+      response: detected.response,
       toolCalls: [],
       memoryCandidates: createFallbackCandidate(traceId, fallbackInput),
+      contentType: detected.contentType,
     };
   }
 
   if (output && typeof output === 'object' && 'response' in output) {
     const obj = output as Record<string, unknown>;
+    const rawResponse = typeof obj.response === 'string' ? obj.response : String(output);
+    const detected = detectContentType(rawResponse);
     return {
-      response: typeof obj.response === 'string' ? obj.response : String(output),
+      response: detected.response,
       toolCalls: parseToolCalls(obj.toolCalls),
       memoryCandidates: parseMemoryCandidates(
         obj.memoryCandidates,
         traceId,
         fallbackInput,
       ),
+      contentType: detected.contentType,
     };
   }
 
+  const detected = detectContentType(String(output ?? ''));
   return {
-    response: String(output ?? ''),
+    response: detected.response,
     toolCalls: [],
     memoryCandidates: createFallbackCandidate(traceId, fallbackInput),
+    contentType: detected.contentType,
   };
 }
 

--- a/self/shared/src/types/__tests__/card-action.test.ts
+++ b/self/shared/src/types/__tests__/card-action.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { CardActionSchema, ActionResultSchema } from '../card-action.js';
+
+describe('CardActionSchema', () => {
+  // ── Tier 1: Contract Tests ─────────────────────────────────────────────
+
+  it('accepts valid approve action', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'approve',
+      cardId: 'card-1',
+      payload: { reason: 'looks good' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid reject action', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'reject',
+      cardId: 'card-2',
+      payload: { reason: 'not ready' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid navigate action', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'navigate',
+      cardId: 'card-3',
+      payload: { panel: 'settings' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid submit action with form payload', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'submit',
+      cardId: 'card-4',
+      payload: { name: 'test', value: 42, nested: { deep: true } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid followup action with prompt', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'followup',
+      cardId: 'card-5',
+      payload: { prompt: 'Tell me more about this' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid actionType', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'invalid',
+      cardId: 'card-1',
+      payload: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing cardId', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'approve',
+      payload: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing payload', () => {
+    const result = CardActionSchema.safeParse({
+      actionType: 'approve',
+      cardId: 'card-1',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ActionResultSchema', () => {
+  it('accepts valid result with all fields', () => {
+    const result = ActionResultSchema.safeParse({
+      ok: true,
+      message: 'Action submitted',
+      traceId: 'trace-abc',
+      contentType: 'openui',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts result with optional fields omitted', () => {
+    const result = ActionResultSchema.safeParse({
+      ok: true,
+      message: 'Action submitted',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects result with ok missing', () => {
+    const result = ActionResultSchema.safeParse({
+      message: 'Action submitted',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects result with message missing', () => {
+    const result = ActionResultSchema.safeParse({
+      ok: true,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/self/shared/src/types/card-action.ts
+++ b/self/shared/src/types/card-action.ts
@@ -1,0 +1,37 @@
+/**
+ * Card action schemas for OpenUI interactive cards.
+ *
+ * CardActionSchema validates user interactions with rendered cards (button clicks,
+ * form submissions, etc.) at the tRPC boundary. ActionResultSchema normalizes the
+ * response from both executeTurn (followup) and submitTaskToSystem (approve/reject/submit).
+ */
+import { z } from 'zod';
+
+// --- Card Action Type ---
+export const CardActionTypeSchema = z.enum([
+  'approve',
+  'reject',
+  'navigate',
+  'submit',
+  'followup',
+]);
+export type CardActionType = z.infer<typeof CardActionTypeSchema>;
+
+// --- Card Action ---
+export const CardActionSchema = z.object({
+  actionType: CardActionTypeSchema,
+  cardId: z.string(),
+  payload: z.record(z.unknown()),
+});
+export type CardAction = z.infer<typeof CardActionSchema>;
+
+// --- Action Result ---
+// Normalized return type from chat.sendAction that covers both
+// TurnResult (followup) and SystemSubmissionReceipt (approve/reject/submit).
+export const ActionResultSchema = z.object({
+  ok: z.boolean(),
+  message: z.string(),
+  traceId: z.string().optional(),
+  contentType: z.enum(['text', 'openui']).optional(),
+});
+export type ActionResult = z.infer<typeof ActionResultSchema>;

--- a/self/shared/src/types/cortex.ts
+++ b/self/shared/src/types/cortex.ts
@@ -82,6 +82,7 @@ export const TurnResultSchema = z.object({
   traceId: TraceIdSchema,
   memoryCandidates: z.array(MemoryWriteCandidateSchema),
   pfcDecisions: z.array(PfcDecisionSchema),
+  contentType: z.enum(['text', 'openui']).optional(),
 });
 export type TurnResult = z.infer<typeof TurnResultSchema>;
 

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -37,6 +37,7 @@ export * from './chat-intent.js';
 export * from './chat-turn.js';
 export * from './chat-thread.js';
 export * from './chat-node-context.js';
+export * from './card-action.js';
 export * from './chat-card.js';
 export * from './chat-scope.js';
 export * from './ingress-trigger.js';

--- a/self/transport/src/hooks/__tests__/useChatApi.test.ts
+++ b/self/transport/src/hooks/__tests__/useChatApi.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useChatApi } from '../useChatApi'
+
+// ─── Mock tRPC client ──────────────────────────────────────────────────────────
+
+const mockMutateAsync = {
+  sendMessage: vi.fn(),
+  sendAction: vi.fn(),
+}
+
+const mockFetch = {
+  getHistory: vi.fn(),
+}
+
+const mockInvalidate = {
+  getHistory: vi.fn(),
+}
+
+vi.mock('../../client', () => ({
+  trpc: {
+    useUtils: () => ({
+      chat: {
+        getHistory: {
+          fetch: mockFetch.getHistory,
+          invalidate: mockInvalidate.getHistory,
+        },
+      },
+    }),
+    chat: {
+      sendMessage: {
+        useMutation: () => ({ mutateAsync: mockMutateAsync.sendMessage }),
+      },
+      sendAction: {
+        useMutation: () => ({ mutateAsync: mockMutateAsync.sendAction }),
+      },
+    },
+  },
+}))
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useChatApi — sendAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Tier 1: Contract ────────────────────────────────────────────────────
+
+  it('returned object has sendAction method', () => {
+    const { result } = renderHook(() => useChatApi())
+    expect(typeof result.current.sendAction).toBe('function')
+  })
+
+  // ── Tier 2: Behavior ───────────────────────────────────────────────────
+
+  it('sendAction calls chat.sendAction tRPC mutation with correct payload', async () => {
+    const mockResult = { ok: true, message: 'Action submitted', traceId: 'run-1' }
+    mockMutateAsync.sendAction.mockResolvedValueOnce(mockResult)
+
+    const { result } = renderHook(() => useChatApi())
+    const action = { actionType: 'approve' as const, cardId: 'card-1', payload: { reason: 'lgtm' } }
+    const data = await result.current.sendAction(action)
+
+    expect(mockMutateAsync.sendAction).toHaveBeenCalledWith({ action })
+    expect(data).toEqual(mockResult)
+  })
+
+  it('sendAction includes projectId when provided', async () => {
+    const mockResult = { ok: true, message: 'Action submitted' }
+    mockMutateAsync.sendAction.mockResolvedValueOnce(mockResult)
+
+    const { result } = renderHook(() => useChatApi({ projectId: 'proj-1' }))
+    const action = { actionType: 'followup' as const, cardId: 'card-2', payload: { prompt: 'more' } }
+    await result.current.sendAction(action)
+
+    expect(mockMutateAsync.sendAction).toHaveBeenCalledWith({ action, projectId: 'proj-1' })
+  })
+
+  it('sendAction returns ActionResult from mutation', async () => {
+    const mockResult = { ok: true, message: 'Follow-up response', traceId: 'trace-abc', contentType: 'text' as const }
+    mockMutateAsync.sendAction.mockResolvedValueOnce(mockResult)
+
+    const { result } = renderHook(() => useChatApi())
+    const action = { actionType: 'followup' as const, cardId: 'card-3', payload: { prompt: 'details' } }
+    const data = await result.current.sendAction(action)
+
+    expect(data.ok).toBe(true)
+    expect(data.message).toBe('Follow-up response')
+    expect(data.traceId).toBe('trace-abc')
+  })
+})

--- a/self/transport/src/hooks/useChatApi.ts
+++ b/self/transport/src/hooks/useChatApi.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react'
 import { trpc } from '../client'
+import type { CardAction, ActionResult } from '@nous/shared'
 
 export interface UseChatApiOptions {
   projectId?: string
@@ -15,6 +16,7 @@ interface ChatApiShape {
     contentType?: 'text' | 'openui'
     actionOutcome?: { actionType: string; label: string; timestamp: string }
   }[]>
+  sendAction: (action: CardAction) => Promise<ActionResult>
 }
 
 /**
@@ -34,11 +36,14 @@ export function useChatApi(options?: UseChatApiOptions): ChatApiShape {
   const projectId = options?.projectId
   const utils = trpc.useUtils()
   const sendMessage = trpc.chat.sendMessage.useMutation()
+  const sendActionMutation = trpc.chat.sendAction.useMutation()
 
   // Store unstable references so the useMemo closure always calls the latest
   // mutateAsync / utils without needing them as dependencies.
   const sendRef = useRef(sendMessage.mutateAsync)
   sendRef.current = sendMessage.mutateAsync
+  const sendActionRef = useRef(sendActionMutation.mutateAsync)
+  sendActionRef.current = sendActionMutation.mutateAsync
   const utilsRef = useRef(utils)
   utilsRef.current = utils
 
@@ -66,6 +71,12 @@ export function useChatApi(options?: UseChatApiOptions): ChatApiShape {
             ...(e.metadata?.contentType ? { contentType: e.metadata.contentType as 'text' | 'openui' } : {}),
             ...(e.metadata?.actionOutcome ? { actionOutcome: e.metadata.actionOutcome as { actionType: string; label: string; timestamp: string } } : {}),
           }))
+      },
+      sendAction: async (action: CardAction) => {
+        const result = await sendActionRef.current(
+          projectId ? { action, projectId } : { action },
+        )
+        return result as ActionResult
       },
     }),
     // Only recompute when the logical identity changes (projectId).

--- a/self/transport/src/hooks/useChatApi.ts
+++ b/self/transport/src/hooks/useChatApi.ts
@@ -7,8 +7,14 @@ export interface UseChatApiOptions {
 
 /** Matches the ChatAPI interface from @nous/ui/panels (structural compatibility). */
 interface ChatApiShape {
-  send: (message: string) => Promise<{ response: string; traceId: string }>
-  getHistory: () => Promise<{ role: 'user' | 'assistant'; content: string; timestamp: string }[]>
+  send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui' }>
+  getHistory: () => Promise<{
+    role: 'user' | 'assistant'
+    content: string
+    timestamp: string
+    contentType?: 'text' | 'openui'
+    actionOutcome?: { actionType: string; label: string; timestamp: string }
+  }[]>
 }
 
 /**
@@ -45,7 +51,7 @@ export function useChatApi(options?: UseChatApiOptions): ChatApiShape {
         if (projectId) {
           await utilsRef.current.chat.getHistory.invalidate({ projectId })
         }
-        return { response: result.response, traceId: result.traceId }
+        return { response: result.response, traceId: result.traceId, contentType: result.contentType }
       },
       getHistory: async () => {
         const data = await utilsRef.current.chat.getHistory.fetch(
@@ -57,6 +63,8 @@ export function useChatApi(options?: UseChatApiOptions): ChatApiShape {
             role: e.role as 'user' | 'assistant',
             content: e.content,
             timestamp: e.timestamp,
+            ...(e.metadata?.contentType ? { contentType: e.metadata.contentType as 'text' | 'openui' } : {}),
+            ...(e.metadata?.actionOutcome ? { actionOutcome: e.metadata.actionOutcome as { actionType: string; label: string; timestamp: string } } : {}),
           }))
       },
     }),

--- a/self/ui/src/components/chat/cards/__tests__/action-card.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/action-card.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ActionCard } from '../action-card'
+import type { CardRendererProps } from '../../openui-adapter/types'
+
+function makeProps(
+  overrides?: Partial<Record<string, unknown>>,
+): CardRendererProps<unknown> {
+  return {
+    props: {
+      title: 'Action Required',
+      description: 'Please choose an action',
+      actions: [
+        { label: 'Approve', actionType: 'approve', variant: 'primary' },
+        { label: 'Cancel', actionType: 'reject', variant: 'secondary' },
+      ],
+      ...overrides,
+    },
+  }
+}
+
+describe('ActionCard', () => {
+  it('renders title and description', () => {
+    render(<ActionCard {...makeProps()} />)
+    expect(screen.getByText('Action Required')).toBeTruthy()
+    expect(screen.getByText('Please choose an action')).toBeTruthy()
+  })
+
+  it('renders action buttons', () => {
+    render(<ActionCard {...makeProps()} />)
+    expect(screen.getByText('Approve')).toBeTruthy()
+    expect(screen.getByText('Cancel')).toBeTruthy()
+  })
+
+  it('calls onAction with correct CardAction payload on button click', () => {
+    const onAction = vi.fn()
+    render(<ActionCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('action-btn-approve'))
+    expect(onAction).toHaveBeenCalledTimes(1)
+    const action = onAction.mock.calls[0][0]
+    expect(action.actionType).toBe('approve')
+    expect(action.payload).toEqual({})
+  })
+
+  it('emits correct payload for reject action', () => {
+    const onAction = vi.fn()
+    render(<ActionCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('action-btn-reject'))
+    expect(onAction).toHaveBeenCalledTimes(1)
+    expect(onAction.mock.calls[0][0].actionType).toBe('reject')
+  })
+
+  it('emits action with custom payload when provided', () => {
+    const onAction = vi.fn()
+    const actions = [
+      {
+        label: 'Go',
+        actionType: 'navigate',
+        variant: 'primary',
+        payload: { target: '/dashboard' },
+      },
+    ]
+    render(<ActionCard props={{ title: 'T', description: 'D', actions }} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('action-btn-navigate'))
+    expect(onAction.mock.calls[0][0].payload).toEqual({ target: '/dashboard' })
+  })
+
+  it('renders maximum 4 actions correctly', () => {
+    const actions = Array.from({ length: 4 }, (_, i) => ({
+      label: `Action ${i}`,
+      actionType: 'approve' as const,
+      variant: 'secondary' as const,
+    }))
+    render(<ActionCard props={{ title: 'T', description: 'D', actions }} />)
+    expect(screen.getAllByRole('button')).toHaveLength(4)
+  })
+
+  it('stale with actionOutcome renders outcome badge', () => {
+    render(
+      <ActionCard
+        {...makeProps()}
+        stale={true}
+        actionOutcome={{ actionType: 'approve', label: 'Approved', timestamp: '2026-01-01' }}
+      />,
+    )
+    expect(screen.getByTestId('action-card-outcome')).toBeTruthy()
+    expect(screen.getByText('Approved')).toBeTruthy()
+  })
+
+  it('stale without actionOutcome renders disabled "Expired" buttons', () => {
+    render(<ActionCard {...makeProps()} stale={true} />)
+    const expiredBtns = screen.getAllByTestId('action-card-expired-btn')
+    expect(expiredBtns.length).toBeGreaterThan(0)
+    for (const btn of expiredBtns) {
+      expect(btn).toHaveProperty('disabled', true)
+    }
+  })
+
+  it('renders invalid props fallback', () => {
+    render(<ActionCard props={{}} />)
+    expect(screen.getByTestId('action-card-invalid')).toBeTruthy()
+    expect(screen.getByText('Invalid action card data')).toBeTruthy()
+  })
+
+  it('action with absent optional payload emits valid CardAction', () => {
+    const onAction = vi.fn()
+    const actions = [{ label: 'Go', actionType: 'approve', variant: 'primary' }]
+    render(<ActionCard props={{ title: 'T', description: 'D', actions }} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('action-btn-approve'))
+    const cardAction = onAction.mock.calls[0][0]
+    expect(cardAction.payload).toEqual({})
+    expect(cardAction.actionType).toBe('approve')
+  })
+})

--- a/self/ui/src/components/chat/cards/__tests__/approval-card.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/approval-card.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { ApprovalCard } from '../approval-card'
+import type { CardRendererProps } from '../../openui-adapter/types'
+
+function makeProps(
+  overrides?: Partial<Record<string, unknown>>,
+): CardRendererProps<unknown> {
+  return {
+    props: {
+      title: 'Approve Command',
+      description: 'Please review this command',
+      tier: 't1',
+      command: 'rm -rf /tmp/cache',
+      ...overrides,
+    },
+  }
+}
+
+describe('ApprovalCard', () => {
+  it('renders title, description, and command block', () => {
+    render(<ApprovalCard {...makeProps()} />)
+    expect(screen.getByText('Approve Command')).toBeTruthy()
+    expect(screen.getByText('Please review this command')).toBeTruthy()
+    expect(screen.getByText('rm -rf /tmp/cache')).toBeTruthy()
+  })
+
+  it('renders tier badge for t1', () => {
+    render(<ApprovalCard {...makeProps({ tier: 't1' })} />)
+    expect(screen.getByTestId('approval-tier-badge')).toBeTruthy()
+    expect(screen.getByText('Routine')).toBeTruthy()
+  })
+
+  it('renders tier badge for t2', () => {
+    render(<ApprovalCard {...makeProps({ tier: 't2' })} />)
+    expect(screen.getByText('Caution')).toBeTruthy()
+  })
+
+  it('renders tier badge for t3', () => {
+    render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+    expect(screen.getByText('Critical')).toBeTruthy()
+  })
+
+  it('applies correct left-border color for t1', () => {
+    render(<ApprovalCard {...makeProps({ tier: 't1' })} />)
+    const card = screen.getByTestId('approval-card')
+    expect(card.style.borderLeft).toContain('var(--nous-accent)')
+  })
+
+  it('applies correct left-border color for t2', () => {
+    render(<ApprovalCard {...makeProps({ tier: 't2' })} />)
+    const card = screen.getByTestId('approval-card')
+    expect(card.style.borderLeft).toContain('var(--nous-alert-warning)')
+  })
+
+  it('applies correct left-border color for t3', () => {
+    render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+    const card = screen.getByTestId('approval-card')
+    expect(card.style.borderLeft).toContain('var(--nous-alert-error)')
+  })
+
+  it('command block uses monospace font', () => {
+    render(<ApprovalCard {...makeProps()} />)
+    const cmdBlock = screen.getByTestId('approval-command-block')
+    expect(cmdBlock.style.fontFamily).toContain('var(--nous-font-mono)')
+  })
+
+  it('renders context when provided', () => {
+    render(<ApprovalCard {...makeProps({ context: { source: 'user', env: 'prod' } })} />)
+    expect(screen.getByTestId('approval-context')).toBeTruthy()
+    expect(screen.getByText(/source:/)).toBeTruthy()
+  })
+
+  it('t1 approve button is immediately clickable', () => {
+    const onAction = vi.fn()
+    render(<ApprovalCard {...makeProps({ tier: 't1' })} onAction={onAction} />)
+    const approveBtn = screen.getByTestId('approval-approve-btn')
+    expect(approveBtn).not.toHaveProperty('disabled', true)
+    fireEvent.click(approveBtn)
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('t2 approve button is immediately clickable', () => {
+    const onAction = vi.fn()
+    render(<ApprovalCard {...makeProps({ tier: 't2' })} onAction={onAction} />)
+    const approveBtn = screen.getByTestId('approval-approve-btn')
+    expect(approveBtn).not.toHaveProperty('disabled', true)
+    fireEvent.click(approveBtn)
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('approve emits correct CardAction payload', () => {
+    const onAction = vi.fn()
+    render(<ApprovalCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('approval-approve-btn'))
+    const action = onAction.mock.calls[0][0]
+    expect(action.actionType).toBe('approve')
+    expect(action.payload.command).toBe('rm -rf /tmp/cache')
+    expect(action.payload.tier).toBe('t1')
+  })
+
+  it('reject emits correct CardAction payload', () => {
+    const onAction = vi.fn()
+    render(<ApprovalCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('approval-reject-btn'))
+    expect(onAction.mock.calls[0][0].actionType).toBe('reject')
+  })
+
+  describe('T3 2-second approve delay', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('t3 approve button is disabled initially', () => {
+      render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+      const approveBtn = screen.getByTestId('approval-approve-btn')
+      expect(approveBtn).toHaveProperty('disabled', true)
+    })
+
+    it('t3 approve button shows countdown text', () => {
+      render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+      const approveBtn = screen.getByTestId('approval-approve-btn')
+      expect(approveBtn.textContent).toContain('Approve (2s)')
+    })
+
+    it('t3 approve button enables after 2 seconds', () => {
+      render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+
+      const approveBtn = screen.getByTestId('approval-approve-btn')
+      expect(approveBtn).not.toHaveProperty('disabled', true)
+      expect(approveBtn.textContent).toBe('Approve')
+    })
+
+    it('t3 countdown updates during the delay', () => {
+      render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      const approveBtn = screen.getByTestId('approval-approve-btn')
+      expect(approveBtn.textContent).toContain('Approve (1s)')
+    })
+
+    it('t3 countdown timer cleanup on component unmount', () => {
+      const { unmount } = render(<ApprovalCard {...makeProps({ tier: 't3' })} />)
+
+      // Unmount before timer fires — should not cause errors
+      unmount()
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      // No error means cleanup worked
+      expect(true).toBe(true)
+    })
+  })
+
+  it('stale variant shows outcome badge when actionOutcome present', () => {
+    render(
+      <ApprovalCard
+        {...makeProps()}
+        stale={true}
+        actionOutcome={{ actionType: 'approve', label: 'Approved', timestamp: '2026-01-01' }}
+      />,
+    )
+    expect(screen.getByTestId('approval-card-outcome')).toBeTruthy()
+    expect(screen.getByText('Approved')).toBeTruthy()
+  })
+
+  it('stale variant shows disabled buttons when no actionOutcome', () => {
+    render(<ApprovalCard {...makeProps()} stale={true} />)
+    const expiredBtn = screen.getByTestId('approval-expired-btn')
+    expect(expiredBtn).toHaveProperty('disabled', true)
+  })
+
+  it('stale variant applies muted border', () => {
+    render(<ApprovalCard {...makeProps()} stale={true} />)
+    const card = screen.getByTestId('approval-card')
+    expect(card.style.borderLeft).toContain('var(--nous-fg-muted)')
+  })
+
+  it('renders invalid props fallback', () => {
+    render(<ApprovalCard props={{}} />)
+    expect(screen.getByTestId('approval-card-invalid')).toBeTruthy()
+  })
+})

--- a/self/ui/src/components/chat/cards/__tests__/follow-up-block.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/follow-up-block.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { FollowUpBlock } from '../follow-up-block'
+import type { CardRendererProps } from '../../openui-adapter/types'
+
+function makeProps(
+  overrides?: Partial<Record<string, unknown>>,
+): CardRendererProps<unknown> {
+  return {
+    props: {
+      suggestions: [
+        { label: 'Tell me more', prompt: 'Explain in detail' },
+        { label: 'Show code', prompt: 'Show the code example' },
+      ],
+      ...overrides,
+    },
+  }
+}
+
+describe('FollowUpBlock', () => {
+  it('renders pill buttons in a flex container', () => {
+    render(<FollowUpBlock {...makeProps()} />)
+    const container = screen.getByTestId('followup-block')
+    expect(container.style.display).toBe('flex')
+    expect(container.style.flexWrap).toBe('wrap')
+  })
+
+  it('renders correct number of pills', () => {
+    render(<FollowUpBlock {...makeProps()} />)
+    const pills = screen.getAllByTestId('followup-pill')
+    expect(pills).toHaveLength(2)
+  })
+
+  it('does NOT render inside a Card container', () => {
+    const { container } = render(<FollowUpBlock {...makeProps()} />)
+    // Card container has border with --nous-shell-column-border — FollowUpBlock should not
+    const outerDiv = container.firstElementChild as HTMLElement
+    expect(outerDiv?.style.border ?? '').not.toContain('--nous-shell-column-border')
+    expect(outerDiv?.tagName).toBe('DIV')
+    expect(outerDiv?.getAttribute('data-testid')).toBe('followup-block')
+  })
+
+  it('each pill click calls onAction with correct payload', () => {
+    const onAction = vi.fn()
+    render(<FollowUpBlock {...makeProps()} onAction={onAction} />)
+    const pills = screen.getAllByTestId('followup-pill')
+    fireEvent.click(pills[0])
+    expect(onAction).toHaveBeenCalledTimes(1)
+    const action = onAction.mock.calls[0][0]
+    expect(action.actionType).toBe('followup')
+    expect(action.payload.prompt).toBe('Explain in detail')
+  })
+
+  it('pill uses label as fallback when prompt is absent', () => {
+    const onAction = vi.fn()
+    const suggestions = [{ label: 'Quick help' }]
+    render(
+      <FollowUpBlock props={{ suggestions }} onAction={onAction} />,
+    )
+    fireEvent.click(screen.getByTestId('followup-pill'))
+    expect(onAction.mock.calls[0][0].payload.prompt).toBe('Quick help')
+  })
+
+  it('renders maximum 6 suggestions correctly', () => {
+    const suggestions = Array.from({ length: 6 }, (_, i) => ({
+      label: `Suggestion ${i + 1}`,
+    }))
+    render(<FollowUpBlock props={{ suggestions }} />)
+    const pills = screen.getAllByTestId('followup-pill')
+    expect(pills).toHaveLength(6)
+  })
+
+  it('stale variant renders Badge components instead of buttons', () => {
+    render(<FollowUpBlock {...makeProps()} stale={true} />)
+    const stalePills = screen.getAllByTestId('followup-stale-pill')
+    expect(stalePills).toHaveLength(2)
+    // Should not have interactive pills
+    expect(screen.queryAllByTestId('followup-pill')).toHaveLength(0)
+  })
+
+  it('stale pills are non-interactive (no click handler fires onAction)', () => {
+    const onAction = vi.fn()
+    render(<FollowUpBlock {...makeProps()} stale={true} onAction={onAction} />)
+    const stalePills = screen.getAllByTestId('followup-stale-pill')
+    fireEvent.click(stalePills[0])
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it('renders invalid props fallback', () => {
+    render(<FollowUpBlock props={{}} />)
+    expect(screen.getByTestId('followup-block-invalid')).toBeTruthy()
+    expect(screen.getByText('Invalid follow-up block data')).toBeTruthy()
+  })
+
+  it('renders invalid fallback for empty suggestions array', () => {
+    render(<FollowUpBlock props={{ suggestions: [] }} />)
+    expect(screen.getByTestId('followup-block-invalid')).toBeTruthy()
+  })
+
+  it('pill actionType defaults to followup when not specified', () => {
+    const onAction = vi.fn()
+    const suggestions = [{ label: 'Test' }]
+    render(<FollowUpBlock props={{ suggestions }} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('followup-pill'))
+    expect(onAction.mock.calls[0][0].actionType).toBe('followup')
+  })
+
+  it('respects custom actionType from suggestion', () => {
+    const onAction = vi.fn()
+    const suggestions = [{ label: 'Go', actionType: 'navigate' }]
+    render(<FollowUpBlock props={{ suggestions }} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('followup-pill'))
+    expect(onAction.mock.calls[0][0].actionType).toBe('navigate')
+  })
+})

--- a/self/ui/src/components/chat/cards/__tests__/schemas.test.ts
+++ b/self/ui/src/components/chat/cards/__tests__/schemas.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { StatusCardSchema } from '../status-card'
+import { ActionCardSchema } from '../action-card'
+import { ApprovalCardSchema } from '../approval-card'
+import { WorkflowCardSchema } from '../workflow-card'
+import { FollowUpBlockSchema } from '../follow-up-block'
+
+// ---------------------------------------------------------------------------
+// StatusCardSchema
+// ---------------------------------------------------------------------------
+
+describe('StatusCardSchema', () => {
+  it('accepts valid props', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      status: 'active',
+      message: 'Running',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid props with optional fields', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      status: 'complete',
+      message: 'Done',
+      detail: 'All tasks finished',
+      progress: 100,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing required field: title', () => {
+    const result = StatusCardSchema.safeParse({
+      status: 'active',
+      message: 'Running',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing required field: status', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      message: 'Running',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid status enum value', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      status: 'invalid',
+      message: 'Running',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects progress outside range (>100)', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      status: 'active',
+      message: 'Running',
+      progress: 150,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects progress outside range (<0)', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      status: 'active',
+      message: 'Running',
+      progress: -10,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('strips extra properties', () => {
+    const result = StatusCardSchema.safeParse({
+      title: 'Test',
+      status: 'active',
+      message: 'Running',
+      extraProp: 'should be stripped',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).extraProp).toBeUndefined()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ActionCardSchema
+// ---------------------------------------------------------------------------
+
+describe('ActionCardSchema', () => {
+  it('accepts valid props', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions: [{ label: 'Go', actionType: 'approve' }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('applies default variant when not specified', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions: [{ label: 'Go', actionType: 'approve' }],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.actions[0].variant).toBe('secondary')
+    }
+  })
+
+  it('rejects missing required field: actions', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty actions array (min 1)', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions: [],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects actions array exceeding max 4', () => {
+    const actions = Array.from({ length: 5 }, (_, i) => ({
+      label: `Action ${i}`,
+      actionType: 'approve',
+    }))
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('validates variant enum', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions: [{ label: 'Go', actionType: 'approve', variant: 'invalid' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('validates actionType enum', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions: [{ label: 'Go', actionType: 'invalid' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('strips extra properties', () => {
+    const result = ActionCardSchema.safeParse({
+      title: 'Action',
+      description: 'Do something',
+      actions: [{ label: 'Go', actionType: 'approve' }],
+      extraProp: 'should be stripped',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).extraProp).toBeUndefined()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ApprovalCardSchema
+// ---------------------------------------------------------------------------
+
+describe('ApprovalCardSchema', () => {
+  it('accepts valid props', () => {
+    const result = ApprovalCardSchema.safeParse({
+      title: 'Approve',
+      description: 'Review this',
+      tier: 't1',
+      command: 'echo hello',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid props with optional context', () => {
+    const result = ApprovalCardSchema.safeParse({
+      title: 'Approve',
+      description: 'Review this',
+      tier: 't2',
+      command: 'deploy',
+      context: { env: 'prod' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing required field: tier', () => {
+    const result = ApprovalCardSchema.safeParse({
+      title: 'Approve',
+      description: 'Review this',
+      command: 'echo hello',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing required field: command', () => {
+    const result = ApprovalCardSchema.safeParse({
+      title: 'Approve',
+      description: 'Review this',
+      tier: 't1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('validates tier enum', () => {
+    const result = ApprovalCardSchema.safeParse({
+      title: 'Approve',
+      description: 'Review this',
+      tier: 't4',
+      command: 'echo hello',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('strips extra properties', () => {
+    const result = ApprovalCardSchema.safeParse({
+      title: 'Approve',
+      description: 'Review this',
+      tier: 't1',
+      command: 'echo hello',
+      extraProp: 'should be stripped',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).extraProp).toBeUndefined()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WorkflowCardSchema
+// ---------------------------------------------------------------------------
+
+describe('WorkflowCardSchema', () => {
+  it('accepts valid props with minimal fields', () => {
+    const result = WorkflowCardSchema.safeParse({
+      title: 'Pipeline',
+      workflowId: 'wf-1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid props with all optional fields', () => {
+    const result = WorkflowCardSchema.safeParse({
+      title: 'Pipeline',
+      workflowId: 'wf-1',
+      nodeCount: 5,
+      status: 'running',
+      summary: 'Processing data',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing required field: title', () => {
+    const result = WorkflowCardSchema.safeParse({
+      workflowId: 'wf-1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing required field: workflowId', () => {
+    const result = WorkflowCardSchema.safeParse({
+      title: 'Pipeline',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('validates status enum', () => {
+    const result = WorkflowCardSchema.safeParse({
+      title: 'Pipeline',
+      workflowId: 'wf-1',
+      status: 'invalid',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('strips extra properties', () => {
+    const result = WorkflowCardSchema.safeParse({
+      title: 'Pipeline',
+      workflowId: 'wf-1',
+      extraProp: 'should be stripped',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).extraProp).toBeUndefined()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FollowUpBlockSchema
+// ---------------------------------------------------------------------------
+
+describe('FollowUpBlockSchema', () => {
+  it('accepts valid props', () => {
+    const result = FollowUpBlockSchema.safeParse({
+      suggestions: [{ label: 'Tell me more' }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('applies default actionType when not specified', () => {
+    const result = FollowUpBlockSchema.safeParse({
+      suggestions: [{ label: 'Tell me more' }],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.suggestions[0].actionType).toBe('followup')
+    }
+  })
+
+  it('rejects missing required field: suggestions', () => {
+    const result = FollowUpBlockSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty suggestions array (min 1)', () => {
+    const result = FollowUpBlockSchema.safeParse({ suggestions: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects suggestions array exceeding max 6', () => {
+    const suggestions = Array.from({ length: 7 }, (_, i) => ({
+      label: `Suggestion ${i}`,
+    }))
+    const result = FollowUpBlockSchema.safeParse({ suggestions })
+    expect(result.success).toBe(false)
+  })
+
+  it('validates actionType enum', () => {
+    const result = FollowUpBlockSchema.safeParse({
+      suggestions: [{ label: 'Go', actionType: 'invalid' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts valid actionType values', () => {
+    for (const actionType of ['followup', 'navigate', 'submit']) {
+      const result = FollowUpBlockSchema.safeParse({
+        suggestions: [{ label: 'Go', actionType }],
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('strips extra properties', () => {
+    const result = FollowUpBlockSchema.safeParse({
+      suggestions: [{ label: 'Go' }],
+      extraProp: 'should be stripped',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).extraProp).toBeUndefined()
+    }
+  })
+})

--- a/self/ui/src/components/chat/cards/__tests__/status-card.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/status-card.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StatusCard } from '../status-card'
+import type { CardRendererProps } from '../../openui-adapter/types'
+
+function makeProps(
+  overrides?: Partial<Record<string, unknown>>,
+): CardRendererProps<unknown> {
+  return {
+    props: {
+      title: 'Test Status',
+      status: 'active',
+      message: 'Something is happening',
+      ...overrides,
+    },
+  }
+}
+
+describe('StatusCard', () => {
+  it('renders title and message', () => {
+    render(<StatusCard {...makeProps()} />)
+    expect(screen.getByText('Test Status')).toBeTruthy()
+    expect(screen.getByText('Something is happening')).toBeTruthy()
+  })
+
+  it('renders detail when provided', () => {
+    render(<StatusCard {...makeProps({ detail: 'Extra info' })} />)
+    expect(screen.getByText('Extra info')).toBeTruthy()
+  })
+
+  it('applies correct left-border color for active status', () => {
+    render(<StatusCard {...makeProps({ status: 'active' })} />)
+    const card = screen.getByTestId('status-card')
+    expect(card.style.borderLeft).toContain('var(--nous-state-active)')
+  })
+
+  it('applies correct left-border color for complete status', () => {
+    render(<StatusCard {...makeProps({ status: 'complete' })} />)
+    const card = screen.getByTestId('status-card')
+    expect(card.style.borderLeft).toContain('var(--nous-state-complete)')
+  })
+
+  it('applies correct left-border color for error status', () => {
+    render(<StatusCard {...makeProps({ status: 'error' })} />)
+    const card = screen.getByTestId('status-card')
+    expect(card.style.borderLeft).toContain('var(--nous-state-blocked)')
+  })
+
+  it('applies correct left-border color for waiting status', () => {
+    render(<StatusCard {...makeProps({ status: 'waiting' })} />)
+    const card = screen.getByTestId('status-card')
+    expect(card.style.borderLeft).toContain('var(--nous-state-waiting)')
+  })
+
+  it('renders progress bar when progress prop is provided', () => {
+    render(<StatusCard {...makeProps({ progress: 60 })} />)
+    expect(screen.getByTestId('status-card-progress')).toBeTruthy()
+  })
+
+  it('does not render progress bar when progress is absent', () => {
+    render(<StatusCard {...makeProps()} />)
+    expect(screen.queryByTestId('status-card-progress')).toBeNull()
+  })
+
+  it('renders invalid props fallback', () => {
+    render(<StatusCard props={{}} />)
+    expect(screen.getByTestId('status-card-invalid')).toBeTruthy()
+    expect(screen.getByText('Invalid status card data')).toBeTruthy()
+  })
+
+  it('stale variant applies muted border', () => {
+    render(<StatusCard {...makeProps()} stale={true} />)
+    const card = screen.getByTestId('status-card')
+    expect(card.style.borderLeft).toContain('var(--nous-fg-muted)')
+  })
+
+  it('stale variant applies surface background', () => {
+    render(<StatusCard {...makeProps()} stale={true} />)
+    const card = screen.getByTestId('status-card')
+    expect(card.style.background).toContain('var(--nous-bg-surface)')
+  })
+
+  it('has data-testid="status-card"', () => {
+    render(<StatusCard {...makeProps()} />)
+    expect(screen.getByTestId('status-card')).toBeTruthy()
+  })
+})

--- a/self/ui/src/components/chat/cards/__tests__/workflow-card.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/workflow-card.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WorkflowCard } from '../workflow-card'
+import type { CardRendererProps } from '../../openui-adapter/types'
+
+function makeProps(
+  overrides?: Partial<Record<string, unknown>>,
+): CardRendererProps<unknown> {
+  return {
+    props: {
+      title: 'Data Pipeline',
+      workflowId: 'wf-123',
+      status: 'running',
+      nodeCount: 5,
+      summary: 'Processing data from input sources',
+      ...overrides,
+    },
+  }
+}
+
+describe('WorkflowCard', () => {
+  it('renders title', () => {
+    render(<WorkflowCard {...makeProps()} />)
+    expect(screen.getByText('Data Pipeline')).toBeTruthy()
+  })
+
+  it('renders status indicator dot with correct color for running', () => {
+    render(<WorkflowCard {...makeProps({ status: 'running' })} />)
+    const dot = screen.getByTestId('workflow-status-dot')
+    expect(dot.style.background).toContain('var(--nous-state-active)')
+  })
+
+  it('renders status indicator dot with correct color for completed', () => {
+    render(<WorkflowCard {...makeProps({ status: 'completed' })} />)
+    const dot = screen.getByTestId('workflow-status-dot')
+    expect(dot.style.background).toContain('var(--nous-state-complete)')
+  })
+
+  it('renders status indicator dot with correct color for failed', () => {
+    render(<WorkflowCard {...makeProps({ status: 'failed' })} />)
+    const dot = screen.getByTestId('workflow-status-dot')
+    expect(dot.style.background).toContain('var(--nous-state-blocked)')
+  })
+
+  it('renders status indicator dot with correct color for draft', () => {
+    render(<WorkflowCard {...makeProps({ status: 'draft' })} />)
+    const dot = screen.getByTestId('workflow-status-dot')
+    expect(dot.style.background).toContain('var(--nous-state-idle)')
+  })
+
+  it('renders status indicator dot with correct color for ready', () => {
+    render(<WorkflowCard {...makeProps({ status: 'ready' })} />)
+    const dot = screen.getByTestId('workflow-status-dot')
+    expect(dot.style.background).toContain('var(--nous-state-waiting)')
+  })
+
+  it('renders node count badge when nodeCount is provided', () => {
+    render(<WorkflowCard {...makeProps({ nodeCount: 8 })} />)
+    expect(screen.getByTestId('workflow-node-count')).toBeTruthy()
+    expect(screen.getByText('8 nodes')).toBeTruthy()
+  })
+
+  it('does not render node count badge when nodeCount is absent', () => {
+    render(<WorkflowCard {...makeProps({ nodeCount: undefined })} />)
+    expect(screen.queryByTestId('workflow-node-count')).toBeNull()
+  })
+
+  it('renders summary text when provided', () => {
+    render(<WorkflowCard {...makeProps()} />)
+    expect(screen.getByTestId('workflow-summary')).toBeTruthy()
+    expect(screen.getByText('Processing data from input sources')).toBeTruthy()
+  })
+
+  it('does not render summary when absent', () => {
+    render(<WorkflowCard {...makeProps({ summary: undefined })} />)
+    expect(screen.queryByTestId('workflow-summary')).toBeNull()
+  })
+
+  it('Run button emits correct CardAction payload', () => {
+    const onAction = vi.fn()
+    render(<WorkflowCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('workflow-btn-run'))
+    const action = onAction.mock.calls[0][0]
+    expect(action.actionType).toBe('submit')
+    expect(action.payload.workflowId).toBe('wf-123')
+    expect(action.payload.action).toBe('run')
+  })
+
+  it('Edit button emits correct CardAction payload', () => {
+    const onAction = vi.fn()
+    render(<WorkflowCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('workflow-btn-edit'))
+    const action = onAction.mock.calls[0][0]
+    expect(action.actionType).toBe('navigate')
+    expect(action.payload.action).toBe('edit')
+  })
+
+  it('Inspect button emits correct CardAction payload', () => {
+    const onAction = vi.fn()
+    render(<WorkflowCard {...makeProps()} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('workflow-btn-inspect'))
+    const action = onAction.mock.calls[0][0]
+    expect(action.actionType).toBe('navigate')
+    expect(action.payload.action).toBe('inspect')
+  })
+
+  it('stale with actionOutcome renders outcome badge', () => {
+    render(
+      <WorkflowCard
+        {...makeProps()}
+        stale={true}
+        actionOutcome={{ actionType: 'submit', label: 'Executed', timestamp: '2026-01-01' }}
+      />,
+    )
+    expect(screen.getByTestId('workflow-card-outcome')).toBeTruthy()
+    expect(screen.getByText('Executed')).toBeTruthy()
+  })
+
+  it('stale without actionOutcome renders disabled "Expired" buttons', () => {
+    render(<WorkflowCard {...makeProps()} stale={true} />)
+    const expiredBtns = screen.getAllByText('Expired')
+    expect(expiredBtns.length).toBe(3)
+  })
+
+  it('stale variant applies muted status dot', () => {
+    render(<WorkflowCard {...makeProps()} stale={true} />)
+    const dot = screen.getByTestId('workflow-status-dot')
+    expect(dot.style.background).toContain('var(--nous-fg-muted)')
+  })
+
+  it('renders invalid props fallback', () => {
+    render(<WorkflowCard props={{}} />)
+    expect(screen.getByTestId('workflow-card-invalid')).toBeTruthy()
+    expect(screen.getByText('Invalid workflow card data')).toBeTruthy()
+  })
+})

--- a/self/ui/src/components/chat/cards/action-card.tsx
+++ b/self/ui/src/components/chat/cards/action-card.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import React from 'react'
+import { z } from 'zod'
+import { Card, CardHeader, CardTitle, CardContent } from '../../card'
+import { Button } from '../../button'
+import { Badge } from '../../badge'
+import type { CardRendererProps, CardAction } from '../openui-adapter/types'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const ActionCardSchema = z
+  .object({
+    title: z.string(),
+    description: z.string(),
+    actions: z
+      .array(
+        z.object({
+          label: z.string(),
+          actionType: z.enum(['approve', 'reject', 'navigate', 'followup']),
+          payload: z.record(z.unknown()).optional(),
+          variant: z.enum(['primary', 'secondary', 'ghost']).default('secondary'),
+        }),
+      )
+      .min(1)
+      .max(4),
+  })
+  .strip()
+
+export type ActionCardProps = z.infer<typeof ActionCardSchema>
+
+// ---------------------------------------------------------------------------
+// Variant mapping: schema names -> Button component variants
+// ---------------------------------------------------------------------------
+
+const VARIANT_MAP: Record<string, 'default' | 'outline' | 'ghost'> = {
+  primary: 'default',
+  secondary: 'outline',
+  ghost: 'ghost',
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+export function ActionCard({
+  props,
+  stale,
+  actionOutcome,
+  onAction,
+}: CardRendererProps<unknown>) {
+  const result = ActionCardSchema.safeParse(props)
+  if (!result.success) {
+    return (
+      <div
+        data-testid="action-card-invalid"
+        style={{
+          padding: 'var(--nous-space-sm)',
+          color: 'var(--nous-fg-muted)',
+          fontSize: 'var(--nous-font-size-xs)',
+        }}
+      >
+        Invalid action card data
+      </div>
+    )
+  }
+
+  const data = result.data
+  const borderColor = stale ? 'var(--nous-fg-muted)' : undefined
+  const bgColor = stale ? 'var(--nous-bg-surface)' : undefined
+
+  return (
+    <Card
+      data-testid="action-card"
+      style={{
+        ...(borderColor ? { borderColor } : {}),
+        ...(bgColor ? { background: bgColor } : {}),
+      }}
+    >
+      <CardHeader>
+        <CardTitle style={{ fontSize: 'var(--nous-font-size-sm)' }}>
+          {data.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div
+          style={{
+            fontSize: 'var(--nous-font-size-sm)',
+            color: 'var(--nous-text-primary)',
+            marginBottom: 'var(--nous-space-sm)',
+          }}
+        >
+          {data.description}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 'var(--nous-space-xs)',
+            flexWrap: 'wrap',
+          }}
+        >
+          {stale && actionOutcome ? (
+            <Badge
+              data-testid="action-card-outcome"
+              variant="secondary"
+            >
+              {actionOutcome.label}
+            </Badge>
+          ) : stale ? (
+            data.actions.map((action, i) => (
+              <Button
+                key={i}
+                variant="outline"
+                size="sm"
+                disabled
+                data-testid="action-card-expired-btn"
+              >
+                Expired
+              </Button>
+            ))
+          ) : (
+            data.actions.map((action, i) => (
+              <Button
+                key={i}
+                variant={VARIANT_MAP[action.variant] ?? 'outline'}
+                size="sm"
+                data-testid={`action-btn-${action.actionType}`}
+                onClick={() => {
+                  if (onAction) {
+                    const cardAction: CardAction = {
+                      actionType: action.actionType,
+                      cardId: '',
+                      payload: action.payload ?? {},
+                    }
+                    onAction(cardAction)
+                  }
+                }}
+              >
+                {action.label}
+              </Button>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/self/ui/src/components/chat/cards/approval-card.tsx
+++ b/self/ui/src/components/chat/cards/approval-card.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react'
+import { z } from 'zod'
+import { Card, CardHeader, CardTitle, CardContent } from '../../card'
+import { Button } from '../../button'
+import { Badge } from '../../badge'
+import type { CardRendererProps, CardAction } from '../openui-adapter/types'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const ApprovalCardSchema = z
+  .object({
+    title: z.string(),
+    description: z.string(),
+    tier: z.enum(['t1', 't2', 't3']),
+    command: z.string(),
+    context: z.record(z.unknown()).optional(),
+  })
+  .strip()
+
+export type ApprovalCardProps = z.infer<typeof ApprovalCardSchema>
+
+// ---------------------------------------------------------------------------
+// Token mappings
+// ---------------------------------------------------------------------------
+
+const TIER_BORDER_COLOR: Record<ApprovalCardProps['tier'], string> = {
+  t1: 'var(--nous-accent)',
+  t2: 'var(--nous-alert-warning)',
+  t3: 'var(--nous-alert-error)',
+}
+
+const TIER_BADGE: Record<
+  ApprovalCardProps['tier'],
+  { label: string; variant: 'secondary' | 'default'; style?: React.CSSProperties }
+> = {
+  t1: { label: 'Routine', variant: 'secondary' },
+  t2: {
+    label: 'Caution',
+    variant: 'default',
+    style: { background: 'var(--nous-alert-warning)', color: 'var(--nous-fg-on-color)' },
+  },
+  t3: {
+    label: 'Critical',
+    variant: 'default',
+    style: { background: 'var(--nous-alert-error)', color: 'var(--nous-fg-on-color)' },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// T3 approve delay (2 seconds)
+// ---------------------------------------------------------------------------
+
+const T3_DELAY_MS = 2000
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+export function ApprovalCard({
+  props,
+  stale,
+  actionOutcome,
+  onAction,
+}: CardRendererProps<unknown>) {
+  const result = ApprovalCardSchema.safeParse(props)
+  const [t3Unlocked, setT3Unlocked] = useState(false)
+  const [countdown, setCountdown] = useState(T3_DELAY_MS / 1000)
+
+  const isT3 = result.success && result.data.tier === 't3'
+  const needsDelay = isT3 && !stale
+
+  useEffect(() => {
+    if (!needsDelay) return
+
+    const interval = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    const timer = setTimeout(() => {
+      setT3Unlocked(true)
+    }, T3_DELAY_MS)
+
+    return () => {
+      clearTimeout(timer)
+      clearInterval(interval)
+    }
+  }, [needsDelay])
+
+  const handleAction = useCallback(
+    (actionType: 'approve' | 'reject') => {
+      if (onAction) {
+        const cardAction: CardAction = {
+          actionType,
+          cardId: '',
+          payload: result.success
+            ? { command: result.data.command, tier: result.data.tier }
+            : {},
+        }
+        onAction(cardAction)
+      }
+    },
+    [onAction, result],
+  )
+
+  if (!result.success) {
+    return (
+      <div
+        data-testid="approval-card-invalid"
+        style={{
+          padding: 'var(--nous-space-sm)',
+          color: 'var(--nous-fg-muted)',
+          fontSize: 'var(--nous-font-size-xs)',
+        }}
+      >
+        Invalid approval card data
+      </div>
+    )
+  }
+
+  const data = result.data
+  const borderColor = stale ? 'var(--nous-fg-muted)' : TIER_BORDER_COLOR[data.tier]
+  const bgColor = stale ? 'var(--nous-bg-surface)' : undefined
+  const badge = TIER_BADGE[data.tier]
+  const approveDisabled = isT3 && !t3Unlocked && !stale
+
+  return (
+    <Card
+      data-testid="approval-card"
+      style={{
+        borderLeft: `3px solid ${borderColor}`,
+        ...(bgColor ? { background: bgColor } : {}),
+      }}
+    >
+      <CardHeader>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--nous-space-sm)',
+          }}
+        >
+          <CardTitle style={{ fontSize: 'var(--nous-font-size-sm)' }}>
+            {data.title}
+          </CardTitle>
+          <Badge
+            data-testid="approval-tier-badge"
+            variant={badge.variant}
+            style={badge.style}
+          >
+            {badge.label}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div
+          style={{
+            fontSize: 'var(--nous-font-size-sm)',
+            color: 'var(--nous-text-primary)',
+            marginBottom: 'var(--nous-space-sm)',
+          }}
+        >
+          {data.description}
+        </div>
+        <div
+          data-testid="approval-command-block"
+          style={{
+            fontFamily: 'var(--nous-font-mono)',
+            fontSize: 'var(--nous-font-size-xs)',
+            padding: 'var(--nous-space-sm)',
+            background: 'var(--nous-bg-elevated)',
+            borderRadius: 'var(--nous-radius-sm)',
+            color: 'var(--nous-text-primary)',
+            marginBottom: 'var(--nous-space-sm)',
+            overflowX: 'auto',
+          }}
+        >
+          {data.command}
+        </div>
+        {data.context && (
+          <div
+            data-testid="approval-context"
+            style={{
+              fontSize: 'var(--nous-font-size-xs)',
+              color: 'var(--nous-fg-subtle)',
+              marginBottom: 'var(--nous-space-sm)',
+            }}
+          >
+            {Object.entries(data.context).map(([key, value]) => (
+              <div key={key}>
+                <span style={{ fontWeight: 'var(--nous-font-weight-medium)' as any }}>
+                  {key}:
+                </span>{' '}
+                {String(value)}
+              </div>
+            ))}
+          </div>
+        )}
+        <div
+          style={{
+            display: 'flex',
+            gap: 'var(--nous-space-xs)',
+            alignItems: 'center',
+          }}
+        >
+          {stale && actionOutcome ? (
+            <Badge
+              data-testid="approval-card-outcome"
+              variant="secondary"
+            >
+              {actionOutcome.label}
+            </Badge>
+          ) : stale ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled
+                data-testid="approval-expired-btn"
+              >
+                Expired
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="default"
+                size="sm"
+                disabled={approveDisabled}
+                data-testid="approval-approve-btn"
+                onClick={() => handleAction('approve')}
+              >
+                {approveDisabled ? `Approve (${countdown}s)` : 'Approve'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="approval-reject-btn"
+                onClick={() => handleAction('reject')}
+              >
+                Reject
+              </Button>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/self/ui/src/components/chat/cards/card-prompt-fragment.md
+++ b/self/ui/src/components/chat/cards/card-prompt-fragment.md
@@ -1,0 +1,26 @@
+## Structured Response Cards
+
+You can respond with interactive cards using OpenUI markup when the situation calls for structured interaction. Use the %%openui prefix to indicate card content.
+
+### When to use cards:
+- Presenting a decision that requires user approval or choice (ActionCard or ApprovalCard)
+- Reporting operation status with progress (StatusCard)
+- Summarizing a workflow with actionable options (WorkflowCard)
+- Suggesting follow-up actions after completing a task (FollowUpBlock)
+
+### When NOT to use cards:
+- Simple conversational replies, explanations, or discussions
+- Responses that are purely informational with no actionable component
+- When the user asked a question that deserves a direct text answer
+- Error messages or apologies -- use plain text
+
+### Card type reference:
+- StatusCard: { title, status: active|complete|error|waiting, message, detail?, progress? }
+- ActionCard: { title, description, actions: [{ label, actionType, payload?, variant? }] }
+- ApprovalCard: { title, description, tier: t1|t2|t3, command, context? }
+- WorkflowCard: { title, workflowId, nodeCount?, status?, summary? }
+- FollowUpBlock: { suggestions: [{ label, prompt?, actionType?, payload? }] }
+
+### Format:
+Prefix card responses with %%openui on its own line, then the card markup.
+You may mix plain text and cards in a single response -- text before %%openui is rendered normally.

--- a/self/ui/src/components/chat/cards/card-prompt-fragment.md
+++ b/self/ui/src/components/chat/cards/card-prompt-fragment.md
@@ -15,12 +15,43 @@ You can respond with interactive cards using OpenUI markup when the situation ca
 - Error messages or apologies -- use plain text
 
 ### Card type reference:
-- StatusCard: { title, status: active|complete|error|waiting, message, detail?, progress? }
-- ActionCard: { title, description, actions: [{ label, actionType, payload?, variant? }] }
-- ApprovalCard: { title, description, tier: t1|t2|t3, command, context? }
-- WorkflowCard: { title, workflowId, nodeCount?, status?, summary? }
-- FollowUpBlock: { suggestions: [{ label, prompt?, actionType?, payload? }] }
+
+Each card is written as a self-closing XML-style tag with PascalCase name and props.
+String props use key="value". Non-string props (numbers, arrays, objects) use key={json}.
+
+**StatusCard** -- report operation status with optional progress
+Required: title, status (active|complete|error|waiting), message
+Optional: detail, progress (0-100)
+<StatusCard title="Indexing complete" status="complete" message="Processed 142 files" progress={100} />
+
+**ActionCard** -- present action buttons for user choice
+Required: title, description, actions (array of {label, actionType: approve|reject|navigate|followup})
+Optional per action: payload, variant (primary|secondary|ghost, default: secondary)
+<ActionCard title="Deploy options" description="Choose a deployment target" actions={[{"label":"Production","actionType":"approve","variant":"primary"},{"label":"Staging","actionType":"approve","variant":"secondary"}]} />
+
+**ApprovalCard** -- request user approval with tier-based controls
+Required: title, description, tier (t1|t2|t3), command
+Optional: context (object)
+<ApprovalCard title="Run migration" description="Apply database schema changes" tier="t2" command="pnpm db:migrate --production" />
+
+**WorkflowCard** -- show workflow status and controls
+Required: title, workflowId
+Optional: nodeCount, status (draft|ready|running|completed|failed), summary
+<WorkflowCard title="CI Pipeline" workflowId="ci-main-branch" status="running" nodeCount={5} summary="Running lint and test stages" />
+
+**FollowUpBlock** -- suggest follow-up actions as pill buttons
+Required: suggestions (array of {label}, 1-6 items)
+Optional per suggestion: prompt, actionType (followup|navigate|submit, default: followup), payload
+<FollowUpBlock suggestions={[{"label":"Show details"},{"label":"Run again","prompt":"Re-run the last operation"},{"label":"Open logs","actionType":"navigate"}]} />
 
 ### Format:
 Prefix card responses with %%openui on its own line, then the card markup.
 You may mix plain text and cards in a single response -- text before %%openui is rendered normally.
+
+Example complete response:
+I've finished analyzing the repository. Here are the results:
+
+%%openui
+<StatusCard title="Analysis complete" status="complete" message="Found 3 issues across 12 files" detail="2 warnings, 1 error" progress={100} />
+
+<FollowUpBlock suggestions={[{"label":"Show issues"},{"label":"Auto-fix warnings","prompt":"Fix the 2 warnings automatically"},{"label":"View full report","actionType":"navigate"}]} />

--- a/self/ui/src/components/chat/cards/follow-up-block.tsx
+++ b/self/ui/src/components/chat/cards/follow-up-block.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import React from 'react'
+import { z } from 'zod'
+import { Badge } from '../../badge'
+import type { CardRendererProps, CardAction } from '../openui-adapter/types'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const FollowUpBlockSchema = z
+  .object({
+    suggestions: z
+      .array(
+        z.object({
+          label: z.string(),
+          prompt: z.string().optional(),
+          actionType: z
+            .enum(['followup', 'navigate', 'submit'])
+            .default('followup'),
+          payload: z.record(z.unknown()).optional(),
+        }),
+      )
+      .min(1)
+      .max(6),
+  })
+  .strip()
+
+export type FollowUpBlockProps = z.infer<typeof FollowUpBlockSchema>
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+// FollowUpBlock renders as a flex-wrap pill row WITHOUT a card container.
+// This is intentionally different from other cards.
+// ---------------------------------------------------------------------------
+
+export function FollowUpBlock({
+  props,
+  stale,
+  onAction,
+}: CardRendererProps<unknown>) {
+  const result = FollowUpBlockSchema.safeParse(props)
+  if (!result.success) {
+    return (
+      <div
+        data-testid="followup-block-invalid"
+        style={{
+          padding: 'var(--nous-space-sm)',
+          color: 'var(--nous-fg-muted)',
+          fontSize: 'var(--nous-font-size-xs)',
+        }}
+      >
+        Invalid follow-up block data
+      </div>
+    )
+  }
+
+  const data = result.data
+
+  return (
+    <div
+      data-testid="followup-block"
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 'var(--nous-space-xs)',
+      }}
+    >
+      {stale
+        ? data.suggestions.map((suggestion, i) => (
+            <Badge
+              key={i}
+              variant="outline"
+              data-testid="followup-stale-pill"
+              style={{
+                fontSize: 'var(--nous-font-size-xs)',
+                borderRadius: 'var(--nous-radius-md)',
+                cursor: 'default',
+              }}
+            >
+              {suggestion.label}
+            </Badge>
+          ))
+        : data.suggestions.map((suggestion, i) => (
+            <button
+              key={i}
+              type="button"
+              data-testid="followup-pill"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                padding: 'var(--nous-space-xs) var(--nous-space-sm)',
+                background: 'var(--nous-bg-elevated)',
+                border: '1px solid var(--nous-shell-column-border)',
+                borderRadius: 'var(--nous-radius-md)',
+                fontSize: 'var(--nous-font-size-xs)',
+                color: 'var(--nous-text-primary)',
+                cursor: 'pointer',
+                transition: 'background-color 0.15s',
+              }}
+              onClick={() => {
+                if (onAction) {
+                  const cardAction: CardAction = {
+                    actionType: suggestion.actionType,
+                    cardId: '',
+                    payload: {
+                      prompt: suggestion.prompt ?? suggestion.label,
+                      ...(suggestion.payload ?? {}),
+                    },
+                  }
+                  onAction(cardAction)
+                }
+              }}
+            >
+              {suggestion.label}
+            </button>
+          ))}
+    </div>
+  )
+}

--- a/self/ui/src/components/chat/cards/index.ts
+++ b/self/ui/src/components/chat/cards/index.ts
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------
+// cards/index.ts — Card registration and exports
+// ---------------------------------------------------------------------------
+// Importing this module registers all 5 card types with the adapter registry
+// at module evaluation time. This is the only import consumers need to ensure
+// all cards are available for rendering.
+// ---------------------------------------------------------------------------
+
+import { registerNousCard } from '../openui-adapter'
+import type { NousCardDefinition } from '../openui-adapter'
+
+import { StatusCardSchema, StatusCard } from './status-card'
+import { ActionCardSchema, ActionCard } from './action-card'
+import { ApprovalCardSchema, ApprovalCard } from './approval-card'
+import { WorkflowCardSchema, WorkflowCard } from './workflow-card'
+import { FollowUpBlockSchema, FollowUpBlock } from './follow-up-block'
+
+// ---------------------------------------------------------------------------
+// Card definitions
+// ---------------------------------------------------------------------------
+
+const cardDefinitions: NousCardDefinition[] = [
+  {
+    name: 'StatusCard',
+    description: 'Displays status information with optional progress indicator',
+    propsSchema: StatusCardSchema,
+    renderer: StatusCard,
+  },
+  {
+    name: 'ActionCard',
+    description: 'Presents action buttons for user interaction',
+    propsSchema: ActionCardSchema,
+    renderer: ActionCard,
+  },
+  {
+    name: 'ApprovalCard',
+    description: 'Approval request with tier-based security controls',
+    propsSchema: ApprovalCardSchema,
+    renderer: ApprovalCard,
+  },
+  {
+    name: 'WorkflowCard',
+    description: 'Workflow status and management controls',
+    propsSchema: WorkflowCardSchema,
+    renderer: WorkflowCard,
+  },
+  {
+    name: 'FollowUpBlock',
+    description: 'Follow-up suggestion pills for conversation continuation',
+    propsSchema: FollowUpBlockSchema,
+    renderer: FollowUpBlock,
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Register all cards at module evaluation time
+// ---------------------------------------------------------------------------
+
+for (const definition of cardDefinitions) {
+  registerNousCard(definition)
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { StatusCardSchema, type StatusCardProps } from './status-card'
+export { ActionCardSchema, type ActionCardProps } from './action-card'
+export { ApprovalCardSchema, type ApprovalCardProps } from './approval-card'
+export { WorkflowCardSchema, type WorkflowCardProps } from './workflow-card'
+export { FollowUpBlockSchema, type FollowUpBlockProps } from './follow-up-block'

--- a/self/ui/src/components/chat/cards/status-card.tsx
+++ b/self/ui/src/components/chat/cards/status-card.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import React from 'react'
+import { z } from 'zod'
+import { Card, CardHeader, CardTitle, CardContent } from '../../card'
+import type { CardRendererProps } from '../openui-adapter/types'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const StatusCardSchema = z
+  .object({
+    title: z.string(),
+    status: z.enum(['active', 'complete', 'error', 'waiting']),
+    message: z.string(),
+    detail: z.string().optional(),
+    progress: z.number().min(0).max(100).optional(),
+  })
+  .strip()
+
+export type StatusCardProps = z.infer<typeof StatusCardSchema>
+
+// ---------------------------------------------------------------------------
+// Token mappings
+// ---------------------------------------------------------------------------
+
+const STATUS_BORDER_COLOR: Record<StatusCardProps['status'], string> = {
+  active: 'var(--nous-state-active)',
+  complete: 'var(--nous-state-complete)',
+  error: 'var(--nous-state-blocked)',
+  waiting: 'var(--nous-state-waiting)',
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+export function StatusCard({
+  props,
+  stale,
+  actionOutcome,
+}: CardRendererProps<unknown>) {
+  const result = StatusCardSchema.safeParse(props)
+  if (!result.success) {
+    return (
+      <div
+        data-testid="status-card-invalid"
+        style={{
+          padding: 'var(--nous-space-sm)',
+          color: 'var(--nous-fg-muted)',
+          fontSize: 'var(--nous-font-size-xs)',
+        }}
+      >
+        Invalid status card data
+      </div>
+    )
+  }
+
+  const data = result.data
+  const borderColor = stale
+    ? 'var(--nous-fg-muted)'
+    : STATUS_BORDER_COLOR[data.status]
+  const bgColor = stale ? 'var(--nous-bg-surface)' : undefined
+
+  return (
+    <Card
+      data-testid="status-card"
+      style={{
+        borderLeft: `3px solid ${borderColor}`,
+        ...(bgColor ? { background: bgColor } : {}),
+      }}
+    >
+      <CardHeader>
+        <CardTitle
+          style={{ fontSize: 'var(--nous-font-size-sm)' }}
+        >
+          {data.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div
+          style={{
+            fontSize: 'var(--nous-font-size-sm)',
+            color: 'var(--nous-text-primary)',
+          }}
+        >
+          {data.message}
+        </div>
+        {data.detail && (
+          <div
+            style={{
+              marginTop: 'var(--nous-space-xs)',
+              fontSize: 'var(--nous-font-size-xs)',
+              color: 'var(--nous-fg-subtle)',
+            }}
+          >
+            {data.detail}
+          </div>
+        )}
+        {data.progress != null && (
+          <div
+            data-testid="status-card-progress"
+            style={{
+              marginTop: 'var(--nous-space-sm)',
+              height: '4px',
+              borderRadius: 'var(--nous-radius-sm)',
+              background: 'var(--nous-bg-elevated)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                width: `${data.progress}%`,
+                height: '100%',
+                background: stale
+                  ? 'var(--nous-fg-muted)'
+                  : 'var(--nous-state-active)',
+                borderRadius: 'var(--nous-radius-sm)',
+                transition: 'width 0.3s ease',
+              }}
+            />
+          </div>
+        )}
+        {stale && actionOutcome && (
+          <div
+            data-testid="status-card-outcome"
+            style={{
+              marginTop: 'var(--nous-space-sm)',
+              fontSize: 'var(--nous-font-size-xs)',
+              color: 'var(--nous-fg-muted)',
+            }}
+          >
+            {actionOutcome.label}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/self/ui/src/components/chat/cards/workflow-card.tsx
+++ b/self/ui/src/components/chat/cards/workflow-card.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import React from 'react'
+import { z } from 'zod'
+import { Card, CardHeader, CardTitle, CardContent } from '../../card'
+import { Button } from '../../button'
+import { Badge } from '../../badge'
+import type { CardRendererProps, CardAction } from '../openui-adapter/types'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const WorkflowCardSchema = z
+  .object({
+    title: z.string(),
+    workflowId: z.string(),
+    nodeCount: z.number().optional(),
+    status: z
+      .enum(['draft', 'ready', 'running', 'completed', 'failed'])
+      .optional(),
+    summary: z.string().optional(),
+  })
+  .strip()
+
+export type WorkflowCardProps = z.infer<typeof WorkflowCardSchema>
+
+// ---------------------------------------------------------------------------
+// Token mappings
+// ---------------------------------------------------------------------------
+
+const STATUS_DOT_COLOR: Record<string, string> = {
+  draft: 'var(--nous-state-idle)',
+  ready: 'var(--nous-state-waiting)',
+  running: 'var(--nous-state-active)',
+  completed: 'var(--nous-state-complete)',
+  failed: 'var(--nous-state-blocked)',
+}
+
+// ---------------------------------------------------------------------------
+// Action definitions for workflow card buttons
+// ---------------------------------------------------------------------------
+
+const WORKFLOW_ACTIONS = [
+  { label: 'Run', actionType: 'submit' as const },
+  { label: 'Edit', actionType: 'navigate' as const },
+  { label: 'Inspect', actionType: 'navigate' as const },
+]
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+export function WorkflowCard({
+  props,
+  stale,
+  actionOutcome,
+  onAction,
+}: CardRendererProps<unknown>) {
+  const result = WorkflowCardSchema.safeParse(props)
+  if (!result.success) {
+    return (
+      <div
+        data-testid="workflow-card-invalid"
+        style={{
+          padding: 'var(--nous-space-sm)',
+          color: 'var(--nous-fg-muted)',
+          fontSize: 'var(--nous-font-size-xs)',
+        }}
+      >
+        Invalid workflow card data
+      </div>
+    )
+  }
+
+  const data = result.data
+  const borderColor = stale ? 'var(--nous-fg-muted)' : undefined
+  const bgColor = stale ? 'var(--nous-bg-surface)' : undefined
+  const dotColor = data.status
+    ? (stale ? 'var(--nous-fg-muted)' : STATUS_DOT_COLOR[data.status] ?? 'var(--nous-fg-muted)')
+    : undefined
+
+  return (
+    <Card
+      data-testid="workflow-card"
+      style={{
+        ...(borderColor ? { borderColor } : {}),
+        ...(bgColor ? { background: bgColor } : {}),
+      }}
+    >
+      <CardHeader>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--nous-space-sm)',
+          }}
+        >
+          {dotColor && (
+            <span
+              data-testid="workflow-status-dot"
+              style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                background: dotColor,
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <CardTitle style={{ fontSize: 'var(--nous-font-size-sm)' }}>
+            {data.title}
+          </CardTitle>
+          {data.nodeCount != null && (
+            <Badge
+              data-testid="workflow-node-count"
+              variant="secondary"
+            >
+              {data.nodeCount} nodes
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {data.summary && (
+          <div
+            data-testid="workflow-summary"
+            style={{
+              fontSize: 'var(--nous-font-size-sm)',
+              color: 'var(--nous-text-primary)',
+              marginBottom: 'var(--nous-space-sm)',
+            }}
+          >
+            {data.summary}
+          </div>
+        )}
+        <div
+          style={{
+            display: 'flex',
+            gap: 'var(--nous-space-xs)',
+            flexWrap: 'wrap',
+          }}
+        >
+          {stale && actionOutcome ? (
+            <Badge
+              data-testid="workflow-card-outcome"
+              variant="secondary"
+            >
+              {actionOutcome.label}
+            </Badge>
+          ) : stale ? (
+            WORKFLOW_ACTIONS.map((action, i) => (
+              <Button
+                key={i}
+                variant="outline"
+                size="sm"
+                disabled
+                data-testid={`workflow-expired-btn-${action.label.toLowerCase()}`}
+              >
+                Expired
+              </Button>
+            ))
+          ) : (
+            WORKFLOW_ACTIONS.map((action, i) => (
+              <Button
+                key={i}
+                variant="outline"
+                size="sm"
+                data-testid={`workflow-btn-${action.label.toLowerCase()}`}
+                onClick={() => {
+                  if (onAction) {
+                    const cardAction: CardAction = {
+                      actionType: action.actionType,
+                      cardId: '',
+                      payload: {
+                        workflowId: data.workflowId,
+                        action: action.label.toLowerCase(),
+                      },
+                    }
+                    onAction(cardAction)
+                  }
+                }}
+              >
+                {action.label}
+              </Button>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/self/ui/src/components/chat/hooks/__tests__/useCardActionHandler.test.ts
+++ b/self/ui/src/components/chat/hooks/__tests__/useCardActionHandler.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useCardActionHandler } from '../useCardActionHandler'
+import { ShellProvider } from '../../../shell/ShellContext'
+import type { CardAction } from '../../openui-adapter/types'
+import type { ChatMessage } from '../../../../panels/ChatPanel'
+
+const mockNavigate = vi.fn()
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      ShellProvider,
+      { navigate: mockNavigate },
+      children,
+    )
+  }
+}
+
+function createMockChatApi() {
+  return {
+    sendAction: vi.fn().mockResolvedValue({ ok: true, message: 'Action submitted' }),
+  }
+}
+
+function createMessages(): ChatMessage[] {
+  return [
+    { role: 'user', content: 'Hello', timestamp: '2026-01-01T00:00:00Z' },
+    {
+      role: 'assistant',
+      content: '<ActionCard title="Test" description="Do something" />',
+      timestamp: '2026-01-01T00:01:00Z',
+      contentType: 'openui' as const,
+    },
+  ]
+}
+
+describe('useCardActionHandler', () => {
+  let chatApi: ReturnType<typeof createMockChatApi>
+  let setMessages: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    chatApi = createMockChatApi()
+    setMessages = vi.fn()
+  })
+
+  // ── Tier 2: Behavior Tests ──────────────────────────────────────────────
+
+  it('navigate action calls useShellContext().navigate() with payload.panel', () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'navigate',
+      cardId: 'card-1',
+      payload: { panel: 'settings' },
+    }
+
+    act(() => {
+      result.current(action, 1)
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('settings')
+  })
+
+  it('navigate action does NOT call chatApi.sendAction', () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'navigate',
+      cardId: 'card-1',
+      payload: { panel: 'observe' },
+    }
+
+    act(() => {
+      result.current(action, 1)
+    })
+
+    expect(chatApi.sendAction).not.toHaveBeenCalled()
+  })
+
+  it('approve action calls chatApi.sendAction with the action', async () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'approve',
+      cardId: 'card-2',
+      payload: { reason: 'approved' },
+    }
+
+    await act(async () => {
+      result.current(action, 1)
+      // Wait for the promise to resolve
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    expect(chatApi.sendAction).toHaveBeenCalledWith(action)
+  })
+
+  it('after successful action, actionOutcome is set on message at correct index', async () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'approve',
+      cardId: 'card-2',
+      payload: {},
+    }
+
+    await act(async () => {
+      result.current(action, 1)
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    expect(setMessages).toHaveBeenCalled()
+    // Get the updater function and call it with mock messages
+    const updater = setMessages.mock.calls[0][0]
+    const messages = createMessages()
+    const updated = updater(messages)
+
+    // Index 0 (user message) should be unchanged
+    expect(updated[0].actionOutcome).toBeUndefined()
+    // Index 1 (assistant card message) should have actionOutcome
+    expect(updated[1].actionOutcome).toBeDefined()
+    expect(updated[1].actionOutcome.actionType).toBe('approve')
+  })
+
+  it('actionOutcome contains correct actionType and timestamp', async () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'reject',
+      cardId: 'card-3',
+      payload: {},
+    }
+
+    await act(async () => {
+      result.current(action, 1)
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    const updater = setMessages.mock.calls[0][0]
+    const updated = updater(createMessages())
+
+    expect(updated[1].actionOutcome.actionType).toBe('reject')
+    expect(updated[1].actionOutcome.label).toBe('reject')
+    expect(typeof updated[1].actionOutcome.timestamp).toBe('string')
+    // Timestamp should be a valid ISO string
+    expect(new Date(updated[1].actionOutcome.timestamp).toISOString()).toBe(updated[1].actionOutcome.timestamp)
+  })
+
+  it('followup action calls chatApi.sendAction', async () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'followup',
+      cardId: 'card-4',
+      payload: { prompt: 'Tell me more' },
+    }
+
+    await act(async () => {
+      result.current(action, 1)
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    expect(chatApi.sendAction).toHaveBeenCalledWith(action)
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  // ── Tier 3: Edge Case Tests ─────────────────────────────────────────────
+
+  it('action on out-of-bounds message index does not crash', async () => {
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'approve',
+      cardId: 'card-5',
+      payload: {},
+    }
+
+    // Should not throw even with an out-of-bounds index
+    await act(async () => {
+      result.current(action, 999)
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    // setMessages still called (functional update handles bounds gracefully via .map)
+    expect(setMessages).toHaveBeenCalled()
+  })
+
+  it('does nothing when chatApi.sendAction is undefined', () => {
+    const noSendApi = {} as { sendAction?: typeof chatApi.sendAction }
+    const { result } = renderHook(
+      () => useCardActionHandler({ chatApi: noSendApi, setMessages }),
+      { wrapper: createWrapper() },
+    )
+
+    const action: CardAction = {
+      actionType: 'approve',
+      cardId: 'card-6',
+      payload: {},
+    }
+
+    act(() => {
+      result.current(action, 0)
+    })
+
+    // No crash, no setMessages call
+    expect(setMessages).not.toHaveBeenCalled()
+  })
+})

--- a/self/ui/src/components/chat/hooks/useCardActionHandler.ts
+++ b/self/ui/src/components/chat/hooks/useCardActionHandler.ts
@@ -1,0 +1,54 @@
+import { useCallback, useContext } from 'react'
+import { ShellContext } from '../../shell/ShellContext'
+import type { CardAction } from '../openui-adapter/types'
+import type { ChatMessage, ActionResult } from '../../../panels/ChatPanel'
+
+export interface UseCardActionHandlerOptions {
+  chatApi: {
+    sendAction?: (action: CardAction) => Promise<ActionResult>
+  }
+  setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>
+}
+
+/**
+ * Hook that returns a handler for card action events.
+ *
+ * - `navigate` actions are handled client-side via shell context `navigate()`
+ * - All other action types are dispatched via `chatApi.sendAction()`
+ * - On successful dispatch, sets `actionOutcome` on the originating message
+ *   to transition the card to stale state.
+ *
+ * Gracefully handles absence of ShellProvider — navigate actions become no-ops.
+ */
+export function useCardActionHandler({ chatApi, setMessages }: UseCardActionHandlerOptions) {
+  const shellContext = useContext(ShellContext)
+
+  return useCallback(
+    (action: CardAction, messageIndex: number) => {
+      if (action.actionType === 'navigate') {
+        shellContext?.navigate(String(action.payload.panel))
+        return
+      }
+
+      if (!chatApi.sendAction) return
+
+      chatApi.sendAction(action).then(() => {
+        setMessages(prev =>
+          prev.map((msg, i) =>
+            i === messageIndex
+              ? {
+                  ...msg,
+                  actionOutcome: {
+                    actionType: action.actionType,
+                    label: action.actionType,
+                    timestamp: new Date().toISOString(),
+                  },
+                }
+              : msg,
+          ),
+        )
+      })
+    },
+    [shellContext, chatApi, setMessages],
+  )
+}

--- a/self/ui/src/components/chat/openui-adapter/__tests__/adapter.test.ts
+++ b/self/ui/src/components/chat/openui-adapter/__tests__/adapter.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import {
+  parseCardContent,
+  renderCardTree,
+  registerNousCard,
+  getCardRegistry,
+} from '../index'
+import type { NousCardDefinition, CardRendererProps } from '../types'
+import { _clearRegistry } from '../registry'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDummyCard(name: string): NousCardDefinition {
+  return {
+    name,
+    description: `Test ${name}`,
+    propsSchema: { parse: (v: unknown) => v } as any,
+    renderer: (({ props }: CardRendererProps<unknown>) =>
+      React.createElement('div', { 'data-testid': `test-${name}` }, `Rendered ${name}`)) as any,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registry tests
+// ---------------------------------------------------------------------------
+
+describe('Card Registry', () => {
+  beforeEach(() => {
+    _clearRegistry()
+  })
+
+  it('registers a card definition and reports has() as true', () => {
+    registerNousCard(makeDummyCard('TestCard'))
+    expect(getCardRegistry().has('TestCard')).toBe(true)
+  })
+
+  it('returns false for unregistered card names', () => {
+    expect(getCardRegistry().has('NonExistent')).toBe(false)
+  })
+
+  it('get() returns definition for registered card', () => {
+    const def = makeDummyCard('TestCard')
+    registerNousCard(def)
+    expect(getCardRegistry().get('TestCard')).toEqual(def)
+  })
+
+  it('get() returns undefined for unregistered card', () => {
+    expect(getCardRegistry().get('NonExistent')).toBeUndefined()
+  })
+
+  it('list() returns all registered card names', () => {
+    registerNousCard(makeDummyCard('CardA'))
+    registerNousCard(makeDummyCard('CardB'))
+    const names = getCardRegistry().list()
+    expect(names).toContain('CardA')
+    expect(names).toContain('CardB')
+    expect(names).toHaveLength(2)
+  })
+
+  it('list() returns empty array when no cards registered', () => {
+    expect(getCardRegistry().list()).toEqual([])
+  })
+
+  it('overwrites existing card with same name', () => {
+    registerNousCard(makeDummyCard('TestCard'))
+    const updated = makeDummyCard('TestCard')
+    updated.description = 'Updated description'
+    registerNousCard(updated)
+    expect(getCardRegistry().get('TestCard')?.description).toBe('Updated description')
+    expect(getCardRegistry().list()).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Parser tests
+// ---------------------------------------------------------------------------
+
+describe('parseCardContent', () => {
+  it('parses valid self-closing card markup', () => {
+    const result = parseCardContent('<StatusCard title="Test" status="active" message="Hello" />')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.tree).toHaveLength(1)
+      expect(result.tree[0].type).toBe('StatusCard')
+      expect(result.tree[0].props.title).toBe('Test')
+      expect(result.tree[0].props.status).toBe('active')
+      expect(result.tree[0].props.message).toBe('Hello')
+    }
+  })
+
+  it('parses card markup with JSON prop values', () => {
+    const result = parseCardContent('<StatusCard title="Test" status="active" message="Hi" progress={75} />')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.tree[0].props.progress).toBe(75)
+    }
+  })
+
+  it('parses card markup with array prop values', () => {
+    const result = parseCardContent('<ActionCard title="T" description="D" actions={[{"label":"Go","actionType":"approve"}]} />')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.tree[0].props.actions).toEqual([{ label: 'Go', actionType: 'approve' }])
+    }
+  })
+
+  it('parses card markup with closing tags', () => {
+    const result = parseCardContent('<StatusCard title="Test" status="active" message="Hello">content</StatusCard>')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.tree).toHaveLength(1)
+      expect(result.tree[0].type).toBe('StatusCard')
+      expect(result.tree[0].children).toContain('content')
+    }
+  })
+
+  it('parses multiple card elements', () => {
+    const result = parseCardContent(
+      '<StatusCard title="A" status="active" message="M1" /><StatusCard title="B" status="complete" message="M2" />',
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.tree).toHaveLength(2)
+      expect(result.tree[0].props.title).toBe('A')
+      expect(result.tree[1].props.title).toBe('B')
+    }
+  })
+
+  it('returns { ok: false } for empty string', () => {
+    const result = parseCardContent('')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.raw).toBe('')
+      expect(result.error).toBe('Empty content')
+    }
+  })
+
+  it('returns { ok: false } for whitespace-only string', () => {
+    const result = parseCardContent('   \n\t  ')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe('Empty content')
+    }
+  })
+
+  it('returns { ok: false } for plain text without card tags', () => {
+    const result = parseCardContent('just some plain text without any tags')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.raw).toBe('just some plain text without any tags')
+      expect(result.error).toBe('No card elements found in content')
+    }
+  })
+
+  it('returns { ok: false } for invalid/malformed markup', () => {
+    const result = parseCardContent('<lowercase not="a card" />')
+    expect(result.ok).toBe(false)
+  })
+
+  it('handles null input gracefully', () => {
+    const result = parseCardContent(null as any)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Invalid input')
+    }
+  })
+
+  it('handles undefined input gracefully', () => {
+    const result = parseCardContent(undefined as any)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Invalid input')
+    }
+  })
+
+  it('never throws regardless of input', () => {
+    // Test a variety of bad inputs
+    const inputs = [null, undefined, 42, {}, [], true, '<<<<', '>>>>', '<Foo><Bar>']
+    for (const input of inputs) {
+      expect(() => parseCardContent(input as any)).not.toThrow()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Renderer tests
+// ---------------------------------------------------------------------------
+
+describe('renderCardTree', () => {
+  beforeEach(() => {
+    _clearRegistry()
+  })
+
+  it('renders registered card types using their renderer', () => {
+    registerNousCard(makeDummyCard('TestCard'))
+    const tree = [{ type: 'TestCard', props: { value: 42 }, children: [] }]
+    const handlers = { onAction: () => {} }
+
+    const { container } = render(
+      React.createElement(() => renderCardTree(tree, handlers)),
+    )
+    expect(container.querySelector('[data-testid="test-TestCard"]')).toBeTruthy()
+    expect(container.textContent).toContain('Rendered TestCard')
+  })
+
+  it('renders fallback for unregistered card types', () => {
+    const tree = [{ type: 'UnknownCard', props: {}, children: [] }]
+    const handlers = { onAction: () => {} }
+
+    const { container } = render(
+      React.createElement(() => renderCardTree(tree, handlers)),
+    )
+    const fallback = container.querySelector('[data-testid="unknown-card-fallback"]')
+    expect(fallback).toBeTruthy()
+    expect(fallback?.textContent).toContain('Unknown card type: UnknownCard')
+  })
+
+  it('handles empty tree array', () => {
+    const handlers = { onAction: () => {} }
+    const element = renderCardTree([], handlers)
+    expect(element).toBeTruthy()
+    const { container } = render(React.createElement(() => element))
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('handles mixed registered and unregistered types', () => {
+    registerNousCard(makeDummyCard('KnownCard'))
+    const tree = [
+      { type: 'KnownCard', props: {}, children: [] },
+      { type: 'UnknownCard', props: {}, children: [] },
+    ]
+    const handlers = { onAction: () => {} }
+
+    const { container } = render(
+      React.createElement(() => renderCardTree(tree, handlers)),
+    )
+    expect(container.querySelector('[data-testid="test-KnownCard"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="unknown-card-fallback"]')).toBeTruthy()
+  })
+
+  it('never throws regardless of input', () => {
+    const handlers = { onAction: () => {} }
+    expect(() => renderCardTree(null as any, handlers)).not.toThrow()
+    expect(() => renderCardTree(undefined as any, handlers)).not.toThrow()
+    expect(() => renderCardTree([], handlers)).not.toThrow()
+  })
+})

--- a/self/ui/src/components/chat/openui-adapter/__tests__/adapter.test.ts
+++ b/self/ui/src/components/chat/openui-adapter/__tests__/adapter.test.ts
@@ -250,4 +250,85 @@ describe('renderCardTree', () => {
     expect(() => renderCardTree(undefined as any, handlers)).not.toThrow()
     expect(() => renderCardTree([], handlers)).not.toThrow()
   })
+
+  // Phase 1.2 — RenderCardContext parameter tests
+  it('accepts optional third context parameter without error (backward compat)', () => {
+    registerNousCard(makeDummyCard('TestCard'))
+    const tree = [{ type: 'TestCard', props: { value: 1 }, children: [] }]
+    const handlers = { onAction: () => {} }
+
+    // No context (backward compat)
+    expect(() => renderCardTree(tree, handlers)).not.toThrow()
+    // With context
+    expect(() => renderCardTree(tree, handlers, { stale: false })).not.toThrow()
+    expect(() => renderCardTree(tree, handlers, { stale: true })).not.toThrow()
+  })
+
+  it('passes stale: true to card renderer when context.stale is true', () => {
+    let receivedProps: any = null
+    const staleSpy: any = {
+      name: 'StaleTestCard',
+      description: 'Test stale behavior',
+      propsSchema: { parse: (v: unknown) => v } as any,
+      renderer: ((p: any) => {
+        receivedProps = p
+        return React.createElement('div', { 'data-testid': 'stale-test' }, 'Stale')
+      }) as any,
+    }
+    registerNousCard(staleSpy)
+    const tree = [{ type: 'StaleTestCard', props: { v: 1 }, children: [] }]
+    const handlers = { onAction: () => {} }
+
+    render(
+      React.createElement(() => renderCardTree(tree, handlers, { stale: true })),
+    )
+    expect(receivedProps?.stale).toBe(true)
+    // onAction should NOT be passed when stale
+    expect(receivedProps?.onAction).toBeUndefined()
+  })
+
+  it('passes actionOutcome to card renderer when context provides it', () => {
+    let receivedProps: any = null
+    const outcomeCard: any = {
+      name: 'OutcomeCard',
+      description: 'Test outcome',
+      propsSchema: { parse: (v: unknown) => v } as any,
+      renderer: ((p: any) => {
+        receivedProps = p
+        return React.createElement('div', null, 'Outcome')
+      }) as any,
+    }
+    registerNousCard(outcomeCard)
+    const tree = [{ type: 'OutcomeCard', props: {}, children: [] }]
+    const handlers = { onAction: () => {} }
+    const actionOutcome = { actionType: 'approve', label: 'Done', timestamp: '2026-01-01T00:00:00Z' }
+
+    render(
+      React.createElement(() => renderCardTree(tree, handlers, { stale: true, actionOutcome })),
+    )
+    expect(receivedProps?.actionOutcome).toEqual(actionOutcome)
+  })
+
+  it('passes onAction when context.stale is false', () => {
+    let receivedProps: any = null
+    const liveCard: any = {
+      name: 'LiveCard',
+      description: 'Test live',
+      propsSchema: { parse: (v: unknown) => v } as any,
+      renderer: ((p: any) => {
+        receivedProps = p
+        return React.createElement('div', null, 'Live')
+      }) as any,
+    }
+    registerNousCard(liveCard)
+    const tree = [{ type: 'LiveCard', props: {}, children: [] }]
+    const mockAction = () => {}
+    const handlers = { onAction: mockAction }
+
+    render(
+      React.createElement(() => renderCardTree(tree, handlers, { stale: false })),
+    )
+    expect(receivedProps?.onAction).toBe(mockAction)
+    expect(receivedProps?.stale).toBeUndefined()
+  })
 })

--- a/self/ui/src/components/chat/openui-adapter/index.ts
+++ b/self/ui/src/components/chat/openui-adapter/index.ts
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------
+// openui-adapter — Public API
+// ---------------------------------------------------------------------------
+// This is the sole entry point for consuming the OpenUI adapter. All boundary
+// types are Nous-owned. Zero @openuidev/* imports in this file.
+// ---------------------------------------------------------------------------
+
+// Boundary types
+export type {
+  NousCardDefinition,
+  NousCardElement,
+  NousCardTree,
+  NousParseResult,
+  CardAction,
+  CardActionHandlers,
+  NousCardRegistry,
+  CardRendererProps,
+} from './types'
+
+// Facade functions
+export { registerNousCard, getCardRegistry } from './registry'
+export { parseCardContent } from './parser'
+export { renderCardTree } from './renderer'

--- a/self/ui/src/components/chat/openui-adapter/index.ts
+++ b/self/ui/src/components/chat/openui-adapter/index.ts
@@ -15,6 +15,7 @@ export type {
   CardActionHandlers,
   NousCardRegistry,
   CardRendererProps,
+  RenderCardContext,
 } from './types'
 
 // Facade functions

--- a/self/ui/src/components/chat/openui-adapter/parser.ts
+++ b/self/ui/src/components/chat/openui-adapter/parser.ts
@@ -1,0 +1,274 @@
+// ---------------------------------------------------------------------------
+// parser.ts — Parse OpenUI-like markup into NousCardTree
+// ---------------------------------------------------------------------------
+// FALLBACK IMPLEMENTATION: @openuidev/react-lang v0.1.4 is not available on
+// npm. This module implements a simple custom parser for the OpenUI-like
+// markup syntax (XML-style tags with JSON-encoded props). The public API
+// (parseCardContent) remains identical — when/if @openuidev packages become
+// available, only this file needs to change.
+//
+// Expected markup format:
+//   <StatusCard title="..." status="active" message="..." />
+//   <ActionCard title="..." description="...">
+//     ... nested content ...
+//   </ActionCard>
+//
+// Props can be:
+//   - Quoted strings: key="value"
+//   - JSON values: key={42} or key={true} or key={["a","b"]}
+//   - Object values: key={{ "nested": "object" }}
+// ---------------------------------------------------------------------------
+
+import type { NousCardElement, NousCardTree, NousParseResult } from './types'
+
+/**
+ * Parse a string containing OpenUI-like card markup into a NousCardTree.
+ *
+ * **Never throws.** Returns `{ ok: true, tree }` on success,
+ * `{ ok: false, raw, error }` on any failure.
+ */
+export function parseCardContent(content: string): NousParseResult {
+  try {
+    if (content == null || typeof content !== 'string') {
+      return { ok: false, raw: String(content ?? ''), error: 'Invalid input: expected string' }
+    }
+
+    const trimmed = content.trim()
+    if (trimmed === '') {
+      return { ok: false, raw: '', error: 'Empty content' }
+    }
+
+    const elements = parseElements(trimmed)
+    if (elements.length === 0) {
+      return { ok: false, raw: content, error: 'No card elements found in content' }
+    }
+
+    return { ok: true, tree: elements }
+  } catch (err) {
+    return {
+      ok: false,
+      raw: typeof content === 'string' ? content : '',
+      error: err instanceof Error ? err.message : 'Unknown parse error',
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseElements(input: string): NousCardTree {
+  const elements: NousCardTree = []
+  let pos = 0
+
+  while (pos < input.length) {
+    // Skip whitespace
+    while (pos < input.length && /\s/.test(input[pos])) pos++
+    if (pos >= input.length) break
+
+    if (input[pos] === '<') {
+      // Check for closing tag — means we've hit a parent's end
+      if (input[pos + 1] === '/') break
+
+      const result = parseElement(input, pos)
+      if (result) {
+        elements.push(result.element)
+        pos = result.end
+      } else {
+        // Cannot parse further; stop
+        break
+      }
+    } else {
+      // Text content — gather until next tag
+      const textEnd = input.indexOf('<', pos)
+      if (textEnd === -1) break
+      pos = textEnd
+    }
+  }
+
+  return elements
+}
+
+interface ParseElementResult {
+  element: NousCardElement
+  end: number
+}
+
+function parseElement(input: string, start: number): ParseElementResult | null {
+  // Match opening tag: <TagName
+  const tagMatch = input.slice(start).match(/^<([A-Z][A-Za-z0-9]*)/)
+  if (!tagMatch) return null
+
+  const tagName = tagMatch[1]
+  let pos = start + tagMatch[0].length
+
+  // Parse props
+  const props: Record<string, unknown> = {}
+  while (pos < input.length) {
+    // Skip whitespace
+    while (pos < input.length && /\s/.test(input[pos])) pos++
+    if (pos >= input.length) return null
+
+    // Self-closing tag: />
+    if (input[pos] === '/' && input[pos + 1] === '>') {
+      return {
+        element: { type: tagName, props, children: [] },
+        end: pos + 2,
+      }
+    }
+
+    // End of opening tag: >
+    if (input[pos] === '>') {
+      pos++ // skip '>'
+      break
+    }
+
+    // Parse prop: key="value" or key={value}
+    const propResult = parseProp(input, pos)
+    if (propResult) {
+      props[propResult.key] = propResult.value
+      pos = propResult.end
+    } else {
+      pos++ // skip unrecognized character
+    }
+  }
+
+  // Parse children until closing tag
+  const children: (NousCardElement | string)[] = []
+  while (pos < input.length) {
+    // Skip whitespace
+    const wsStart = pos
+    while (pos < input.length && /\s/.test(input[pos])) pos++
+
+    // Check for closing tag
+    const closeTag = `</${tagName}>`
+    if (input.slice(pos).startsWith(closeTag)) {
+      return {
+        element: { type: tagName, props, children },
+        end: pos + closeTag.length,
+      }
+    }
+
+    if (pos >= input.length) break
+
+    if (input[pos] === '<' && input[pos + 1] !== '/') {
+      // Nested element
+      const childResult = parseElement(input, pos)
+      if (childResult) {
+        children.push(childResult.element)
+        pos = childResult.end
+      } else {
+        break
+      }
+    } else if (input[pos] === '<' && input[pos + 1] === '/') {
+      // Closing tag (for this or parent element)
+      if (input.slice(pos).startsWith(closeTag)) {
+        return {
+          element: { type: tagName, props, children },
+          end: pos + closeTag.length,
+        }
+      }
+      // Mismatched close tag — bail
+      break
+    } else {
+      // Text content
+      const textEnd = input.indexOf('<', pos)
+      const text = textEnd === -1 ? input.slice(pos) : input.slice(pos, textEnd)
+      if (text.trim()) {
+        children.push(text.trim())
+      }
+      pos = textEnd === -1 ? input.length : textEnd
+    }
+  }
+
+  // If we exit without finding closing tag, still return what we have
+  return {
+    element: { type: tagName, props, children },
+    end: pos,
+  }
+}
+
+interface PropResult {
+  key: string
+  value: unknown
+  end: number
+}
+
+function parseProp(input: string, start: number): PropResult | null {
+  // Match key=
+  const keyMatch = input.slice(start).match(/^([a-zA-Z_][a-zA-Z0-9_]*)=/)
+  if (!keyMatch) return null
+
+  const key = keyMatch[1]
+  let pos = start + keyMatch[0].length
+
+  if (pos >= input.length) return null
+
+  // String value: "..."
+  if (input[pos] === '"') {
+    pos++ // skip opening quote
+    let value = ''
+    while (pos < input.length && input[pos] !== '"') {
+      if (input[pos] === '\\' && pos + 1 < input.length) {
+        value += input[pos + 1]
+        pos += 2
+      } else {
+        value += input[pos]
+        pos++
+      }
+    }
+    if (pos < input.length) pos++ // skip closing quote
+    return { key, value, end: pos }
+  }
+
+  // JSX expression value: {...}
+  if (input[pos] === '{') {
+    const braceResult = extractBraceContent(input, pos)
+    if (braceResult) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(braceResult.content)
+      } catch {
+        parsed = braceResult.content
+      }
+      return { key, value: parsed, end: braceResult.end }
+    }
+  }
+
+  return null
+}
+
+interface BraceResult {
+  content: string
+  end: number
+}
+
+function extractBraceContent(input: string, start: number): BraceResult | null {
+  if (input[start] !== '{') return null
+
+  let depth = 0
+  let pos = start
+
+  while (pos < input.length) {
+    if (input[pos] === '{') depth++
+    else if (input[pos] === '}') {
+      depth--
+      if (depth === 0) {
+        return {
+          content: input.slice(start + 1, pos),
+          end: pos + 1,
+        }
+      }
+    } else if (input[pos] === '"') {
+      // Skip string contents
+      pos++
+      while (pos < input.length && input[pos] !== '"') {
+        if (input[pos] === '\\') pos++
+        pos++
+      }
+    }
+    pos++
+  }
+
+  return null
+}

--- a/self/ui/src/components/chat/openui-adapter/registry.ts
+++ b/self/ui/src/components/chat/openui-adapter/registry.ts
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// registry.ts — Card registration and lookup
+// ---------------------------------------------------------------------------
+// FALLBACK IMPLEMENTATION: @openuidev/react-lang v0.1.4 is not available on
+// npm (the published versions start at a later range). This module implements
+// the same public API using a simple in-memory Map registry instead of
+// wrapping OpenUI's `defineComponent`. The public interface (registerNousCard,
+// getCardRegistry) remains identical — when/if @openuidev packages become
+// available at the expected version, only this file needs to change.
+// ---------------------------------------------------------------------------
+
+import type { NousCardDefinition, NousCardRegistry } from './types'
+
+const cardRegistry = new Map<string, NousCardDefinition>()
+
+/**
+ * Register a card definition in the adapter registry.
+ * If a card with the same name already exists, it is overwritten.
+ */
+export function registerNousCard(definition: NousCardDefinition): void {
+  cardRegistry.set(definition.name, definition)
+}
+
+/**
+ * Returns a read-only view of the card registry.
+ */
+export function getCardRegistry(): NousCardRegistry {
+  return {
+    has(name: string): boolean {
+      return cardRegistry.has(name)
+    },
+    get(name: string): NousCardDefinition | undefined {
+      return cardRegistry.get(name)
+    },
+    list(): string[] {
+      return Array.from(cardRegistry.keys())
+    },
+  }
+}
+
+/**
+ * Clear all registered cards. Exposed for testing only.
+ * @internal
+ */
+export function _clearRegistry(): void {
+  cardRegistry.clear()
+}

--- a/self/ui/src/components/chat/openui-adapter/renderer.ts
+++ b/self/ui/src/components/chat/openui-adapter/renderer.ts
@@ -14,6 +14,7 @@ import type {
   NousCardElement,
   CardActionHandlers,
   CardRendererProps,
+  RenderCardContext,
 } from './types'
 import { getCardRegistry } from './registry'
 
@@ -27,6 +28,7 @@ import { getCardRegistry } from './registry'
 export function renderCardTree(
   tree: NousCardTree,
   handlers: CardActionHandlers,
+  context?: RenderCardContext,
 ): React.ReactElement {
   try {
     if (!tree || tree.length === 0) {
@@ -34,7 +36,7 @@ export function renderCardTree(
     }
 
     const children = tree.map((element, index) =>
-      renderElement(element, handlers, `card-${index}`),
+      renderElement(element, handlers, `card-${index}`, context),
     )
 
     return React.createElement(React.Fragment, null, ...children)
@@ -47,6 +49,7 @@ function renderElement(
   element: NousCardElement,
   handlers: CardActionHandlers,
   key: string,
+  context?: RenderCardContext,
 ): React.ReactElement {
   try {
     const registry = getCardRegistry()
@@ -73,7 +76,9 @@ function renderElement(
 
     const rendererProps: CardRendererProps<unknown> = {
       props: element.props,
-      onAction: handlers.onAction,
+      ...(context?.stale
+        ? { stale: true, actionOutcome: context.actionOutcome }
+        : { onAction: handlers.onAction }),
     }
 
     return React.createElement(definition.renderer, { key, ...rendererProps })

--- a/self/ui/src/components/chat/openui-adapter/renderer.ts
+++ b/self/ui/src/components/chat/openui-adapter/renderer.ts
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------
+// renderer.ts — Render NousCardTree to React elements
+// ---------------------------------------------------------------------------
+// FALLBACK IMPLEMENTATION: @openuidev/react-lang v0.1.4 is not available on
+// npm. This module implements a direct React renderer that maps NousCardTree
+// elements to registered card components via the registry. The public API
+// (renderCardTree) remains identical — when/if @openuidev packages become
+// available, only this file needs to change.
+// ---------------------------------------------------------------------------
+
+import React from 'react'
+import type {
+  NousCardTree,
+  NousCardElement,
+  CardActionHandlers,
+  CardRendererProps,
+} from './types'
+import { getCardRegistry } from './registry'
+
+/**
+ * Render a parsed NousCardTree into React elements.
+ *
+ * **Never throws.** Renders a fallback element for unregistered card types.
+ * Each registered card type is rendered via its registered renderer component
+ * with the parsed props.
+ */
+export function renderCardTree(
+  tree: NousCardTree,
+  handlers: CardActionHandlers,
+): React.ReactElement {
+  try {
+    if (!tree || tree.length === 0) {
+      return React.createElement(React.Fragment)
+    }
+
+    const children = tree.map((element, index) =>
+      renderElement(element, handlers, `card-${index}`),
+    )
+
+    return React.createElement(React.Fragment, null, ...children)
+  } catch {
+    return React.createElement(React.Fragment)
+  }
+}
+
+function renderElement(
+  element: NousCardElement,
+  handlers: CardActionHandlers,
+  key: string,
+): React.ReactElement {
+  try {
+    const registry = getCardRegistry()
+    const definition = registry.get(element.type)
+
+    if (!definition) {
+      // Fallback for unregistered card type
+      return React.createElement(
+        'div',
+        {
+          key,
+          'data-testid': 'unknown-card-fallback',
+          style: {
+            padding: 'var(--nous-space-sm)',
+            color: 'var(--nous-fg-muted)',
+            fontSize: 'var(--nous-font-size-xs)',
+            border: '1px dashed var(--nous-fg-muted)',
+            borderRadius: 'var(--nous-radius-sm)',
+          },
+        },
+        `Unknown card type: ${element.type}`,
+      )
+    }
+
+    const rendererProps: CardRendererProps<unknown> = {
+      props: element.props,
+      onAction: handlers.onAction,
+    }
+
+    return React.createElement(definition.renderer, { key, ...rendererProps })
+  } catch {
+    // Error rendering a specific element — return fallback
+    return React.createElement(
+      'div',
+      {
+        key,
+        'data-testid': 'card-render-error',
+        style: {
+          padding: 'var(--nous-space-sm)',
+          color: 'var(--nous-fg-muted)',
+          fontSize: 'var(--nous-font-size-xs)',
+        },
+      },
+      'Card render error',
+    )
+  }
+}

--- a/self/ui/src/components/chat/openui-adapter/types.ts
+++ b/self/ui/src/components/chat/openui-adapter/types.ts
@@ -1,0 +1,91 @@
+import type { ReactElement } from 'react'
+import type { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// CardRendererProps<T>
+// ---------------------------------------------------------------------------
+// Shared interface for all card renderers. The `stale` flag, `actionOutcome`,
+// and `onAction` handler are provided by the ChatPanel (sub-phase 1.2) based
+// on the card-persistence-model-v1 decision.
+// ---------------------------------------------------------------------------
+
+export interface CardRendererProps<T = unknown> {
+  props: T
+  stale?: boolean
+  actionOutcome?: {
+    actionType: string
+    label: string
+    timestamp: string
+  }
+  onAction?: (action: CardAction) => void
+}
+
+// ---------------------------------------------------------------------------
+// NousCardDefinition
+// ---------------------------------------------------------------------------
+// Registry entry for a card type. Each card registers one of these.
+//
+// SF-1: The `renderer` type uses `CardRendererProps<unknown>` per
+// card-persistence-model-v1, superseding the adapter-boundary-v1 original
+// type signature of `React.ComponentType<{ props: unknown; children?: React.ReactNode }>`.
+// `children` is dropped because card content is delivered via typed props.
+// ---------------------------------------------------------------------------
+
+export interface NousCardDefinition {
+  name: string
+  description: string
+  propsSchema: z.ZodType<unknown>
+  renderer: React.ComponentType<CardRendererProps<unknown>>
+}
+
+// ---------------------------------------------------------------------------
+// NousCardElement — parsed tree node
+// ---------------------------------------------------------------------------
+
+export interface NousCardElement {
+  type: string
+  props: Record<string, unknown>
+  children: (NousCardElement | string)[]
+}
+
+// ---------------------------------------------------------------------------
+// NousCardTree — array of parsed elements
+// ---------------------------------------------------------------------------
+
+export type NousCardTree = NousCardElement[]
+
+// ---------------------------------------------------------------------------
+// NousParseResult — discriminated union for parser output
+// ---------------------------------------------------------------------------
+
+export type NousParseResult =
+  | { ok: true; tree: NousCardTree }
+  | { ok: false; raw: string; error?: string }
+
+// ---------------------------------------------------------------------------
+// CardAction — runtime event emitted by card renderers
+// ---------------------------------------------------------------------------
+
+export interface CardAction {
+  actionType: 'approve' | 'reject' | 'navigate' | 'submit' | 'followup'
+  cardId: string
+  payload: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// CardActionHandlers — callback interface for renderCardTree
+// ---------------------------------------------------------------------------
+
+export interface CardActionHandlers {
+  onAction: (action: CardAction) => void
+}
+
+// ---------------------------------------------------------------------------
+// NousCardRegistry — read-only registry interface
+// ---------------------------------------------------------------------------
+
+export interface NousCardRegistry {
+  has(name: string): boolean
+  get(name: string): NousCardDefinition | undefined
+  list(): string[]
+}

--- a/self/ui/src/components/chat/openui-adapter/types.ts
+++ b/self/ui/src/components/chat/openui-adapter/types.ts
@@ -81,6 +81,23 @@ export interface CardActionHandlers {
 }
 
 // ---------------------------------------------------------------------------
+// RenderCardContext — rendering context passed to renderCardTree
+// ---------------------------------------------------------------------------
+// Carries stale-state and actionOutcome information from ChatPanel to
+// individual card renderers. When stale is true, cards render in muted
+// mode with no action handler.
+// ---------------------------------------------------------------------------
+
+export interface RenderCardContext {
+  stale?: boolean
+  actionOutcome?: {
+    actionType: string
+    label: string
+    timestamp: string
+  }
+}
+
+// ---------------------------------------------------------------------------
 // NousCardRegistry — read-only registry interface
 // ---------------------------------------------------------------------------
 

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -14,7 +14,8 @@ import {
 } from '../components/thought'
 import type { ThoughtEvent } from '../components/thought'
 import { parseCardContent, renderCardTree } from '../components/chat/openui-adapter'
-import type { RenderCardContext } from '../components/chat/openui-adapter'
+import type { RenderCardContext, CardAction } from '../components/chat/openui-adapter'
+import { useCardActionHandler } from '../components/chat/hooks/useCardActionHandler'
 // Side-effect import: registers all 5 card types at module evaluation time
 import '../components/chat/cards/index'
 
@@ -33,9 +34,17 @@ export interface ChatMessage {
   }
 }
 
+export interface ActionResult {
+  ok: boolean
+  message: string
+  traceId?: string
+  contentType?: 'text' | 'openui'
+}
+
 export interface ChatAPI {
   send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui' }>
   getHistory: () => Promise<ChatMessage[]>
+  sendAction?: (action: import('../components/chat/openui-adapter').CardAction) => Promise<ActionResult>
 }
 
 export interface ChatPanelCoreProps {
@@ -90,10 +99,12 @@ function ChatCardRenderer({
   content,
   stale,
   actionOutcome,
+  onAction,
 }: {
   content: string
   stale: boolean
   actionOutcome?: ChatMessage['actionOutcome']
+  onAction?: (action: CardAction) => void
 }) {
   try {
     const parsed = parseCardContent(content)
@@ -118,7 +129,7 @@ function ChatCardRenderer({
     }
     const handlers = stale
       ? { onAction: () => {} }
-      : { onAction: () => { /* stub: full action routing is sub-phase 1.3 */ } }
+      : { onAction: onAction ?? (() => {}) }
 
     return (
       <div data-testid="openui-card-container" {...(stale ? { 'data-stale': 'true' } : {})}>
@@ -179,6 +190,8 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
   const chatApi = 'params' in props ? props.params?.chatApi : props.chatApi
   const conversationContext = 'conversationContext' in props ? props.conversationContext : undefined
   const className = 'className' in props ? props.className : undefined
+
+  const handleCardAction = useCardActionHandler({ chatApi: chatApi ?? {}, setMessages })
 
   useEffect(() => {
     if (chatApi?.getHistory) {
@@ -343,6 +356,7 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
                     content={cardContent}
                     stale={isStale}
                     actionOutcome={msg.actionOutcome}
+                    onAction={isStale ? undefined : (action) => handleCardAction(action, i)}
                   />
                 ) : (
                   msg.content

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -13,16 +13,28 @@ import {
   BUFFER_MAX,
 } from '../components/thought'
 import type { ThoughtEvent } from '../components/thought'
+import { parseCardContent, renderCardTree } from '../components/chat/openui-adapter'
+import type { RenderCardContext } from '../components/chat/openui-adapter'
+// Side-effect import: registers all 5 card types at module evaluation time
+import '../components/chat/cards/index'
+
+const OPENUI_PREFIX = '%%openui\n'
 
 export interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
   timestamp: string
   traceId?: string
+  contentType?: 'text' | 'openui'
+  actionOutcome?: {
+    actionType: string
+    label: string
+    timestamp: string
+  }
 }
 
 export interface ChatAPI {
-  send: (message: string) => Promise<{ response: string; traceId: string }>
+  send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui' }>
   getHistory: () => Promise<ChatMessage[]>
 }
 
@@ -53,6 +65,98 @@ type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition
 
 interface ChatPanelProps extends IDockviewPanelProps {
   params: { chatApi?: ChatAPI }
+}
+
+/**
+ * Determine whether a message should be treated as OpenUI card content.
+ * Uses contentType metadata (primary) with %%openui\n prefix fallback (secondary).
+ * Returns the content to render (with prefix stripped if needed) and the detected type.
+ */
+function detectCardContent(msg: ChatMessage): { isCard: boolean; content: string } {
+  if (msg.contentType === 'openui') {
+    return { isCard: true, content: msg.content }
+  }
+  if (!msg.contentType && msg.content.startsWith(OPENUI_PREFIX)) {
+    return { isCard: true, content: msg.content.slice(OPENUI_PREFIX.length) }
+  }
+  return { isCard: false, content: msg.content }
+}
+
+/**
+ * Render an OpenUI card message. Falls back to plain text on parse failure.
+ * Never throws.
+ */
+function ChatCardRenderer({
+  content,
+  stale,
+  actionOutcome,
+}: {
+  content: string
+  stale: boolean
+  actionOutcome?: ChatMessage['actionOutcome']
+}) {
+  try {
+    const parsed = parseCardContent(content)
+    if (!parsed.ok) {
+      return (
+        <div data-testid="card-parse-error">
+          <div style={{ whiteSpace: 'pre-wrap' }}>{content}</div>
+          <div style={{
+            fontSize: 'var(--nous-font-size-2xs)',
+            color: 'var(--nous-fg-subtle)',
+            marginTop: 'var(--nous-space-xs)',
+          }}>
+            Could not render card
+          </div>
+        </div>
+      )
+    }
+
+    const context: RenderCardContext = {
+      stale,
+      ...(actionOutcome ? { actionOutcome } : {}),
+    }
+    const handlers = stale
+      ? { onAction: () => {} }
+      : { onAction: () => { /* stub: full action routing is sub-phase 1.3 */ } }
+
+    return (
+      <div data-testid="openui-card-container" {...(stale ? { 'data-stale': 'true' } : {})}>
+        {stale && <span data-testid="stale-card" style={{ display: 'none' }} />}
+        {renderCardTree(parsed.tree, handlers, context)}
+        {actionOutcome && (
+          <div
+            data-testid="action-outcome-badge"
+            style={{
+              fontSize: 'var(--nous-font-size-2xs)',
+              color: 'var(--nous-fg-muted)',
+              marginTop: 'var(--nous-space-xs)',
+              padding: 'var(--nous-space-xs) var(--nous-space-sm)',
+              background: 'var(--nous-bg-elevated)',
+              borderRadius: 'var(--nous-radius-xs)',
+              display: 'inline-block',
+            }}
+          >
+            {actionOutcome.label}
+          </div>
+        )}
+      </div>
+    )
+  } catch {
+    // Never-throws invariant: fall back to plain text
+    return (
+      <div data-testid="card-parse-error">
+        <div style={{ whiteSpace: 'pre-wrap' }}>{content}</div>
+        <div style={{
+          fontSize: 'var(--nous-font-size-2xs)',
+          color: 'var(--nous-fg-subtle)',
+          marginTop: 'var(--nous-space-xs)',
+        }}>
+          Could not render card
+        </div>
+      </div>
+    )
+  }
 }
 
 export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
@@ -136,6 +240,7 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
         content: result.response,
         timestamp: new Date().toISOString(),
         traceId: result.traceId,
+        contentType: result.contentType,
       }])
     } catch (e) {
       setMessages(prev => [...prev, { role: 'assistant', content: 'Error: could not reach Nous.', timestamp: new Date().toISOString() }])
@@ -185,6 +290,14 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
       ? 'Ambient'
       : 'Principal ↔ Cortex'
 
+  // Find the index of the last assistant message for stale detection
+  const lastAssistantIndex = (() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'assistant') return i
+    }
+    return -1
+  })()
+
   return (
     <div className={clsx(className)} style={{ display: 'flex', flexDirection: 'column', height: '100%', color: 'var(--nous-fg)' }}>
       {/* Header */}
@@ -213,20 +326,34 @@ export function ChatPanel(props: ChatPanelProps | ChatPanelCoreProps) {
             {historyError}
           </div>
         )}
-        {messages.map((msg, i) => (
-          <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
-            <div style={{
-              maxWidth: '80%', padding: 'var(--nous-space-md) var(--nous-space-xl)', borderRadius: 'var(--nous-radius-md)', fontSize: 'var(--nous-font-size-base)', lineHeight: '1.5',
-              background: msg.role === 'user' ? 'var(--nous-chat-user-bg)' : 'var(--nous-bg-elevated)',
-              color: 'var(--nous-fg)',
-            }}>
-              {msg.content}
+        {messages.map((msg, i) => {
+          const isAssistant = msg.role === 'assistant'
+          const { isCard, content: cardContent } = isAssistant ? detectCardContent(msg) : { isCard: false, content: msg.content }
+          const isStale = isAssistant && (!!msg.actionOutcome || i !== lastAssistantIndex)
+
+          return (
+            <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
+              <div style={{
+                maxWidth: '80%', padding: 'var(--nous-space-md) var(--nous-space-xl)', borderRadius: 'var(--nous-radius-md)', fontSize: 'var(--nous-font-size-base)', lineHeight: '1.5',
+                background: msg.role === 'user' ? 'var(--nous-chat-user-bg)' : 'var(--nous-bg-elevated)',
+                color: 'var(--nous-fg)',
+              }}>
+                {isCard ? (
+                  <ChatCardRenderer
+                    content={cardContent}
+                    stale={isStale}
+                    actionOutcome={msg.actionOutcome}
+                  />
+                ) : (
+                  msg.content
+                )}
+              </div>
+              {isAssistant && msg.traceId && !sending && (
+                <ThoughtSummary traceId={msg.traceId} />
+              )}
             </div>
-            {msg.role === 'assistant' && msg.traceId && !sending && (
-              <ThoughtSummary traceId={msg.traceId} />
-            )}
-          </div>
-        ))}
+          )
+        })}
         {thoughts.length > 0 && (
           <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
             <div style={{ maxWidth: '80%' }}>

--- a/self/ui/src/panels/__tests__/ChatPanel.action-routing.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.action-routing.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeAll } from 'vitest'
+import { ChatPanel } from '../ChatPanel'
+import type { ChatAPI, ChatMessage } from '../ChatPanel'
+import { ShellProvider } from '../../components/shell/ShellContext'
+
+beforeAll(() => {
+  // jsdom does not implement scrollIntoView
+  Element.prototype.scrollIntoView = () => {}
+})
+
+const mockNavigate = vi.fn()
+
+function makeChatApi(messages: ChatMessage[], sendAction = vi.fn().mockResolvedValue({ ok: true, message: 'Submitted' })): ChatAPI {
+  return {
+    send: vi.fn().mockResolvedValue({ response: 'ok', traceId: '123' }),
+    getHistory: vi.fn().mockResolvedValue(messages),
+    sendAction,
+  }
+}
+
+function renderWithShell(ui: React.ReactElement) {
+  return render(
+    React.createElement(ShellProvider, { navigate: mockNavigate }, ui),
+  )
+}
+
+describe('ChatPanel — Action Routing Integration', () => {
+  // ---------------------------------------------------------------------------
+  // Tier 2: Integration — Action handler wiring
+  // ---------------------------------------------------------------------------
+
+  it('non-stale card receives live action buttons', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<ActionCard title="Deploy" description="Ready to deploy" actions=\'[{"label":"Approve","actionType":"approve","payload":{}}]\' />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+    ])
+    renderWithShell(React.createElement(ChatPanel, { chatApi: api }))
+
+    // Wait for card to render
+    const container = await screen.findByTestId('openui-card-container')
+    expect(container).toBeTruthy()
+    // Non-stale card should NOT have data-stale attribute
+    expect(container.getAttribute('data-stale')).toBeNull()
+  })
+
+  it('stale card (has actionOutcome) renders with stale marker', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<ActionCard title="Deployed" description="Was deployed" actions=\'[{"label":"Approve","actionType":"approve","payload":{}}]\' />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+        actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
+      },
+    ])
+    renderWithShell(React.createElement(ChatPanel, { chatApi: api }))
+
+    const container = await screen.findByTestId('openui-card-container')
+    expect(container.getAttribute('data-stale')).toBe('true')
+  })
+
+  it('stale card shows action outcome badge', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Done" status="complete" message="Finished" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+        actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
+      },
+    ])
+    renderWithShell(React.createElement(ChatPanel, { chatApi: api }))
+
+    const badge = await screen.findByTestId('action-outcome-badge')
+    expect(badge).toBeTruthy()
+    expect(badge.textContent).toContain('Approved')
+  })
+
+  it('only the last assistant message without actionOutcome is non-stale', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="First" status="active" message="First card" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Second" status="active" message="Second card" />',
+        timestamp: '2026-01-01T00:01:00Z',
+        contentType: 'openui',
+      },
+    ])
+    renderWithShell(React.createElement(ChatPanel, { chatApi: api }))
+
+    const containers = await screen.findAllByTestId('openui-card-container')
+    expect(containers).toHaveLength(2)
+    // First card is stale (not the last assistant message)
+    expect(containers[0].getAttribute('data-stale')).toBe('true')
+    // Second card is non-stale (is the last assistant message)
+    expect(containers[1].getAttribute('data-stale')).toBeNull()
+  })
+})

--- a/self/ui/src/panels/__tests__/ChatPanel.content-detection.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.content-detection.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, beforeAll } from 'vitest'
+import { ChatPanel } from '../ChatPanel'
+import type { ChatAPI, ChatMessage } from '../ChatPanel'
+
+beforeAll(() => {
+  // jsdom does not implement scrollIntoView
+  Element.prototype.scrollIntoView = () => {}
+})
+
+function makeChatApi(messages: ChatMessage[]): ChatAPI {
+  return {
+    send: async () => ({ response: 'ok', traceId: '123' }),
+    getHistory: async () => messages,
+  }
+}
+
+describe('ChatPanel — Content Detection and Renderer Branching', () => {
+  // ---------------------------------------------------------------------------
+  // Tier 2 — Behavior: Content detection
+  // ---------------------------------------------------------------------------
+
+  it('assistant message with contentType text: renders plain text, no card container', async () => {
+    const api = makeChatApi([
+      { role: 'assistant', content: 'Hello world', timestamp: '2026-01-01T00:00:00Z', contentType: 'text' },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    // Wait for getHistory to populate
+    expect(await screen.findByText('Hello world')).toBeTruthy()
+    expect(screen.queryByTestId('openui-card-container')).toBeNull()
+  })
+
+  it('assistant message with contentType openui and valid markup: renders card container', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Test" status="active" message="Hi" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByTestId('openui-card-container')).toBeTruthy()
+  })
+
+  it('assistant message with absent contentType and %%openui\\n prefix: renders card (prefix fallback)', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '%%openui\n<StatusCard title="Fallback" status="active" message="Fb" />',
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByTestId('openui-card-container')).toBeTruthy()
+  })
+
+  it('assistant message with absent contentType and no prefix: renders plain text', async () => {
+    const api = makeChatApi([
+      { role: 'assistant', content: 'Regular text.', timestamp: '2026-01-01T00:00:00Z' },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByText('Regular text.')).toBeTruthy()
+    expect(screen.queryByTestId('openui-card-container')).toBeNull()
+  })
+
+  it('assistant message with contentType openui and malformed markup: renders parse error fallback', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: 'this is not valid card markup at all',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByTestId('card-parse-error')).toBeTruthy()
+    expect(screen.getByText('Could not render card')).toBeTruthy()
+  })
+
+  it('user message: always plain text regardless of content', async () => {
+    const api = makeChatApi([
+      {
+        role: 'user',
+        content: '<StatusCard title="Fake" status="active" message="M" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui' as any,
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    // User messages should render as plain text
+    expect(await screen.findByText('<StatusCard title="Fake" status="active" message="M" />')).toBeTruthy()
+    expect(screen.queryByTestId('openui-card-container')).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tier 2 — Behavior: Stale detection
+  // ---------------------------------------------------------------------------
+
+  it('multiple assistant messages: only last one is live, others are stale', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Old" status="complete" message="Done" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+      { role: 'user', content: 'next', timestamp: '2026-01-01T00:01:00Z' },
+      {
+        role: 'assistant',
+        content: '<StatusCard title="New" status="active" message="Current" />',
+        timestamp: '2026-01-01T00:02:00Z',
+        contentType: 'openui',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    const containers = await screen.findAllByTestId('openui-card-container')
+    expect(containers).toHaveLength(2)
+    // First card should be stale
+    expect(screen.getAllByTestId('stale-card')).toHaveLength(1)
+  })
+
+  it('message with actionOutcome: rendered as stale', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Actioned" status="complete" message="Done" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+        actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByTestId('stale-card')).toBeTruthy()
+    expect(screen.getByTestId('action-outcome-badge')).toBeTruthy()
+    // "Approved" text appears in both card renderer and outcome badge — use getAllByText
+    expect(screen.getAllByText('Approved').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('single assistant card message that is latest: treated as live (not stale)', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Live" status="active" message="Current" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    const container = await screen.findByTestId('openui-card-container')
+    expect(container).toBeTruthy()
+    expect(screen.queryByTestId('stale-card')).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tier 3 — Edge Cases
+  // ---------------------------------------------------------------------------
+
+  it('empty messages array: no crash, empty state displayed', async () => {
+    const api = makeChatApi([])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByText('Start a conversation with Nous.')).toBeTruthy()
+  })
+
+  it('rendering never throws even on unexpected input', async () => {
+    // Test that ChatPanel doesn't crash with weird message content
+    const api = makeChatApi([
+      { role: 'assistant', content: '', timestamp: '2026-01-01T00:00:00Z', contentType: 'openui' },
+    ])
+    expect(() => render(<ChatPanel chatApi={api} />)).not.toThrow()
+  })
+
+  it('stale card with both actionOutcome and historical position: still stale (OR logic)', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Old" status="complete" message="Done" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+        actionOutcome: { actionType: 'approve', label: 'Done', timestamp: '2026-01-01T00:01:00Z' },
+      },
+      { role: 'user', content: 'next', timestamp: '2026-01-01T00:02:00Z' },
+      {
+        role: 'assistant',
+        content: '<StatusCard title="New" status="active" message="Cur" />',
+        timestamp: '2026-01-01T00:03:00Z',
+        contentType: 'openui',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    // Both stale indicators: historical position AND actionOutcome
+    expect(await screen.findByTestId('stale-card')).toBeTruthy()
+  })
+})

--- a/self/ui/src/panels/__tests__/ChatPanel.persistence.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.persistence.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, beforeAll } from 'vitest'
+import { ChatPanel } from '../ChatPanel'
+import type { ChatAPI, ChatMessage } from '../ChatPanel'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+function makeChatApi(messages: ChatMessage[]): ChatAPI {
+  return {
+    send: async () => ({ response: 'ok', traceId: '123' }),
+    getHistory: async () => messages,
+  }
+}
+
+describe('ChatPanel — Persistence Round-Trip', () => {
+  // ---------------------------------------------------------------------------
+  // These tests verify that contentType and actionOutcome survive the
+  // STM round-trip (simulated via mocked getHistory return values).
+  // ---------------------------------------------------------------------------
+
+  it('getHistory entries with contentType openui: messages render as cards', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Persisted" status="active" message="From STM" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByTestId('openui-card-container')).toBeTruthy()
+  })
+
+  it('getHistory entries with actionOutcome: messages render with outcome badge', async () => {
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Actioned" status="complete" message="Done" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+        actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByTestId('action-outcome-badge')).toBeTruthy()
+    // "Approved" text may appear in both the card's own outcome rendering and the badge
+    expect(screen.getAllByText('Approved').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('getHistory entries without metadata: messages have contentType undefined (backward compat)', async () => {
+    const api = makeChatApi([
+      { role: 'assistant', content: 'Legacy message', timestamp: '2026-01-01T00:00:00Z' },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByText('Legacy message')).toBeTruthy()
+    expect(screen.queryByTestId('openui-card-container')).toBeNull()
+  })
+
+  it('getHistory entries with empty metadata: fields are undefined', async () => {
+    // Simulates messages that went through STM with empty metadata
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: 'Message with empty metadata',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: undefined,
+        actionOutcome: undefined,
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByText('Message with empty metadata')).toBeTruthy()
+    expect(screen.queryByTestId('openui-card-container')).toBeNull()
+  })
+
+  it('actionOutcome round-trip: value preserved through getHistory', async () => {
+    const outcome = { actionType: 'reject', label: 'Rejected', timestamp: '2026-01-01T00:05:00Z' }
+    const api = makeChatApi([
+      {
+        role: 'assistant',
+        content: '<ApprovalCard title="Request" description="Approve this" tier="standard" />',
+        timestamp: '2026-01-01T00:00:00Z',
+        contentType: 'openui',
+        actionOutcome: outcome,
+      },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    expect(await screen.findByText('Rejected')).toBeTruthy()
+  })
+
+  it('multiple history entries with mixed contentType: correct rendering for each', async () => {
+    const api = makeChatApi([
+      { role: 'user', content: 'First question', timestamp: '2026-01-01T00:00:00Z' },
+      {
+        role: 'assistant',
+        content: '<StatusCard title="Card1" status="complete" message="Old" />',
+        timestamp: '2026-01-01T00:01:00Z',
+        contentType: 'openui',
+        actionOutcome: { actionType: 'approve', label: 'Done', timestamp: '2026-01-01T00:02:00Z' },
+      },
+      { role: 'user', content: 'Second question', timestamp: '2026-01-01T00:03:00Z' },
+      { role: 'assistant', content: 'Just text reply', timestamp: '2026-01-01T00:04:00Z', contentType: 'text' },
+    ])
+    render(<ChatPanel chatApi={api} />)
+    // The card message should render as a card (stale + actioned)
+    expect(await screen.findByTestId('openui-card-container')).toBeTruthy()
+    expect(screen.getByTestId('stale-card')).toBeTruthy()
+    // The plain text message should render as text
+    expect(screen.getByText('Just text reply')).toBeTruthy()
+  })
+})

--- a/self/ui/src/panels/__tests__/ChatPanel.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.test.tsx
@@ -113,4 +113,52 @@ describe('ChatPanel', () => {
     }
     expect(msg.traceId).toBeUndefined()
   })
+
+  // Phase 1.2 — New type fields
+  it('ChatMessage type includes optional contentType field', () => {
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: 'test',
+      timestamp: new Date().toISOString(),
+      contentType: 'openui',
+    }
+    expect(msg.contentType).toBe('openui')
+  })
+
+  it('ChatMessage type allows omitting contentType (optional field)', () => {
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: 'test',
+      timestamp: new Date().toISOString(),
+    }
+    expect(msg.contentType).toBeUndefined()
+  })
+
+  it('ChatMessage type includes optional actionOutcome field', () => {
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: 'test',
+      timestamp: new Date().toISOString(),
+      actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:00:00Z' },
+    }
+    expect(msg.actionOutcome?.actionType).toBe('approve')
+    expect(msg.actionOutcome?.label).toBe('Approved')
+  })
+
+  it('ChatMessage type allows omitting actionOutcome (optional field)', () => {
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: 'test',
+      timestamp: new Date().toISOString(),
+    }
+    expect(msg.actionOutcome).toBeUndefined()
+  })
+
+  it('ChatAPI.send return type includes optional contentType field', () => {
+    const api: ChatAPI = {
+      send: async () => ({ response: 'ok', traceId: '123', contentType: 'openui' as const }),
+      getHistory: async () => [],
+    }
+    expect(api).toBeDefined()
+  })
 })


### PR DESCRIPTION
## Summary

- **OpenUI adapter facade** with boundary types, custom parser, and React renderer — isolates pre-1.0 OpenUI dependency behind stable internal API
- **5 Nous-specific card types** (StatusCard, ActionCard, ApprovalCard, WorkflowCard, FollowUpBlock) with Zod schemas, React renderers, and stale-state variants
- **ChatPanel card rendering** with content detection (`%%openui` prefix → `contentType` field), renderer branching, parse failure graceful degradation, and stale card persistence in history
- **Action routing pipeline** — `chat.sendAction` tRPC mutation dispatches card button clicks to chat turns (followup), System inbox (approve/reject/submit), or shell navigation (navigate)
- **Agent prompt integration** — Worker agents receive card syntax examples in system prompt for structured response generation

## Stats

- 4 sub-phases (1.1 adapter+cards, 1.2 ChatPanel+detection, 1.3 action routing+prompts, 1.4 prompt syntax fix)
- 50 files changed, ~4,800 lines added
- 91 test files, 1,121 tests passing
- 6 ratified architecture decisions, full six-document gate cycle per sub-phase
- BT: Round 1 found prompt syntax gap → fixed in 1.4, Round 2 passed

## Test plan

- [x] `pnpm --filter @nous/ui test` — 91 files, 1,121 tests passing
- [x] Adapter boundary: parse valid/invalid markup, render registered/unregistered types, registry CRUD
- [x] Card types: all 5 cards render with correct props, stale variants, action payloads
- [x] Content detection: %%openui prefix detection, contentType field, prefix fallback
- [x] Persistence: stale detection, actionOutcome tracking, history rehydration
- [x] Action routing: CardActionSchema validation, sendAction dispatch, navigate filtering
- [x] Import containment: @openuidev references only in openui-adapter/
- [ ] Visual BT with production-capable model (deferred — local model too weak for structured output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)