### PR TITLE
feat(WR-112): Cost governance — budget tracking and enforcement

### DIFF
--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -84,7 +84,7 @@ import {
 import { DocumentArtifactStore } from '@nous/subcortex-artifacts';
 import { DocumentEscalationStore, EscalationService } from '@nous/subcortex-escalation';
 import { ModelRouter } from '@nous/subcortex-router';
-import { ProviderRegistry, TokenAccumulatorService } from '@nous/subcortex-providers';
+import { ProviderRegistry, TokenAccumulatorService, ModelPricingRegistry, CostGovernanceService } from '@nous/subcortex-providers';
 import {
   DiscoverProjectsTool,
   EchoTool,
@@ -742,6 +742,24 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
   });
   const providerRegistry = new ProviderRegistry(appConfig, { eventBus });
   const tokenAccumulator = new TokenAccumulatorService(eventBus);
+  const pricingRegistry = new ModelPricingRegistry();
+  // Sync config cache for CostGovernanceService (event-driven, needs sync access).
+  // Populated lazily via async lookups; budget enforcement starts once cached.
+  const projectConfigCache = new Map<string, import('@nous/shared').ProjectConfig>();
+  const costGovernanceService = new CostGovernanceService({
+    eventBus,
+    opctlService,
+    pricingRegistry,
+    getProjectConfig: (projectId: string) => {
+      const cached = projectConfigCache.get(projectId);
+      if (cached) return cached;
+      // Trigger async population (fire-and-forget)
+      projectStore.get(projectId as ProjectId).then((config) => {
+        if (config) projectConfigCache.set(projectId, config);
+      }).catch(() => { /* noop */ });
+      return null;
+    },
+  });
   const inferenceAdapter = new InferenceProjectionAdapter(eventBus);
   const thoughtEmitter = new ThoughtEmitterImpl(eventBus);
   Cortex.setThoughtEmitter(thoughtEmitter);
@@ -1308,6 +1326,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     healthAggregator,
     healthMonitor,
     tokenAccumulator,
+    costGovernanceService,
   };
 
   console.log(`[nous:${runtimeLabel}] bootstrap complete`);

--- a/self/apps/shared-server/src/context.ts
+++ b/self/apps/shared-server/src/context.ts
@@ -30,6 +30,7 @@ import type {
   IEventBus,
   IHealthAggregator,
   IHealthMonitor,
+  ICostGovernanceService,
 } from '@nous/shared';
 import type { PanelTranspiler } from '@nous/subcortex-apps';
 import type { ProviderRegistry, TokenAccumulatorService } from '@nous/subcortex-providers';
@@ -108,4 +109,5 @@ export interface NousContext {
   healthAggregator: IHealthAggregator;
   healthMonitor: IHealthMonitor;
   tokenAccumulator: TokenAccumulatorService;
+  costGovernanceService: ICostGovernanceService;
 }

--- a/self/apps/shared-server/src/trpc/root.ts
+++ b/self/apps/shared-server/src/trpc/root.ts
@@ -23,6 +23,7 @@ import { codingAgentsRouter } from './routers/coding-agents';
 import { preferencesRouter } from './routers/preferences';
 import { hardwareRouter } from './routers/hardware';
 import { inferenceRouter } from './routers/inference';
+import { costGovernanceRouter } from './routers/cost-governance';
 import { systemActivityRouter } from './routers/system-activity';
 
 export const appRouter = router({
@@ -48,6 +49,7 @@ export const appRouter = router({
   hardware: hardwareRouter,
   systemActivity: systemActivityRouter,
   inference: inferenceRouter,
+  costGovernance: costGovernanceRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/self/apps/shared-server/src/trpc/routers/cost-governance.ts
+++ b/self/apps/shared-server/src/trpc/routers/cost-governance.ts
@@ -1,0 +1,91 @@
+/**
+ * Cost governance tRPC router — budget status, cost snapshots, pricing management.
+ *
+ * Exposes query and mutation procedures backed by ICostGovernanceService
+ * and IProjectStore for budget policy persistence.
+ */
+import { z } from 'zod';
+import {
+  CostWindowSchema,
+  CostBudgetPolicySchema,
+  ModelPricingEntrySchema,
+} from '@nous/shared';
+import type { ProjectId } from '@nous/shared';
+import { router, publicProcedure } from '../trpc';
+
+export const costGovernanceRouter = router({
+  getCostSummary: publicProcedure
+    .input(
+      z.object({
+        projectId: z.string().min(1),
+        window: CostWindowSchema,
+      }),
+    )
+    .query(({ ctx, input }) => {
+      return ctx.costGovernanceService.getProjectCostSnapshot(
+        input.projectId,
+        input.window,
+      );
+    }),
+
+  getBudgetStatus: publicProcedure
+    .input(z.object({ projectId: z.string().min(1) }))
+    .query(({ ctx, input }) => {
+      return ctx.costGovernanceService.getBudgetStatus(input.projectId);
+    }),
+
+  getProviderBreakdown: publicProcedure
+    .input(
+      z.object({
+        projectId: z.string().min(1),
+        window: CostWindowSchema,
+      }),
+    )
+    .query(({ ctx, input }) => {
+      return ctx.costGovernanceService.getProviderBreakdown(
+        input.projectId,
+        input.window,
+      );
+    }),
+
+  getPricingTable: publicProcedure.query(({ ctx }) => {
+    return ctx.costGovernanceService.getPricingTable();
+  }),
+
+  setBudgetPolicy: publicProcedure
+    .input(
+      z.object({
+        projectId: z.string().min(1),
+        policy: CostBudgetPolicySchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await ctx.projectStore.update(
+        input.projectId as ProjectId,
+        { costBudget: input.policy },
+      );
+      return { ok: true };
+    }),
+
+  setPricingEntry: publicProcedure
+    .input(ModelPricingEntrySchema)
+    .mutation(({ ctx, input }) => {
+      ctx.costGovernanceService.setPricingEntry(input);
+      return { ok: true };
+    }),
+
+  removePricingEntry: publicProcedure
+    .input(
+      z.object({
+        providerId: z.string().min(1),
+        modelId: z.string().min(1),
+      }),
+    )
+    .mutation(({ ctx, input }) => {
+      const removed = ctx.costGovernanceService.removePricingEntry(
+        input.providerId,
+        input.modelId,
+      );
+      return { ok: true, removed };
+    }),
+});

--- a/self/shared/src/event-bus/types.ts
+++ b/self/shared/src/event-bus/types.ts
@@ -242,6 +242,18 @@ export const WorkflowRunCompletedPayloadSchema = z.object({
 });
 export type WorkflowRunCompletedPayload = z.infer<typeof WorkflowRunCompletedPayloadSchema>;
 
+// --- Cost Domain ---
+
+export const CostBudgetAlertPayloadSchema = z.object({
+  projectId: z.string().min(1),
+  alertLevel: z.enum(['normal', 'soft_threshold', 'hard_ceiling']),
+  currentSpendDollars: z.number().nonnegative(),
+  thresholdDollars: z.number().nonnegative(),
+  percentUsed: z.number().nonnegative(),
+  emittedAt: z.string().datetime(),
+});
+export type CostBudgetAlertPayload = z.infer<typeof CostBudgetAlertPayloadSchema>;
+
 // --- Channel Map ---
 
 export interface EventChannelMap {
@@ -269,6 +281,7 @@ export interface EventChannelMap {
   'inference:accumulator-snapshot': InferenceAccumulatorSnapshotPayload;
   'workflow:node-status-changed': WorkflowNodeStatusChangedPayload;
   'workflow:run-completed': WorkflowRunCompletedPayload;
+  'cost:budget-alert': CostBudgetAlertPayload;
 }
 
 /**

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -49,6 +49,7 @@ export type {
   IOpctlService,
   IMaoProjectionService,
   IGtmGateCalculator,
+  ICostGovernanceService,
   PublicMcpAgentInvokeCommand,
   PublicMcpAgentListQuery,
   PublicMcpSystemInfoQuery,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -85,6 +85,11 @@ import type {
   MaoEventType,
   MaoRunGraphSnapshot,
   MaoControlAuditHistoryEntry,
+  CostWindow,
+  CostSnapshot,
+  CostAccumulatorEntry,
+  ModelPricingEntry,
+  BudgetStatus,
   GtmGateReportInput,
   GtmGateReport,
   GtmStageLabel,
@@ -1179,4 +1184,24 @@ export interface IGtmGateCalculator {
     report: GtmGateReport,
     targetStage: GtmStageLabel,
   ): boolean;
+}
+
+export interface ICostGovernanceService {
+  /** Get cost snapshot for a project in a specific window. */
+  getProjectCostSnapshot(projectId: string, window: CostWindow): CostSnapshot | null;
+
+  /** Get budget status (spend vs. thresholds). */
+  getBudgetStatus(projectId: string): BudgetStatus | null;
+
+  /** Get per-provider/model cost breakdown. */
+  getProviderBreakdown(projectId: string, window: CostWindow): CostAccumulatorEntry[];
+
+  /** Get the full pricing table. */
+  getPricingTable(): ModelPricingEntry[];
+
+  /** Set or update a pricing entry. */
+  setPricingEntry(entry: ModelPricingEntry): void;
+
+  /** Remove a pricing entry. Returns true if entry existed. */
+  removePricingEntry(providerId: string, modelId: string): boolean;
 }

--- a/self/shared/src/types/cost-governance.ts
+++ b/self/shared/src/types/cost-governance.ts
@@ -1,0 +1,83 @@
+/**
+ * Cost governance domain types for Nous-OSS.
+ *
+ * Model pricing, budget policies, cost accumulators, snapshots, and budget
+ * status. All schemas use `.strict()` per codebase convention.
+ *
+ * Canonical source: cost-type-system-v1.md
+ */
+import { z } from 'zod';
+
+// --- Model Pricing ---
+
+export const ModelPricingEntrySchema = z.object({
+  providerId: z.string().min(1),
+  modelId: z.string().min(1),
+  inputPricePerMillionTokens: z.number().nonnegative(),
+  outputPricePerMillionTokens: z.number().nonnegative(),
+  effectiveAt: z.string().datetime(),
+}).strict();
+export type ModelPricingEntry = z.infer<typeof ModelPricingEntrySchema>;
+
+// --- Budget Policy ---
+
+export const BudgetPeriodTypeSchema = z.enum(['monthly', 'weekly', 'none']);
+export type BudgetPeriodType = z.infer<typeof BudgetPeriodTypeSchema>;
+
+export const CostBudgetPolicySchema = z.object({
+  enabled: z.boolean().default(true),
+  hardCeilingDollars: z.number().positive(),
+  softThresholdPercent: z.number().min(0).max(100).default(80),
+  periodType: BudgetPeriodTypeSchema.default('monthly'),
+  periodAnchorDate: z.string().datetime().optional(),
+  systemScopeExempt: z.literal(true).default(true),
+}).strict();
+export type CostBudgetPolicy = z.infer<typeof CostBudgetPolicySchema>;
+
+// --- Cost Accumulation ---
+
+export const CostAccumulatorEntrySchema = z.object({
+  providerId: z.string().min(1),
+  modelId: z.string().min(1),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  inputCostDollars: z.number().nonnegative(),
+  outputCostDollars: z.number().nonnegative(),
+  totalCostDollars: z.number().nonnegative(),
+  callCount: z.number().int().nonnegative(),
+}).strict();
+export type CostAccumulatorEntry = z.infer<typeof CostAccumulatorEntrySchema>;
+
+// --- Cost Snapshots ---
+
+export const CostWindowSchema = z.enum(['today', 'week', 'month', 'period']);
+export type CostWindow = z.infer<typeof CostWindowSchema>;
+
+export const CostSnapshotSchema = z.object({
+  projectId: z.string().min(1),
+  window: CostWindowSchema,
+  windowStart: z.string().datetime(),
+  totalCostDollars: z.number().nonnegative(),
+  entries: z.array(CostAccumulatorEntrySchema),
+  snapshotAt: z.string().datetime(),
+}).strict();
+export type CostSnapshot = z.infer<typeof CostSnapshotSchema>;
+
+// --- Budget Status ---
+
+export const BudgetAlertLevelSchema = z.enum(['normal', 'soft_threshold', 'hard_ceiling']);
+export type BudgetAlertLevel = z.infer<typeof BudgetAlertLevelSchema>;
+
+export const BudgetStatusSchema = z.object({
+  projectId: z.string().min(1),
+  currentSpendDollars: z.number().nonnegative(),
+  hardCeilingDollars: z.number().positive(),
+  softThresholdDollars: z.number().nonnegative(),
+  percentUsed: z.number().nonnegative(),
+  alertLevel: BudgetAlertLevelSchema,
+  periodType: BudgetPeriodTypeSchema,
+  periodStart: z.string().datetime(),
+  periodEnd: z.string().datetime().optional(),
+  isPaused: z.boolean(),
+}).strict();
+export type BudgetStatus = z.infer<typeof BudgetStatusSchema>;

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -85,3 +85,4 @@ export * from './agent-gateway.js';
 export * from './workflow-spec.js';
 export * from './workflow-node-types.js';
 export * from './workflow-package.js';
+export * from './cost-governance.js';

--- a/self/shared/src/types/project.ts
+++ b/self/shared/src/types/project.ts
@@ -27,6 +27,7 @@ import {
   MemoryAccessPolicySchema,
 } from './memory.js';
 import { InAppEscalationSurfaceSchema } from './escalation.js';
+import { CostBudgetPolicySchema } from './cost-governance.js';
 import {
   WorkflowDefinitionSchema,
   WorkflowEdgeDefinitionSchema,
@@ -198,6 +199,7 @@ export const ProjectConfigSchema = z.object({
   escalationPreferences: ProjectEscalationPreferencesSchema.default({}),
   workflow: ProjectWorkflowConfigurationSchema.optional(),
   packageDefaultIntake: z.array(ProjectPackageDefaultIntakeSchema).default([]),
+  costBudget: CostBudgetPolicySchema.optional(),
   retrievalBudgetTokens: z.number().positive().default(500),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/self/subcortex/providers/src/__tests__/cost-governance-service.test.ts
+++ b/self/subcortex/providers/src/__tests__/cost-governance-service.test.ts
@@ -1,0 +1,550 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CostGovernanceService } from '../cost-governance-service.js';
+import { ModelPricingRegistry } from '../model-pricing-registry.js';
+import type {
+  IEventBus,
+  IOpctlService,
+  InferenceCallCompletePayload,
+  ProjectConfig,
+  ModelPricingEntry,
+  ProjectId,
+} from '@nous/shared';
+import { SYSTEM_SCOPE_SENTINEL_PROJECT_ID } from '@nous/shared';
+
+// --- Helpers ---
+
+type Handler = (payload: any) => void;
+
+function createMockEventBus(): IEventBus & {
+  handlers: Map<string, Handler>;
+  simulateEvent: (channel: string, payload: any) => void;
+} {
+  const handlers = new Map<string, Handler>();
+  let subId = 0;
+  return {
+    handlers,
+    publish: vi.fn(),
+    subscribe: vi.fn().mockImplementation((channel: string, handler: Handler) => {
+      const id = `sub-${subId++}`;
+      handlers.set(id, handler);
+      handlers.set(`channel:${channel}`, handler);
+      return id;
+    }),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+    simulateEvent(channel: string, payload: any) {
+      const handler = handlers.get(`channel:${channel}`);
+      if (handler) handler(payload);
+    },
+  };
+}
+
+function createMockOpctlService(): IOpctlService {
+  return {
+    submitCommand: vi.fn().mockResolvedValue({ status: 'applied' }),
+    requestConfirmationProof: vi.fn(),
+    validateConfirmationProof: vi.fn(),
+    resolveScope: vi.fn(),
+    hasStartLock: vi.fn(),
+    setStartLock: vi.fn(),
+    releaseStartLock: vi.fn(),
+    getProjectControlState: vi.fn(),
+  } as unknown as IOpctlService;
+}
+
+function createPricingEntry(overrides?: Partial<ModelPricingEntry>): ModelPricingEntry {
+  return {
+    providerId: 'provider-1',
+    modelId: 'model-1',
+    inputPricePerMillionTokens: 3,
+    outputPricePerMillionTokens: 15,
+    effectiveAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createCallCompletePayload(
+  overrides?: Partial<InferenceCallCompletePayload>,
+): InferenceCallCompletePayload {
+  return {
+    providerId: 'provider-1',
+    modelId: 'model-1',
+    agentClass: 'Cortex::Principal',
+    traceId: 'trace-1',
+    projectId: 'project-1',
+    laneKey: 'lane-1',
+    inputTokens: 1_000_000,
+    outputTokens: 500_000,
+    latencyMs: 200,
+    emittedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createProjectConfig(
+  overrides?: Partial<ProjectConfig>,
+): ProjectConfig {
+  return {
+    id: 'project-1' as ProjectId,
+    name: 'Test Project',
+    type: 'autonomous',
+    pfcTier: 'tier-2',
+    governanceDefaults: {
+      defaultNodeGovernance: 'must',
+      requireExplicitReviewForShouldDeviation: true,
+      blockedActionFeedbackMode: 'reason_coded',
+    },
+    modelAssignments: undefined,
+    memoryAccessPolicy: { canReadFrom: [], canBeReadBy: [] },
+    escalationChannels: ['in_app'],
+    escalationPreferences: {
+      routeByPriority: {
+        low: ['projects'],
+        medium: ['projects'],
+        high: ['projects', 'chat', 'mobile'],
+        critical: ['projects', 'chat', 'mao', 'mobile'],
+      },
+      acknowledgementSurfaces: ['projects', 'chat', 'mobile'],
+      mirrorToChat: true,
+    },
+    packageDefaultIntake: [],
+    retrievalBudgetTokens: 500,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    costBudget: {
+      enabled: true,
+      hardCeilingDollars: 100,
+      softThresholdPercent: 80,
+      periodType: 'monthly',
+      systemScopeExempt: true,
+    },
+    ...overrides,
+  } as ProjectConfig;
+}
+
+describe('CostGovernanceService', () => {
+  let eventBus: ReturnType<typeof createMockEventBus>;
+  let opctlService: ReturnType<typeof createMockOpctlService>;
+  let pricingRegistry: ModelPricingRegistry;
+  let projectConfigs: Map<string, ProjectConfig>;
+  let service: CostGovernanceService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    eventBus = createMockEventBus();
+    opctlService = createMockOpctlService();
+    pricingRegistry = new ModelPricingRegistry();
+    pricingRegistry.setEntry(createPricingEntry());
+    projectConfigs = new Map();
+    projectConfigs.set('project-1', createProjectConfig());
+
+    service = new CostGovernanceService({
+      eventBus,
+      opctlService,
+      pricingRegistry,
+      getProjectConfig: (id) => projectConfigs.get(id) ?? null,
+    });
+  });
+
+  afterEach(() => {
+    service.dispose();
+    vi.useRealTimers();
+  });
+
+  // --- Cost Calculation ---
+
+  describe('token-to-dollar conversion', () => {
+    it('calculates cost correctly from token counts and pricing', () => {
+      // 1M input tokens at $3/M = $3.00
+      // 500K output tokens at $15/M = $7.50
+      // Total = $10.50
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+
+      const snapshot = service.getProjectCostSnapshot('project-1', 'period');
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.totalCostDollars).toBeCloseTo(10.5, 6);
+
+      const entries = snapshot!.entries;
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.inputCostDollars).toBeCloseTo(3.0, 6);
+      expect(entries[0]!.outputCostDollars).toBeCloseTo(7.5, 6);
+    });
+
+    it('accumulates across multiple events', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+
+      const snapshot = service.getProjectCostSnapshot('project-1', 'period');
+      expect(snapshot!.totalCostDollars).toBeCloseTo(21.0, 6);
+      expect(snapshot!.entries[0]!.callCount).toBe(2);
+    });
+
+    it('handles stream-complete events identically', () => {
+      eventBus.simulateEvent('inference:stream-complete', createCallCompletePayload());
+
+      const snapshot = service.getProjectCostSnapshot('project-1', 'period');
+      expect(snapshot!.totalCostDollars).toBeCloseTo(10.5, 6);
+    });
+  });
+
+  // --- Per-Project Accumulation ---
+
+  describe('per-project accumulation', () => {
+    it('accumulates independently per project', () => {
+      projectConfigs.set('project-2', createProjectConfig({ id: 'project-2' as ProjectId }));
+
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({ projectId: 'project-1' }));
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({ projectId: 'project-2' }));
+
+      const snap1 = service.getProjectCostSnapshot('project-1', 'period');
+      const snap2 = service.getProjectCostSnapshot('project-2', 'period');
+      expect(snap1!.totalCostDollars).toBeCloseTo(10.5, 6);
+      expect(snap2!.totalCostDollars).toBeCloseTo(10.5, 6);
+    });
+
+    it('returns null for unknown project', () => {
+      expect(service.getProjectCostSnapshot('unknown', 'period')).toBeNull();
+    });
+  });
+
+  // --- Soft Threshold ---
+
+  describe('soft threshold', () => {
+    it('fires once when soft threshold is crossed', () => {
+      // Budget: $100, soft at 80% = $80
+      // Each event: $10.50 → need 8 events to cross $80 (8 * $10.50 = $84)
+      for (let i = 0; i < 8; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const alertCalls = (eventBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => call[0] === 'cost:budget-alert',
+      );
+      const softAlerts = alertCalls.filter(
+        (call: unknown[]) => (call[1] as any).alertLevel === 'soft_threshold',
+      );
+      expect(softAlerts).toHaveLength(1);
+    });
+
+    it('does not re-fire on subsequent events', () => {
+      // Push past soft threshold
+      for (let i = 0; i < 9; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const alertCalls = (eventBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) =>
+          call[0] === 'cost:budget-alert' && (call[1] as any).alertLevel === 'soft_threshold',
+      );
+      expect(alertCalls).toHaveLength(1);
+    });
+
+    it('emits escalation:new when soft threshold fires', () => {
+      for (let i = 0; i < 8; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const escalationCalls = (eventBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => call[0] === 'escalation:new',
+      );
+      expect(escalationCalls).toHaveLength(1);
+      expect((escalationCalls[0]![1] as any).severity).toBe('medium');
+    });
+  });
+
+  // --- Hard Ceiling ---
+
+  describe('hard ceiling', () => {
+    it('fires once when hard ceiling is crossed and triggers opctl pause', () => {
+      // Budget: $100, need 10 events (10 * $10.50 = $105)
+      for (let i = 0; i < 10; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const hardAlerts = (eventBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) =>
+          call[0] === 'cost:budget-alert' && (call[1] as any).alertLevel === 'hard_ceiling',
+      );
+      expect(hardAlerts).toHaveLength(1);
+      expect(opctlService.submitCommand).toHaveBeenCalledTimes(1);
+
+      const envelope = (opctlService.submitCommand as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(envelope.action).toBe('pause');
+      expect(envelope.scope.project_id).toBe('project-1');
+      expect(envelope.actor_type).toBe('orchestration_agent');
+    });
+
+    it('does not trigger opctl pause on subsequent events', () => {
+      for (let i = 0; i < 12; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      expect(opctlService.submitCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it('still accumulates cost after hard ceiling', () => {
+      for (let i = 0; i < 12; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const snapshot = service.getProjectCostSnapshot('project-1', 'period');
+      expect(snapshot!.totalCostDollars).toBeCloseTo(126.0, 6);
+    });
+  });
+
+  // --- System-Scope Exemption ---
+
+  describe('system-scope exemption', () => {
+    it('skips events with SYSTEM_SCOPE_SENTINEL_PROJECT_ID', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({
+        projectId: SYSTEM_SCOPE_SENTINEL_PROJECT_ID,
+      }));
+
+      expect(service.getProjectCostSnapshot(SYSTEM_SCOPE_SENTINEL_PROJECT_ID, 'period')).toBeNull();
+    });
+
+    it('skips events with undefined projectId', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({
+        projectId: undefined,
+      }));
+
+      // No accumulators created
+      expect(service.getProjectCostSnapshot('project-1', 'period')).toBeNull();
+    });
+  });
+
+  // --- Unpriced Models ---
+
+  describe('unpriced models', () => {
+    it('accumulates tokens with zero cost for unpriced models', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({
+        providerId: 'local',
+        modelId: 'llama3',
+      }));
+
+      const snapshot = service.getProjectCostSnapshot('project-1', 'period');
+      expect(snapshot!.totalCostDollars).toBe(0);
+      expect(snapshot!.entries[0]!.inputTokens).toBe(1_000_000);
+      expect(snapshot!.entries[0]!.callCount).toBe(1);
+    });
+  });
+
+  // --- Period Rotation ---
+
+  describe('period rotation', () => {
+    it('monthly period resets on calendar month boundary', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      expect(service.getProjectCostSnapshot('project-1', 'period')!.totalCostDollars).toBeCloseTo(10.5, 6);
+
+      // Advance to the next month
+      const now = new Date();
+      const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 2));
+      vi.setSystemTime(nextMonth);
+
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      // Should only have the new event's cost
+      expect(service.getProjectCostSnapshot('project-1', 'period')!.totalCostDollars).toBeCloseTo(10.5, 6);
+    });
+
+    it('weekly period resets on ISO week boundary', () => {
+      projectConfigs.set('project-1', createProjectConfig({
+        costBudget: {
+          enabled: true,
+          hardCeilingDollars: 100,
+          softThresholdPercent: 80,
+          periodType: 'weekly',
+          systemScopeExempt: true,
+        },
+      }));
+
+      // Force new accumulator creation with weekly period
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+
+      // Advance to next Monday
+      const now = new Date();
+      const daysUntilMonday = ((8 - now.getUTCDay()) % 7) || 7;
+      const nextMonday = new Date(Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() + daysUntilMonday,
+        1,
+      ));
+      vi.setSystemTime(nextMonday);
+
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      expect(service.getProjectCostSnapshot('project-1', 'period')!.totalCostDollars).toBeCloseTo(10.5, 6);
+    });
+
+    it('resets threshold flags on period rotation', () => {
+      // Cross soft threshold
+      for (let i = 0; i < 8; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const softAlertsBefore = (eventBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) =>
+          call[0] === 'cost:budget-alert' && (call[1] as any).alertLevel === 'soft_threshold',
+      );
+      expect(softAlertsBefore).toHaveLength(1);
+
+      // Advance to next month (reset)
+      const now = new Date();
+      const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 2));
+      vi.setSystemTime(nextMonth);
+
+      // Clear mock calls to count fresh
+      (eventBus.publish as ReturnType<typeof vi.fn>).mockClear();
+
+      // Cross soft threshold again in new period
+      for (let i = 0; i < 8; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const softAlertsAfter = (eventBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) =>
+          call[0] === 'cost:budget-alert' && (call[1] as any).alertLevel === 'soft_threshold',
+      );
+      expect(softAlertsAfter).toHaveLength(1);
+    });
+
+    it('none period never rotates', () => {
+      projectConfigs.set('project-1', createProjectConfig({
+        costBudget: {
+          enabled: true,
+          hardCeilingDollars: 1000,
+          softThresholdPercent: 80,
+          periodType: 'none',
+          systemScopeExempt: true,
+        },
+      }));
+
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+
+      // Advance a year
+      const future = new Date();
+      future.setFullYear(future.getFullYear() + 1);
+      vi.setSystemTime(future);
+
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      // Should have accumulated both events
+      expect(service.getProjectCostSnapshot('project-1', 'period')!.totalCostDollars).toBeCloseTo(21.0, 6);
+    });
+  });
+
+  // --- Budget Status ---
+
+  describe('getBudgetStatus()', () => {
+    it('returns correct status for project with budget', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+
+      const status = service.getBudgetStatus('project-1');
+      expect(status).not.toBeNull();
+      expect(status!.currentSpendDollars).toBeCloseTo(10.5, 6);
+      expect(status!.hardCeilingDollars).toBe(100);
+      expect(status!.softThresholdDollars).toBe(80);
+      expect(status!.percentUsed).toBeCloseTo(10.5, 4);
+      expect(status!.alertLevel).toBe('normal');
+      expect(status!.isPaused).toBe(false);
+    });
+
+    it('returns null for project without budget policy', () => {
+      projectConfigs.set('no-budget', createProjectConfig({
+        id: 'no-budget' as ProjectId,
+        costBudget: undefined,
+      }));
+
+      expect(service.getBudgetStatus('no-budget')).toBeNull();
+    });
+
+    it('reflects hard_ceiling alert level when paused', () => {
+      for (let i = 0; i < 10; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      }
+
+      const status = service.getBudgetStatus('project-1');
+      expect(status!.alertLevel).toBe('hard_ceiling');
+      expect(status!.isPaused).toBe(true);
+    });
+  });
+
+  // --- Provider Breakdown ---
+
+  describe('getProviderBreakdown()', () => {
+    it('returns per-provider/model entries', () => {
+      pricingRegistry.setEntry(createPricingEntry({ providerId: 'p2', modelId: 'm2', inputPricePerMillionTokens: 1, outputPricePerMillionTokens: 5 }));
+
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({ providerId: 'p2', modelId: 'm2' }));
+
+      const breakdown = service.getProviderBreakdown('project-1', 'period');
+      expect(breakdown).toHaveLength(2);
+    });
+
+    it('returns empty for unknown project', () => {
+      expect(service.getProviderBreakdown('unknown', 'period')).toEqual([]);
+    });
+  });
+
+  // --- Pricing Delegation ---
+
+  describe('pricing delegation', () => {
+    it('getPricingTable delegates to registry', () => {
+      expect(service.getPricingTable()).toHaveLength(1);
+    });
+
+    it('setPricingEntry delegates to registry', () => {
+      service.setPricingEntry(createPricingEntry({ providerId: 'new', modelId: 'new' }));
+      expect(service.getPricingTable()).toHaveLength(2);
+    });
+
+    it('removePricingEntry delegates to registry', () => {
+      expect(service.removePricingEntry('provider-1', 'model-1')).toBe(true);
+      expect(service.getPricingTable()).toHaveLength(0);
+    });
+  });
+
+  // --- Dispose ---
+
+  describe('dispose()', () => {
+    it('unsubscribes from event bus and clears accumulators', () => {
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      expect(service.getProjectCostSnapshot('project-1', 'period')).not.toBeNull();
+
+      service.dispose();
+
+      expect(eventBus.unsubscribe).toHaveBeenCalledTimes(2);
+      expect(service.getProjectCostSnapshot('project-1', 'period')).toBeNull();
+    });
+
+    it('ignores events after dispose', () => {
+      service.dispose();
+      eventBus.simulateEvent('inference:call-complete', createCallCompletePayload());
+      expect(service.getProjectCostSnapshot('project-1', 'period')).toBeNull();
+    });
+  });
+
+  // --- Pause Envelope ---
+
+  describe('pause envelope construction', () => {
+    it('produces unique command IDs across multiple hard ceiling triggers', () => {
+      // Need two projects both hitting ceiling
+      projectConfigs.set('project-2', createProjectConfig({ id: 'project-2' as ProjectId }));
+
+      for (let i = 0; i < 10; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({ projectId: 'project-1' }));
+      }
+      for (let i = 0; i < 10; i++) {
+        eventBus.simulateEvent('inference:call-complete', createCallCompletePayload({ projectId: 'project-2' }));
+      }
+
+      const calls = (opctlService.submitCommand as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls).toHaveLength(2);
+
+      const envelope1 = calls[0]![0] as any;
+      const envelope2 = calls[1]![0] as any;
+      expect(envelope1.control_command_id).not.toBe(envelope2.control_command_id);
+      expect(envelope1.nonce).not.toBe(envelope2.nonce);
+      expect(envelope1.actor_seq).toBeLessThan(envelope2.actor_seq);
+    });
+  });
+});

--- a/self/subcortex/providers/src/__tests__/model-pricing-registry.test.ts
+++ b/self/subcortex/providers/src/__tests__/model-pricing-registry.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { ModelPricingRegistry } from '../model-pricing-registry.js';
+import type { ModelPricingEntry } from '@nous/shared';
+
+function createEntry(overrides?: Partial<ModelPricingEntry>): ModelPricingEntry {
+  return {
+    providerId: 'anthropic',
+    modelId: 'claude-3-opus',
+    inputPricePerMillionTokens: 15,
+    outputPricePerMillionTokens: 75,
+    effectiveAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('ModelPricingRegistry', () => {
+  describe('setEntry() and getPrice()', () => {
+    it('returns pricing after entry is set', () => {
+      const registry = new ModelPricingRegistry();
+      registry.setEntry(createEntry());
+
+      const price = registry.getPrice('anthropic', 'claude-3-opus');
+      expect(price).toEqual({
+        inputPricePerMillionTokens: 15,
+        outputPricePerMillionTokens: 75,
+      });
+    });
+
+    it('overwrites existing entry for same provider/model', () => {
+      const registry = new ModelPricingRegistry();
+      registry.setEntry(createEntry({ inputPricePerMillionTokens: 10 }));
+      registry.setEntry(createEntry({ inputPricePerMillionTokens: 20 }));
+
+      const price = registry.getPrice('anthropic', 'claude-3-opus');
+      expect(price?.inputPricePerMillionTokens).toBe(20);
+    });
+  });
+
+  describe('getPrice()', () => {
+    it('returns null for unknown provider/model', () => {
+      const registry = new ModelPricingRegistry();
+      expect(registry.getPrice('unknown', 'model')).toBeNull();
+    });
+  });
+
+  describe('removeEntry()', () => {
+    it('removes an existing entry and returns true', () => {
+      const registry = new ModelPricingRegistry();
+      registry.setEntry(createEntry());
+
+      const removed = registry.removeEntry('anthropic', 'claude-3-opus');
+      expect(removed).toBe(true);
+      expect(registry.getPrice('anthropic', 'claude-3-opus')).toBeNull();
+    });
+
+    it('returns false for non-existent entry', () => {
+      const registry = new ModelPricingRegistry();
+      expect(registry.removeEntry('unknown', 'model')).toBe(false);
+    });
+  });
+
+  describe('getAll()', () => {
+    it('returns all entries', () => {
+      const registry = new ModelPricingRegistry();
+      registry.setEntry(createEntry({ providerId: 'a', modelId: 'm1' }));
+      registry.setEntry(createEntry({ providerId: 'b', modelId: 'm2' }));
+
+      const all = registry.getAll();
+      expect(all).toHaveLength(2);
+      expect(all.map((e) => e.providerId).sort()).toEqual(['a', 'b']);
+    });
+
+    it('returns empty array when no entries exist', () => {
+      const registry = new ModelPricingRegistry();
+      expect(registry.getAll()).toEqual([]);
+    });
+  });
+});

--- a/self/subcortex/providers/src/cost-governance-service.ts
+++ b/self/subcortex/providers/src/cost-governance-service.ts
@@ -1,0 +1,421 @@
+/**
+ * CostGovernanceService — Real-time cost tracking and budget enforcement.
+ *
+ * Subscribes to inference:call-complete and inference:stream-complete events,
+ * calculates dollar costs from token usage via the pricing registry, and
+ * enforces budget thresholds by emitting alerts and triggering opctl pause
+ * commands when ceilings are reached.
+ *
+ * Canonical sources:
+ * - cost-governance-service-v1.md
+ * - opctl-internal-actor-v1.md
+ * - budget-policy-lifecycle-v1.md
+ */
+import { createHash } from 'node:crypto';
+import type {
+  IEventBus,
+  IOpctlService,
+  ICostGovernanceService,
+  InferenceCallCompletePayload,
+  ProjectConfig,
+  CostWindow,
+  CostSnapshot,
+  CostAccumulatorEntry,
+  ModelPricingEntry,
+  BudgetStatus,
+  BudgetAlertLevel,
+  BudgetPeriodType,
+  ControlCommandEnvelope,
+  ControlCommandId,
+  ProjectId,
+} from '@nous/shared';
+import { SYSTEM_SCOPE_SENTINEL_PROJECT_ID } from '@nous/shared';
+import { ModelPricingRegistry } from './model-pricing-registry.js';
+
+// --- Internal Actor Constants (per opctl-internal-actor-v1.md) ---
+
+const COST_GOVERNANCE_ACTOR_ID = '00000000-0000-4000-a000-000000000001';
+const COST_GOVERNANCE_SESSION_ID = '00000000-0000-4000-a000-000000000002';
+
+// --- Internal Accumulator Types ---
+
+interface AccumulatorEntry {
+  inputTokens: number;
+  outputTokens: number;
+  inputCostDollars: number;
+  outputCostDollars: number;
+  callCount: number;
+}
+
+interface ProjectCostAccumulator {
+  periodStart: Date;
+  periodType: BudgetPeriodType;
+  /** Keyed by `${providerId}:${modelId}` */
+  entries: Map<string, AccumulatorEntry>;
+  totalCostDollars: number;
+  softThresholdFired: boolean;
+  hardCeilingFired: boolean;
+}
+
+// --- Dependencies ---
+
+export interface CostGovernanceServiceDeps {
+  eventBus: IEventBus;
+  opctlService: IOpctlService;
+  pricingRegistry: ModelPricingRegistry;
+  getProjectConfig: (projectId: string) => ProjectConfig | null;
+}
+
+// --- Helpers ---
+
+function startOfMonth(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCDate(1);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+function startOfNextMonth(date: Date): Date {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1));
+  return d;
+}
+
+function startOfWeek(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getUTCDay();
+  // Monday = start of ISO week
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+function startOfNextWeek(date: Date): Date {
+  const d = startOfWeek(date);
+  d.setUTCDate(d.getUTCDate() + 7);
+  return d;
+}
+
+function entryKey(providerId: string, modelId: string): string {
+  return `${providerId}:${modelId}`;
+}
+
+// --- Service ---
+
+export class CostGovernanceService implements ICostGovernanceService {
+  private projectAccumulators = new Map<string, ProjectCostAccumulator>();
+  private subscriptionIds: string[] = [];
+  private disposed = false;
+  private actorSeq = 0;
+
+  constructor(private readonly deps: CostGovernanceServiceDeps) {
+    const callCompleteId = this.deps.eventBus.subscribe(
+      'inference:call-complete',
+      (payload) => { this.handleInferenceEvent(payload); },
+    );
+    const streamCompleteId = this.deps.eventBus.subscribe(
+      'inference:stream-complete',
+      (payload) => { this.handleInferenceEvent(payload); },
+    );
+    this.subscriptionIds.push(callCompleteId, streamCompleteId);
+  }
+
+  // --- Event Handling ---
+
+  private handleInferenceEvent(payload: InferenceCallCompletePayload): void {
+    if (this.disposed) return;
+
+    const { projectId, providerId, modelId, inputTokens, outputTokens } = payload;
+
+    // Guard: skip system-scope and unattributed events
+    if (!projectId || projectId === SYSTEM_SCOPE_SENTINEL_PROJECT_ID) return;
+
+    // Look up pricing
+    const pricing = this.deps.pricingRegistry.getPrice(providerId, modelId);
+    const input = inputTokens ?? 0;
+    const output = outputTokens ?? 0;
+    const inputCost = pricing ? (input / 1_000_000) * pricing.inputPricePerMillionTokens : 0;
+    const outputCost = pricing ? (output / 1_000_000) * pricing.outputPricePerMillionTokens : 0;
+    const totalCost = inputCost + outputCost;
+
+    // Get or create accumulator
+    const accum = this.getOrCreateAccumulator(projectId);
+
+    // Period rotation (lazy, checked on every event)
+    this.rotatePeriodIfNeeded(accum, projectId);
+
+    // Accumulate
+    const key = entryKey(providerId, modelId);
+    const existing = accum.entries.get(key);
+    if (existing) {
+      existing.inputTokens += input;
+      existing.outputTokens += output;
+      existing.inputCostDollars += inputCost;
+      existing.outputCostDollars += outputCost;
+      existing.callCount += 1;
+    } else {
+      accum.entries.set(key, {
+        inputTokens: input,
+        outputTokens: output,
+        inputCostDollars: inputCost,
+        outputCostDollars: outputCost,
+        callCount: 1,
+      });
+    }
+    accum.totalCostDollars += totalCost;
+
+    // Budget check
+    this.checkBudgetThresholds(projectId, accum);
+  }
+
+  private getOrCreateAccumulator(projectId: string): ProjectCostAccumulator {
+    let accum = this.projectAccumulators.get(projectId);
+    if (!accum) {
+      const config = this.deps.getProjectConfig(projectId);
+      const periodType: BudgetPeriodType = config?.costBudget?.periodType ?? 'monthly';
+      accum = {
+        periodStart: this.computePeriodStart(periodType, new Date()),
+        periodType,
+        entries: new Map(),
+        totalCostDollars: 0,
+        softThresholdFired: false,
+        hardCeilingFired: false,
+      };
+      this.projectAccumulators.set(projectId, accum);
+    }
+    return accum;
+  }
+
+  private computePeriodStart(periodType: BudgetPeriodType, now: Date): Date {
+    switch (periodType) {
+      case 'monthly': return startOfMonth(now);
+      case 'weekly': return startOfWeek(now);
+      case 'none': return now;
+    }
+  }
+
+  private computePeriodEnd(periodType: BudgetPeriodType, periodStart: Date): Date | undefined {
+    switch (periodType) {
+      case 'monthly': return startOfNextMonth(periodStart);
+      case 'weekly': return startOfNextWeek(periodStart);
+      case 'none': return undefined;
+    }
+  }
+
+  private rotatePeriodIfNeeded(accum: ProjectCostAccumulator, projectId: string): void {
+    if (accum.periodType === 'none') return;
+
+    const now = new Date();
+    const periodEnd = this.computePeriodEnd(accum.periodType, accum.periodStart);
+    if (periodEnd && now >= periodEnd) {
+      // Reset accumulator
+      accum.entries.clear();
+      accum.totalCostDollars = 0;
+      accum.softThresholdFired = false;
+      accum.hardCeilingFired = false;
+      accum.periodStart = this.computePeriodStart(accum.periodType, now);
+
+      // Re-check if period type changed in config
+      const config = this.deps.getProjectConfig(projectId);
+      if (config?.costBudget?.periodType && config.costBudget.periodType !== accum.periodType) {
+        accum.periodType = config.costBudget.periodType;
+        accum.periodStart = this.computePeriodStart(accum.periodType, now);
+      }
+    }
+  }
+
+  private checkBudgetThresholds(projectId: string, accum: ProjectCostAccumulator): void {
+    const config = this.deps.getProjectConfig(projectId);
+    const policy = config?.costBudget;
+    if (!policy || !policy.enabled) return;
+
+    const softThresholdDollars = (policy.hardCeilingDollars * policy.softThresholdPercent) / 100;
+    const percentUsed = (accum.totalCostDollars / policy.hardCeilingDollars) * 100;
+    const now = new Date().toISOString();
+
+    // Check soft threshold first (ordering: soft, then hard)
+    if (
+      accum.totalCostDollars >= softThresholdDollars &&
+      !accum.softThresholdFired
+    ) {
+      accum.softThresholdFired = true;
+      try {
+        this.deps.eventBus.publish('cost:budget-alert', {
+          projectId,
+          alertLevel: 'soft_threshold',
+          currentSpendDollars: accum.totalCostDollars,
+          thresholdDollars: softThresholdDollars,
+          percentUsed,
+          emittedAt: now,
+        });
+      } catch { /* fire-and-forget */ }
+      try {
+        this.deps.eventBus.publish('escalation:new', {
+          escalationId: `cost-soft-${projectId}-${Date.now()}`,
+          projectId,
+          severity: 'medium',
+          message: `Cost budget warning: project ${projectId} has reached ${percentUsed.toFixed(1)}% of the $${policy.hardCeilingDollars} budget ceiling ($${accum.totalCostDollars.toFixed(4)} spent).`,
+        });
+      } catch { /* fire-and-forget */ }
+    }
+
+    // Check hard ceiling
+    if (
+      accum.totalCostDollars >= policy.hardCeilingDollars &&
+      !accum.hardCeilingFired
+    ) {
+      accum.hardCeilingFired = true;
+      try {
+        this.deps.eventBus.publish('cost:budget-alert', {
+          projectId,
+          alertLevel: 'hard_ceiling',
+          currentSpendDollars: accum.totalCostDollars,
+          thresholdDollars: policy.hardCeilingDollars,
+          percentUsed,
+          emittedAt: now,
+        });
+      } catch { /* fire-and-forget */ }
+
+      // Trigger opctl pause (async fire-and-forget)
+      const envelope = this.buildPauseEnvelope(projectId);
+      this.deps.opctlService.submitCommand(envelope).catch(() => {
+        /* logged externally — hardCeilingFired prevents retries */
+      });
+    }
+  }
+
+  // --- Envelope Construction (per opctl-internal-actor-v1.md) ---
+
+  private buildPauseEnvelope(projectId: string): ControlCommandEnvelope {
+    const commandId = crypto.randomUUID() as ControlCommandId;
+    const nonce = crypto.randomUUID();
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 60_000); // 1 minute TTL
+
+    return {
+      control_command_id: commandId,
+      actor_type: 'orchestration_agent',
+      actor_id: COST_GOVERNANCE_ACTOR_ID,
+      actor_session_id: COST_GOVERNANCE_SESSION_ID,
+      actor_seq: ++this.actorSeq,
+      nonce,
+      issued_at: now.toISOString(),
+      expires_at: expiresAt.toISOString(),
+      scope: {
+        class: 'project_run_scope',
+        kind: 'project_run',
+        target_ids: [],
+        project_id: projectId as ProjectId,
+      },
+      payload_hash: createHash('sha256')
+        .update(JSON.stringify({ action: 'pause', projectId }))
+        .digest('hex'),
+      command_signature: 'cost-governance-internal',
+      action: 'pause',
+    };
+  }
+
+  // --- Public API ---
+
+  getProjectCostSnapshot(projectId: string, window: CostWindow): CostSnapshot | null {
+    const accum = this.projectAccumulators.get(projectId);
+    if (!accum) return null;
+
+    // For 'period' window, use the accumulator directly.
+    // For today/week/month, we only maintain the period accumulator per the decision doc.
+    // The period accumulator is the authoritative source.
+    const entries = this.buildCostEntries(accum);
+    const windowStart = accum.periodStart;
+
+    return {
+      projectId,
+      window,
+      windowStart: windowStart.toISOString(),
+      totalCostDollars: accum.totalCostDollars,
+      entries,
+      snapshotAt: new Date().toISOString(),
+    };
+  }
+
+  getBudgetStatus(projectId: string): BudgetStatus | null {
+    const config = this.deps.getProjectConfig(projectId);
+    const policy = config?.costBudget;
+    if (!policy) return null;
+
+    const accum = this.projectAccumulators.get(projectId);
+    const currentSpend = accum?.totalCostDollars ?? 0;
+    const softThresholdDollars = (policy.hardCeilingDollars * policy.softThresholdPercent) / 100;
+    const percentUsed = (currentSpend / policy.hardCeilingDollars) * 100;
+    const periodStart = accum?.periodStart ?? this.computePeriodStart(policy.periodType, new Date());
+    const periodEnd = this.computePeriodEnd(policy.periodType, periodStart);
+
+    let alertLevel: BudgetAlertLevel = 'normal';
+    if (currentSpend >= policy.hardCeilingDollars) {
+      alertLevel = 'hard_ceiling';
+    } else if (currentSpend >= softThresholdDollars) {
+      alertLevel = 'soft_threshold';
+    }
+
+    return {
+      projectId,
+      currentSpendDollars: currentSpend,
+      hardCeilingDollars: policy.hardCeilingDollars,
+      softThresholdDollars,
+      percentUsed,
+      alertLevel,
+      periodType: policy.periodType,
+      periodStart: periodStart.toISOString(),
+      periodEnd: periodEnd?.toISOString(),
+      isPaused: accum?.hardCeilingFired ?? false,
+    };
+  }
+
+  getProviderBreakdown(projectId: string, _window: CostWindow): CostAccumulatorEntry[] {
+    const accum = this.projectAccumulators.get(projectId);
+    if (!accum) return [];
+    return this.buildCostEntries(accum);
+  }
+
+  getPricingTable(): ModelPricingEntry[] {
+    return this.deps.pricingRegistry.getAll();
+  }
+
+  setPricingEntry(entry: ModelPricingEntry): void {
+    this.deps.pricingRegistry.setEntry(entry);
+  }
+
+  removePricingEntry(providerId: string, modelId: string): boolean {
+    return this.deps.pricingRegistry.removeEntry(providerId, modelId);
+  }
+
+  // --- Lifecycle ---
+
+  dispose(): void {
+    this.disposed = true;
+    for (const id of this.subscriptionIds) {
+      this.deps.eventBus.unsubscribe(id);
+    }
+    this.subscriptionIds = [];
+    this.projectAccumulators.clear();
+  }
+
+  // --- Private Helpers ---
+
+  private buildCostEntries(accum: ProjectCostAccumulator): CostAccumulatorEntry[] {
+    const result: CostAccumulatorEntry[] = [];
+    for (const [key, entry] of accum.entries) {
+      const [providerId, modelId] = key.split(':');
+      result.push({
+        providerId: providerId!,
+        modelId: modelId!,
+        inputTokens: entry.inputTokens,
+        outputTokens: entry.outputTokens,
+        inputCostDollars: entry.inputCostDollars,
+        outputCostDollars: entry.outputCostDollars,
+        totalCostDollars: entry.inputCostDollars + entry.outputCostDollars,
+        callCount: entry.callCount,
+      });
+    }
+    return result;
+  }
+}

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -14,3 +14,6 @@ export { TokenAccumulatorService } from './token-accumulator-service.js';
 export type { WindowSummary, ProviderBreakdownEntry } from './token-accumulator-service.js';
 export { TextModelInputSchema } from './schemas.js';
 export type { TextModelInput } from './schemas.js';
+export { ModelPricingRegistry } from './model-pricing-registry.js';
+export { CostGovernanceService } from './cost-governance-service.js';
+export type { CostGovernanceServiceDeps } from './cost-governance-service.js';

--- a/self/subcortex/providers/src/model-pricing-registry.ts
+++ b/self/subcortex/providers/src/model-pricing-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * ModelPricingRegistry — In-memory pricing table for model cost lookups.
+ *
+ * Maps (providerId, modelId) pairs to per-million-token pricing. Used by
+ * CostGovernanceService for real-time cost calculation on inference events.
+ */
+import type { ModelPricingEntry } from '@nous/shared';
+
+export class ModelPricingRegistry {
+  /** Keyed by `${providerId}:${modelId}` */
+  private entries = new Map<string, ModelPricingEntry>();
+
+  private static key(providerId: string, modelId: string): string {
+    return `${providerId}:${modelId}`;
+  }
+
+  /** Look up pricing for a provider/model pair. Returns null if not found. */
+  getPrice(
+    providerId: string,
+    modelId: string,
+  ): { inputPricePerMillionTokens: number; outputPricePerMillionTokens: number } | null {
+    const entry = this.entries.get(ModelPricingRegistry.key(providerId, modelId));
+    if (!entry) return null;
+    return {
+      inputPricePerMillionTokens: entry.inputPricePerMillionTokens,
+      outputPricePerMillionTokens: entry.outputPricePerMillionTokens,
+    };
+  }
+
+  /** Set or update a pricing entry. */
+  setEntry(entry: ModelPricingEntry): void {
+    this.entries.set(
+      ModelPricingRegistry.key(entry.providerId, entry.modelId),
+      entry,
+    );
+  }
+
+  /** Remove a pricing entry. Returns true if the entry existed. */
+  removeEntry(providerId: string, modelId: string): boolean {
+    return this.entries.delete(ModelPricingRegistry.key(providerId, modelId));
+  }
+
+  /** Get all pricing entries. */
+  getAll(): ModelPricingEntry[] {
+    return [...this.entries.values()];
+  }
+}

--- a/self/ui/src/panels/dashboard/__tests__/CostBreakdownWidget.test.tsx
+++ b/self/ui/src/panels/dashboard/__tests__/CostBreakdownWidget.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { CostBreakdownWidget } from '../widgets/CostBreakdownWidget'
+import type { IDockviewPanelProps } from 'dockview-react'
+
+vi.mock('@nous/transport', () => ({
+  trpc: {
+    costGovernance: {
+      getBudgetStatus: {
+        useQuery: vi.fn().mockReturnValue({ data: undefined, isLoading: true, error: null }),
+      },
+      getProviderBreakdown: {
+        useQuery: vi.fn().mockReturnValue({ data: undefined, isLoading: true, error: null }),
+      },
+    },
+  },
+}))
+
+import { trpc } from '@nous/transport'
+
+const mockBudgetData = {
+  projectId: 'test-project',
+  currentSpendDollars: 12.50,
+  hardCeilingDollars: 50.00,
+  softThresholdDollars: 40.00,
+  percentUsed: 25,
+  alertLevel: 'normal' as const,
+  periodType: 'monthly' as const,
+  periodStart: '2026-04-01T00:00:00Z',
+  periodEnd: '2026-05-01T00:00:00Z',
+  isPaused: false,
+}
+
+const mockBreakdownData = [
+  {
+    providerId: 'anthropic',
+    modelId: 'claude-sonnet-4-20250514',
+    inputTokens: 50000,
+    outputTokens: 30000,
+    inputCostDollars: 0.15,
+    outputCostDollars: 0.45,
+    totalCostDollars: 0.60,
+    callCount: 25,
+  },
+  {
+    providerId: 'openai',
+    modelId: 'gpt-4o',
+    inputTokens: 20000,
+    outputTokens: 15000,
+    inputCostDollars: 0.05,
+    outputCostDollars: 0.30,
+    totalCostDollars: 0.35,
+    callCount: 10,
+  },
+]
+
+const dockviewProps = { params: { projectId: 'test-project' } } as unknown as IDockviewPanelProps
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CostBreakdownWidget', () => {
+  it('renders loading skeleton when budget query is pending', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByTestId('budget-skeleton')).toBeTruthy()
+    expect(screen.getByTestId('breakdown-skeleton')).toBeTruthy()
+  })
+
+  it('renders budget gauge and spend info when data is available', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: mockBudgetData,
+      isLoading: false,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: mockBreakdownData,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+
+    expect(screen.getByText(/\$12\.50/)).toBeTruthy()
+    expect(screen.getByText(/\$50\.00/)).toBeTruthy()
+    expect(screen.getByTestId('budget-gauge')).toBeTruthy()
+    expect(screen.getByTestId('budget-alert-level')).toBeTruthy()
+    expect(screen.getByText('Normal')).toBeTruthy()
+  })
+
+  it('renders warning state when soft threshold breached', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: { ...mockBudgetData, alertLevel: 'soft_threshold', percentUsed: 85 },
+      isLoading: false,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByText('Warning')).toBeTruthy()
+  })
+
+  it('renders paused state when hard ceiling reached', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: { ...mockBudgetData, alertLevel: 'hard_ceiling', percentUsed: 100, isPaused: true },
+      isLoading: false,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByText('Paused (ceiling reached)')).toBeTruthy()
+  })
+
+  it('renders no-budget placeholder when budget is null', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByTestId('no-budget')).toBeTruthy()
+    expect(screen.getByText('No budget policy configured')).toBeTruthy()
+  })
+
+  it('renders provider breakdown table with cost data', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: mockBudgetData,
+      isLoading: false,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: mockBreakdownData,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByText('anthropic')).toBeTruthy()
+    expect(screen.getByText(/gpt-4o/)).toBeTruthy()
+    expect(screen.getByText('$0.6000')).toBeTruthy()
+    expect(screen.getByText('$0.3500')).toBeTruthy()
+  })
+
+  it('renders empty breakdown placeholder when no cost data', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: mockBudgetData,
+      isLoading: false,
+      error: null,
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByTestId('no-breakdown')).toBeTruthy()
+    expect(screen.getByText('No cost data available')).toBeTruthy()
+  })
+
+  it('renders error state when budget query fails', () => {
+    vi.mocked(trpc.costGovernance.getBudgetStatus.useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    } as any)
+    vi.mocked(trpc.costGovernance.getProviderBreakdown.useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<CostBreakdownWidget {...dockviewProps} />)
+    expect(screen.getByTestId('budget-error')).toBeTruthy()
+    expect(screen.getByText(/Failed to load budget: Network error/)).toBeTruthy()
+  })
+})

--- a/self/ui/src/panels/dashboard/widgets/CostBreakdownWidget.tsx
+++ b/self/ui/src/panels/dashboard/widgets/CostBreakdownWidget.tsx
@@ -1,0 +1,185 @@
+/**
+ * CostBreakdownWidget — Budget gauge, provider cost breakdown, and alert states.
+ *
+ * Displays real-time budget usage with color-coded thresholds and a
+ * per-provider/model cost table. Requires a projectId prop.
+ */
+import type { IDockviewPanelProps } from 'dockview-react'
+import type { CSSProperties } from 'react'
+import { trpc } from '@nous/transport'
+
+// --- Styles ---
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: 'var(--nous-space-sm) var(--nous-space-xl)',
+  fontSize: 'var(--nous-font-size-sm)',
+  borderBottom: '1px solid var(--nous-border-subtle)',
+}
+
+const sectionHeader: CSSProperties = {
+  padding: 'var(--nous-space-sm) var(--nous-space-xl) var(--nous-space-2xs)',
+  fontSize: 'var(--nous-font-size-xs)',
+  fontWeight: 'var(--nous-font-weight-semibold)' as any,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: 'var(--nous-fg-subtle)',
+  borderBottom: '1px solid var(--nous-border-subtle)',
+}
+
+const gaugeTrack: CSSProperties = {
+  height: '8px',
+  borderRadius: '4px',
+  background: 'var(--nous-bg-subtle)',
+  overflow: 'hidden',
+  margin: '0 var(--nous-space-xl)',
+  marginTop: 'var(--nous-space-xs)',
+  marginBottom: 'var(--nous-space-sm)',
+}
+
+// --- Alert level colors ---
+
+const ALERT_COLORS = {
+  normal: 'var(--nous-state-active, #22c55e)',
+  soft_threshold: 'var(--nous-state-caution, #f59e0b)',
+  hard_ceiling: 'var(--nous-state-blocked, #ef4444)',
+} as const
+
+// --- Component ---
+
+export interface CostBreakdownWidgetParams {
+  projectId: string
+}
+
+export function CostBreakdownWidget(props: IDockviewPanelProps<CostBreakdownWidgetParams>) {
+  const projectId = props.params?.projectId ?? ''
+  const budgetQuery = trpc.costGovernance.getBudgetStatus.useQuery(
+    { projectId },
+    { refetchInterval: 10_000 },
+  )
+  const breakdownQuery = trpc.costGovernance.getProviderBreakdown.useQuery(
+    { projectId, window: 'period' as const },
+    { refetchInterval: 10_000 },
+  )
+
+  const budget = budgetQuery.data
+  const breakdown = breakdownQuery.data
+
+  return (
+    <div style={{ height: '100%', overflow: 'auto', color: 'var(--nous-fg)' }}>
+      {/* --- Budget Gauge Section --- */}
+      <div style={sectionHeader}>Budget</div>
+
+      {budgetQuery.isLoading && !budget ? (
+        <div style={{ ...rowStyle, opacity: 0.5 }} data-testid="budget-skeleton">
+          <span style={{ color: 'var(--nous-fg-muted)' }}>Loading budget...</span>
+        </div>
+      ) : budgetQuery.error ? (
+        <div style={{ ...rowStyle, color: 'var(--nous-state-blocked)' }} data-testid="budget-error">
+          Failed to load budget: {budgetQuery.error.message}
+        </div>
+      ) : budget ? (
+        <>
+          {/* Spend vs ceiling */}
+          <div style={rowStyle}>
+            <span style={{ color: 'var(--nous-fg-muted)' }}>Spend</span>
+            <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+              ${budget.currentSpendDollars.toFixed(2)}
+              <span style={{ color: 'var(--nous-fg-subtle)' }}> / ${budget.hardCeilingDollars.toFixed(2)}</span>
+            </span>
+          </div>
+
+          {/* Gauge bar */}
+          <div style={gaugeTrack} data-testid="budget-gauge">
+            <div
+              style={{
+                height: '100%',
+                width: `${Math.min(budget.percentUsed, 100)}%`,
+                borderRadius: '4px',
+                background: ALERT_COLORS[budget.alertLevel],
+                transition: 'width 0.3s ease, background 0.3s ease',
+              }}
+              data-testid="budget-gauge-fill"
+            />
+          </div>
+
+          {/* Alert and period info */}
+          <div style={rowStyle}>
+            <span style={{ color: 'var(--nous-fg-muted)' }}>Status</span>
+            <span
+              style={{ color: ALERT_COLORS[budget.alertLevel], fontWeight: 'var(--nous-font-weight-medium)' as any }}
+              data-testid="budget-alert-level"
+            >
+              {budget.isPaused
+                ? 'Paused (ceiling reached)'
+                : budget.alertLevel === 'soft_threshold'
+                  ? 'Warning'
+                  : budget.alertLevel === 'hard_ceiling'
+                    ? 'Ceiling reached'
+                    : 'Normal'}
+            </span>
+          </div>
+
+          <div style={rowStyle}>
+            <span style={{ color: 'var(--nous-fg-muted)' }}>Period</span>
+            <span style={{ fontVariantNumeric: 'tabular-nums', color: 'var(--nous-fg-subtle)' }}>
+              {budget.periodType}
+              {budget.periodStart && ` from ${new Date(budget.periodStart).toLocaleDateString()}`}
+            </span>
+          </div>
+        </>
+      ) : (
+        <div style={{ ...rowStyle, color: 'var(--nous-fg-muted)' }} data-testid="no-budget">
+          No budget policy configured
+        </div>
+      )}
+
+      {/* --- Provider Breakdown Section --- */}
+      <div style={{ ...sectionHeader, marginTop: 'var(--nous-space-xs)' }}>Provider Breakdown</div>
+
+      {breakdownQuery.isLoading && !breakdown ? (
+        <div style={{ ...rowStyle, opacity: 0.5 }} data-testid="breakdown-skeleton">
+          <span style={{ color: 'var(--nous-fg-muted)' }}>Loading breakdown...</span>
+        </div>
+      ) : breakdownQuery.error ? (
+        <div style={{ ...rowStyle, color: 'var(--nous-state-blocked)' }} data-testid="breakdown-error">
+          Failed to load breakdown: {breakdownQuery.error.message}
+        </div>
+      ) : breakdown && breakdown.length > 0 ? (
+        <>
+          {/* Table header */}
+          <div style={{ ...rowStyle, fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-subtle)' }}>
+            <span style={{ flex: 2 }}>Provider / Model</span>
+            <span style={{ flex: 1, textAlign: 'right' }}>Tokens</span>
+            <span style={{ flex: 1, textAlign: 'right' }}>Cost</span>
+          </div>
+          {breakdown.map((entry) => {
+            const totalTokens = entry.inputTokens + entry.outputTokens
+            return (
+              <div key={`${entry.providerId}:${entry.modelId}`} style={rowStyle}>
+                <span style={{ flex: 2, fontWeight: 'var(--nous-font-weight-medium)' as any }}>
+                  {entry.providerId}
+                  <span style={{ color: 'var(--nous-fg-subtle)', fontSize: 'var(--nous-font-size-xs)' }}>
+                    {' / '}{entry.modelId}
+                  </span>
+                </span>
+                <span style={{ flex: 1, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                  {totalTokens.toLocaleString()}
+                </span>
+                <span style={{ flex: 1, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                  ${entry.totalCostDollars.toFixed(4)}
+                </span>
+              </div>
+            )
+          })}
+        </>
+      ) : (
+        <div style={{ ...rowStyle, color: 'var(--nous-fg-muted)' }} data-testid="no-breakdown">
+          No cost data available
+        </div>
+      )}
+    </div>
+  )
+}

--- a/self/ui/src/panels/dashboard/widgets/index.ts
+++ b/self/ui/src/panels/dashboard/widgets/index.ts
@@ -3,6 +3,7 @@ import { ActiveAgentsWidget } from './ActiveAgentsWidget'
 import { ProviderHealthWidget } from './ProviderHealthWidget'
 import { RecentEventsWidget } from './RecentEventsWidget'
 import { TokenUsageWidget } from './TokenUsageWidget'
+import { CostBreakdownWidget } from './CostBreakdownWidget'
 
 export const dashboardWidgets = {
   'system-status': SystemStatusWidget,
@@ -10,6 +11,7 @@ export const dashboardWidgets = {
   'provider-health': ProviderHealthWidget,
   'recent-events': RecentEventsWidget,
   'token-usage': TokenUsageWidget,
+  'cost-breakdown': CostBreakdownWidget,
 }
 
 export type WidgetDef = { id: string; component: string; title: string }
@@ -20,4 +22,5 @@ export const WIDGET_DEFS: WidgetDef[] = [
   { id: 'provider-health', component: 'provider-health', title: 'Provider Health' },
   { id: 'token-usage', component: 'token-usage', title: 'Token Usage' },
   { id: 'recent-events', component: 'recent-events', title: 'Recent Events' },
+  { id: 'cost-breakdown', component: 'cost-breakdown', title: 'Cost Breakdown' },
 ]


### PR DESCRIPTION
## Summary

- **New `CostGovernanceService`** — subscribes to inference events, maps token usage to dollar costs via `ModelPricingRegistry`, accumulates per-project costs with time-windowed buckets (today/week/month/period), enforces budget policies
- **Hard ceiling enforcement** — auto-pauses projects via `opctlService` when spend exceeds `hardCeilingDollars`. System-scope agents exempt.
- **Soft threshold alerts** — emits `escalation:new` + `cost:budget-alert` events when spend crosses configurable percentage threshold
- **Budget policy on `ProjectConfigSchema`** — optional `costBudget` field with soft/hard thresholds, period types (monthly/weekly/none)
- **7-procedure tRPC router** — budget CRUD, cost queries, pricing management
- **`CostBreakdownWidget`** — dashboard panel with budget gauge, provider breakdown table, alert state banners
- **Full qualification artifacts** — discovery report, 6 ratified decision specs in `.architecture/`

## New files

| File | Purpose |
|------|---------|
| `shared/src/types/cost-governance.ts` | Zod schemas: pricing, budget, cost snapshots, alerts |
| `subcortex/providers/src/model-pricing-registry.ts` | In-memory (providerId, modelId) → dollar pricing |
| `subcortex/providers/src/cost-governance-service.ts` | Core service: event handling, accumulation, enforcement |
| `apps/shared-server/src/trpc/routers/cost-governance.ts` | tRPC router with 7 procedures |
| `ui/src/panels/dashboard/widgets/CostBreakdownWidget.tsx` | Dashboard widget |

## Test plan

- [x] 109 provider tests pass (including 28 new cost governance + pricing registry tests)
- [x] 8 CostBreakdownWidget tests pass (all render states)
- [x] 34 dashboard tests pass (no regressions)
- [x] `tsc --noEmit` clean for shared and providers packages
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)