### PR TITLE
feat: WR-110 Phase 2 — mixed-content card rendering + prop normalization

### DIFF
--- a/self/cortex/core/src/__tests__/gateway-runtime/card-prompt-injection.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/card-prompt-injection.test.ts
@@ -4,8 +4,8 @@ import { CARD_PROMPT_FRAGMENT } from '../../gateway-runtime/card-prompt-fragment
 describe('CARD_PROMPT_FRAGMENT — content contract', () => {
   // ── Tier 1: Contract Tests ─────────────────────────────────────────────
 
-  it('contains %%openui format instructions', () => {
-    expect(CARD_PROMPT_FRAGMENT).toContain('%%openui');
+  it('contains inline card tag format instructions', () => {
+    expect(CARD_PROMPT_FRAGMENT).toContain('Place card tags directly inline');
   });
 
   it('contains all 5 card type names', () => {
@@ -30,7 +30,7 @@ describe('CARD_PROMPT_FRAGMENT — content contract', () => {
 
   it('contains format section', () => {
     expect(CARD_PROMPT_FRAGMENT).toContain('Format:');
-    expect(CARD_PROMPT_FRAGMENT).toContain('Prefix card responses with %%openui');
+    expect(CARD_PROMPT_FRAGMENT).toContain('Place card tags directly inline');
   });
 
   it('is a non-empty string', () => {

--- a/self/cortex/core/src/__tests__/gateway-runtime/gateway-turn-executor.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/gateway-turn-executor.test.ts
@@ -211,7 +211,7 @@ describe('GatewayBackedTurnExecutor', () => {
     const provider = {
       invoke: vi.fn().mockResolvedValue({
         output: JSON.stringify({
-          response: '%%openui\n<StatusCard title="Test" status="active" message="Hi" />',
+          response: '%%openui\n<StatusCard title="Test" status="active" description="Hi" />',
           toolCalls: [],
           memoryCandidates: [],
         }),
@@ -263,7 +263,7 @@ describe('GatewayBackedTurnExecutor', () => {
     // contentType should be propagated in the return value
     expect(result.contentType).toBe('openui');
     // Prefix should be stripped from response
-    expect(result.response).toBe('<StatusCard title="Test" status="active" message="Hi" />');
+    expect(result.response).toBe('<StatusCard title="Test" status="active" description="Hi" />');
     expect(result.response).not.toContain('%%openui');
 
     // STM assistant entry should have contentType in metadata

--- a/self/cortex/core/src/__tests__/output-parser.test.ts
+++ b/self/cortex/core/src/__tests__/output-parser.test.ts
@@ -31,20 +31,20 @@ describe('parseModelOutput — contentType detection', () => {
   });
 
   it('%%openui\\n prefixed input: prefix stripped, contentType openui', () => {
-    const input = '%%openui\n<StatusCard title="Test" status="active" message="Hello" />';
+    const input = '%%openui\n<StatusCard title="Test" status="active" description="Hello" />';
     const result = parseModelOutput(input, TRACE_ID);
-    expect(result.response).toBe('<StatusCard title="Test" status="active" message="Hello" />');
+    expect(result.response).toBe('<StatusCard title="Test" status="active" description="Hello" />');
     expect(result.contentType).toBe('openui');
   });
 
   it('JSON envelope with %%openui\\n in response field: prefix stripped, contentType openui', () => {
     const input = JSON.stringify({
-      response: '%%openui\n<StatusCard title="Test" status="active" message="Hi" />',
+      response: '%%openui\n<StatusCard title="Test" status="active" description="Hi" />',
       toolCalls: [],
       memoryCandidates: [],
     });
     const result = parseModelOutput(input, TRACE_ID);
-    expect(result.response).toBe('<StatusCard title="Test" status="active" message="Hi" />');
+    expect(result.response).toBe('<StatusCard title="Test" status="active" description="Hi" />');
     expect(result.contentType).toBe('openui');
   });
 
@@ -78,10 +78,11 @@ describe('parseModelOutput — contentType detection', () => {
   // Tier 3 — Edge Cases
   // ---------------------------------------------------------------------------
 
-  it('%%openui without trailing \\n: treated as plain text', () => {
+  it('%%openui without trailing \\n: prefix not stripped, but inline <StatusCard detected as openui', () => {
     const result = parseModelOutput('%%openui<StatusCard />', TRACE_ID);
+    // Prefix not stripped (no \n), but <StatusCard tag detected inline
     expect(result.response).toBe('%%openui<StatusCard />');
-    expect(result.contentType).toBe('text');
+    expect(result.contentType).toBe('openui');
   });
 
   it('%%openui\\n prefix but no content after: contentType openui, empty response', () => {
@@ -111,5 +112,47 @@ describe('parseModelOutput — contentType detection', () => {
     const result = parseModelOutput({ response: 'Plain text.' }, TRACE_ID);
     expect(result.response).toBe('Plain text.');
     expect(result.contentType).toBe('text');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 2 — Inline card tag detection (Phase 2.1)
+  // ---------------------------------------------------------------------------
+
+  it('inline <StatusCard without prefix: contentType openui, response unchanged', () => {
+    const input = 'Here are results:\n<StatusCard title="Done" status="complete" description="OK" />';
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.contentType).toBe('openui');
+    expect(result.response).toBe(input);
+  });
+
+  it('mixed prose with <ActionCard inline: contentType openui', () => {
+    const input = 'Try this:\n<ActionCard title="Go" description="Now" actions={[]} />\nDone.';
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.contentType).toBe('openui');
+    expect(result.response).toBe(input);
+  });
+
+  it('%%openui\\n prefix backward compat: prefix stripped, contentType openui', () => {
+    const input = '%%openui\n<StatusCard title="T" status="active" description="M" />';
+    const result = parseModelOutput(input, TRACE_ID);
+    expect(result.contentType).toBe('openui');
+    expect(result.response).toBe('<StatusCard title="T" status="active" description="M" />');
+  });
+
+  it('plain text with no card tags: contentType text', () => {
+    const result = parseModelOutput('Just explaining something.', TRACE_ID);
+    expect(result.contentType).toBe('text');
+    expect(result.response).toBe('Just explaining something.');
+  });
+
+  it('non-registered <SomeComponent> tag: contentType text', () => {
+    const result = parseModelOutput('<SomeComponent prop="val" />', TRACE_ID);
+    expect(result.contentType).toBe('text');
+  });
+
+  it('prefix present but no card tags after stripping: contentType openui (backward compat)', () => {
+    const result = parseModelOutput('%%openui\nJust some text', TRACE_ID);
+    expect(result.contentType).toBe('openui');
+    expect(result.response).toBe('Just some text');
   });
 });

--- a/self/cortex/core/src/gateway-runtime/card-prompt-fragment.ts
+++ b/self/cortex/core/src/gateway-runtime/card-prompt-fragment.ts
@@ -32,9 +32,9 @@ Each card is written as a self-closing XML-style tag with PascalCase name and pr
 String props use key="value". Non-string props (numbers, arrays, objects) use key={json}.
 
 **StatusCard** -- report operation status with optional progress
-Required: title, status (active|complete|error|waiting), message
+Required: title, status (active|complete|error|waiting), description
 Optional: detail, progress (0-100)
-<StatusCard title="Indexing complete" status="complete" message="Processed 142 files" progress={100} />
+<StatusCard title="Indexing complete" status="complete" description="Processed 142 files" progress={100} />
 
 **ActionCard** -- present action buttons for user choice
 Required: title, description, actions (array of {label, actionType: approve|reject|navigate|followup})
@@ -48,22 +48,24 @@ Optional: context (object)
 
 **WorkflowCard** -- show workflow status and controls
 Required: title, workflowId
-Optional: nodeCount, status (draft|ready|running|completed|failed), summary
-<WorkflowCard title="CI Pipeline" workflowId="ci-main-branch" status="running" nodeCount={5} summary="Running lint and test stages" />
+Optional: nodeCount, status (draft|ready|running|completed|failed), description
+<WorkflowCard title="CI Pipeline" workflowId="ci-main-branch" status="running" nodeCount={5} description="Running lint and test stages" />
 
 **FollowUpBlock** -- suggest follow-up actions as pill buttons
 Required: suggestions (array of {label}, 1-6 items)
+Optional: description (introductory text above pills)
 Optional per suggestion: prompt, actionType (followup|navigate|submit, default: followup), payload
 <FollowUpBlock suggestions={[{"label":"Show details"},{"label":"Run again","prompt":"Re-run the last operation"},{"label":"Open logs","actionType":"navigate"}]} />
 
 ### Format:
-Prefix card responses with %%openui on its own line, then the card markup.
-You may mix plain text and cards in a single response -- text before %%openui is rendered normally.
+Place card tags directly inline in your response. No prefix or delimiter is needed.
+You may freely mix plain text and cards in a single response.
 
 Example complete response:
 I've finished analyzing the repository. Here are the results:
 
-%%openui
-<StatusCard title="Analysis complete" status="complete" message="Found 3 issues across 12 files" detail="2 warnings, 1 error" progress={100} />
+<StatusCard title="Analysis complete" status="complete" description="Found 3 issues across 12 files" detail="2 warnings, 1 error" progress={100} />
+
+Would you like to address these issues?
 
 <FollowUpBlock suggestions={[{"label":"Show issues"},{"label":"Auto-fix warnings","prompt":"Fix the 2 warnings automatically"},{"label":"View full report","actionType":"navigate"}]} />`;

--- a/self/cortex/core/src/output-parser.ts
+++ b/self/cortex/core/src/output-parser.ts
@@ -19,13 +19,35 @@ export interface ParsedModelOutput {
 const OPENUI_PREFIX = '%%openui\n';
 
 /**
- * Detect and strip the `%%openui\n` prefix from a response string.
- * Returns the stripped response and contentType.
+ * Detect whether a response contains OpenUI card content.
+ * Checks for `%%openui\n` prefix (legacy, stripped when present) and
+ * inline card tag patterns (`<StatusCard`, `<ActionCard`, etc.).
+ * Returns the (possibly stripped) response and contentType.
  */
 function detectContentType(response: string): { response: string; contentType: 'text' | 'openui' } {
+  // 1. Strip %%openui\n prefix if present (backward compat)
+  let stripped = response;
+  let hadPrefix = false;
   if (response.startsWith(OPENUI_PREFIX)) {
-    return { response: response.slice(OPENUI_PREFIX.length), contentType: 'openui' };
+    stripped = response.slice(OPENUI_PREFIX.length);
+    hadPrefix = true;
   }
+
+  // 2. Check for registered card tag patterns inline
+  const CARD_TAG_PATTERNS = [
+    '<StatusCard',
+    '<ActionCard',
+    '<ApprovalCard',
+    '<WorkflowCard',
+    '<FollowUpBlock',
+  ];
+  const hasCardTag = CARD_TAG_PATTERNS.some(pattern => stripped.includes(pattern));
+
+  // 3. If prefix was present OR card tags found, it's openui content
+  if (hadPrefix || hasCardTag) {
+    return { response: stripped, contentType: 'openui' };
+  }
+
   return { response, contentType: 'text' };
 }
 

--- a/self/ui/src/components/chat/cards/__tests__/follow-up-block.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/follow-up-block.test.tsx
@@ -24,8 +24,10 @@ describe('FollowUpBlock', () => {
   it('renders pill buttons in a flex container', () => {
     render(<FollowUpBlock {...makeProps()} />)
     const container = screen.getByTestId('followup-block')
-    expect(container.style.display).toBe('flex')
-    expect(container.style.flexWrap).toBe('wrap')
+    expect(container).toBeTruthy()
+    // Pills should be inside the block
+    const pills = screen.getAllByTestId('followup-pill')
+    expect(pills.length).toBeGreaterThan(0)
   })
 
   it('renders correct number of pills', () => {

--- a/self/ui/src/components/chat/cards/__tests__/schemas.test.ts
+++ b/self/ui/src/components/chat/cards/__tests__/schemas.test.ts
@@ -16,7 +16,7 @@ describe('StatusCardSchema', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
       status: 'active',
-      message: 'Running',
+      description: 'Running',
     })
     expect(result.success).toBe(true)
   })
@@ -25,7 +25,7 @@ describe('StatusCardSchema', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
       status: 'complete',
-      message: 'Done',
+      description: 'Done',
       detail: 'All tasks finished',
       progress: 100,
     })
@@ -35,7 +35,7 @@ describe('StatusCardSchema', () => {
   it('rejects missing required field: title', () => {
     const result = StatusCardSchema.safeParse({
       status: 'active',
-      message: 'Running',
+      description: 'Running',
     })
     expect(result.success).toBe(false)
   })
@@ -43,7 +43,7 @@ describe('StatusCardSchema', () => {
   it('rejects missing required field: status', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
-      message: 'Running',
+      description: 'Running',
     })
     expect(result.success).toBe(false)
   })
@@ -52,7 +52,7 @@ describe('StatusCardSchema', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
       status: 'invalid',
-      message: 'Running',
+      description: 'Running',
     })
     expect(result.success).toBe(false)
   })
@@ -61,7 +61,7 @@ describe('StatusCardSchema', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
       status: 'active',
-      message: 'Running',
+      description: 'Running',
       progress: 150,
     })
     expect(result.success).toBe(false)
@@ -71,7 +71,7 @@ describe('StatusCardSchema', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
       status: 'active',
-      message: 'Running',
+      description: 'Running',
       progress: -10,
     })
     expect(result.success).toBe(false)
@@ -81,7 +81,7 @@ describe('StatusCardSchema', () => {
     const result = StatusCardSchema.safeParse({
       title: 'Test',
       status: 'active',
-      message: 'Running',
+      description: 'Running',
       extraProp: 'should be stripped',
     })
     expect(result.success).toBe(true)
@@ -267,7 +267,7 @@ describe('WorkflowCardSchema', () => {
       workflowId: 'wf-1',
       nodeCount: 5,
       status: 'running',
-      summary: 'Processing data',
+      description: 'Processing data',
     })
     expect(result.success).toBe(true)
   })

--- a/self/ui/src/components/chat/cards/__tests__/status-card.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/status-card.test.tsx
@@ -13,14 +13,14 @@ function makeProps(
     props: {
       title: 'Test Status',
       status: 'active',
-      message: 'Something is happening',
+      description: 'Something is happening',
       ...overrides,
     },
   }
 }
 
 describe('StatusCard', () => {
-  it('renders title and message', () => {
+  it('renders title and description', () => {
     render(<StatusCard {...makeProps()} />)
     expect(screen.getByText('Test Status')).toBeTruthy()
     expect(screen.getByText('Something is happening')).toBeTruthy()

--- a/self/ui/src/components/chat/cards/__tests__/workflow-card.test.tsx
+++ b/self/ui/src/components/chat/cards/__tests__/workflow-card.test.tsx
@@ -15,7 +15,7 @@ function makeProps(
       workflowId: 'wf-123',
       status: 'running',
       nodeCount: 5,
-      summary: 'Processing data from input sources',
+      description: 'Processing data from input sources',
       ...overrides,
     },
   }
@@ -68,15 +68,15 @@ describe('WorkflowCard', () => {
     expect(screen.queryByTestId('workflow-node-count')).toBeNull()
   })
 
-  it('renders summary text when provided', () => {
+  it('renders description text when provided', () => {
     render(<WorkflowCard {...makeProps()} />)
-    expect(screen.getByTestId('workflow-summary')).toBeTruthy()
+    expect(screen.getByTestId('workflow-description')).toBeTruthy()
     expect(screen.getByText('Processing data from input sources')).toBeTruthy()
   })
 
-  it('does not render summary when absent', () => {
-    render(<WorkflowCard {...makeProps({ summary: undefined })} />)
-    expect(screen.queryByTestId('workflow-summary')).toBeNull()
+  it('does not render description when absent', () => {
+    render(<WorkflowCard {...makeProps({ description: undefined })} />)
+    expect(screen.queryByTestId('workflow-description')).toBeNull()
   })
 
   it('Run button emits correct CardAction payload', () => {

--- a/self/ui/src/components/chat/cards/action-card.tsx
+++ b/self/ui/src/components/chat/cards/action-card.tsx
@@ -53,6 +53,7 @@ export function ActionCard({
 }: CardRendererProps<unknown>) {
   const result = ActionCardSchema.safeParse(props)
   if (!result.success) {
+    console.warn('[ActionCard] Validation failed:', result.error.format(), 'Received props:', props)
     return (
       <div
         data-testid="action-card-invalid"

--- a/self/ui/src/components/chat/cards/approval-card.tsx
+++ b/self/ui/src/components/chat/cards/approval-card.tsx
@@ -113,6 +113,7 @@ export function ApprovalCard({
   )
 
   if (!result.success) {
+    console.warn('[ApprovalCard] Validation failed:', result.error.format(), 'Received props:', props)
     return (
       <div
         data-testid="approval-card-invalid"

--- a/self/ui/src/components/chat/cards/card-prompt-fragment.md
+++ b/self/ui/src/components/chat/cards/card-prompt-fragment.md
@@ -1,6 +1,6 @@
 ## Structured Response Cards
 
-You can respond with interactive cards using OpenUI markup when the situation calls for structured interaction. Use the %%openui prefix to indicate card content.
+You can respond with interactive cards using OpenUI markup when the situation calls for structured interaction. Place card tags directly inline in your response.
 
 ### When to use cards:
 - Presenting a decision that requires user approval or choice (ActionCard or ApprovalCard)
@@ -20,9 +20,9 @@ Each card is written as a self-closing XML-style tag with PascalCase name and pr
 String props use key="value". Non-string props (numbers, arrays, objects) use key={json}.
 
 **StatusCard** -- report operation status with optional progress
-Required: title, status (active|complete|error|waiting), message
+Required: title, status (active|complete|error|waiting), description
 Optional: detail, progress (0-100)
-<StatusCard title="Indexing complete" status="complete" message="Processed 142 files" progress={100} />
+<StatusCard title="Indexing complete" status="complete" description="Processed 142 files" progress={100} />
 
 **ActionCard** -- present action buttons for user choice
 Required: title, description, actions (array of {label, actionType: approve|reject|navigate|followup})
@@ -36,22 +36,24 @@ Optional: context (object)
 
 **WorkflowCard** -- show workflow status and controls
 Required: title, workflowId
-Optional: nodeCount, status (draft|ready|running|completed|failed), summary
-<WorkflowCard title="CI Pipeline" workflowId="ci-main-branch" status="running" nodeCount={5} summary="Running lint and test stages" />
+Optional: nodeCount, status (draft|ready|running|completed|failed), description
+<WorkflowCard title="CI Pipeline" workflowId="ci-main-branch" status="running" nodeCount={5} description="Running lint and test stages" />
 
 **FollowUpBlock** -- suggest follow-up actions as pill buttons
 Required: suggestions (array of {label}, 1-6 items)
+Optional: description (introductory text above pills)
 Optional per suggestion: prompt, actionType (followup|navigate|submit, default: followup), payload
 <FollowUpBlock suggestions={[{"label":"Show details"},{"label":"Run again","prompt":"Re-run the last operation"},{"label":"Open logs","actionType":"navigate"}]} />
 
 ### Format:
-Prefix card responses with %%openui on its own line, then the card markup.
-You may mix plain text and cards in a single response -- text before %%openui is rendered normally.
+Place card tags directly inline in your response. No prefix or delimiter is needed.
+You may freely mix plain text and cards in a single response.
 
 Example complete response:
 I've finished analyzing the repository. Here are the results:
 
-%%openui
-<StatusCard title="Analysis complete" status="complete" message="Found 3 issues across 12 files" detail="2 warnings, 1 error" progress={100} />
+<StatusCard title="Analysis complete" status="complete" description="Found 3 issues across 12 files" detail="2 warnings, 1 error" progress={100} />
+
+Would you like to address these issues?
 
 <FollowUpBlock suggestions={[{"label":"Show issues"},{"label":"Auto-fix warnings","prompt":"Fix the 2 warnings automatically"},{"label":"View full report","actionType":"navigate"}]} />

--- a/self/ui/src/components/chat/cards/follow-up-block.tsx
+++ b/self/ui/src/components/chat/cards/follow-up-block.tsx
@@ -11,6 +11,7 @@ import type { CardRendererProps, CardAction } from '../openui-adapter/types'
 
 export const FollowUpBlockSchema = z
   .object({
+    description: z.string().optional(),
     suggestions: z
       .array(
         z.object({
@@ -43,6 +44,7 @@ export function FollowUpBlock({
 }: CardRendererProps<unknown>) {
   const result = FollowUpBlockSchema.safeParse(props)
   if (!result.success) {
+    console.warn('[FollowUpBlock] Validation failed:', result.error.format(), 'Received props:', props)
     return (
       <div
         data-testid="followup-block-invalid"
@@ -60,14 +62,26 @@ export function FollowUpBlock({
   const data = result.data
 
   return (
-    <div
-      data-testid="followup-block"
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 'var(--nous-space-xs)',
-      }}
-    >
+    <div data-testid="followup-block">
+      {data.description && (
+        <div
+          data-testid="followup-description"
+          style={{
+            fontSize: 'var(--nous-font-size-xs)',
+            color: 'var(--nous-fg-muted)',
+            marginBottom: 'var(--nous-space-xs)',
+          }}
+        >
+          {data.description}
+        </div>
+      )}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 'var(--nous-space-xs)',
+        }}
+      >
       {stale
         ? data.suggestions.map((suggestion, i) => (
             <Badge
@@ -117,6 +131,7 @@ export function FollowUpBlock({
               {suggestion.label}
             </button>
           ))}
+      </div>
     </div>
   )
 }

--- a/self/ui/src/components/chat/cards/status-card.tsx
+++ b/self/ui/src/components/chat/cards/status-card.tsx
@@ -13,7 +13,7 @@ export const StatusCardSchema = z
   .object({
     title: z.string(),
     status: z.enum(['active', 'complete', 'error', 'waiting']),
-    message: z.string(),
+    description: z.string(),
     detail: z.string().optional(),
     progress: z.number().min(0).max(100).optional(),
   })
@@ -43,6 +43,7 @@ export function StatusCard({
 }: CardRendererProps<unknown>) {
   const result = StatusCardSchema.safeParse(props)
   if (!result.success) {
+    console.warn('[StatusCard] Validation failed:', result.error.format(), 'Received props:', props)
     return (
       <div
         data-testid="status-card-invalid"
@@ -85,7 +86,7 @@ export function StatusCard({
             color: 'var(--nous-text-primary)',
           }}
         >
-          {data.message}
+          {data.description}
         </div>
         {data.detail && (
           <div

--- a/self/ui/src/components/chat/cards/workflow-card.tsx
+++ b/self/ui/src/components/chat/cards/workflow-card.tsx
@@ -19,7 +19,7 @@ export const WorkflowCardSchema = z
     status: z
       .enum(['draft', 'ready', 'running', 'completed', 'failed'])
       .optional(),
-    summary: z.string().optional(),
+    description: z.string().optional(),
   })
   .strip()
 
@@ -59,6 +59,7 @@ export function WorkflowCard({
 }: CardRendererProps<unknown>) {
   const result = WorkflowCardSchema.safeParse(props)
   if (!result.success) {
+    console.warn('[WorkflowCard] Validation failed:', result.error.format(), 'Received props:', props)
     return (
       <div
         data-testid="workflow-card-invalid"
@@ -122,16 +123,16 @@ export function WorkflowCard({
         </div>
       </CardHeader>
       <CardContent>
-        {data.summary && (
+        {data.description && (
           <div
-            data-testid="workflow-summary"
+            data-testid="workflow-description"
             style={{
               fontSize: 'var(--nous-font-size-sm)',
               color: 'var(--nous-text-primary)',
               marginBottom: 'var(--nous-space-sm)',
             }}
           >
-            {data.summary}
+            {data.description}
           </div>
         )}
         <div

--- a/self/ui/src/panels/__tests__/ChatPanel.action-routing.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.action-routing.test.tsx
@@ -71,7 +71,7 @@ describe('ChatPanel — Action Routing Integration', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Done" status="complete" message="Finished" />',
+        content: '<StatusCard title="Done" status="complete" description="Finished" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
         actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
@@ -88,13 +88,13 @@ describe('ChatPanel — Action Routing Integration', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="First" status="active" message="First card" />',
+        content: '<StatusCard title="First" status="active" description="First card" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
       },
       {
         role: 'assistant',
-        content: '<StatusCard title="Second" status="active" message="Second card" />',
+        content: '<StatusCard title="Second" status="active" description="Second card" />',
         timestamp: '2026-01-01T00:01:00Z',
         contentType: 'openui',
       },

--- a/self/ui/src/panels/__tests__/ChatPanel.content-detection.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.content-detection.test.tsx
@@ -37,7 +37,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Test" status="active" message="Hi" />',
+        content: '<StatusCard title="Test" status="active" description="Hi" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
       },
@@ -50,7 +50,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '%%openui\n<StatusCard title="Fallback" status="active" message="Fb" />',
+        content: '%%openui\n<StatusCard title="Fallback" status="active" description="Fb" />',
         timestamp: '2026-01-01T00:00:00Z',
       },
     ])
@@ -67,7 +67,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     expect(screen.queryByTestId('openui-card-container')).toBeNull()
   })
 
-  it('assistant message with contentType openui and malformed markup: falls back to plain text', async () => {
+  it('assistant message with contentType openui but no card tags: renders as plain text (segment splitter finds no cards)', async () => {
     const api = makeChatApi([
       {
         role: 'assistant',
@@ -77,24 +77,23 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
       },
     ])
     render(<ChatPanel chatApi={api} />)
-    // Malformed content cannot parse to valid registered cards → plain text fallback
+    // Segment splitter finds no card tags, so content renders as plain text
     expect(await screen.findByText('this is not valid card markup at all')).toBeTruthy()
     expect(screen.queryByTestId('openui-card-container')).toBeNull()
-    expect(screen.queryByTestId('card-parse-error')).toBeNull()
   })
 
   it('user message: always plain text regardless of content', async () => {
     const api = makeChatApi([
       {
         role: 'user',
-        content: '<StatusCard title="Fake" status="active" message="M" />',
+        content: '<StatusCard title="Fake" status="active" description="M" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui' as any,
       },
     ])
     render(<ChatPanel chatApi={api} />)
     // User messages should render as plain text
-    expect(await screen.findByText('<StatusCard title="Fake" status="active" message="M" />')).toBeTruthy()
+    expect(await screen.findByText('<StatusCard title="Fake" status="active" description="M" />')).toBeTruthy()
     expect(screen.queryByTestId('openui-card-container')).toBeNull()
   })
 
@@ -106,14 +105,14 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Old" status="complete" message="Done" />',
+        content: '<StatusCard title="Old" status="complete" description="Done" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
       },
       { role: 'user', content: 'next', timestamp: '2026-01-01T00:01:00Z' },
       {
         role: 'assistant',
-        content: '<StatusCard title="New" status="active" message="Current" />',
+        content: '<StatusCard title="New" status="active" description="Current" />',
         timestamp: '2026-01-01T00:02:00Z',
         contentType: 'openui',
       },
@@ -129,7 +128,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Actioned" status="complete" message="Done" />',
+        content: '<StatusCard title="Actioned" status="complete" description="Done" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
         actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
@@ -146,7 +145,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Live" status="active" message="Current" />',
+        content: '<StatusCard title="Live" status="active" description="Current" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
       },
@@ -204,7 +203,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Old" status="complete" message="Done" />',
+        content: '<StatusCard title="Old" status="complete" description="Done" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
         actionOutcome: { actionType: 'approve', label: 'Done', timestamp: '2026-01-01T00:01:00Z' },
@@ -212,7 +211,7 @@ describe('ChatPanel — Content Detection and Renderer Branching', () => {
       { role: 'user', content: 'next', timestamp: '2026-01-01T00:02:00Z' },
       {
         role: 'assistant',
-        content: '<StatusCard title="New" status="active" message="Cur" />',
+        content: '<StatusCard title="New" status="active" description="Cur" />',
         timestamp: '2026-01-01T00:03:00Z',
         contentType: 'openui',
       },

--- a/self/ui/src/panels/__tests__/ChatPanel.persistence.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.persistence.test.tsx
@@ -27,7 +27,7 @@ describe('ChatPanel — Persistence Round-Trip', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Persisted" status="active" message="From STM" />',
+        content: '<StatusCard title="Persisted" status="active" description="From STM" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
       },
@@ -40,7 +40,7 @@ describe('ChatPanel — Persistence Round-Trip', () => {
     const api = makeChatApi([
       {
         role: 'assistant',
-        content: '<StatusCard title="Actioned" status="complete" message="Done" />',
+        content: '<StatusCard title="Actioned" status="complete" description="Done" />',
         timestamp: '2026-01-01T00:00:00Z',
         contentType: 'openui',
         actionOutcome: { actionType: 'approve', label: 'Approved', timestamp: '2026-01-01T00:01:00Z' },
@@ -97,7 +97,7 @@ describe('ChatPanel — Persistence Round-Trip', () => {
       { role: 'user', content: 'First question', timestamp: '2026-01-01T00:00:00Z' },
       {
         role: 'assistant',
-        content: '<StatusCard title="Card1" status="complete" message="Old" />',
+        content: '<StatusCard title="Card1" status="complete" description="Old" />',
         timestamp: '2026-01-01T00:01:00Z',
         contentType: 'openui',
         actionOutcome: { actionType: 'approve', label: 'Done', timestamp: '2026-01-01T00:02:00Z' },

--- a/self/ui/src/panels/__tests__/splitMessageSegments.test.ts
+++ b/self/ui/src/panels/__tests__/splitMessageSegments.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { splitMessageSegments } from '../chat/message-segments'
+import { registerNousCard, _clearRegistry } from '../../components/chat/openui-adapter/registry'
+import type { NousCardDefinition } from '../../components/chat/openui-adapter/types'
+import { z } from 'zod'
+
+// Minimal card definition for testing — the splitter only uses registry.list()
+function makeCardDef(name: string): NousCardDefinition {
+  return {
+    name,
+    description: `${name} test definition`,
+    propsSchema: z.object({}) as z.ZodType<unknown>,
+    renderer: (() => null) as unknown as NousCardDefinition['renderer'],
+  }
+}
+
+describe('splitMessageSegments', () => {
+  beforeEach(() => {
+    registerNousCard(makeCardDef('StatusCard'))
+    registerNousCard(makeCardDef('ActionCard'))
+    registerNousCard(makeCardDef('ApprovalCard'))
+    registerNousCard(makeCardDef('WorkflowCard'))
+    registerNousCard(makeCardDef('FollowUpBlock'))
+  })
+
+  afterEach(() => {
+    _clearRegistry()
+  })
+
+  // ---------------------------------------------------------------------------
+  // 1. Text-only input
+  // ---------------------------------------------------------------------------
+  it('text-only input returns single text segment', () => {
+    const result = splitMessageSegments('Hello world')
+    expect(result).toEqual([{ type: 'text', content: 'Hello world' }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 2. Card-only input (self-closing)
+  // ---------------------------------------------------------------------------
+  it('card-only input (self-closing) returns single card segment', () => {
+    const input = '<StatusCard title="Test" status="active" description="Hello" />'
+    const result = splitMessageSegments(input)
+    expect(result).toEqual([{ type: 'card', content: input }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 3. Card-only input (open/close)
+  // ---------------------------------------------------------------------------
+  it('card-only input (open/close tags) returns single card segment', () => {
+    const input = '<ActionCard title="Act" description="Do">Some content</ActionCard>'
+    const result = splitMessageSegments(input)
+    expect(result).toEqual([{ type: 'card', content: input }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 4. Mixed text + card
+  // ---------------------------------------------------------------------------
+  it('mixed text + card returns 3 segments', () => {
+    const input = 'Hello\n<StatusCard title="Test" status="active" description="Hi" />\nGoodbye'
+    const result = splitMessageSegments(input)
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({ type: 'text', content: 'Hello\n' })
+    expect(result[1]).toEqual({
+      type: 'card',
+      content: '<StatusCard title="Test" status="active" description="Hi" />',
+    })
+    expect(result[2]).toEqual({ type: 'text', content: '\nGoodbye' })
+  })
+
+  // ---------------------------------------------------------------------------
+  // 5. Multiple cards with text
+  // ---------------------------------------------------------------------------
+  it('multiple cards with text between returns 5 segments', () => {
+    const input =
+      'A\n<StatusCard title="S" status="active" description="M" />\nB\n<FollowUpBlock suggestions={[{"label":"Go"}]} />\nC'
+    const result = splitMessageSegments(input)
+    expect(result).toHaveLength(5)
+    expect(result[0].type).toBe('text')
+    expect(result[1].type).toBe('card')
+    expect(result[2].type).toBe('text')
+    expect(result[3].type).toBe('card')
+    expect(result[4].type).toBe('text')
+  })
+
+  // ---------------------------------------------------------------------------
+  // 6. Adjacent cards (no text between)
+  // ---------------------------------------------------------------------------
+  it('adjacent cards with only whitespace between returns 2 card segments', () => {
+    const input =
+      '<StatusCard title="S" status="active" description="M" />\n<FollowUpBlock suggestions={[{"label":"Go"}]} />'
+    const result = splitMessageSegments(input)
+    expect(result).toHaveLength(2)
+    expect(result[0].type).toBe('card')
+    expect(result[1].type).toBe('card')
+  })
+
+  // ---------------------------------------------------------------------------
+  // 7. %%openui\n prefix stripped
+  // ---------------------------------------------------------------------------
+  it('strips %%openui\\n prefix before splitting', () => {
+    const input = '%%openui\n<StatusCard title="Test" status="active" description="Hello" />'
+    const result = splitMessageSegments(input)
+    expect(result).toEqual([
+      {
+        type: 'card',
+        content: '<StatusCard title="Test" status="active" description="Hello" />',
+      },
+    ])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 8. Malformed XML (unclosed tag) — does not throw
+  // ---------------------------------------------------------------------------
+  it('malformed XML (unclosed tag) does not throw', () => {
+    const input = '<StatusCard title="test"'
+    expect(() => splitMessageSegments(input)).not.toThrow()
+    const result = splitMessageSegments(input)
+    expect(result.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 9. Empty string
+  // ---------------------------------------------------------------------------
+  it('empty string returns empty array', () => {
+    expect(splitMessageSegments('')).toEqual([])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 10. Unregistered tag not treated as card
+  // ---------------------------------------------------------------------------
+  it('unregistered tag is not treated as a card segment', () => {
+    const input = '<CustomWidget title="x" />'
+    const result = splitMessageSegments(input)
+    expect(result).toEqual([{ type: 'text', content: '<CustomWidget title="x" />' }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 11. Self-closing ApprovalCard
+  // ---------------------------------------------------------------------------
+  it('self-closing ApprovalCard returns single card segment', () => {
+    const input = '<ApprovalCard title="Approve" tier="t1" command="deploy" />'
+    const result = splitMessageSegments(input)
+    expect(result).toEqual([{ type: 'card', content: input }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 12. Prefix + mixed content
+  // ---------------------------------------------------------------------------
+  it('%%openui\\n prefix + mixed content strips prefix and splits correctly', () => {
+    const input =
+      '%%openui\nHello\n<StatusCard title="Test" status="active" description="Hi" />'
+    const result = splitMessageSegments(input)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ type: 'text', content: 'Hello\n' })
+    expect(result[1]).toEqual({
+      type: 'card',
+      content: '<StatusCard title="Test" status="active" description="Hi" />',
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // 13. Whitespace-only input
+  // ---------------------------------------------------------------------------
+  it('whitespace-only input returns empty array', () => {
+    expect(splitMessageSegments('   \n  ')).toEqual([])
+  })
+
+  // ---------------------------------------------------------------------------
+  // 14. Null/undefined guard (via empty check)
+  // ---------------------------------------------------------------------------
+  it('null-ish input returns empty array', () => {
+    expect(splitMessageSegments(null as unknown as string)).toEqual([])
+    expect(splitMessageSegments(undefined as unknown as string)).toEqual([])
+  })
+})

--- a/self/ui/src/panels/chat/ChatCardRenderer.tsx
+++ b/self/ui/src/panels/chat/ChatCardRenderer.tsx
@@ -1,39 +1,6 @@
-import { parseCardContent, renderCardTree, getCardRegistry } from '../../components/chat/openui-adapter'
-import type { RenderCardContext, CardAction, NousCardElement } from '../../components/chat/openui-adapter'
+import { parseCardContent, renderCardTree } from '../../components/chat/openui-adapter'
+import type { RenderCardContext, CardAction } from '../../components/chat/openui-adapter'
 import type { ChatMessage } from './types'
-
-const OPENUI_PREFIX = '%%openui\n'
-
-/**
- * Determine whether a message should be treated as OpenUI card content.
- * Uses contentType metadata (primary) with %%openui\n prefix fallback (secondary).
- *
- * Validates that all card types in the content are registered. If any
- * unknown/hallucinated types are found, falls back to plain text rendering.
- */
-export function detectCardContent(msg: ChatMessage): { isCard: boolean; content: string } {
-  let candidate: string | null = null
-
-  if (msg.contentType === 'openui') {
-    candidate = msg.content
-  } else if (!msg.contentType && msg.content.startsWith(OPENUI_PREFIX)) {
-    candidate = msg.content.slice(OPENUI_PREFIX.length)
-  }
-
-  if (candidate !== null && containsOnlyRegisteredCards(candidate)) {
-    return { isCard: true, content: candidate }
-  }
-  return { isCard: false, content: msg.content }
-}
-
-/** Parse content and verify every card type exists in the registry. */
-function containsOnlyRegisteredCards(content: string): boolean {
-  const result = parseCardContent(content)
-  if (!result.ok) return false
-
-  const registry = getCardRegistry()
-  return result.tree.every(el => typeof el === 'string' || registry.has((el as NousCardElement).type))
-}
 
 /**
  * Render an OpenUI card message. Falls back to plain text on parse failure.

--- a/self/ui/src/panels/chat/ChatMessageList.tsx
+++ b/self/ui/src/panels/chat/ChatMessageList.tsx
@@ -1,7 +1,8 @@
 import { useRef, useEffect } from 'react'
 import { ThoughtSummary } from '../../components/thought'
 import type { CardAction } from '../../components/chat/openui-adapter'
-import { detectCardContent, ChatCardRenderer } from './ChatCardRenderer'
+import { ChatCardRenderer } from './ChatCardRenderer'
+import { splitMessageSegments } from './message-segments'
 import { InlineThoughtGroup } from './InlineThoughtGroup'
 import type { InlineThoughtItem } from './inline-thoughts'
 import type { ChatMessage } from './types'
@@ -90,7 +91,8 @@ function ChatMessageRow({
         )
     }
 
-    const { isCard, content } = detectCardContent(message)
+    const segments = splitMessageSegments(message.content)
+    const hasCardSegments = segments.some(s => s.type === 'card')
     const isStale = !!message.actionOutcome || !isLastAssistant
 
     return (
@@ -99,13 +101,22 @@ function ChatMessageRow({
                 <InlineThoughtGroup items={thoughts} active={false} />
             )}
             <div style={styles.bubble}>
-                {isCard ? (
-                    <ChatCardRenderer
-                        content={content}
-                        stale={isStale}
-                        actionOutcome={message.actionOutcome}
-                        onAction={isStale ? undefined : onCardAction}
-                    />
+                {hasCardSegments ? (
+                    segments.map((segment, segIdx) =>
+                        segment.type === 'card' ? (
+                            <ChatCardRenderer
+                                key={`seg-${segIdx}`}
+                                content={segment.content}
+                                stale={isStale}
+                                actionOutcome={message.actionOutcome}
+                                onAction={isStale ? undefined : onCardAction}
+                            />
+                        ) : (
+                            <span key={`seg-${segIdx}`} style={{ whiteSpace: 'pre-wrap' }}>
+                                {segment.content}
+                            </span>
+                        )
+                    )
                 ) : (
                     message.content
                 )}

--- a/self/ui/src/panels/chat/message-segments.ts
+++ b/self/ui/src/panels/chat/message-segments.ts
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------------
+// message-segments.ts — Segment splitter for mixed-content chat messages
+// ---------------------------------------------------------------------------
+// Splits a chat message into ordered text and card segments so that prose
+// and card markup can be interleaved in a single assistant response.
+// Uses getCardRegistry().list() for registry-driven tag detection.
+// ---------------------------------------------------------------------------
+
+import { getCardRegistry } from '../../components/chat/openui-adapter/registry'
+
+/**
+ * A segment of a chat message -- either prose text or card markup.
+ */
+export type MessageSegment =
+  | { type: 'text'; content: string }
+  | { type: 'card'; content: string }
+
+const OPENUI_PREFIX = '%%openui\n'
+
+/**
+ * Escape special regex characters in a string.
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Find the end position of a card tag starting at `start` in `content`.
+ * Handles self-closing tags (`/>`), matched close tags (`</TagName>`),
+ * and falls back gracefully for malformed markup.
+ */
+export function findCardTagEnd(content: string, start: number, tagName: string): number {
+  const fragment = content.slice(start)
+
+  // Check for self-closing tag: <TagName ... />
+  const selfCloseRegex = new RegExp(`^<${escapeRegex(tagName)}[^>]*/>`)
+  const selfCloseMatch = fragment.match(selfCloseRegex)
+  if (selfCloseMatch) {
+    return start + selfCloseMatch[0].length
+  }
+
+  // Find matching closing tag: </TagName>
+  const closeTag = `</${tagName}>`
+  const closeIndex = content.indexOf(closeTag, start)
+  if (closeIndex !== -1) {
+    return closeIndex + closeTag.length
+  }
+
+  // No closing tag found -- best-effort: find > on this line
+  const nextNewline = content.indexOf('\n', start)
+  if (nextNewline !== -1) {
+    const lineEnd = content.slice(start, nextNewline)
+    const gtIndex = lineEnd.lastIndexOf('>')
+    if (gtIndex !== -1) {
+      return start + gtIndex + 1
+    }
+  }
+
+  // Absolute fallback: consume to end of content
+  return content.length
+}
+
+/**
+ * Split a chat message into ordered text and card segments.
+ *
+ * - Strips legacy `%%openui\n` prefix before splitting.
+ * - Queries `getCardRegistry().list()` for registered card tag names.
+ * - Never throws. Malformed content falls through as text segments.
+ *
+ * @param content     The raw message content string.
+ * @param registeredTags  Optional override for registered tag names (for testing).
+ */
+export function splitMessageSegments(
+  content: string,
+  registeredTags?: string[],
+): MessageSegment[] {
+  // 1. Guard: empty/null input
+  if (!content || content.trim() === '') return []
+
+  // 2. Strip legacy %%openui\n prefix
+  let working = content
+  if (working.startsWith(OPENUI_PREFIX)) {
+    working = working.slice(OPENUI_PREFIX.length)
+  }
+
+  // 3. Get registered card tag names
+  const cardNames = registeredTags ?? getCardRegistry().list()
+  if (cardNames.length === 0) {
+    return [{ type: 'text', content: working }]
+  }
+
+  // 4. Build regex to find card tag opening positions
+  const tagNamesPattern = cardNames.map(escapeRegex).join('|')
+  const openTagRegex = new RegExp(`<(${tagNamesPattern})(?=[\\s/>])`, 'g')
+
+  // 5. Find all opening tag positions
+  const tagStarts: number[] = []
+  let match: RegExpExecArray | null
+  while ((match = openTagRegex.exec(working)) !== null) {
+    tagStarts.push(match.index)
+  }
+
+  // 6. No card tags found -- entire content is text
+  if (tagStarts.length === 0) {
+    return [{ type: 'text', content: working }]
+  }
+
+  // 7. Walk through content, splitting at tag boundaries
+  const segments: MessageSegment[] = []
+  let cursor = 0
+
+  for (const tagStart of tagStarts) {
+    // Skip if this position is inside a previously consumed card segment
+    if (tagStart < cursor) continue
+
+    // 7a. Text before this card tag
+    if (tagStart > cursor) {
+      const textContent = working.slice(cursor, tagStart)
+      if (textContent.trim() !== '') {
+        segments.push({ type: 'text', content: textContent })
+      }
+    }
+
+    // 7b. Find the tag name at this position
+    const tagNameMatch = working.slice(tagStart).match(/^<([A-Z][A-Za-z0-9]*)/)
+    if (!tagNameMatch) {
+      cursor = tagStart + 1
+      continue
+    }
+    const tagName = tagNameMatch[1]
+
+    // 7c. Find the end of this card element
+    const tagEnd = findCardTagEnd(working, tagStart, tagName)
+
+    // 7d. Extract card content
+    const cardContent = working.slice(tagStart, tagEnd)
+    segments.push({ type: 'card', content: cardContent })
+    cursor = tagEnd
+  }
+
+  // 8. Text after the last card tag
+  if (cursor < working.length) {
+    const trailing = working.slice(cursor)
+    if (trailing.trim() !== '') {
+      segments.push({ type: 'text', content: trailing })
+    }
+  }
+
+  // 9. If no segments produced (edge case), return entire content as text
+  if (segments.length === 0) {
+    return [{ type: 'text', content: working }]
+  }
+
+  return segments
+}


### PR DESCRIPTION
## Summary

- **Segment-based mixed-content rendering** — replaces binary `detectCardContent()` with `splitMessageSegments()` that splits messages into interleaved text and card segments. Registry-driven tag detection (no hardcoded tag list). Legacy `%%openui\n` prefix stripped before splitting.
- **Inline card tag detection** — `detectContentType()` in the output parser now detects `<CardTag>` patterns without requiring `%%openui\n` prefix.
- **Card prop normalization** — all card body text props unified to `description` (StatusCard `message` → `description`, WorkflowCard `summary` → `description`, FollowUpBlock gained optional `description`). Eliminates LLM prop hallucination vector.
- **ADR supersession** — `content-detection-strategy-v2` supersedes v1.
- **Debug logging** — `console.warn` with Zod error details on card validation failure for easier diagnosis.

23 files changed, +527 / -112. 20 new tests. 1,403 tests passing.

## Test plan

- [x] Segment splitter unit tests (14 cases: text-only, card-only, mixed, multiple cards, adjacent, prefix stripping, malformed, empty, unregistered tags, self-closing)
- [x] Output parser detection tests (6 new: inline tag detection, mixed prose, prefix backward compat, plain text, non-registered tags)
- [x] UI test suite passes (1,376 tests)
- [x] Cortex test suite passes (27 tests)
- [x] Zero type errors in changed files
- [x] BT Round 1: segment splitting works, card positions correct, graceful fallback on invalid props

🤖 Generated with [Claude Code](https://claude.com/claude-code)