### PR TITLE
feat(ui): design tokens, font/icon setup, component visual polish — WR-115 SP 2.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1155,6 +1155,12 @@ importers:
 
   self/ui:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.1.1
+        version: 5.2.8
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.1.1
+        version: 5.2.7
       '@nous/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1164,6 +1170,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      lucide-react:
+        specifier: ^0.469.0
+        version: 0.469.0(react@19.2.3)
       yaml:
         specifier: ^2.7.0
         version: 2.8.2
@@ -1795,6 +1804,12 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource-variable/inter@5.2.8':
+    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
 
   '@formatjs/fast-memoize@3.1.0':
     resolution: {integrity: sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==}
@@ -5588,6 +5603,11 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lucide-react@0.469.0:
+    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
     peerDependencies:
@@ -7996,6 +8016,10 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource-variable/inter@5.2.8': {}
+
+  '@fontsource/ibm-plex-mono@5.2.7': {}
 
   '@formatjs/fast-memoize@3.1.0':
     dependencies:
@@ -10910,7 +10934,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -10933,7 +10957,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10948,14 +10972,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10970,7 +10994,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12128,6 +12152,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@0.469.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   lucide-react@0.563.0(react@19.2.3):
     dependencies:

--- a/self/ui/package.json
+++ b/self/ui/package.json
@@ -18,9 +18,12 @@
     "./lib/cn": "./src/lib/cn.ts"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.1.1",
+    "@fontsource/ibm-plex-mono": "^5.1.1",
     "@nous/shared": "workspace:*",
     "@nous/transport": "workspace:*",
     "clsx": "^2.1.0",
+    "lucide-react": "^0.469.0",
     "yaml": "^2.7.0",
     "zod": "^3.25.76"
   },

--- a/self/ui/src/components/shell/AssetSidebar.tsx
+++ b/self/ui/src/components/shell/AssetSidebar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import { clsx } from 'clsx'
+import { ChevronDown, ChevronRight, Settings, Plus } from 'lucide-react'
 import type {
   AssetSection,
   AssetSectionItem,
@@ -62,14 +63,14 @@ function TopNavItemRow({ item, isActive, onNavigate }: TopNavItemRowProps) {
           : isHovered
             ? 'var(--nous-bg-hover)'
             : 'transparent',
-        color: isActive ? 'var(--nous-text-primary)' : 'var(--nous-text-secondary)',
+        color: isActive ? 'var(--nous-text-primary)' : 'var(--nous-sidebar-item-fg)',
         fontSize: 'var(--nous-font-size-sm)',
         cursor: 'pointer',
         transition: 'var(--nous-hover-button-transition)',
         textAlign: 'left',
       }}
     >
-      <span style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+      <span style={{ display: 'flex', alignItems: 'center', flexShrink: 0, color: 'var(--nous-sidebar-item-icon-fg)' }}>
         {item.icon}
       </span>
       <span>{item.label}</span>
@@ -106,7 +107,7 @@ function SectionHeader({ section, isCollapsed, onToggleCollapse }: SectionHeader
           gap: 'var(--nous-space-xs)',
           border: 'none',
           background: 'transparent',
-          color: 'var(--nous-text-secondary)',
+          color: 'var(--nous-sidebar-section-label-fg)',
           fontSize: 'var(--nous-font-size-xs)',
           fontWeight: 'var(--nous-font-weight-medium, 500)',
           textTransform: 'uppercase',
@@ -119,13 +120,14 @@ function SectionHeader({ section, isCollapsed, onToggleCollapse }: SectionHeader
           <span
             data-collapse-chevron
             style={{
-              display: 'inline-block',
+              display: 'inline-flex',
+              alignItems: 'center',
+              color: 'var(--nous-sidebar-section-chevron-fg)',
               transition: 'transform var(--nous-duration-fast, 150ms) var(--nous-ease-out, ease-out)',
               transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
-              fontSize: '10px',
             }}
           >
-            &#x25BE;
+            <ChevronDown size={12} />
           </span>
         ) : null}
         <span>{section.label}</span>
@@ -140,15 +142,16 @@ function SectionHeader({ section, isCollapsed, onToggleCollapse }: SectionHeader
               data-action="settings"
               onClick={section.onSettings}
               style={{
+                display: 'inline-flex',
+                alignItems: 'center',
                 border: 'none',
                 background: 'transparent',
-                color: 'var(--nous-text-tertiary)',
+                color: 'var(--nous-sidebar-section-icon-fg)',
                 cursor: 'pointer',
                 padding: '2px',
-                fontSize: 'var(--nous-font-size-xs)',
               }}
             >
-              &#x2699;
+              <Settings size={12} />
             </button>
           ) : null}
           {section.onAdd ? (
@@ -158,15 +161,16 @@ function SectionHeader({ section, isCollapsed, onToggleCollapse }: SectionHeader
               data-action="add"
               onClick={section.onAdd}
               style={{
+                display: 'inline-flex',
+                alignItems: 'center',
                 border: 'none',
                 background: 'transparent',
-                color: 'var(--nous-text-tertiary)',
+                color: 'var(--nous-sidebar-section-icon-fg)',
                 cursor: 'pointer',
                 padding: '2px',
-                fontSize: 'var(--nous-font-size-xs)',
               }}
             >
-              +
+              <Plus size={12} />
             </button>
           ) : null}
         </div>
@@ -213,7 +217,7 @@ function SectionItemRow({ item, isActive, disabled, onNavigate }: SectionItemRow
           ? 'var(--nous-text-tertiary)'
           : isActive
             ? 'var(--nous-text-primary)'
-            : 'var(--nous-text-secondary)',
+            : 'var(--nous-sidebar-item-fg)',
         fontSize: 'var(--nous-font-size-sm)',
         cursor: disabled ? 'not-allowed' : 'pointer',
         opacity: disabled ? 0.5 : 1,
@@ -222,7 +226,7 @@ function SectionItemRow({ item, isActive, disabled, onNavigate }: SectionItemRow
       }}
     >
       {item.icon ? (
-        <span style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+        <span style={{ display: 'flex', alignItems: 'center', flexShrink: 0, color: 'var(--nous-sidebar-item-icon-fg)' }}>
           {item.icon}
         </span>
       ) : null}
@@ -269,7 +273,15 @@ function AssetSectionBlock({ section, activeRoute, onNavigate }: AssetSectionBlo
         isCollapsed={isCollapsed}
         onToggleCollapse={toggleCollapse}
       />
-      {!isCollapsed ? (
+      <div
+        data-section-items={section.id}
+        style={{
+          maxHeight: isCollapsed ? '0px' : '500px',
+          overflow: 'hidden',
+          opacity: isCollapsed ? 0 : 1,
+          transition: 'max-height var(--nous-duration-normal) var(--nous-ease-out), opacity var(--nous-duration-fast) var(--nous-ease-out)',
+        }}
+      >
         <div
           style={{
             display: 'flex',
@@ -287,7 +299,7 @@ function AssetSectionBlock({ section, activeRoute, onNavigate }: AssetSectionBlo
             />
           ))}
         </div>
-      ) : null}
+      </div>
     </div>
   )
 }
@@ -334,7 +346,7 @@ export function AssetSidebar({
           style={{
             fontSize: 'var(--nous-font-size-sm)',
             fontWeight: 'var(--nous-font-weight-medium, 500)',
-            color: 'var(--nous-text-primary)',
+            color: 'var(--nous-sidebar-header-fg)',
           }}
         >
           {projectName}

--- a/self/ui/src/components/shell/CollapsibleObserveEdge.tsx
+++ b/self/ui/src/components/shell/CollapsibleObserveEdge.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import { clsx } from 'clsx'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 const COLLAPSED_THRESHOLD = 60
 
@@ -12,6 +13,45 @@ export interface CollapsibleObserveEdgeProps
   /** Called when the user clicks the expand chevron */
   onExpandToggle: () => void
   children: React.ReactNode
+}
+
+interface ExpandCollapseButtonProps {
+  action: 'expand' | 'collapse'
+  label: string
+  onClick: () => void
+  icon: React.ReactNode
+  fullSize?: boolean
+}
+
+function ExpandCollapseButton({ action, label, onClick, icon, fullSize }: ExpandCollapseButtonProps) {
+  const [isHovered, setIsHovered] = React.useState(false)
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      data-action={action}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: fullSize ? '100%' : 'auto',
+        height: fullSize ? '100%' : 'auto',
+        border: 'none',
+        background: isHovered ? 'var(--nous-bg-hover)' : 'transparent',
+        borderRadius: 'var(--nous-radius-sm)',
+        color: 'var(--nous-text-tertiary)',
+        cursor: 'pointer',
+        padding: fullSize ? 0 : '2px 4px',
+        transition: 'var(--nous-hover-button-transition)',
+      }}
+    >
+      {icon}
+    </button>
+  )
 }
 
 export function CollapsibleObserveEdge({
@@ -39,28 +79,13 @@ export function CollapsibleObserveEdge({
       {...props}
     >
       {isCollapsed ? (
-        <button
-          type="button"
-          aria-label="Expand observe panel"
-          data-action="expand"
+        <ExpandCollapseButton
+          action="expand"
+          label="Expand observe panel"
           onClick={onExpandToggle}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '100%',
-            height: '100%',
-            border: 'none',
-            background: 'transparent',
-            color: 'var(--nous-text-tertiary)',
-            cursor: 'pointer',
-            fontSize: 'var(--nous-font-size-md, 16px)',
-            padding: 0,
-            transition: 'var(--nous-hover-button-transition)',
-          }}
-        >
-          &#x2039;
-        </button>
+          icon={<ChevronLeft size={16} />}
+          fullSize
+        />
       ) : (
         <>
           <div
@@ -72,26 +97,12 @@ export function CollapsibleObserveEdge({
               flexShrink: 0,
             }}
           >
-            <button
-              type="button"
-              aria-label="Collapse observe panel"
-              data-action="collapse"
+            <ExpandCollapseButton
+              action="collapse"
+              label="Collapse observe panel"
               onClick={onExpandToggle}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                border: 'none',
-                background: 'transparent',
-                color: 'var(--nous-text-tertiary)',
-                cursor: 'pointer',
-                fontSize: 'var(--nous-font-size-md, 16px)',
-                padding: '2px 4px',
-                transition: 'var(--nous-hover-button-transition)',
-              }}
-            >
-              &#x203A;
-            </button>
+              icon={<ChevronRight size={16} />}
+            />
           </div>
           <div style={{ flex: '1 1 0%', overflow: 'auto' }}>
             {children}

--- a/self/ui/src/components/shell/PlaceholderRoute.tsx
+++ b/self/ui/src/components/shell/PlaceholderRoute.tsx
@@ -12,6 +12,10 @@ export interface PlaceholderRouteProps extends ContentRouterRenderProps {
  * Renders the route label + "Coming soon" message.
  */
 export function PlaceholderRoute({ label }: PlaceholderRouteProps) {
+  const isDisabledSection = label
+    ? ['TASKS', 'TEAMS', 'AGENTS'].includes(label.toUpperCase())
+    : false
+
   return (
     <div
       data-shell-component="placeholder-route"
@@ -21,8 +25,10 @@ export function PlaceholderRoute({ label }: PlaceholderRouteProps) {
         alignItems: 'center',
         justifyContent: 'center',
         height: '100%',
+        padding: 'var(--nous-space-3xl)',
         gap: 'var(--nous-space-md)',
         color: 'var(--nous-text-secondary)',
+        opacity: isDisabledSection ? 0.6 : 1,
       }}
     >
       {label ? (
@@ -30,7 +36,7 @@ export function PlaceholderRoute({ label }: PlaceholderRouteProps) {
           style={{
             fontSize: 'var(--nous-font-size-lg, 18px)',
             fontWeight: 'var(--nous-font-weight-medium, 500)',
-            color: 'var(--nous-text-primary)',
+            color: isDisabledSection ? 'var(--nous-text-ghost)' : 'var(--nous-sidebar-header-fg)',
           }}
         >
           {label}

--- a/self/ui/src/components/shell/ProjectSwitcherRail.tsx
+++ b/self/ui/src/components/shell/ProjectSwitcherRail.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import { clsx } from 'clsx'
+import { Plus } from 'lucide-react'
 import type { ProjectItem, ProjectSwitcherRailProps } from './types'
 
 const AVATAR_SIZE = 32
@@ -34,37 +35,53 @@ function ProjectAvatar({ project, isActive, onSelect }: ProjectAvatarProps) {
   const bgColor = avatarColorFromId(project.id)
 
   return (
-    <button
-      type="button"
-      aria-label={project.name}
-      aria-current={isActive ? 'true' : undefined}
-      data-project-id={project.id}
-      onClick={() => onSelect(project.id)}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: AVATAR_SIZE,
-        height: AVATAR_SIZE,
-        borderRadius: 'var(--nous-radius-full, 50%)',
-        border: isActive
-          ? '2px solid var(--nous-accent)'
-          : '2px solid transparent',
-        background: bgColor,
-        color: '#fff',
-        fontSize: 'var(--nous-font-size-xs)',
-        fontWeight: 'var(--nous-font-weight-medium, 500)',
-        cursor: 'pointer',
-        transition: 'var(--nous-hover-button-transition)',
-        opacity: isHovered && !isActive ? 0.85 : 1,
-        padding: 0,
-        outline: 'none',
-      }}
-    >
-      {project.icon ?? getInitial(project.name)}
-    </button>
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {isActive && (
+        <span
+          data-active-indicator
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            width: '3px',
+            height: '20px',
+            borderRadius: '0 2px 2px 0',
+            background: 'var(--nous-accent)',
+          }}
+        />
+      )}
+      <button
+        type="button"
+        aria-label={project.name}
+        title={project.name}
+        aria-current={isActive ? 'true' : undefined}
+        data-project-id={project.id}
+        onClick={() => onSelect(project.id)}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: AVATAR_SIZE,
+          height: AVATAR_SIZE,
+          borderRadius: 'var(--nous-radius-full, 50%)',
+          border: '2px solid transparent',
+          background: bgColor,
+          color: 'var(--nous-fg-on-color)',
+          fontSize: 'var(--nous-font-size-xs)',
+          fontWeight: 'var(--nous-font-weight-medium, 500)',
+          cursor: 'pointer',
+          transition: 'var(--nous-hover-button-transition)',
+          opacity: isHovered && !isActive ? 0.85 : 1,
+          padding: 0,
+          outline: 'none',
+        }}
+      >
+        {project.icon ?? getInitial(project.name)}
+      </button>
+    </div>
   )
 }
 
@@ -157,7 +174,7 @@ export function ProjectSwitcherRail({
             transition: 'var(--nous-hover-button-transition)',
           }}
         >
-          +
+          <Plus size={14} />
         </button>
       ) : null}
     </div>

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -111,6 +111,10 @@ export function SimpleShellLayout({
     onColumnResize?.({ sidebar: sidebarWidthRef.current, observe: nextWidth })
   }, [onColumnResize])
 
+  // Track whether a toggle animation is in progress (gates grid transition)
+  const [isAnimating, setIsAnimating] = React.useState(false)
+  const animationTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
   /** Snap observe to expanded width — called by CollapsibleObserveEdge */
   const handleObserveExpandToggle = React.useCallback(() => {
     const EXPANDED_WIDTH = 280
@@ -118,6 +122,9 @@ export function SimpleShellLayout({
     observeWidthRef.current = next
     setObserveWidth(next)
     onColumnResize?.({ sidebar: sidebarWidthRef.current, observe: next })
+    setIsAnimating(true)
+    if (animationTimerRef.current) clearTimeout(animationTimerRef.current)
+    animationTimerRef.current = setTimeout(() => setIsAnimating(false), 200)
   }, [onColumnResize])
 
   const showObserve = breakpoint === 'full'
@@ -161,6 +168,7 @@ export function SimpleShellLayout({
     width: '100%',
     height: '100%',
     background: 'var(--nous-bg-base)',
+    transition: isAnimating ? 'grid-template-columns var(--nous-duration-normal) var(--nous-ease-out)' : undefined,
     ...style,
   }
 

--- a/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
+++ b/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
@@ -128,8 +128,10 @@ describe('AssetSidebar', () => {
 
   it('collapses section on header click and persists to localStorage', async () => {
     await renderSidebar()
-    // Items visible initially
-    expect(container.querySelector('[data-section-item="wf-1"]')).toBeTruthy()
+    // Items visible initially — wrapper has maxHeight 500px
+    const wrapper = container.querySelector('[data-section-items="workflows"]') as HTMLElement
+    expect(wrapper.style.maxHeight).toBe('500px')
+    expect(wrapper.style.opacity).toBe('1')
 
     // Click collapse
     const header = container.querySelector('[data-section-header="workflows"] button') as HTMLButtonElement
@@ -138,8 +140,10 @@ describe('AssetSidebar', () => {
       await flush()
     })
 
-    // Items hidden
-    expect(container.querySelector('[data-section-item="wf-1"]')).toBeNull()
+    // Items still in DOM but clipped via maxHeight: 0
+    expect(container.querySelector('[data-section-item="wf-1"]')).toBeTruthy()
+    expect(wrapper.style.maxHeight).toBe('0px')
+    expect(wrapper.style.overflow).toBe('hidden')
 
     // localStorage updated
     expect(localStorage.getItem('nous-sidebar-collapse-workflows')).toBe('true')
@@ -148,8 +152,29 @@ describe('AssetSidebar', () => {
   it('restores collapse state from localStorage', async () => {
     localStorage.setItem('nous-sidebar-collapse-workflows', 'true')
     await renderSidebar()
-    // Items should be hidden
-    expect(container.querySelector('[data-section-item="wf-1"]')).toBeNull()
+    // Items in DOM but clipped
+    const wrapper = container.querySelector('[data-section-items="workflows"]') as HTMLElement
+    expect(wrapper.style.maxHeight).toBe('0px')
+  })
+
+  it('renders Lucide SVG icons in section headers and action buttons', async () => {
+    await renderSidebar()
+    // Collapse chevron should render as SVG
+    const chevron = container.querySelector('[data-collapse-chevron]')
+    expect(chevron?.querySelector('svg')).toBeTruthy()
+    // Settings button should render as SVG
+    const settingsBtn = container.querySelector('[data-action="settings"]')
+    expect(settingsBtn?.querySelector('svg')).toBeTruthy()
+    // Add button should render as SVG
+    const addBtn = container.querySelector('[data-action="add"]')
+    expect(addBtn?.querySelector('svg')).toBeTruthy()
+  })
+
+  it('collapse animation wrapper has transition property', async () => {
+    await renderSidebar()
+    const wrapper = container.querySelector('[data-section-items="workflows"]') as HTMLElement
+    expect(wrapper.style.transition).toContain('max-height')
+    expect(wrapper.style.transition).toContain('opacity')
   })
 
   it('disables interaction on disabled sections', async () => {

--- a/self/ui/src/components/shell/__tests__/CollapsibleObserveEdge.test.tsx
+++ b/self/ui/src/components/shell/__tests__/CollapsibleObserveEdge.test.tsx
@@ -90,4 +90,29 @@ describe('CollapsibleObserveEdge', () => {
     const btn = container.querySelector('[data-action="expand"]') as HTMLButtonElement
     expect(btn.getAttribute('aria-label')).toBe('Expand observe panel')
   })
+
+  it('renders Lucide SVG icons for expand and collapse buttons', async () => {
+    // Collapsed state — expand button
+    await renderEdge({ width: 20 })
+    const expandBtn = container.querySelector('[data-action="expand"]')
+    expect(expandBtn?.querySelector('svg')).toBeTruthy()
+
+    // Expanded state — collapse button
+    await renderEdge({ width: 280 })
+    const collapseBtn = container.querySelector('[data-action="collapse"]')
+    expect(collapseBtn?.querySelector('svg')).toBeTruthy()
+  })
+
+  it('expand/collapse buttons have hover-capable styles (default transparent background with border-radius)', async () => {
+    await renderEdge({ width: 20 })
+    const expandBtn = container.querySelector('[data-action="expand"]') as HTMLElement
+    // Default background is transparent, ready for hover state
+    expect(expandBtn.style.background).toBe('transparent')
+    expect(expandBtn.style.borderRadius).toBe('var(--nous-radius-sm)')
+
+    await renderEdge({ width: 280 })
+    const collapseBtn = container.querySelector('[data-action="collapse"]') as HTMLElement
+    expect(collapseBtn.style.background).toBe('transparent')
+    expect(collapseBtn.style.borderRadius).toBe('var(--nous-radius-sm)')
+  })
 })

--- a/self/ui/src/components/shell/__tests__/ProjectSwitcherRail.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ProjectSwitcherRail.test.tsx
@@ -127,4 +127,37 @@ describe('ProjectSwitcherRail', () => {
     // Different IDs produce different colors
     expect(avatar1.style.background).not.toBe(avatar2.style.background)
   })
+
+  it('renders tooltip (title) on project avatar buttons', async () => {
+    await renderRail()
+    const alpha = container.querySelector('[data-project-id="proj-1"]') as HTMLElement
+    expect(alpha.getAttribute('title')).toBe('Alpha')
+    const beta = container.querySelector('[data-project-id="proj-2"]') as HTMLElement
+    expect(beta.getAttribute('title')).toBe('Beta')
+  })
+
+  it('renders active indicator side bar for active project', async () => {
+    await renderRail({ activeProjectId: 'proj-1' })
+    // The active project wrapper should contain the indicator span
+    const activeAvatar = container.querySelector('[data-project-id="proj-1"]')
+    const wrapper = activeAvatar?.parentElement
+    const indicator = wrapper?.querySelector('[data-active-indicator]') as HTMLElement
+    expect(indicator).toBeTruthy()
+    expect(indicator.style.width).toBe('3px')
+    expect(indicator.style.background).toBe('var(--nous-accent)')
+  })
+
+  it('does not render active indicator for inactive projects', async () => {
+    await renderRail({ activeProjectId: 'proj-1' })
+    const inactiveAvatar = container.querySelector('[data-project-id="proj-2"]')
+    const wrapper = inactiveAvatar?.parentElement
+    const indicator = wrapper?.querySelector('[data-active-indicator]')
+    expect(indicator).toBeNull()
+  })
+
+  it('new project button renders SVG icon instead of text', async () => {
+    await renderRail({ onNewProject: vi.fn() })
+    const btn = container.querySelector('[data-rail-action="new-project"]')
+    expect(btn?.querySelector('svg')).toBeTruthy()
+  })
 })

--- a/self/ui/src/styles/components.css
+++ b/self/ui/src/styles/components.css
@@ -9,7 +9,7 @@
 
 :root {
   /* ── Shell rail ─────────────────────────────────────────────────────── */
-  --nous-rail-bg:              var(--nous-bg-base);
+  --nous-rail-bg:              var(--nous-rail-surface);
   --nous-rail-fg:              var(--nous-text-secondary);
   --nous-rail-item-active-bg:  var(--nous-bg-active);
   --nous-rail-hover-bg:        var(--nous-bg-hover);
@@ -18,6 +18,15 @@
   /* ── Shell columns ──────────────────────────────────────────────────── */
   --nous-shell-column-border:  var(--nous-border-strong);
   --nous-observe-bg:           var(--nous-bg-surface);
+
+  /* ── Asset sidebar ──────────────────────────────────────────────────── */
+  --nous-sidebar-section-label-fg:   var(--nous-sidebar-label);
+  --nous-sidebar-section-chevron-fg: var(--nous-sidebar-chevron);
+  --nous-sidebar-section-icon-fg:    var(--nous-sidebar-group-icon);
+  --nous-sidebar-item-fg:            var(--nous-sidebar-button-fg);
+  --nous-sidebar-item-icon-fg:       var(--nous-sidebar-button-icon);
+  --nous-sidebar-header-fg:          var(--nous-sidebar-title);
+  --nous-sidebar-collapse-fg:        var(--nous-sidebar-collapse-icon);
 
   /* ── Ambient stream ─────────────────────────────────────────────────── */
   --nous-ambient-fg:           var(--nous-text-tertiary);

--- a/self/ui/src/styles/index.css
+++ b/self/ui/src/styles/index.css
@@ -3,11 +3,14 @@
  *
  * Import via: import '@nous/ui/styles'
  *
+ * 0. Font imports      — @fontsource self-hosted web fonts (must precede tokens)
  * 1. tokens.css        — design primitives (colours, scales, dimensions)
  * 2. interactions.css  — semantic interaction compositions
  * 3. animations.css    — shared keyframes and motion helpers
  * 4. components.css    — semantic aliases (header, tab, menu, card, …)
  */
+@import '@fontsource-variable/inter/wght.css';
+@import '@fontsource/ibm-plex-mono/400.css';
 @import './tokens.css';
 @import './interactions.css';
 @import './animations.css';

--- a/self/ui/src/styles/tokens.css
+++ b/self/ui/src/styles/tokens.css
@@ -13,12 +13,14 @@
   --nous-surface:        #030303;  /* outer "table" — panels sit on top of this */
   --nous-surface-nested: #131313;  /* inset surface — nested widget gaps inside a panel */
   --nous-bg:             #131313;
-  --nous-bg-base:        #000000;
-  --nous-bg-surface:     #0a0a0a;
+  --nous-bg-base:        #010101;
+  --nous-bg-surface:     #050505;
   --nous-bg-elevated:    #141414;
   --nous-bg-hover:       #1a1a1a;
   --nous-bg-active:      #222222;
   --nous-bg-input:       #0f0f0f;
+  --nous-rail-surface:   #090909;
+  --nous-ambient-gradient: linear-gradient(to bottom, rgba(9,9,9,1) 60%, rgba(9,9,9,0) 100%);
 
   /* ── Borders ─────────────────────────────────────────────────────────── */
   --nous-border:        #1a1a1a;
@@ -36,6 +38,15 @@
   --nous-text-secondary: rgba(255,255,255,0.60);
   --nous-text-tertiary:  rgba(255,255,255,0.35);
   --nous-text-ghost:     rgba(255,255,255,0.12);
+
+  /* ── Sidebar font colors ────────────────────────────────────────────── */
+  --nous-sidebar-label:          #2C2C2C;
+  --nous-sidebar-chevron:        #606060;
+  --nous-sidebar-group-icon:     #4B4B4B;
+  --nous-sidebar-button-fg:      #A9A9A9;
+  --nous-sidebar-button-icon:    #FFFFFF;
+  --nous-sidebar-title:          #FFFFFF;
+  --nous-sidebar-collapse-icon:  #949494;
 
   /* ── Accent / interactive ────────────────────────────────────────────── */
   --nous-accent:       #007acc;
@@ -118,8 +129,8 @@
   --nous-line-height-normal:  1.4;
 
   /* ── Font family ────────────────────────────────────────────────────── */
-  --nous-font-family:      "Segoe WPC", "Segoe UI", system-ui, -apple-system, Ubuntu, "Droid Sans", sans-serif;
-  --nous-font-family-mono: "Cascadia Code", "Fira Code", monospace;
+  --nous-font-family:      "Inter", "Segoe UI", system-ui, -apple-system, Ubuntu, "Droid Sans", sans-serif;
+  --nous-font-family-mono: "IBM Plex Mono", "Cascadia Code", "Fira Code", monospace;
 
   /* ── Border radius ──────────────────────────────────────────────────── */
   --nous-radius-xs: 4px;

--- a/self/ui/src/styles/tokens.css
+++ b/self/ui/src/styles/tokens.css
@@ -129,7 +129,7 @@
   --nous-line-height-normal:  1.4;
 
   /* ── Font family ────────────────────────────────────────────────────── */
-  --nous-font-family:      "Inter", "Segoe UI", system-ui, -apple-system, Ubuntu, "Droid Sans", sans-serif;
+  --nous-font-family:      "Inter Variable", "Inter", "Segoe UI", system-ui, -apple-system, Ubuntu, "Droid Sans", sans-serif;
   --nous-font-family-mono: "IBM Plex Mono", "Cascadia Code", "Fira Code", monospace;
 
   /* ── Border radius ──────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Apply Principal-provided design token color palette (#010101, #050505, #090909, 7 sidebar font-color tokens)
- Install and configure Inter Variable + IBM Plex Mono fonts via @fontsource
- Install lucide-react, migrate all 6 HTML entity icons to Lucide across 3 shell components
- Visual polish: AssetSidebar collapse animations + token colors, ProjectSwitcherRail side indicator + tooltips, CollapsibleObserveEdge Lucide icons + hover, PlaceholderRoute empty states

## Test plan
- [x] 1225 tests passing (96 test files)
- [x] Full build succeeds (desktop + web)
- [x] BT Round 1 — Principal approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)