### PR TITLE
fix(ui): title bar drag and sidebar same-group navigation — WR-122

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -882,9 +882,21 @@ function DesktopAssetSidebarConnected() {
   const { data: projectList } = trpc.projects.list.useQuery()
   const tasksApi = useTasks({ projectId: activeProjectId })
 
+  // Track the raw sidebar routeId for highlight state.
+  // Encoded items like "task-detail::taskId" resolve to activeRoute "task-detail"
+  // for content routing, but the sidebar needs the full routeId to highlight
+  // the correct item within a group.
+  const [sidebarSelection, setSidebarSelection] = useState(activeRoute)
+
+  // Sync when activeRoute changes externally (e.g. top-nav click, goBack)
+  useEffect(() => {
+    setSidebarSelection(activeRoute)
+  }, [activeRoute])
+
   // Wrap navigate to parse task-detail::<taskId> encoding from sidebar items
   // and forward as navigate('task-detail', { taskId }) with params.
   const handleNavigate = useCallback((routeId: string) => {
+    setSidebarSelection(routeId)
     if (routeId.startsWith(TASK_DETAIL_PREFIX)) {
       const taskId = routeId.slice(TASK_DETAIL_PREFIX.length)
       navigate('task-detail', { taskId })
@@ -920,7 +932,7 @@ function DesktopAssetSidebarConnected() {
       projectName={projectName}
       topNav={DESKTOP_TOP_NAV}
       sections={sections}
-      activeRoute={activeRoute}
+      activeRoute={sidebarSelection}
       onNavigate={handleNavigate}
     />
   )

--- a/self/apps/desktop/src/renderer/src/components/TitleBar.tsx
+++ b/self/apps/desktop/src/renderer/src/components/TitleBar.tsx
@@ -55,6 +55,7 @@ export function TitleBar({
         background: 'var(--nous-bg-surface)',
         userSelect: 'none',
         flexShrink: 0,
+        WebkitAppRegion: 'drag',
       } as ElectronStyle}
     >
       {/* App branding — left anchor, no-drag */}

--- a/self/ui/src/components/shell/ContentRouter.tsx
+++ b/self/ui/src/components/shell/ContentRouter.tsx
@@ -38,7 +38,11 @@ export function ContentRouter({
   }, [stack])
 
   React.useEffect(() => {
-    if (!activeRoute || activeRoute === lastPropRouteRef.current) {
+    if (!activeRoute) return
+
+    // Same route — only update params (e.g. switching items within the same group)
+    if (activeRoute === lastPropRouteRef.current) {
+      setNavigationParams(externalParams)
       return
     }
 


### PR DESCRIPTION
## Summary
- Add `WebkitAppRegion: 'drag'` to TitleBar root div — window is now draggable
- Fix ContentRouter to update params when `activeRoute` stays the same (same-group item switching)
- Track raw sidebar selection for encoded routeIds (`task-detail::id`) so highlight follows clicks within a group

## Root cause
Task sidebar items encode as `task-detail::taskId` but resolve to `activeRoute = 'task-detail'`. Two failures: (a) sidebar highlight never matched (`task-detail::taskA !== task-detail`), (b) ContentRouter early-returned on param-only changes because the route string didn't change.

## Test plan
- [x] 47 existing tests pass (ContentRouter, AssetSidebar, SimpleShellLayout, useTasks)
- [x] No new type errors (72 pre-existing in shared-server/TokenUsageWidget)
- [x] BT approved — title bar drag and sidebar navigation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)