### PR TITLE
feat(mao): MAO observe panel — route wiring + Tailwind migration — WR-126

### DIFF
--- a/self/ui/src/components/mao/MaoPanel.tsx
+++ b/self/ui/src/components/mao/MaoPanel.tsx
@@ -8,9 +8,9 @@ import { MaoServicesProvider } from './mao-services-context';
 import type { MaoServicesContextValue } from './mao-services-context';
 
 /** Inert link — MAO deep links are rendered as plain text in panel context. */
-function InertLink(props: { href: string; className?: string; children: React.ReactNode }) {
+function InertLink(props: { href: string; className?: string; style?: React.CSSProperties; children: React.ReactNode }) {
   return (
-    <span className={props.className} style={{ cursor: 'default' }}>
+    <span className={props.className} style={{ cursor: 'default', ...props.style }}>
       {props.children}
     </span>
   );

--- a/self/ui/src/components/mao/__tests__/mao-backlog-pressure-card.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-backlog-pressure-card.test.tsx
@@ -109,16 +109,17 @@ describe('MaoBacklogPressureCard', () => {
     expect(screen.getByText(/Decreasing/)).toBeTruthy();
   });
 
-  it('applies red-toned class for increasing pressure and green-toned for decreasing', () => {
+  it('applies red-toned style for increasing pressure and green-toned for decreasing', () => {
     mockUseQuery = vi.fn().mockReturnValue({
       data: createSystemStatus({ pressureTrend: 'increasing' }),
       isLoading: false,
       isError: false,
     });
 
-    const { container, unmount } = render(<MaoBacklogPressureCard />);
-    const increasingBadge = container.querySelector('.border-red-500\\/40');
-    expect(increasingBadge).toBeTruthy();
+    const { unmount } = render(<MaoBacklogPressureCard />);
+    const increasingBadge = screen.getByText(/Increasing/);
+    // jsdom normalizes hex to rgb
+    expect((increasingBadge as HTMLElement).style.color).toContain('rgb(239');
     unmount();
 
     mockUseQuery = vi.fn().mockReturnValue({
@@ -127,9 +128,9 @@ describe('MaoBacklogPressureCard', () => {
       isError: false,
     });
 
-    const { container: container2 } = render(<MaoBacklogPressureCard />);
-    const decreasingBadge = container2.querySelector('.border-emerald-500\\/40');
-    expect(decreasingBadge).toBeTruthy();
+    render(<MaoBacklogPressureCard />);
+    const decreasingBadge = screen.getByText(/Decreasing/);
+    expect((decreasingBadge as HTMLElement).style.color).toContain('rgb(16');
   });
 
   it('renders loading state gracefully without crashing', () => {

--- a/self/ui/src/components/mao/__tests__/mao-density-grid.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-density-grid.test.tsx
@@ -269,10 +269,10 @@ describe('MaoDensityGrid D4 tiny square', () => {
       <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
     )
 
-    const d4Tile = screen.getByTestId('density-tile-d4')
+    const d4Tile = screen.getByTestId('density-tile-d4') as HTMLElement
     expect(d4Tile).toBeTruthy()
-    expect(d4Tile.className).toContain('w-6')
-    expect(d4Tile.className).toContain('h-6')
+    expect(d4Tile.style.width).toBe('1.5rem')
+    expect(d4Tile.style.height).toBe('1.5rem')
     // No text content at D4
     expect(screen.queryByText('Visible Name')).toBeNull()
     expect(screen.queryByText('dispatched')).toBeNull()
@@ -408,8 +408,10 @@ describe('MaoDensityGrid urgent indicators', () => {
       <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
     )
 
-    const d3Tile = screen.getByTestId('density-tile-d3')
-    expect(d3Tile.className).toContain('border-red-500')
+    const d3Tile = screen.getByTestId('density-tile-d3') as HTMLElement
+    // Urgent D3 tiles get a 2px solid red border via individual properties
+    expect(d3Tile.style.borderWidth).toBe('2px')
+    expect(d3Tile.style.borderStyle).toBe('solid')
     expect(screen.getByTestId('urgent-icon')).toBeTruthy()
   })
 
@@ -424,8 +426,8 @@ describe('MaoDensityGrid urgent indicators', () => {
       <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
     )
 
-    const d4Tile = screen.getByTestId('density-tile-d4')
-    expect(d4Tile.className).toContain('ring-red-500')
+    const d4Tile = screen.getByTestId('density-tile-d4') as HTMLElement
+    expect(d4Tile.style.boxShadow).toContain('#ef4444')
   })
 
   it('pins urgent agents to top of grid at D0-D3', () => {
@@ -455,12 +457,13 @@ describe('MaoDensityGrid state color handling', () => {
       <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
     )
 
-    const button = container.querySelector('[aria-label="Inspect Execute task"]')
-    expect(button?.className).toContain('border-slate-500/40')
-    expect(button?.className).toContain('bg-slate-500/10')
+    const button = container.querySelector('[aria-label="Inspect Execute task"]') as HTMLElement
+    // Canceled state uses idle tone from CSS custom properties
+    expect(button?.style.borderColor).toBe('var(--nous-state-idle-tone-border)')
+    expect(button?.style.backgroundColor).toBe('var(--nous-state-idle-tone-bg)')
   })
 
-  it('renders appropriate tone classes for hard_stopped state (not default)', () => {
+  it('renders appropriate tone styles for hard_stopped state (not default)', () => {
     const tile = createTile({ agent_id: 'stopped-agent', state: 'hard_stopped' })
     const snapshot = createSnapshot('D2', [tile])
 
@@ -468,8 +471,9 @@ describe('MaoDensityGrid state color handling', () => {
       <MaoDensityGrid snapshot={snapshot} selectedAgentId={null} onSelectTile={noop} />,
     )
 
-    const button = container.querySelector('[aria-label="Inspect Execute task"]')
-    expect(button?.className).toContain('border-red-700/40')
-    expect(button?.className).toContain('bg-red-700/10')
+    const button = container.querySelector('[aria-label="Inspect Execute task"]') as HTMLElement
+    // hard_stopped uses blocked tone from CSS custom properties
+    expect(button?.style.borderColor).toBe('var(--nous-state-blocked-tone-border)')
+    expect(button?.style.backgroundColor).toBe('var(--nous-state-blocked-tone-bg)')
   })
 })

--- a/self/ui/src/components/mao/__tests__/mao-edge-connector.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-edge-connector.test.tsx
@@ -107,8 +107,7 @@ describe('MaoEdgeConnector', () => {
     );
 
     const svg = screen.getByTestId('edge-connector-svg');
-    // SVG className is an SVGAnimatedString in jsdom; use getAttribute
-    expect(svg.getAttribute('class')).toContain('pointer-events-none');
+    expect(svg.style.pointerEvents).toBe('none');
   });
 
   it('has aria-hidden attribute', () => {

--- a/self/ui/src/components/mao/__tests__/mao-lease-tree.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-lease-tree.test.tsx
@@ -355,8 +355,8 @@ describe('MaoLeaseTree urgent indicators', () => {
       />,
     );
 
-    const rootButton = container.querySelector('[data-agent-id="root-1"]');
-    expect(rootButton?.className).toContain('ring-red-500');
+    const rootButton = container.querySelector('[data-agent-id="root-1"]') as HTMLElement;
+    expect(rootButton?.style.boxShadow).toContain('#ef4444');
   });
 });
 
@@ -454,8 +454,11 @@ describe('MaoLeaseTree state color handling', () => {
       />,
     );
 
-    const dots = container.querySelectorAll('.bg-slate-500');
-    expect(dots.length).toBeGreaterThan(0);
+    const dotSpans = container.querySelectorAll('span[style]');
+    const hasDot = Array.from(dotSpans).some(
+      (el) => (el as HTMLElement).style.backgroundColor === 'var(--nous-state-idle)',
+    );
+    expect(hasDot).toBe(true);
   });
 
   it('renders appropriate dot color for hard_stopped state', () => {
@@ -478,7 +481,10 @@ describe('MaoLeaseTree state color handling', () => {
       />,
     );
 
-    const dots = container.querySelectorAll('.bg-red-700');
-    expect(dots.length).toBeGreaterThan(0);
+    const dotSpans = container.querySelectorAll('span[style]');
+    const hasDot = Array.from(dotSpans).some(
+      (el) => (el as HTMLElement).style.backgroundColor === 'var(--nous-state-blocked)',
+    );
+    expect(hasDot).toBe(true);
   });
 });

--- a/self/ui/src/components/mao/__tests__/mao-run-graph.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-run-graph.test.tsx
@@ -52,70 +52,70 @@ afterEach(() => {
 });
 
 describe('MaoRunGraph node color-coding', () => {
-  it('renders running node with emerald border', () => {
+  it('renders running node with active tone border', () => {
     const node = createNode({ id: 'n1', label: 'Running Node', state: 'running' });
     const graph = createGraph([node], []);
 
-    const { container } = render(
+    render(
       <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
     );
 
-    const nodeEl = screen.getByTestId('run-graph-node');
-    expect(nodeEl.className).toContain('border-emerald-500/40');
-    expect(nodeEl.className).toContain('bg-emerald-500/10');
+    const nodeEl = screen.getByTestId('run-graph-node') as HTMLElement;
+    expect(nodeEl.style.borderColor).toBe('var(--nous-state-active-tone-border)');
+    expect(nodeEl.style.backgroundColor).toBe('var(--nous-state-active-tone-bg)');
   });
 
-  it('renders blocked node with amber border', () => {
+  it('renders blocked node with waiting tone border', () => {
     const node = createNode({ id: 'n1', label: 'Blocked Node', state: 'blocked' });
     const graph = createGraph([node], []);
 
-    const { container } = render(
+    render(
       <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
     );
 
-    const nodeEl = screen.getByTestId('run-graph-node');
-    expect(nodeEl.className).toContain('border-amber-500/40');
-    expect(nodeEl.className).toContain('bg-amber-500/10');
+    const nodeEl = screen.getByTestId('run-graph-node') as HTMLElement;
+    expect(nodeEl.style.borderColor).toBe('var(--nous-state-waiting-tone-border)');
+    expect(nodeEl.style.backgroundColor).toBe('var(--nous-state-waiting-tone-bg)');
   });
 
-  it('renders failed node with red border', () => {
+  it('renders failed node with blocked tone border', () => {
     const node = createNode({ id: 'n1', label: 'Failed Node', state: 'failed' });
     const graph = createGraph([node], []);
 
-    const { container } = render(
+    render(
       <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
     );
 
-    const nodeEl = screen.getByTestId('run-graph-node');
-    expect(nodeEl.className).toContain('border-red-500/40');
-    expect(nodeEl.className).toContain('bg-red-500/10');
+    const nodeEl = screen.getByTestId('run-graph-node') as HTMLElement;
+    expect(nodeEl.style.borderColor).toBe('var(--nous-state-blocked-tone-border)');
+    expect(nodeEl.style.backgroundColor).toBe('var(--nous-state-blocked-tone-bg)');
   });
 
-  it('renders completed node with slate border', () => {
+  it('renders completed node with complete tone border', () => {
     const node = createNode({ id: 'n1', label: 'Done Node', state: 'completed' });
     const graph = createGraph([node], []);
 
-    const { container } = render(
+    render(
       <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
     );
 
-    const nodeEl = screen.getByTestId('run-graph-node');
-    expect(nodeEl.className).toContain('border-slate-500/40');
+    const nodeEl = screen.getByTestId('run-graph-node') as HTMLElement;
+    expect(nodeEl.style.borderColor).toBe('var(--nous-state-complete-tone-border)');
   });
 
   it('renders neutral styling when node state is undefined', () => {
     const node = createNode({ id: 'n1', label: 'No State Node' });
     const graph = createGraph([node], []);
 
-    const { container } = render(
+    render(
       <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
     );
 
-    const nodeEl = screen.getByTestId('run-graph-node');
-    expect(nodeEl.className).toContain('border-border');
+    const nodeEl = screen.getByTestId('run-graph-node') as HTMLElement;
+    expect(nodeEl.style.borderColor).toBe('var(--nous-border-subtle)');
   });
 
-  it('selected node overrides state color with border-primary', () => {
+  it('selected node overrides state color with accent border', () => {
     const node = createNode({
       id: 'n1',
       label: 'Selected Node',
@@ -124,13 +124,13 @@ describe('MaoRunGraph node color-coding', () => {
     });
     const graph = createGraph([node], []);
 
-    const { container } = render(
+    render(
       <MaoRunGraph graph={graph} selectedNodeId="wnd-1" onSelectNode={noop} />,
     );
 
-    const nodeEl = screen.getByTestId('run-graph-node');
-    expect(nodeEl.className).toContain('border-primary');
-    expect(nodeEl.className).toContain('bg-primary/10');
+    const nodeEl = screen.getByTestId('run-graph-node') as HTMLElement;
+    expect(nodeEl.style.borderColor).toBe('var(--nous-accent)');
+    expect(nodeEl.style.backgroundColor).toContain('rgba(0');
   });
 });
 
@@ -154,11 +154,11 @@ describe('MaoRunGraph corrective arc emphasis', () => {
       <MaoRunGraph graph={graph} selectedNodeId={null} onSelectNode={noop} />,
     );
 
-    const correctiveArc = screen.getByTestId('corrective-arc');
+    const correctiveArc = screen.getByTestId('corrective-arc') as HTMLElement;
     expect(correctiveArc).toBeTruthy();
-    expect(correctiveArc.className).toContain('border-amber-500/60');
-    expect(correctiveArc.className).toContain('bg-amber-500/5');
-    expect(correctiveArc.className).toContain('border-l-amber-500');
+    expect(correctiveArc.style.borderColor).toContain('rgba(245');
+    expect(correctiveArc.style.backgroundColor).toContain('rgba(245');
+    expect(correctiveArc.style.borderLeftColor).toContain('rgb(245');
   });
 
   it.each([

--- a/self/ui/src/components/mao/__tests__/mao-state-utils.test.ts
+++ b/self/ui/src/components/mao/__tests__/mao-state-utils.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { getStateVisuals, CLUSTER_STATE_ORDER } from '../mao-state-utils';
+
+describe('getStateVisuals', () => {
+  // -- Active states --
+
+  it('returns active token styles for running state', () => {
+    const result = getStateVisuals('running');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-active)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-active-tone-border)',
+      backgroundColor: 'var(--nous-state-active-tone-bg)',
+    });
+    expect(result.pulse).toBe('nous-state-pulse-subtle');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  it('returns active token styles for resuming state', () => {
+    const result = getStateVisuals('resuming');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-active)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-active-tone-border)',
+      backgroundColor: 'var(--nous-state-active-tone-bg)',
+    });
+    expect(result.pulse).toBe('nous-state-pulse-subtle');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  // -- Waiting states --
+
+  it('returns waiting token styles for blocked state', () => {
+    const result = getStateVisuals('blocked');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-waiting)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-waiting-tone-border)',
+      backgroundColor: 'var(--nous-state-waiting-tone-bg)',
+    });
+    expect(result.pulse).toBe('nous-state-pulse-strong');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  it('returns waiting token styles for waiting_pfc state', () => {
+    const result = getStateVisuals('waiting_pfc');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-waiting)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-waiting-tone-border)',
+      backgroundColor: 'var(--nous-state-waiting-tone-bg)',
+    });
+    expect(result.pulse).toBe('nous-state-pulse-strong');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  // -- Blocked states --
+
+  it('returns blocked token styles for failed state', () => {
+    const result = getStateVisuals('failed');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-blocked)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-blocked-tone-border)',
+      backgroundColor: 'var(--nous-state-blocked-tone-bg)',
+    });
+    expect(result.pulse).toBe('nous-state-pulse-strong');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  it('returns blocked token styles for hard_stopped state', () => {
+    const result = getStateVisuals('hard_stopped');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-blocked)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-blocked-tone-border)',
+      backgroundColor: 'var(--nous-state-blocked-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(true);
+  });
+
+  // -- Complete state --
+
+  it('returns complete token styles for completed state', () => {
+    const result = getStateVisuals('completed');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-complete)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-complete-tone-border)',
+      backgroundColor: 'var(--nous-state-complete-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(true);
+  });
+
+  // -- Idle / terminal states --
+
+  it('returns idle token styles for canceled state', () => {
+    const result = getStateVisuals('canceled');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-idle)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-idle-tone-border)',
+      backgroundColor: 'var(--nous-state-idle-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(true);
+  });
+
+  // -- Default / passive states --
+
+  it('returns idle token styles for queued state', () => {
+    const result = getStateVisuals('queued');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-idle)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-idle-tone-border)',
+      backgroundColor: 'var(--nous-state-idle-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  it('returns idle token styles for ready state', () => {
+    const result = getStateVisuals('ready');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-idle)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-idle-tone-border)',
+      backgroundColor: 'var(--nous-state-idle-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  it('returns idle token styles for waiting_async state', () => {
+    const result = getStateVisuals('waiting_async');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-idle)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-idle-tone-border)',
+      backgroundColor: 'var(--nous-state-idle-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(false);
+  });
+
+  it('returns idle token styles for paused state', () => {
+    const result = getStateVisuals('paused');
+    expect(result.dotStyle).toEqual({ backgroundColor: 'var(--nous-state-idle)' });
+    expect(result.toneStyle).toEqual({
+      borderColor: 'var(--nous-state-idle-tone-border)',
+      backgroundColor: 'var(--nous-state-idle-tone-bg)',
+    });
+    expect(result.pulse).toBe('');
+    expect(result.isTerminal).toBe(false);
+  });
+});
+
+describe('CLUSTER_STATE_ORDER', () => {
+  it('contains all 12 lifecycle states in the correct order', () => {
+    expect(CLUSTER_STATE_ORDER).toEqual([
+      'running',
+      'resuming',
+      'blocked',
+      'waiting_pfc',
+      'failed',
+      'queued',
+      'ready',
+      'waiting_async',
+      'paused',
+      'completed',
+      'canceled',
+      'hard_stopped',
+    ]);
+  });
+
+  it('has exactly 12 entries', () => {
+    expect(CLUSTER_STATE_ORDER).toHaveLength(12);
+  });
+});

--- a/self/ui/src/components/mao/__tests__/mao-workflow-group-card.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-workflow-group-card.test.tsx
@@ -195,8 +195,8 @@ describe('MaoWorkflowGroupCard', () => {
       />,
     );
 
-    const selectedButton = container.querySelector('[data-agent-id="orch-1"]');
-    expect(selectedButton?.className).toContain('border-primary');
+    const selectedButton = container.querySelector('[data-agent-id="orch-1"]') as HTMLElement;
+    expect(selectedButton?.style.borderColor).toContain('var(--nous-accent)');
   });
 });
 
@@ -275,8 +275,8 @@ describe('MaoWorkflowGroupCard urgent indicators', () => {
       />,
     );
 
-    const orchButton = container.querySelector('[data-agent-id="orch-1"]');
-    expect(orchButton?.className).toContain('ring-red-500');
+    const orchButton = container.querySelector('[data-agent-id="orch-1"]') as HTMLElement;
+    expect(orchButton?.style.boxShadow).toContain('#ef4444');
   });
 });
 
@@ -297,8 +297,8 @@ describe('MaoWorkflowGroupCard D4 hover-expand', () => {
     const orchButton = container.querySelector('[data-agent-id="orch-1"]');
     expect(orchButton).toBeTruthy();
 
-    // Before hover: should be w-6 h-6 (D4)
-    expect(orchButton?.className).toContain('w-6');
+    // Before hover: should be 1.5rem x 1.5rem (D4)
+    expect((orchButton as HTMLElement)?.style.width).toBe('1.5rem');
 
     // Simulate hover
     fireEvent.mouseEnter(orchButton!);
@@ -348,9 +348,12 @@ describe('MaoWorkflowGroupCard state color handling', () => {
       />,
     );
 
-    // The dot span should have bg-slate-500 (not default bg-slate-400)
-    const dots = container.querySelectorAll('.bg-slate-500');
-    expect(dots.length).toBeGreaterThan(0);
+    // The dot span should have backgroundColor from the idle state CSS custom property
+    const dotSpans = container.querySelectorAll('span[style]');
+    const hasDot = Array.from(dotSpans).some(
+      (el) => (el as HTMLElement).style.backgroundColor === 'var(--nous-state-idle)',
+    );
+    expect(hasDot).toBe(true);
   });
 
   it('renders appropriate dot color for hard_stopped state', () => {
@@ -366,8 +369,11 @@ describe('MaoWorkflowGroupCard state color handling', () => {
       />,
     );
 
-    // The dot span should have bg-red-700
-    const dots = container.querySelectorAll('.bg-red-700');
-    expect(dots.length).toBeGreaterThan(0);
+    // The dot span should have backgroundColor from the blocked state CSS custom property
+    const dotSpans = container.querySelectorAll('span[style]');
+    const hasDot = Array.from(dotSpans).some(
+      (el) => (el as HTMLElement).style.backgroundColor === 'var(--nous-state-blocked)',
+    );
+    expect(hasDot).toBe(true);
   });
 });

--- a/self/ui/src/components/mao/mao-audit-trail-panel.tsx
+++ b/self/ui/src/components/mao/mao-audit-trail-panel.tsx
@@ -32,33 +32,35 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
 
   const entries = auditQuery.data ?? [];
 
+  const mutedText: React.CSSProperties = { color: 'var(--nous-fg-muted)' };
+
   return (
     <Card>
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center justify-between gap-3 text-base">
+      <CardHeader style={{ borderBottom: '1px solid var(--nous-border-subtle)' }}>
+        <CardTitle style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-md)', fontSize: 'var(--nous-font-size-base)' }}>
           <span>Audit trail</span>
           {entries.length > 0 ? (
             <Badge variant="outline">{entries.length} entries</Badge>
           ) : null}
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3 pt-4 text-sm">
+      <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)', paddingTop: 'var(--nous-space-lg)', fontSize: 'var(--nous-font-size-sm)' }}>
         {isSentinel ? (
-          <p className="text-muted-foreground" data-testid="sentinel-indicator">
+          <p style={mutedText} data-testid="sentinel-indicator">
             System-level agent — audit trail scoped to project context.
           </p>
         ) : auditQuery.isLoading ? (
-          <p className="text-muted-foreground">Loading audit history...</p>
+          <p style={mutedText}>Loading audit history...</p>
         ) : auditQuery.isError ? (
-          <p className="text-muted-foreground">
+          <p style={mutedText}>
             Failed to load audit history.
           </p>
         ) : entries.length === 0 ? (
-          <p className="text-muted-foreground">
+          <p style={mutedText}>
             No control actions have been recorded for this project.
           </p>
         ) : (
-          <div className="space-y-2">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
             {entries.map((entry) => {
               const isExpanded = expandedId === entry.commandId;
 
@@ -66,50 +68,58 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
                 <button
                   key={entry.commandId}
                   type="button"
-                  className="w-full rounded-md border border-border px-3 py-2 text-left transition-colors hover:bg-muted/20"
+                  style={{
+                    width: '100%',
+                    borderRadius: 'var(--nous-radius-sm)',
+                    border: '1px solid var(--nous-border-subtle)',
+                    paddingInline: 'var(--nous-space-md)',
+                    paddingBlock: 'var(--nous-space-sm)',
+                    textAlign: 'left',
+                    transition: 'background-color 0.15s',
+                  }}
                   onClick={() =>
                     setExpandedId(isExpanded ? null : entry.commandId)
                   }
                   aria-expanded={isExpanded}
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--nous-space-sm)' }}>
                       <Badge variant="outline">
                         {entry.action.replace(/_/g, ' ')}
                       </Badge>
-                      <span className="text-xs text-muted-foreground">
+                      <span style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                         {entry.actorId}
                       </span>
                     </div>
-                    <span className="text-xs text-muted-foreground">
+                    <span style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                       {new Date(entry.at).toLocaleString()}
                     </span>
                   </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
+                  <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                     {entry.reason}
                   </div>
 
                   {isExpanded ? (
-                    <div className="mt-3 space-y-1 border-t border-border pt-2 text-xs text-muted-foreground">
+                    <div style={{ marginTop: 'var(--nous-space-xl)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-2xs)', borderTop: '1px solid var(--nous-border-subtle)', paddingTop: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                       <div>
-                        <span className="font-medium">Command ID:</span>{' '}
+                        <span style={{ fontWeight: 500 }}>Command ID:</span>{' '}
                         {entry.commandId}
                       </div>
                       <div>
-                        <span className="font-medium">Reason code:</span>{' '}
+                        <span style={{ fontWeight: 500 }}>Reason code:</span>{' '}
                         {entry.reasonCode}
                       </div>
                       <div>
-                        <span className="font-medium">Resume readiness:</span>{' '}
+                        <span style={{ fontWeight: 500 }}>Resume readiness:</span>{' '}
                         {entry.resumeReadinessStatus}
                       </div>
                       <div>
-                        <span className="font-medium">Decision ref:</span>{' '}
+                        <span style={{ fontWeight: 500 }}>Decision ref:</span>{' '}
                         {entry.decisionRef}
                       </div>
                       {entry.evidenceRefs.length > 0 ? (
                         <div>
-                          <span className="font-medium">Evidence refs:</span>{' '}
+                          <span style={{ fontWeight: 500 }}>Evidence refs:</span>{' '}
                           {entry.evidenceRefs.join(', ')}
                         </div>
                       ) : null}

--- a/self/ui/src/components/mao/mao-backlog-pressure-card.tsx
+++ b/self/ui/src/components/mao/mao-backlog-pressure-card.tsx
@@ -1,27 +1,28 @@
 'use client';
 
 import * as React from 'react';
+import type { CSSProperties } from 'react';
 import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 import { trpc, useEventSubscription } from '@nous/transport';
 
-const TREND_CONFIG = {
+const TREND_CONFIG: Record<string, { label: string; arrow: string; style: CSSProperties }> = {
   increasing: {
     label: 'Increasing',
     arrow: '\u2191',
-    className: 'border-red-500/40 bg-red-500/10 text-red-500',
+    style: { borderColor: 'rgba(239,68,68,0.4)', backgroundColor: 'rgba(239,68,68,0.1)', color: '#ef4444' },
   },
   stable: {
     label: 'Stable',
     arrow: '\u2192',
-    className: 'border-border bg-background text-muted-foreground',
+    style: { borderColor: 'var(--nous-border-subtle)', backgroundColor: 'var(--nous-bg)', color: 'var(--nous-fg-muted)' },
   },
   decreasing: {
     label: 'Decreasing',
     arrow: '\u2193',
-    className: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-500',
+    style: { borderColor: 'rgba(16,185,129,0.4)', backgroundColor: 'rgba(16,185,129,0.1)', color: '#10b981' },
   },
-} as const;
+};
 
 export function MaoBacklogPressureCard() {
   const utils = trpc.useUtils();
@@ -39,57 +40,62 @@ export function MaoBacklogPressureCard() {
   const trend = backlog?.pressureTrend;
   const trendConfig = trend ? TREND_CONFIG[trend] : null;
 
+  const cellBase: CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-md)',
+    paddingBlock: 'var(--nous-space-sm)',
+  };
+
+  const labelStyle: CSSProperties = {
+    fontSize: 'var(--nous-font-size-xs)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: 'var(--nous-fg-muted)',
+  };
+
+  const valueStyle: CSSProperties = {
+    marginTop: 'var(--nous-space-2xs)',
+    fontSize: 'var(--nous-font-size-lg)',
+    fontWeight: 600,
+  };
+
   return (
     <Card>
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center justify-between gap-3 text-base">
+      <CardHeader style={{ borderBottom: '1px solid var(--nous-border-subtle)' }}>
+        <CardTitle style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-md)', fontSize: 'var(--nous-font-size-base)' }}>
           <span>Backlog pressure</span>
           {trendConfig ? (
-            <Badge
-              variant="outline"
-              className={trendConfig.className}
-            >
+            <Badge variant="outline" style={trendConfig.style}>
               {trendConfig.arrow} {trendConfig.label}
             </Badge>
           ) : null}
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3 pt-4 text-sm">
+      <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)', paddingTop: 'var(--nous-space-lg)', fontSize: 'var(--nous-font-size-sm)' }}>
         {statusQuery.isLoading ? (
-          <p className="text-muted-foreground">Loading system status...</p>
+          <p style={{ color: 'var(--nous-fg-muted)' }}>Loading system status...</p>
         ) : statusQuery.isError ? (
-          <p className="text-muted-foreground">
+          <p style={{ color: 'var(--nous-fg-muted)' }}>
             Failed to load system status.
           </p>
         ) : !backlog ? (
-          <p className="text-muted-foreground">
+          <p style={{ color: 'var(--nous-fg-muted)' }}>
             Backlog analytics are not available.
           </p>
         ) : (
-          <div className="grid gap-3 md:grid-cols-3">
-            <div className="rounded-md border border-border px-3 py-2">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                Queued
-              </div>
-              <div className="mt-1 text-lg font-semibold">
-                {backlog.queuedCount}
-              </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' }}>
+            <div style={cellBase}>
+              <div style={labelStyle}>Queued</div>
+              <div style={valueStyle}>{backlog.queuedCount}</div>
             </div>
-            <div className="rounded-md border border-border px-3 py-2">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                Active
-              </div>
-              <div className="mt-1 text-lg font-semibold">
-                {backlog.activeCount}
-              </div>
+            <div style={cellBase}>
+              <div style={labelStyle}>Active</div>
+              <div style={valueStyle}>{backlog.activeCount}</div>
             </div>
-            <div className="rounded-md border border-border px-3 py-2">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                Suspended
-              </div>
-              <div className="mt-1 text-lg font-semibold">
-                {backlog.suspendedCount}
-              </div>
+            <div style={cellBase}>
+              <div style={labelStyle}>Suspended</div>
+              <div style={valueStyle}>{backlog.suspendedCount}</div>
             </div>
           </div>
         )}

--- a/self/ui/src/components/mao/mao-density-grid.tsx
+++ b/self/ui/src/components/mao/mao-density-grid.tsx
@@ -1,28 +1,27 @@
 'use client';
 
 import * as React from 'react';
+import type { CSSProperties } from 'react';
 import type { MaoDensityMode, MaoGridTileProjection, MaoProjectSnapshot } from '@nous/shared';
 import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 import { resolveAgentLabel } from './mao-workflow-group-card';
 import { getStateVisuals, CLUSTER_STATE_ORDER } from './mao-state-utils';
 
-function gridColumnsForDensity(
-  densityMode: MaoProjectSnapshot['densityMode'],
-): string {
+/** Single-column layout since MAO renders at 280-400px where breakpoints never trigger */
+function gridStyleForDensity(densityMode: MaoProjectSnapshot['densityMode']): CSSProperties {
   switch (densityMode) {
     case 'D0':
-      return 'grid-cols-1';
     case 'D1':
-      return 'grid-cols-1 md:grid-cols-2';
+      return { display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' };
     case 'D2':
-      return 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3';
+      return { display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' };
     case 'D3':
-      return 'grid-cols-2 md:grid-cols-3 xl:grid-cols-4';
+      return { display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-md)' };
     case 'D4':
-      return 'grid-cols-3 md:grid-cols-4 xl:grid-cols-6';
+      return { display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-md)' };
     default:
-      return 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3';
+      return { display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' };
   }
 }
 
@@ -48,9 +47,19 @@ function renderInferenceInfo(
   const tokens = tile.agent.inference_total_tokens;
   const isStreaming = tile.agent.inference_is_streaming;
 
+  const inferenceRowStyle: CSSProperties = {
+    marginTop: 'var(--nous-space-sm)',
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '6px',
+    fontSize: 'var(--nous-font-size-xs)',
+    color: 'var(--nous-fg-muted)',
+  };
+
   if (densityMode === 'D2') {
     return (
-      <div className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="inference-d2">
+      <div style={inferenceRowStyle} data-testid="inference-d2">
         {isStreaming ? <span style={streamingPulseStyle} data-testid="streaming-pulse" /> : null}
         {tokens != null ? <span>{tokens.toLocaleString()} tok</span> : null}
       </div>
@@ -59,11 +68,11 @@ function renderInferenceInfo(
 
   // D0 and D1 share provider, model, latency, tokens
   return (
-    <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground" data-testid={`inference-${densityMode.toLowerCase()}`}>
+    <div style={inferenceRowStyle} data-testid={`inference-${densityMode.toLowerCase()}`}>
       <span>{provider}</span>
-      {model ? <span className="text-muted-foreground/70">{model}</span> : null}
+      {model ? <span style={{ opacity: 0.7 }}>{model}</span> : null}
       {latency != null ? (
-        <Badge variant="outline" className="text-[10px] px-1 py-0">
+        <Badge variant="outline" style={{ fontSize: '10px', paddingInline: 'var(--nous-space-2xs)', paddingBlock: 0 }}>
           {latency}ms
         </Badge>
       ) : null}
@@ -84,7 +93,7 @@ function UrgentIcon() {
       viewBox="0 0 8 8"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className="text-red-500 shrink-0"
+      style={{ color: '#ef4444', flexShrink: 0 }}
       data-testid="urgent-icon"
       aria-hidden="true"
     >
@@ -108,7 +117,7 @@ function UrgentTimer({ lastUpdateAt }: { lastUpdateAt: string }) {
   }, [lastUpdateAt]);
 
   return (
-    <span className="text-[10px] text-red-500" data-testid="urgent-timer">
+    <span style={{ fontSize: '10px', color: '#ef4444' }} data-testid="urgent-timer">
       {minutes}m
     </span>
   );
@@ -183,10 +192,10 @@ export function MaoDensityGrid({
 
   return (
     <Card>
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center justify-between gap-3 text-base">
+      <CardHeader style={{ borderBottom: '1px solid var(--nous-border-subtle)' }}>
+        <CardTitle style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-md)', fontSize: 'var(--nous-font-size-base)' }}>
           <span>Density grid</span>
-          <div className="flex flex-wrap gap-2">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
             <Badge variant="outline">{snapshot.densityMode}</Badge>
             <Badge variant="outline">
               {snapshot.summary.activeAgentCount} active
@@ -197,20 +206,20 @@ export function MaoDensityGrid({
           </div>
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4">
+      <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-lg)', paddingTop: 'var(--nous-space-lg)' }}>
         {!snapshot.grid.length ? (
-          <p className="text-sm text-muted-foreground">
+          <p style={{ fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
             No MAO agent projections are available for the selected project.
           </p>
         ) : densityMode === 'D4' && orderedClusters ? (
           /* D4 clustered rendering */
-          <div className="space-y-3">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' }}>
             {orderedClusters.map(({ state, tiles }) => (
               <div key={state} data-testid={`cluster-${state}`}>
-                <div className="text-[10px] text-muted-foreground font-medium mb-1 uppercase tracking-wider">
+                <div style={{ fontSize: '10px', color: 'var(--nous-fg-muted)', fontWeight: 500, marginBottom: 'var(--nous-space-2xs)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
                   {state} ({tiles.length})
                 </div>
-                <div className="flex flex-wrap gap-1">
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-2xs)' }}>
                   {tiles.map((tile) => {
                     const isSelected = selectedAgentId === tile.agent.agent_id;
                     const urgent =
@@ -225,9 +234,15 @@ export function MaoDensityGrid({
                         aria-label={`Inspect ${resolveAgentLabel(tile.agent)}`}
                         onClick={() => onSelectTile(tile)}
                         data-testid="density-tile-d4"
-                        className={`w-6 h-6 rounded ${visuals.dot} ${
-                          isSelected ? 'ring-2 ring-primary' : ''
-                        } ${urgent ? 'ring-2 ring-red-500' : ''} ${visuals.pulse}`}
+                        className={visuals.pulse || undefined}
+                        style={{
+                          width: '1.5rem',
+                          height: '1.5rem',
+                          borderRadius: 'var(--nous-radius-xs)',
+                          ...visuals.dotStyle,
+                          ...(isSelected ? { boxShadow: '0 0 0 2px var(--nous-accent)' } : {}),
+                          ...(urgent ? { boxShadow: '0 0 0 2px #ef4444' } : {}),
+                        }}
                       />
                     );
                   })}
@@ -237,9 +252,7 @@ export function MaoDensityGrid({
           </div>
         ) : (
           /* D0-D3 flat rendering */
-          <div
-            className={`grid gap-3 ${gridColumnsForDensity(densityMode)}`}
-          >
+          <div style={gridStyleForDensity(densityMode)}>
             {sortedTiles.map((tile) => {
               const isSelected = selectedAgentId === tile.agent.agent_id;
               const urgent =
@@ -259,12 +272,25 @@ export function MaoDensityGrid({
                     aria-label={`Inspect ${resolveAgentLabel(tile.agent)}`}
                     onClick={() => onSelectTile(tile)}
                     data-testid="density-tile-d3"
-                    className={`inline-flex items-center gap-1 rounded border px-1.5 py-1 text-xs transition-colors hover:bg-muted/30 ${
-                      isSelected ? 'border-primary bg-primary/10' : visuals.tone
-                    } ${urgent ? 'border-red-500 border-2' : ''} ${visuals.pulse}`}
+                    className={visuals.pulse || undefined}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 'var(--nous-space-2xs)',
+                      borderRadius: 'var(--nous-radius-xs)',
+                      border: '1px solid',
+                      paddingInline: '6px',
+                      paddingBlock: 'var(--nous-space-2xs)',
+                      fontSize: 'var(--nous-font-size-xs)',
+                      transition: 'background-color 0.15s',
+                      ...(isSelected
+                        ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                        : visuals.toneStyle),
+                      ...(urgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+                    }}
                   >
-                    <span className={`inline-block w-2 h-2 rounded-full ${visuals.dot}`} />
-                    <span className="truncate max-w-16">{resolveAgentLabel(tile.agent).slice(0, 16)}</span>
+                    <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', ...visuals.dotStyle }} />
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '4rem' }}>{resolveAgentLabel(tile.agent).slice(0, 16)}</span>
                     {urgent && <UrgentIcon />}
                   </button>
                 );
@@ -277,23 +303,32 @@ export function MaoDensityGrid({
                   type="button"
                   aria-label={`Inspect ${tile.agent.current_step}`}
                   onClick={() => onSelectTile(tile)}
-                  className={`rounded-lg border p-3 text-left transition-colors hover:bg-muted/20 ${
-                    isSelected ? 'border-primary bg-primary/10' : visuals.tone
-                  } ${urgent ? 'border-red-500 border-2' : ''} ${visuals.pulse}`}
+                  className={visuals.pulse || undefined}
+                  style={{
+                    borderRadius: 'var(--nous-radius-md)',
+                    border: '1px solid',
+                    padding: 'var(--nous-space-xl)',
+                    textAlign: 'left',
+                    transition: 'background-color 0.15s',
+                    ...(isSelected
+                      ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                      : visuals.toneStyle),
+                    ...(urgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+                  }}
                 >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <div className="truncate text-sm font-medium">
+                  <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }}>
                         {tile.agent.current_step}
                       </div>
-                      <div className="mt-1 text-xs text-muted-foreground">
+                      <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                         {tile.agent.dispatch_state}
                       </div>
                     </div>
                     <Badge variant="outline">{tile.agent.state}</Badge>
                   </div>
 
-                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                  <div style={{ marginTop: 'var(--nous-space-xl)', display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-xs)' }}>
                     <Badge variant="outline">{tile.agent.risk_level}</Badge>
                     <Badge variant="outline">{tile.agent.attention_level}</Badge>
                     {tile.inspectOnly ? (
@@ -302,7 +337,7 @@ export function MaoDensityGrid({
                     {urgent ? (
                       <Badge
                         variant="outline"
-                        className="border-red-500 text-red-500 bg-red-500/10"
+                        style={{ borderColor: '#ef4444', color: '#ef4444', backgroundColor: 'rgba(239,68,68,0.1)' }}
                         data-testid="urgent-indicator"
                       >
                         URGENT
@@ -312,12 +347,12 @@ export function MaoDensityGrid({
                   </div>
 
                   {urgent && tile.agent.last_update_at && (
-                    <div className="mt-1">
+                    <div style={{ marginTop: 'var(--nous-space-2xs)' }}>
                       <UrgentTimer lastUpdateAt={tile.agent.last_update_at} />
                     </div>
                   )}
 
-                  <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                  <div style={{ marginTop: 'var(--nous-space-xl)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                     <span>{tile.agent.progress_percent}% complete</span>
                     <span>{tile.agent.reflection_cycle_count} review cycles</span>
                   </div>
@@ -325,7 +360,7 @@ export function MaoDensityGrid({
                   {renderInferenceInfo(tile, snapshot.densityMode)}
 
                   {tile.agent.reasoning_log_preview ? (
-                    <p className="mt-3 line-clamp-2 text-xs text-muted-foreground">
+                    <p style={{ marginTop: 'var(--nous-space-xl)', overflow: 'hidden', display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 2, fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                       {tile.agent.reasoning_log_preview.summary}
                     </p>
                   ) : null}

--- a/self/ui/src/components/mao/mao-edge-connector.tsx
+++ b/self/ui/src/components/mao/mao-edge-connector.tsx
@@ -28,7 +28,7 @@ export interface MaoEdgeConnectorProps {
 interface ComputedEdge {
   key: string;
   path: string;
-  strokeClass: string;
+  strokeColor: string;
 }
 
 function computeEdgePath(
@@ -45,9 +45,9 @@ function computeEdgePath(
   return `M ${x1} ${y1} L ${x1} ${yMid} L ${x2} ${yMid} L ${x2} ${y2}`;
 }
 
-function getStrokeClass(parentAgentClass?: string): string {
+function getStrokeColor(parentAgentClass?: string): string {
   const color = AGENT_CLASS_COLORS[parentAgentClass ?? ''];
-  return color ? color.stroke : FALLBACK_CLASS_COLOR.stroke;
+  return color ? color.strokeColor : FALLBACK_CLASS_COLOR.strokeColor;
 }
 
 export function MaoEdgeConnector({
@@ -93,7 +93,7 @@ export function MaoEdgeConnector({
         result.push({
           key: `${edge.parentId}-${edge.childId}`,
           path: computeEdgePath(parentRect, childRect, containerRect),
-          strokeClass: getStrokeClass(edge.parentAgentClass),
+          strokeColor: getStrokeColor(edge.parentAgentClass),
         });
       }
 
@@ -122,16 +122,21 @@ export function MaoEdgeConnector({
       ref={svgRef}
       data-testid="edge-connector-svg"
       data-animation-state={animationState}
-      className="absolute inset-0 pointer-events-none z-0"
-      style={hidden ? { display: 'none' } : undefined}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: 0,
+        ...(hidden ? { display: 'none' } : {}),
+      }}
       aria-hidden="true"
     >
       {computedEdges.map((edge) => (
         <path
           key={edge.key}
           d={edge.path}
-          className={edge.strokeClass}
           fill="none"
+          stroke={edge.strokeColor}
           strokeWidth={1.5}
           opacity={0.6}
           data-testid="edge-path"

--- a/self/ui/src/components/mao/mao-inspect-panel.tsx
+++ b/self/ui/src/components/mao/mao-inspect-panel.tsx
@@ -34,11 +34,19 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
       reasoningRef: inspectData.agent.reasoning_log_preview?.evidenceRef ?? undefined,
     });
 
+    const linkBase: React.CSSProperties = {
+      borderRadius: 'var(--nous-radius-sm)',
+      border: '1px solid var(--nous-border-subtle)',
+      paddingInline: 'var(--nous-space-sm)',
+      paddingBlock: 'var(--nous-space-2xs)',
+      fontSize: 'var(--nous-font-size-xs)',
+    };
+
     if (!href) {
       return (
         <span
           key={`${link.target}-${index}`}
-          className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground"
+          style={{ ...linkBase, color: 'var(--nous-fg-muted)' }}
         >
           {link.target}
         </span>
@@ -49,31 +57,51 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
       <Link
         key={`${link.target}-${index}`}
         href={href}
-        className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted/20"
+        style={linkBase}
       >
         {link.target}
       </Link>
     );
   }
 
+  const cellBase: React.CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-md)',
+    paddingBlock: 'var(--nous-space-sm)',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 'var(--nous-font-size-xs)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: 'var(--nous-fg-muted)',
+  };
+
+  const sectionStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--nous-space-sm)',
+  };
+
   return (
     <Card>
-      <CardHeader className="border-b border-border">
-        <CardTitle className="text-base">Inspect panel</CardTitle>
+      <CardHeader style={{ borderBottom: '1px solid var(--nous-border-subtle)' }}>
+        <CardTitle style={{ fontSize: 'var(--nous-font-size-base)' }}>Inspect panel</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4 text-sm">
+      <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-lg)', paddingTop: 'var(--nous-space-lg)', fontSize: 'var(--nous-font-size-sm)' }}>
         {isLoading ? (
-          <p className="text-muted-foreground">Loading inspect projection...</p>
+          <p style={{ color: 'var(--nous-fg-muted)' }}>Loading inspect projection...</p>
         ) : !inspect ? (
-          <p className="text-muted-foreground">
+          <p style={{ color: 'var(--nous-fg-muted)' }}>
             Select an MAO tile or graph node to inspect runtime state, reasoning
             previews, and evidence continuity.
           </p>
         ) : (
           <>
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-base font-semibold" data-testid="inspect-primary-label">
+            <div style={sectionStyle}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 'var(--nous-space-sm)' }}>
+                <span style={{ fontSize: 'var(--nous-font-size-base)', fontWeight: 600 }} data-testid="inspect-primary-label">
                   {resolveAgentLabelFromProjection(inspect.agent as any)}
                 </span>
                 {(() => {
@@ -82,7 +110,7 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
                   return classKey ? (
                     <Badge
                       variant="outline"
-                      className={classColor.fill}
+                      style={classColor.fillStyle}
                       data-testid="inspect-agent-class-badge"
                     >
                       {classColor.label}
@@ -94,48 +122,40 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
                 <Badge variant="outline">{inspect.projectControlState}</Badge>
               </div>
               {inspect.agent.dispatching_task_agent_id ? (
-                <div className="text-xs text-muted-foreground" data-testid="inspect-dispatch-lineage">
+                <div style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }} data-testid="inspect-dispatch-lineage">
                   Dispatched by:{' '}
-                  <span className="font-medium">
+                  <span style={{ fontWeight: 500 }}>
                     {resolveAgentLabel
                       ? resolveAgentLabel(inspect.agent.dispatching_task_agent_id)
                       : formatShortId(inspect.agent.dispatching_task_agent_id)}
                   </span>
                 </div>
               ) : null}
-              <div className="grid gap-2 md:grid-cols-2">
-                <div className="rounded-md border border-border px-3 py-2">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                    Agent
-                  </div>
-                  <div className="mt-1">{formatShortId(inspect.agent.agent_id)}</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
+                <div style={cellBase}>
+                  <div style={labelStyle}>Agent</div>
+                  <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{formatShortId(inspect.agent.agent_id)}</div>
                 </div>
-                <div className="rounded-md border border-border px-3 py-2">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                    Run
-                  </div>
-                  <div className="mt-1">
+                <div style={cellBase}>
+                  <div style={labelStyle}>Run</div>
+                  <div style={{ marginTop: 'var(--nous-space-2xs)' }}>
                     {formatShortId(inspect.workflowRunId ?? inspect.agent.workflow_run_id)}
                   </div>
                 </div>
-                <div className="rounded-md border border-border px-3 py-2">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                    Wait posture
-                  </div>
-                  <div className="mt-1">{inspect.waitKind ?? 'n/a'}</div>
+                <div style={cellBase}>
+                  <div style={labelStyle}>Wait posture</div>
+                  <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{inspect.waitKind ?? 'n/a'}</div>
                 </div>
-                <div className="rounded-md border border-border px-3 py-2">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                    Run status
-                  </div>
-                  <div className="mt-1">{inspect.runStatus ?? 'n/a'}</div>
+                <div style={cellBase}>
+                  <div style={labelStyle}>Run status</div>
+                  <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{inspect.runStatus ?? 'n/a'}</div>
                 </div>
               </div>
             </div>
 
             {inspect.agent.reasoning_log_preview ? (
-              <div className="space-y-2 rounded-md border border-border p-3">
-                <div className="flex flex-wrap gap-2">
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)', borderRadius: 'var(--nous-radius-sm)', border: '1px solid var(--nous-border-subtle)', padding: 'var(--nous-space-xl)' }}>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
                   <Badge variant="outline">
                     {inspect.agent.reasoning_log_preview.class}
                   </Badge>
@@ -147,10 +167,10 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
                   </Badge>
                 </div>
                 <p>{inspect.agent.reasoning_log_preview.summary}</p>
-                <div className="text-xs text-muted-foreground">
+                <div style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                   evidence {inspect.agent.reasoning_log_preview.evidenceRef}
                 </div>
-                <div className="flex flex-wrap gap-2">
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
                   {inspect.agent.reasoning_log_preview.chatLink
                     ? renderSurfaceLink(
                         inspect.agent.reasoning_log_preview.chatLink,
@@ -169,43 +189,40 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
               </div>
             ) : null}
 
-            <div className="space-y-2">
-              <div className="font-medium">Latest attempt</div>
+            <div style={sectionStyle}>
+              <div style={{ fontWeight: 500 }}>Latest attempt</div>
               {inspect.latestAttempt ? (
-                <div className="rounded-md border border-border px-3 py-2">
-                  <div className="flex items-center justify-between gap-2">
+                <div style={cellBase}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
                     <span>Attempt {inspect.latestAttempt.attempt}</span>
                     <Badge variant="outline">{inspect.latestAttempt.status}</Badge>
                   </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
+                  <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                     {inspect.latestAttempt.reasonCode}
                   </div>
                 </div>
               ) : (
-                <p className="text-muted-foreground">No attempt history is available.</p>
+                <p style={{ color: 'var(--nous-fg-muted)' }}>No attempt history is available.</p>
               )}
             </div>
 
-            <div className="space-y-2">
-              <div className="font-medium">Correction arcs</div>
+            <div style={sectionStyle}>
+              <div style={{ fontWeight: 500 }}>Correction arcs</div>
               {!inspect.correctionArcs.length ? (
-                <p className="text-muted-foreground">
+                <p style={{ color: 'var(--nous-fg-muted)' }}>
                   No corrective arcs have been recorded for this agent.
                 </p>
               ) : (
                 inspect.correctionArcs.map((arc) => (
-                  <div
-                    key={arc.id}
-                    className="rounded-md border border-border px-3 py-2"
-                  >
-                    <div className="flex items-center justify-between gap-2">
+                  <div key={arc.id} style={cellBase}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
                       <span>
                         attempt {arc.sourceAttempt}
                         {arc.targetAttempt ? ` -> ${arc.targetAttempt}` : ''}
                       </span>
                       <Badge variant="outline">{arc.type}</Badge>
                     </div>
-                    <div className="mt-1 text-xs text-muted-foreground">
+                    <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                       {arc.reasonCode} • {arc.evidenceRefs[0] ?? 'n/a'}
                     </div>
                   </div>
@@ -213,23 +230,23 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
               )}
             </div>
 
-            <div className="space-y-2">
-              <div className="font-medium">Deep links</div>
-              <div className="flex flex-wrap gap-2">
+            <div style={sectionStyle}>
+              <div style={{ fontWeight: 500 }}>Deep links</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
                 {inspect.agent.deepLinks.map((link, index) =>
                   renderSurfaceLink(link, inspect, index),
                 )}
               </div>
             </div>
 
-            <div className="space-y-2">
-              <div className="font-medium">Evidence refs</div>
+            <div style={sectionStyle}>
+              <div style={{ fontWeight: 500 }}>Evidence refs</div>
               {!inspect.evidenceRefs.length ? (
-                <p className="text-muted-foreground">
+                <p style={{ color: 'var(--nous-fg-muted)' }}>
                   No evidence refs are attached to this inspect projection.
                 </p>
               ) : (
-                <div className="flex flex-wrap gap-2">
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
                   {inspect.evidenceRefs.map((ref) => (
                     <Badge key={ref} variant="outline">
                       {ref}
@@ -239,34 +256,34 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
               )}
             </div>
 
-            <div className="space-y-2">
+            <div style={sectionStyle}>
               <button
                 type="button"
                 onClick={() => setInferenceHistoryOpen((prev) => !prev)}
-                className="flex w-full items-center justify-between font-medium"
+                style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between', fontWeight: 500 }}
                 data-testid="inference-history-toggle"
               >
                 <span>Inference History</span>
-                <span className="text-xs text-muted-foreground">
+                <span style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                   {inferenceHistoryOpen ? '\u25B2' : '\u25BC'}
                 </span>
               </button>
               {inferenceHistoryOpen ? (
                 !inspect.inference_history?.length ? (
-                  <p className="text-muted-foreground">
+                  <p style={{ color: 'var(--nous-fg-muted)' }}>
                     No inference history available.
                   </p>
                 ) : (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-xs" data-testid="inference-history-table">
+                  <div style={{ overflowX: 'auto' }}>
+                    <table style={{ width: '100%', fontSize: 'var(--nous-font-size-xs)' }} data-testid="inference-history-table">
                       <thead>
-                        <tr className="border-b border-border text-left text-muted-foreground">
-                          <th className="pb-1 pr-3 font-medium">Timestamp</th>
-                          <th className="pb-1 pr-3 font-medium">Provider</th>
-                          <th className="pb-1 pr-3 font-medium">Model</th>
-                          <th className="pb-1 pr-3 font-medium text-right">In tokens</th>
-                          <th className="pb-1 pr-3 font-medium text-right">Out tokens</th>
-                          <th className="pb-1 font-medium text-right">Latency</th>
+                        <tr style={{ borderBottom: '1px solid var(--nous-border-subtle)', textAlign: 'left', color: 'var(--nous-fg-muted)' }}>
+                          <th style={{ paddingBottom: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', fontWeight: 500 }}>Timestamp</th>
+                          <th style={{ paddingBottom: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', fontWeight: 500 }}>Provider</th>
+                          <th style={{ paddingBottom: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', fontWeight: 500 }}>Model</th>
+                          <th style={{ paddingBottom: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', fontWeight: 500, textAlign: 'right' }}>In tokens</th>
+                          <th style={{ paddingBottom: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', fontWeight: 500, textAlign: 'right' }}>Out tokens</th>
+                          <th style={{ paddingBottom: 'var(--nous-space-2xs)', fontWeight: 500, textAlign: 'right' }}>Latency</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -274,8 +291,8 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
                           .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
                           .slice(0, 50)
                           .map((entry, idx) => (
-                            <tr key={`${entry.traceId}-${idx}`} className="border-b border-border/50">
-                              <td className="py-1 pr-3 whitespace-nowrap">
+                            <tr key={`${entry.traceId}-${idx}`} style={{ borderBottom: '1px solid rgba(18,18,18,0.5)' }}>
+                              <td style={{ paddingBlock: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', whiteSpace: 'nowrap' }}>
                                 {new Date(entry.timestamp).toLocaleString(undefined, {
                                   month: 'short',
                                   day: 'numeric',
@@ -284,15 +301,15 @@ export function MaoInspectPanel({ inspect, isLoading, resolveAgentLabel }: MaoIn
                                   second: '2-digit',
                                 })}
                               </td>
-                              <td className="py-1 pr-3">{entry.providerId}</td>
-                              <td className="py-1 pr-3">{entry.modelId}</td>
-                              <td className="py-1 pr-3 text-right tabular-nums">
+                              <td style={{ paddingBlock: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)' }}>{entry.providerId}</td>
+                              <td style={{ paddingBlock: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)' }}>{entry.modelId}</td>
+                              <td style={{ paddingBlock: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
                                 {entry.inputTokens != null ? entry.inputTokens.toLocaleString() : '\u2014'}
                               </td>
-                              <td className="py-1 pr-3 text-right tabular-nums">
+                              <td style={{ paddingBlock: 'var(--nous-space-2xs)', paddingRight: 'var(--nous-space-xl)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
                                 {entry.outputTokens != null ? entry.outputTokens.toLocaleString() : '\u2014'}
                               </td>
-                              <td className="py-1 text-right tabular-nums">
+                              <td style={{ paddingBlock: 'var(--nous-space-2xs)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
                                 {Math.round(entry.latencyMs)}ms
                               </td>
                             </tr>

--- a/self/ui/src/components/mao/mao-lease-tree.tsx
+++ b/self/ui/src/components/mao/mao-lease-tree.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import type { CSSProperties } from 'react';
 import type { MaoAgentProjection, MaoDensityMode, MaoSystemSnapshot } from '@nous/shared';
 import { MaoWorkflowGroupCard, resolveAgentLabel, AGENT_CLASS_COLORS, FALLBACK_CLASS_COLOR } from './mao-workflow-group-card';
 import { MaoEdgeConnector, type EdgeDef } from './mao-edge-connector';
@@ -152,24 +153,24 @@ function collectEdges(roots: LeaseTreeNode[]): EdgeDef[] {
 // Tile size helpers
 // ---------------------------------------------------------------------------
 
-function rootTileSizeClasses(densityMode: MaoDensityMode): string {
+function rootTileSizeStyle(densityMode: MaoDensityMode): CSSProperties {
   switch (densityMode) {
     case 'D0':
     case 'D1':
-      return 'min-w-64 p-4';
+      return { minWidth: '16rem', padding: 'var(--nous-space-2xl)' };
     case 'D2':
-      return 'min-w-48 p-3';
+      return { minWidth: '12rem', padding: 'var(--nous-space-xl)' };
     case 'D3':
-      return 'min-w-16 p-1.5';
+      return { minWidth: '4rem', padding: '6px' };
     case 'D4':
-      return 'w-6 h-6';
+      return { width: '1.5rem', height: '1.5rem' };
     default:
-      return 'min-w-48 p-3';
+      return { minWidth: '12rem', padding: 'var(--nous-space-xl)' };
   }
 }
 
-function getClassFill(agent: MaoAgentProjection): string {
-  return (AGENT_CLASS_COLORS[agent.agent_class ?? ''] ?? FALLBACK_CLASS_COLOR).fill;
+function getClassFillStyle(agent: MaoAgentProjection): CSSProperties {
+  return (AGENT_CLASS_COLORS[agent.agent_class ?? ''] ?? FALLBACK_CLASS_COLOR).fillStyle;
 }
 
 /** Small SVG exclamation icon for urgent indicators at D3 */
@@ -181,7 +182,7 @@ function UrgentIcon() {
       viewBox="0 0 8 8"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className="text-red-500 shrink-0"
+      style={{ color: '#ef4444', flexShrink: 0 }}
       aria-hidden="true"
     >
       <circle cx="4" cy="4" r="4" fill="currentColor" />
@@ -219,8 +220,8 @@ export function MaoLeaseTree({
 
   if (snapshot.agents.length === 0) {
     return (
-      <div data-testid="lease-tree-empty" className="flex items-center justify-center p-8">
-        <p className="text-sm text-muted-foreground">
+      <div data-testid="lease-tree-empty" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 'var(--nous-space-4xl)' }}>
+        <p style={{ fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
           No agents are currently active across the system.
         </p>
       </div>
@@ -231,15 +232,15 @@ export function MaoLeaseTree({
   const maxDepth = densityMode === 'D1' ? 1 : Infinity;
 
   return (
-    <div className="relative" data-testid="lease-tree">
-      <div className="flex flex-col gap-6">
+    <div style={{ position: 'relative' }} data-testid="lease-tree">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-3xl)' }}>
         {depthRows
           .filter((row) => row.depth <= maxDepth)
           .map((row) => (
             <div key={`depth-${row.depth}`}>
               {row.depth === 0 ? (
                 <div
-                  className="flex flex-wrap gap-4"
+                  style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-2xl)' }}
                   data-testid="lease-root-row"
                 >
                   {row.rootTiles.map((agent) => {
@@ -252,6 +253,7 @@ export function MaoLeaseTree({
                         : densityMode;
                     const visuals = getStateVisuals(agent.state);
                     const isUrgent = agent.urgency_level === 'urgent';
+                    const isSelected = selectedAgentId === agent.agent_id;
 
                     if (effectiveDensity === 'D4') {
                       return (
@@ -260,11 +262,16 @@ export function MaoLeaseTree({
                           type="button"
                           data-agent-id={agent.agent_id}
                           onClick={() => onSelectAgent(agent)}
-                          className={`w-6 h-6 rounded ${visuals.dot} ${
-                            selectedAgentId === agent.agent_id
-                              ? 'ring-2 ring-primary'
-                              : ''
-                          } ${isUrgent ? 'ring-2 ring-red-500' : ''} ${getClassFill(agent)} ${visuals.pulse}`}
+                          className={visuals.pulse || undefined}
+                          style={{
+                            width: '1.5rem',
+                            height: '1.5rem',
+                            borderRadius: 'var(--nous-radius-xs)',
+                            ...visuals.dotStyle,
+                            ...getClassFillStyle(agent),
+                            ...(isSelected ? { boxShadow: '0 0 0 2px var(--nous-accent)' } : {}),
+                            ...(isUrgent ? { boxShadow: '0 0 0 2px #ef4444' } : {}),
+                          }}
                           aria-label={resolveAgentLabel(agent)}
                           onMouseEnter={() => setHoveredId(agent.agent_id)}
                           onMouseLeave={() => setHoveredId(null)}
@@ -280,19 +287,28 @@ export function MaoLeaseTree({
                           type="button"
                           data-agent-id={agent.agent_id}
                           onClick={() => onSelectAgent(agent)}
-                          className={`flex items-center gap-1 rounded border px-1.5 py-1 text-xs transition-colors hover:bg-muted/30 ${
-                            selectedAgentId === agent.agent_id
-                              ? 'border-primary bg-primary/10'
-                              : getClassFill(agent)
-                          } ${isUrgent ? 'border-2 border-red-500' : ''} ${visuals.pulse}`}
+                          className={visuals.pulse || undefined}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 'var(--nous-space-2xs)',
+                            borderRadius: 'var(--nous-radius-xs)',
+                            border: '1px solid',
+                            paddingInline: '6px',
+                            paddingBlock: 'var(--nous-space-2xs)',
+                            fontSize: 'var(--nous-font-size-xs)',
+                            transition: 'background-color 0.15s',
+                            ...(isSelected
+                              ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                              : getClassFillStyle(agent)),
+                            ...(isUrgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+                          }}
                           aria-label={resolveAgentLabel(agent)}
                           onMouseEnter={() => setHoveredId(agent.agent_id)}
                           onMouseLeave={() => setHoveredId(null)}
                         >
-                          <span
-                            className={`inline-block w-2 h-2 rounded-full ${visuals.dot}`}
-                          />
-                          <span className="truncate max-w-24">
+                          <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', ...visuals.dotStyle }} />
+                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '6rem' }}>
                             {resolveAgentLabel(agent)}
                           </span>
                           {isUrgent && (
@@ -309,42 +325,56 @@ export function MaoLeaseTree({
                         type="button"
                         data-agent-id={agent.agent_id}
                         onClick={() => onSelectAgent(agent)}
-                        className={`rounded-lg border text-left transition-colors hover:bg-muted/20 ${rootTileSizeClasses(effectiveDensity)} ${
-                          selectedAgentId === agent.agent_id
-                            ? 'border-primary bg-primary/10'
-                            : `border-border bg-background`
-                        } ${visuals.pulse}`}
+                        className={visuals.pulse || undefined}
+                        style={{
+                          borderRadius: 'var(--nous-radius-md)',
+                          border: '1px solid',
+                          textAlign: 'left',
+                          transition: 'background-color 0.15s',
+                          ...rootTileSizeStyle(effectiveDensity),
+                          ...(isSelected
+                            ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                            : { borderColor: 'var(--nous-border-subtle)', backgroundColor: 'var(--nous-bg)' }),
+                        }}
                         aria-label={resolveAgentLabel(agent)}
                         onMouseEnter={() => setHoveredId(agent.agent_id)}
                         onMouseLeave={() => setHoveredId(null)}
                       >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-1.5 truncate text-sm font-medium">
+                        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+                          <div style={{ minWidth: 0 }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }}>
                               {resolveAgentLabel(agent)}
                               {agent.agent_class && (
                                 <span
-                                  className={`inline-flex items-center rounded-sm px-1 py-0.5 text-[10px] font-medium leading-none ${(AGENT_CLASS_COLORS[agent.agent_class] ?? FALLBACK_CLASS_COLOR).fill}`}
+                                  style={{
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    borderRadius: 'var(--nous-radius-xs)',
+                                    paddingInline: 'var(--nous-space-2xs)',
+                                    paddingBlock: '2px',
+                                    fontSize: '10px',
+                                    fontWeight: 500,
+                                    lineHeight: 1,
+                                    ...(AGENT_CLASS_COLORS[agent.agent_class] ?? FALLBACK_CLASS_COLOR).fillStyle,
+                                  }}
                                   data-testid="agent-class-badge"
                                 >
                                   {(AGENT_CLASS_COLORS[agent.agent_class] ?? FALLBACK_CLASS_COLOR).label}
                                 </span>
                               )}
                             </div>
-                            <div className="mt-1 text-xs text-muted-foreground">
+                            <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                               {agent.state}
                             </div>
                           </div>
-                          <span
-                            className={`inline-block w-2.5 h-2.5 rounded-full mt-1 ${visuals.dot}`}
-                          />
+                          <span style={{ display: 'inline-block', width: '0.625rem', height: '0.625rem', borderRadius: '9999px', marginTop: 'var(--nous-space-2xs)', ...visuals.dotStyle }} />
                         </div>
                       </button>
                     );
                   })}
                 </div>
               ) : (
-                <div className="flex flex-wrap gap-4">
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-2xl)' }}>
                   {row.groups.map((group) => (
                     <MaoWorkflowGroupCard
                       key={group.parentId ?? 'orphan'}

--- a/self/ui/src/components/mao/mao-operating-surface.tsx
+++ b/self/ui/src/components/mao/mao-operating-surface.tsx
@@ -375,17 +375,17 @@ export function MaoOperatingSurface() {
     <div style={{ position: 'relative', height: '100%', display: 'flex', flexDirection: 'column' }}>
     <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 'var(--nous-space-4xl)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-3xl)' }}>
       {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="space-y-1">
-          <h1 className="text-2xl font-semibold">MAO Operating Surface</h1>
-          <p className="text-sm text-muted-foreground">
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', justifyContent: 'space-between', gap: 'var(--nous-space-2xl)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-2xs)' }}>
+          <h1 style={{ fontSize: '1.5rem', fontWeight: 600 }}>MAO Operating Surface</h1>
+          <p style={{ fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
             Inspect density-aware runtime projections, follow evidence-linked
             reasoning previews, and apply governed project-scope controls from
             canonical workflow and opctl truth.
           </p>
         </div>
         {activeTab === 'projects' && snapshot ? (
-          <div className="flex flex-wrap gap-2">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
             <Badge variant="outline">
               {snapshot.controlProjection.project_control_state}
             </Badge>
@@ -398,7 +398,7 @@ export function MaoOperatingSurface() {
               </Badge>
             ) : null}
             {snapshot.diagnostics?.degradedReasonCode ? (
-              <Badge variant="outline" className="border-amber-500/40 text-amber-500">
+              <Badge variant="outline" style={{ borderColor: 'rgba(245,158,11,0.4)', color: '#f59e0b' }}>
                 degraded: {snapshot.diagnostics.degradedReasonCode}
               </Badge>
             ) : null}
@@ -408,7 +408,15 @@ export function MaoOperatingSurface() {
 
       {/* Navigation context banner */}
       {linkedRunId || linkedNodeId || linkedAgentId || maoContext || linkedSource === 'marketplace' ? (
-        <div className="rounded-md border border-border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+        <div style={{
+          borderRadius: 'var(--nous-radius-sm)',
+          border: '1px solid var(--nous-border-subtle)',
+          backgroundColor: 'rgba(26,26,26,0.2)',
+          paddingInline: 'var(--nous-space-2xl)',
+          paddingBlock: 'var(--nous-space-xl)',
+          fontSize: 'var(--nous-font-size-sm)',
+          color: 'var(--nous-fg-muted)',
+        }}>
           {maoContext ? 'MAO return context is active.' : 'Linked runtime context is active.'}
           {linkedRunId ? ` run ${formatShortId(linkedRunId)}` : ''}
           {linkedNodeId ? ` node ${formatShortId(linkedNodeId)}` : ''}
@@ -420,7 +428,7 @@ export function MaoOperatingSurface() {
           {maoContext ? (
             <Link
               href={buildMaoReturnHref(maoContext)}
-              className="ml-2 underline underline-offset-4"
+              style={{ marginLeft: 'var(--nous-space-sm)', textDecoration: 'underline', textUnderlineOffset: '4px' }}
             >
               Return to MAO root context
             </Link>
@@ -429,7 +437,7 @@ export function MaoOperatingSurface() {
       ) : null}
 
       {/* Tab bar */}
-      <div className="flex gap-2" data-testid="tab-bar">
+      <div style={{ display: 'flex', gap: 'var(--nous-space-sm)' }} data-testid="tab-bar">
         <Button
           variant={activeTab === 'system' ? 'default' : 'outline'}
           onClick={() => setActiveTab('system')}
@@ -447,7 +455,7 @@ export function MaoOperatingSurface() {
       </div>
 
       {/* Density mode selector */}
-      <div className="flex flex-wrap gap-2">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
         {DENSITY_MODES.map((mode) => (
           <Button
             key={mode}
@@ -471,8 +479,8 @@ export function MaoOperatingSurface() {
       {activeTab === 'system' ? (
         <div data-testid="system-tab-content">
           {systemSnapshotQuery.isLoading || !systemSnapshot ? (
-            <div className="p-8">
-              <p className="text-muted-foreground">
+            <div style={{ padding: 'var(--nous-space-4xl)' }}>
+              <p style={{ color: 'var(--nous-fg-muted)' }}>
                 Loading system-wide operating surface...
               </p>
             </div>
@@ -488,17 +496,17 @@ export function MaoOperatingSurface() {
       ) : (
         <div data-testid="projects-tab-content">
           {!projectId ? (
-            <div className="flex h-full items-center justify-center p-8">
-              <p className="text-muted-foreground">
+            <div style={{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center', padding: 'var(--nous-space-4xl)' }}>
+              <p style={{ color: 'var(--nous-fg-muted)' }}>
                 Select a project to inspect the MAO operating surface.
               </p>
             </div>
           ) : isProjectsLoading ? (
-            <div className="p-8">
-              <p className="text-muted-foreground">Loading MAO operating surface...</p>
+            <div style={{ padding: 'var(--nous-space-4xl)' }}>
+              <p style={{ color: 'var(--nous-fg-muted)' }}>Loading MAO operating surface...</p>
             </div>
           ) : snapshot ? (
-            <div className="space-y-6">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-3xl)' }}>
               <MaoDensityGrid
                 snapshot={snapshot}
                 selectedAgentId={projectsTab.selectedTarget?.agentId ?? null}
@@ -529,7 +537,7 @@ export function MaoOperatingSurface() {
       </div>
 
       {/* Bottom strip — pinned below scrollable area */}
-      <div className="space-y-4" data-testid="bottom-strip" style={{ flexShrink: 0, padding: '0 var(--nous-space-4xl) var(--nous-space-4xl)' }}>
+      <div data-testid="bottom-strip" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-lg)', flexShrink: 0, padding: '0 var(--nous-space-4xl) var(--nous-space-4xl)' }}>
         <MaoBacklogPressureCard />
         {activeTab === 'system' && systemSnapshot ? (
           <MaoSystemHealthStrip snapshot={systemSnapshot} />

--- a/self/ui/src/components/mao/mao-operating-surface.tsx
+++ b/self/ui/src/components/mao/mao-operating-surface.tsx
@@ -73,6 +73,15 @@ export function MaoOperatingSurface() {
     projectId ? 'projects' : 'system',
   );
 
+  // Auto-switch to projects tab when projectId becomes available after mount
+  const prevProjectId = React.useRef(projectId);
+  React.useEffect(() => {
+    if (prevProjectId.current == null && projectId != null) {
+      setActiveTab('projects');
+    }
+    prevProjectId.current = projectId;
+  }, [projectId]);
+
   const systemTab = useTabState('D2');
   const projectsTab = useTabState('D2');
 

--- a/self/ui/src/components/mao/mao-project-controls.tsx
+++ b/self/ui/src/components/mao/mao-project-controls.tsx
@@ -57,39 +57,57 @@ export function MaoProjectControls({
     },
   ];
 
+  const cellBase: React.CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-md)',
+    paddingBlock: 'var(--nous-space-sm)',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 'var(--nous-font-size-xs)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: 'var(--nous-fg-muted)',
+  };
+
+  const evidenceBtnStyle: React.CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-sm)',
+    paddingBlock: 'var(--nous-space-2xs)',
+    fontSize: 'var(--nous-font-size-xs)',
+  };
+
   return (
     <Card>
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center justify-between gap-3 text-base">
+      <CardHeader style={{ borderBottom: '1px solid var(--nous-border-subtle)' }}>
+        <CardTitle style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-md)', fontSize: 'var(--nous-font-size-base)' }}>
           <span>Project controls</span>
-          <div className="flex flex-wrap gap-2">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
             <Badge variant="outline">{control.project_control_state}</Badge>
             <Badge variant="outline">{control.pfc_project_recommendation}</Badge>
           </div>
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4 text-sm">
-        <div className="grid gap-3 md:grid-cols-2">
-          <div className="rounded-md border border-border px-3 py-2">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Resume readiness
-            </div>
-            <div className="mt-1">{control.resume_readiness_status}</div>
+      <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-lg)', paddingTop: 'var(--nous-space-lg)', fontSize: 'var(--nous-font-size-sm)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' }}>
+          <div style={cellBase}>
+            <div style={labelStyle}>Resume readiness</div>
+            <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{control.resume_readiness_status}</div>
             {control.resume_readiness_reason_code ? (
-              <div className="mt-1 text-xs text-muted-foreground">
+              <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                 {control.resume_readiness_reason_code}
               </div>
             ) : null}
           </div>
-          <div className="rounded-md border border-border px-3 py-2">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Last action
-            </div>
-            <div className="mt-1">
+          <div style={cellBase}>
+            <div style={labelStyle}>Last action</div>
+            <div style={{ marginTop: 'var(--nous-space-2xs)' }}>
               {control.project_last_control_action ?? 'n/a'}
             </div>
             {control.project_last_control_reason ? (
-              <div className="mt-1 text-xs text-muted-foreground">
+              <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                 {control.project_last_control_reason}
               </div>
             ) : null}
@@ -97,11 +115,9 @@ export function MaoProjectControls({
         </div>
 
         {/* B2-a: Cortex review status surface */}
-        <div className="rounded-md border border-border px-3 py-2" data-testid="cortex-review-section">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">
-            Cortex review
-          </div>
-          <div className="mt-1">
+        <div style={cellBase} data-testid="cortex-review-section">
+          <div style={labelStyle}>Cortex review</div>
+          <div style={{ marginTop: 'var(--nous-space-2xs)' }}>
             {control.pfc_project_review_status === 'none'
               ? 'No active Cortex review'
               : control.pfc_project_review_status}
@@ -111,16 +127,14 @@ export function MaoProjectControls({
         {/* B2-b: Evidence links from resume_readiness_evidence_refs */}
         {control.resume_readiness_evidence_refs &&
         control.resume_readiness_evidence_refs.length > 0 ? (
-          <div className="space-y-1" data-testid="resume-readiness-evidence">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Resume readiness evidence
-            </div>
-            <div className="flex flex-wrap gap-1">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-2xs)' }} data-testid="resume-readiness-evidence">
+            <div style={labelStyle}>Resume readiness evidence</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-2xs)' }}>
               {control.resume_readiness_evidence_refs.map((ref) => (
                 <button
                   key={ref}
                   type="button"
-                  className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted/20"
+                  style={evidenceBtnStyle}
                   data-evidence-ref={ref}
                   onClick={() => {
                     /* V1: in-app evidence link placeholder */
@@ -133,11 +147,9 @@ export function MaoProjectControls({
           </div>
         ) : null}
 
-        <div className="rounded-md border border-border p-3">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">
-            Impact summary
-          </div>
-          <div className="mt-2 grid gap-2 md:grid-cols-2">
+        <div style={{ ...cellBase, padding: 'var(--nous-space-xl)' }}>
+          <div style={labelStyle}>Impact summary</div>
+          <div style={{ marginTop: 'var(--nous-space-sm)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
             <div>active runs: {activeRunCount}</div>
             <div>active agents: {snapshot.summary.activeAgentCount}</div>
             <div>blocked agents: {snapshot.summary.blockedAgentCount}</div>
@@ -145,8 +157,8 @@ export function MaoProjectControls({
           </div>
         </div>
 
-        <div className="space-y-2">
-          <label className="text-sm font-medium" htmlFor="mao-control-reason">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
+          <label style={{ fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }} htmlFor="mao-control-reason">
             Control reason
           </label>
           <textarea
@@ -154,11 +166,19 @@ export function MaoProjectControls({
             value={reason}
             onChange={(event) => setReason(event.target.value)}
             placeholder="Capture the operator reason for this project-scope control."
-            className="min-h-24 w-full rounded-md border border-border bg-background px-3 py-2"
+            style={{
+              minHeight: '6rem',
+              width: '100%',
+              borderRadius: 'var(--nous-radius-sm)',
+              border: '1px solid var(--nous-border-subtle)',
+              backgroundColor: 'var(--nous-bg)',
+              paddingInline: 'var(--nous-space-md)',
+              paddingBlock: 'var(--nous-space-sm)',
+            }}
           />
         </div>
 
-        <div className="flex flex-wrap gap-2">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
           {controlButtons.map((button) => (
             <Button
               key={button.action}
@@ -177,23 +197,23 @@ export function MaoProjectControls({
         </div>
 
         {lastResult ? (
-          <div className="rounded-md border border-border px-3 py-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="font-medium">Last result</span>
+          <div style={cellBase}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 'var(--nous-space-sm)' }}>
+              <span style={{ fontWeight: 500 }}>Last result</span>
               <Badge variant="outline">{lastResult.status}</Badge>
               <Badge variant="outline">{lastResult.to_state}</Badge>
             </div>
-            <div className="mt-1 text-xs text-muted-foreground">
+            <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
               {lastResult.reason_code} • {lastResult.decision_ref}
             </div>
             {/* B2-b: Evidence links from lastResult.evidenceRefs */}
             {lastResult.evidenceRefs && lastResult.evidenceRefs.length > 0 ? (
-              <div className="mt-2 flex flex-wrap gap-1" data-testid="last-result-evidence">
+              <div style={{ marginTop: 'var(--nous-space-sm)', display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-2xs)' }} data-testid="last-result-evidence">
                 {lastResult.evidenceRefs.map((ref) => (
                   <button
                     key={ref}
                     type="button"
-                    className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted/20"
+                    style={evidenceBtnStyle}
                     data-evidence-ref={ref}
                     onClick={() => {
                       /* V1: in-app evidence link placeholder */

--- a/self/ui/src/components/mao/mao-run-graph.tsx
+++ b/self/ui/src/components/mao/mao-run-graph.tsx
@@ -22,22 +22,35 @@ export function MaoRunGraph({
   selectedNodeId,
   onSelectNode,
 }: MaoRunGraphProps) {
+  const sectionStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--nous-space-sm)',
+  };
+
+  const cellBase: React.CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-md)',
+    paddingBlock: 'var(--nous-space-sm)',
+  };
+
   return (
     <Card>
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center justify-between gap-3 text-base">
+      <CardHeader style={{ borderBottom: '1px solid var(--nous-border-subtle)' }}>
+        <CardTitle style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-md)', fontSize: 'var(--nous-font-size-base)' }}>
           <span>Run graph</span>
-          <div className="flex flex-wrap gap-2">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
             <Badge variant="outline">{graph.nodes.length} nodes</Badge>
             <Badge variant="outline">{graph.edges.length} edges</Badge>
           </div>
         </CardTitle>
       </CardHeader>
-      <CardContent className="grid gap-4 pt-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <div className="space-y-2">
-          <div className="text-sm font-medium">Nodes</div>
+      <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-lg)', paddingTop: 'var(--nous-space-lg)' }}>
+        <div style={sectionStyle}>
+          <div style={{ fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }}>Nodes</div>
           {!graph.nodes.length ? (
-            <p className="text-sm text-muted-foreground">
+            <p style={{ fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
               No graph nodes are available for the selected run.
             </p>
           ) : (
@@ -47,15 +60,14 @@ export function MaoRunGraph({
                 (selectedNodeId === node.workflowNodeDefinitionId ||
                   selectedNodeId === node.id);
 
-              // State-based color coding for nodes
-              const stateClasses = node.state
+              const stateVisuals = node.state
                 ? getStateVisuals(node.state)
                 : null;
-              const nodeClasses = active
-                ? 'border-primary bg-primary/10'
-                : stateClasses
-                  ? `${stateClasses.tone} hover:bg-muted/20`
-                  : 'border-border hover:bg-muted/20';
+              const nodeStyle: React.CSSProperties = active
+                ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                : stateVisuals
+                  ? { ...stateVisuals.toneStyle }
+                  : { borderColor: 'var(--nous-border-subtle)' };
 
               return (
                 <button
@@ -69,16 +81,24 @@ export function MaoRunGraph({
                       agentId: node.agentId,
                     })
                   }
-                  className={`w-full rounded-md border px-3 py-2 text-left ${nodeClasses}`}
+                  style={{
+                    width: '100%',
+                    borderRadius: 'var(--nous-radius-sm)',
+                    border: '1px solid',
+                    paddingInline: 'var(--nous-space-md)',
+                    paddingBlock: 'var(--nous-space-sm)',
+                    textAlign: 'left',
+                    ...nodeStyle,
+                  }}
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium">{node.label}</span>
-                    <div className="flex flex-wrap gap-2">
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+                    <span style={{ fontWeight: 500 }}>{node.label}</span>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
                       <Badge variant="outline">{node.kind}</Badge>
                       {node.state ? <Badge variant="outline">{node.state}</Badge> : null}
                     </div>
                   </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
+                  <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                     node {formatShortId(node.workflowNodeDefinitionId ?? node.id)} •
                     evidence {node.evidenceRefs[0] ?? 'n/a'}
                   </div>
@@ -88,10 +108,10 @@ export function MaoRunGraph({
           )}
         </div>
 
-        <div className="space-y-2">
-          <div className="text-sm font-medium">Edges</div>
+        <div style={sectionStyle}>
+          <div style={{ fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }}>Edges</div>
           {!graph.edges.length ? (
-            <p className="text-sm text-muted-foreground">
+            <p style={{ fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
               No dispatch or corrective arcs are available.
             </p>
           ) : (
@@ -102,25 +122,30 @@ export function MaoRunGraph({
                 <div
                   key={edge.id}
                   data-testid={isCorrective ? 'corrective-arc' : undefined}
-                  className={`rounded-md border px-3 py-2 text-sm ${
-                    isCorrective
-                      ? 'border-amber-500/60 bg-amber-500/5 border-l-2 border-l-amber-500'
-                      : 'border-border'
-                  }`}
+                  style={{
+                    borderRadius: 'var(--nous-radius-sm)',
+                    border: '1px solid',
+                    paddingInline: 'var(--nous-space-md)',
+                    paddingBlock: 'var(--nous-space-sm)',
+                    fontSize: 'var(--nous-font-size-sm)',
+                    ...(isCorrective
+                      ? { borderColor: 'rgba(245,158,11,0.6)', backgroundColor: 'rgba(245,158,11,0.05)', borderLeftWidth: '2px', borderLeftColor: '#f59e0b' }
+                      : { borderColor: 'var(--nous-border-subtle)' }),
+                  }}
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium">
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+                    <span style={{ fontWeight: 500 }}>
                       {formatShortId(edge.fromNodeId)} {'->'}{' '}
                       {formatShortId(edge.toNodeId)}
                     </span>
                     <Badge
                       variant="outline"
-                      className={isCorrective ? 'border-amber-500 text-amber-500' : ''}
+                      style={isCorrective ? { borderColor: '#f59e0b', color: '#f59e0b' } : {}}
                     >
                       {edge.kind}
                     </Badge>
                   </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
+                  <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                     {edge.reasonCode} • {edge.evidenceRefs[0]}
                   </div>
                 </div>

--- a/self/ui/src/components/mao/mao-services-context.tsx
+++ b/self/ui/src/components/mao/mao-services-context.tsx
@@ -12,6 +12,7 @@ export interface MaoServicesContextValue {
   Link: React.ComponentType<{
     href: string;
     className?: string;
+    style?: React.CSSProperties;
     children: React.ReactNode;
   }>;
   useProject: () => { projectId: string | null; setProjectId: (id: string | null) => void };

--- a/self/ui/src/components/mao/mao-state-utils.ts
+++ b/self/ui/src/components/mao/mao-state-utils.ts
@@ -1,13 +1,21 @@
+import type { CSSProperties } from 'react';
 import type { MaoAgentLifecycleState } from '@nous/shared';
 
+/**
+ * Visual properties for a given MAO agent lifecycle state.
+ * All colour values reference CSS custom properties from tokens.css.
+ */
 export interface StateColorResult {
-  /** Tailwind bg class for dot/square */
-  dot: string;
-  /** Tailwind border + bg classes for tile tone */
-  tone: string;
-  /** CSS utility class for motion pulse (empty string = no pulse) */
+  /** Inline style for state dot/square: { backgroundColor: 'var(--nous-state-*)' } */
+  dotStyle: CSSProperties;
+  /**
+   * Inline style for tile tone surface:
+   * { borderColor: 'var(--nous-state-*-tone-border)', backgroundColor: 'var(--nous-state-*-tone-bg)' }
+   */
+  toneStyle: CSSProperties;
+  /** CSS utility class for motion pulse animation. Empty string means no pulse. */
   pulse: string;
-  /** true for completed, canceled, hard_stopped */
+  /** True for terminal states: completed, canceled, hard_stopped. */
   isTerminal: boolean;
 }
 
@@ -21,52 +29,73 @@ export function getStateVisuals(state: MaoAgentLifecycleState): StateColorResult
     case 'running':
     case 'resuming':
       return {
-        dot: 'bg-emerald-500',
-        tone: 'border-emerald-500/40 bg-emerald-500/10',
+        dotStyle: { backgroundColor: 'var(--nous-state-active)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-active-tone-border)',
+          backgroundColor: 'var(--nous-state-active-tone-bg)',
+        },
         pulse: 'nous-state-pulse-subtle',
         isTerminal: false,
       };
     case 'blocked':
     case 'waiting_pfc':
       return {
-        dot: 'bg-amber-500',
-        tone: 'border-amber-500/40 bg-amber-500/10',
+        dotStyle: { backgroundColor: 'var(--nous-state-waiting)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-waiting-tone-border)',
+          backgroundColor: 'var(--nous-state-waiting-tone-bg)',
+        },
         pulse: 'nous-state-pulse-strong',
         isTerminal: false,
       };
     case 'failed':
       return {
-        dot: 'bg-red-500',
-        tone: 'border-red-500/40 bg-red-500/10',
+        dotStyle: { backgroundColor: 'var(--nous-state-blocked)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-blocked-tone-border)',
+          backgroundColor: 'var(--nous-state-blocked-tone-bg)',
+        },
         pulse: 'nous-state-pulse-strong',
         isTerminal: false,
       };
     case 'completed':
       return {
-        dot: 'bg-slate-400',
-        tone: 'border-slate-500/40 bg-slate-500/10',
+        dotStyle: { backgroundColor: 'var(--nous-state-complete)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-complete-tone-border)',
+          backgroundColor: 'var(--nous-state-complete-tone-bg)',
+        },
         pulse: '',
         isTerminal: true,
       };
     case 'canceled':
       return {
-        dot: 'bg-slate-500',
-        tone: 'border-slate-500/40 bg-slate-500/10',
+        dotStyle: { backgroundColor: 'var(--nous-state-idle)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-idle-tone-border)',
+          backgroundColor: 'var(--nous-state-idle-tone-bg)',
+        },
         pulse: '',
         isTerminal: true,
       };
     case 'hard_stopped':
       return {
-        dot: 'bg-red-700',
-        tone: 'border-red-700/40 bg-red-700/10',
+        dotStyle: { backgroundColor: 'var(--nous-state-blocked)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-blocked-tone-border)',
+          backgroundColor: 'var(--nous-state-blocked-tone-bg)',
+        },
         pulse: '',
         isTerminal: true,
       };
     default:
       // paused, queued, ready, waiting_async
       return {
-        dot: 'bg-slate-400',
-        tone: 'border-border bg-background',
+        dotStyle: { backgroundColor: 'var(--nous-state-idle)' },
+        toneStyle: {
+          borderColor: 'var(--nous-state-idle-tone-border)',
+          backgroundColor: 'var(--nous-state-idle-tone-bg)',
+        },
         pulse: '',
         isTerminal: false,
       };

--- a/self/ui/src/components/mao/mao-system-health-strip.tsx
+++ b/self/ui/src/components/mao/mao-system-health-strip.tsx
@@ -31,61 +31,62 @@ export function MaoSystemHealthStrip({ snapshot }: MaoSystemHealthStripProps) {
   ).length;
   const projectCount = Object.keys(snapshot.projectControls).length;
 
+  const cellBase: React.CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-md)',
+    paddingBlock: 'var(--nous-space-sm)',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 'var(--nous-font-size-xs)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: 'var(--nous-fg-muted)',
+  };
+
+  const valueStyle: React.CSSProperties = {
+    marginTop: 'var(--nous-space-2xs)',
+    fontSize: 'var(--nous-font-size-lg)',
+    fontWeight: 600,
+  };
+
   return (
     <div
-      className="flex flex-wrap gap-3"
+      style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-md)' }}
       data-testid="system-health-strip"
     >
-      <div className="rounded-md border border-border px-3 py-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">
-          Total agents
-        </div>
-        <div className="mt-1 text-lg font-semibold" data-testid="total-agents">
-          {totalAgents}
-        </div>
+      <div style={cellBase}>
+        <div style={labelStyle}>Total agents</div>
+        <div style={valueStyle} data-testid="total-agents">{totalAgents}</div>
       </div>
 
-      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">
-          Active
-        </div>
-        <div className="mt-1 text-lg font-semibold" data-testid="active-agents">
-          {activeCount}
-        </div>
+      <div style={{ ...cellBase, borderColor: 'rgba(16,185,129,0.4)', backgroundColor: 'rgba(16,185,129,0.1)' }}>
+        <div style={labelStyle}>Active</div>
+        <div style={valueStyle} data-testid="active-agents">{activeCount}</div>
       </div>
 
-      <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">
-          Blocked
-        </div>
-        <div className="mt-1 text-lg font-semibold" data-testid="blocked-agents">
-          {blockedCount}
-        </div>
+      <div style={{ ...cellBase, borderColor: 'rgba(245,158,11,0.4)', backgroundColor: 'rgba(245,158,11,0.1)' }}>
+        <div style={labelStyle}>Blocked</div>
+        <div style={valueStyle} data-testid="blocked-agents">{blockedCount}</div>
       </div>
 
-      <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">
-          Failed
-        </div>
-        <div className="mt-1 text-lg font-semibold" data-testid="failed-agents">
-          {failedCount}
-        </div>
+      <div style={{ ...cellBase, borderColor: 'rgba(239,68,68,0.4)', backgroundColor: 'rgba(239,68,68,0.1)' }}>
+        <div style={labelStyle}>Failed</div>
+        <div style={valueStyle} data-testid="failed-agents">{failedCount}</div>
       </div>
 
-      <div className="rounded-md border border-border px-3 py-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">
-          Projects
-        </div>
-        <div className="mt-1 text-lg font-semibold" data-testid="project-count">
-          {projectCount}
-        </div>
+      <div style={cellBase}>
+        <div style={labelStyle}>Projects</div>
+        <div style={valueStyle} data-testid="project-count">{projectCount}</div>
       </div>
 
-      <div className="rounded-md border border-border px-3 py-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">
-          Snapshot
-        </div>
-        <div className="mt-1 text-sm text-muted-foreground" data-testid="snapshot-freshness">
+      <div style={cellBase}>
+        <div style={labelStyle}>Snapshot</div>
+        <div
+          style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}
+          data-testid="snapshot-freshness"
+        >
           {formatFreshness(snapshot.generatedAt)}
         </div>
       </div>

--- a/self/ui/src/components/mao/mao-t3-confirmation-dialog.tsx
+++ b/self/ui/src/components/mao/mao-t3-confirmation-dialog.tsx
@@ -121,93 +121,106 @@ export function MaoT3ConfirmationDialog({
     }
   };
 
+  const overlayBase: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 300,
+    animation: 'var(--nous-modal-enter)',
+  };
+
+  const backdropStyle: React.CSSProperties = {
+    position: 'absolute',
+    inset: 0,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  };
+
+  const panelStyle: React.CSSProperties = {
+    position: 'relative',
+    marginInline: 'var(--nous-space-2xl)',
+    width: '100%',
+    maxWidth: '28rem',
+    borderRadius: 'var(--nous-radius-md)',
+    border: '1px solid var(--nous-border-subtle)',
+    backgroundColor: 'var(--nous-bg)',
+    padding: 'var(--nous-space-3xl)',
+    boxShadow: 'var(--nous-shadow-lg)',
+  };
+
+  const cellBase: React.CSSProperties = {
+    borderRadius: 'var(--nous-radius-sm)',
+    border: '1px solid var(--nous-border-subtle)',
+    paddingInline: 'var(--nous-space-md)',
+    paddingBlock: 'var(--nous-space-sm)',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 'var(--nous-font-size-xs)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: 'var(--nous-fg-muted)',
+  };
+
   // Proof display view — shown after confirmation proof is obtained
   if (confirmedProof) {
     return (
-      <div
-        className="fixed inset-0 flex items-center justify-center"
-        style={{
-          zIndex: 300,
-          animation: 'var(--nous-modal-enter)',
-        }}
-        data-testid="t3-confirmation-dialog"
-      >
-        <div
-          className="absolute inset-0 bg-black/50"
-          onClick={onCancel}
-          aria-hidden="true"
-        />
-        <div className="relative mx-4 w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg">
-          <h2 className="text-lg font-semibold">
+      <div style={overlayBase} data-testid="t3-confirmation-dialog">
+        <div style={backdropStyle} onClick={onCancel} aria-hidden="true" />
+        <div style={panelStyle}>
+          <h2 style={{ fontSize: 'var(--nous-font-size-lg)', fontWeight: 600 }}>
             Proof confirmed
           </h2>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p style={{ marginTop: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
             Confirmation proof obtained. Review details below, then click Done to
             execute the control action.
           </p>
 
-          <div className="mt-4 space-y-2" data-testid="proof-details">
-            <div className="rounded-md border border-border px-3 py-2">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                Proof ID
-              </div>
-              <div className="mt-1 font-mono text-xs" data-testid="proof-id">
+          <div style={{ marginTop: 'var(--nous-space-2xl)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }} data-testid="proof-details">
+            <div style={cellBase}>
+              <div style={labelStyle}>Proof ID</div>
+              <div style={{ marginTop: 'var(--nous-space-2xs)', fontFamily: 'var(--nous-font-family-mono)', fontSize: 'var(--nous-font-size-xs)' }} data-testid="proof-id">
                 {confirmedProof.proof_id}
               </div>
             </div>
-            <div className="grid gap-2 md:grid-cols-2">
-              <div className="rounded-md border border-border px-3 py-2">
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                  Issued at
-                </div>
-                <div className="mt-1 text-xs">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
+              <div style={cellBase}>
+                <div style={labelStyle}>Issued at</div>
+                <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)' }}>
                   {new Date(confirmedProof.issued_at).toLocaleString()}
                 </div>
               </div>
-              <div className="rounded-md border border-border px-3 py-2">
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                  Expires at
-                </div>
-                <div className="mt-1 text-xs">
+              <div style={cellBase}>
+                <div style={labelStyle}>Expires at</div>
+                <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)' }}>
                   {new Date(confirmedProof.expires_at).toLocaleString()}
                 </div>
               </div>
             </div>
-            <div className="grid gap-2 md:grid-cols-2">
-              <div className="rounded-md border border-border px-3 py-2">
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                  Tier
-                </div>
-                <div className="mt-1">{confirmedProof.tier}</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
+              <div style={cellBase}>
+                <div style={labelStyle}>Tier</div>
+                <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{confirmedProof.tier}</div>
               </div>
-              <div className="rounded-md border border-border px-3 py-2">
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                  Action
-                </div>
-                <div className="mt-1">{confirmedProof.action}</div>
+              <div style={cellBase}>
+                <div style={labelStyle}>Action</div>
+                <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{confirmedProof.action}</div>
               </div>
             </div>
-            <div className="rounded-md border border-border px-3 py-2">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                Scope hash
-              </div>
-              <div className="mt-1 truncate font-mono text-xs">
+            <div style={cellBase}>
+              <div style={labelStyle}>Scope hash</div>
+              <div style={{ marginTop: 'var(--nous-space-2xs)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: 'var(--nous-font-family-mono)', fontSize: 'var(--nous-font-size-xs)' }}>
                 {confirmedProof.scope_hash}
               </div>
             </div>
           </div>
 
-          <div className="mt-6 flex justify-end gap-3">
-            <Button
-              variant="outline"
-              onClick={onCancel}
-            >
+          <div style={{ marginTop: 'var(--nous-space-3xl)', display: 'flex', justifyContent: 'flex-end', gap: 'var(--nous-space-md)' }}>
+            <Button variant="outline" onClick={onCancel}>
               Cancel
             </Button>
-            <Button
-              onClick={handleDone}
-              data-testid="proof-done-button"
-            >
+            <Button onClick={handleDone} data-testid="proof-done-button">
               Done
             </Button>
           </div>
@@ -217,53 +230,36 @@ export function MaoT3ConfirmationDialog({
   }
 
   return (
-    <div
-      className="fixed inset-0 flex items-center justify-center"
-      style={{
-        zIndex: 300,
-        animation: 'var(--nous-modal-enter)',
-      }}
-      data-testid="t3-confirmation-dialog"
-    >
-      <div
-        className="absolute inset-0 bg-black/50"
-        onClick={onCancel}
-        aria-hidden="true"
-      />
-      <div className="relative mx-4 w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg">
-        <h2 className="text-lg font-semibold">
+    <div style={overlayBase} data-testid="t3-confirmation-dialog">
+      <div style={backdropStyle} onClick={onCancel} aria-hidden="true" />
+      <div style={panelStyle}>
+        <h2 style={{ fontSize: 'var(--nous-font-size-lg)', fontWeight: 600 }}>
           Confirm T3 action
         </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p style={{ marginTop: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
           This action requires explicit confirmation before it can proceed.
         </p>
 
-        <div className="mt-4 space-y-3">
-          <div className="rounded-md border border-border px-3 py-2">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Action
-            </div>
-            <div className="mt-1 font-medium">{actionLabel}</div>
+        <div style={{ marginTop: 'var(--nous-space-2xl)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' }}>
+          <div style={cellBase}>
+            <div style={labelStyle}>Action</div>
+            <div style={{ marginTop: 'var(--nous-space-2xs)', fontWeight: 500 }}>{actionLabel}</div>
           </div>
 
           {projectName ? (
-            <div className="rounded-md border border-border px-3 py-2">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                Project
-              </div>
-              <div className="mt-1">{projectName}</div>
+            <div style={cellBase}>
+              <div style={labelStyle}>Project</div>
+              <div style={{ marginTop: 'var(--nous-space-2xs)' }}>{projectName}</div>
             </div>
           ) : null}
 
-          <div className="rounded-md border border-border px-3 py-2">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Impact
-            </div>
-            <div className="mt-1 text-sm">
+          <div style={cellBase}>
+            <div style={labelStyle}>Impact</div>
+            <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-sm)' }}>
               {IMPACT_LABELS[action]}
             </div>
             {impactSummary ? (
-              <div className="mt-2 grid grid-cols-2 gap-1 text-xs text-muted-foreground">
+              <div style={{ marginTop: 'var(--nous-space-sm)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                 <span>active runs: {impactSummary.activeRunCount}</span>
                 <span>active agents: {impactSummary.activeAgentCount}</span>
                 <span>blocked agents: {impactSummary.blockedAgentCount}</span>
@@ -274,12 +270,12 @@ export function MaoT3ConfirmationDialog({
         </div>
 
         {proofMutation.isError ? (
-          <div className="mt-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+          <div style={{ marginTop: 'var(--nous-space-md)', borderRadius: 'var(--nous-radius-sm)', border: '1px solid rgba(239,68,68,0.4)', backgroundColor: 'rgba(239,68,68,0.1)', paddingInline: 'var(--nous-space-md)', paddingBlock: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-sm)', color: '#ef4444' }}>
             Failed to obtain confirmation proof. Please try again.
           </div>
         ) : null}
 
-        <div className="mt-6 flex justify-end gap-3">
+        <div style={{ marginTop: 'var(--nous-space-3xl)', display: 'flex', justifyContent: 'flex-end', gap: 'var(--nous-space-md)' }}>
           <Button
             variant="outline"
             onClick={onCancel}

--- a/self/ui/src/components/mao/mao-workflow-group-card.tsx
+++ b/self/ui/src/components/mao/mao-workflow-group-card.tsx
@@ -1,42 +1,45 @@
 'use client';
 
 import * as React from 'react';
+import type { CSSProperties } from 'react';
 import type { MaoAgentProjection, MaoDensityMode } from '@nous/shared';
 import { getStateVisuals } from './mao-state-utils';
 
 /** Agent class color mapping for edge connectors and tile accents */
 export interface AgentClassColor {
-  stroke: string;
-  fill: string;
+  /** SVG stroke color value */
+  strokeColor: string;
+  /** Inline style for tile fill surface */
+  fillStyle: CSSProperties;
   label: string;
 }
 
 export const AGENT_CLASS_COLORS: Record<string, AgentClassColor> = {
   'Cortex::Principal': {
-    stroke: 'stroke-blue-500',
-    fill: 'bg-blue-500/10 border-blue-500/40',
+    strokeColor: '#3b82f6',
+    fillStyle: { backgroundColor: 'rgba(59,130,246,0.1)', borderColor: 'rgba(59,130,246,0.4)' },
     label: 'Principal',
   },
   'Cortex::System': {
-    stroke: 'stroke-violet-500',
-    fill: 'bg-violet-500/10 border-violet-500/40',
+    strokeColor: '#8b5cf6',
+    fillStyle: { backgroundColor: 'rgba(139,92,246,0.1)', borderColor: 'rgba(139,92,246,0.4)' },
     label: 'System',
   },
   Orchestrator: {
-    stroke: 'stroke-amber-500',
-    fill: 'bg-amber-500/10 border-amber-500/40',
+    strokeColor: '#f59e0b',
+    fillStyle: { backgroundColor: 'rgba(245,158,11,0.1)', borderColor: 'rgba(245,158,11,0.4)' },
     label: 'Orchestrator',
   },
   Worker: {
-    stroke: 'stroke-emerald-500',
-    fill: 'bg-emerald-500/10 border-emerald-500/40',
+    strokeColor: '#10b981',
+    fillStyle: { backgroundColor: 'rgba(16,185,129,0.1)', borderColor: 'rgba(16,185,129,0.4)' },
     label: 'Worker',
   },
 };
 
 export const FALLBACK_CLASS_COLOR: AgentClassColor = {
-  stroke: 'stroke-slate-400',
-  fill: 'bg-slate-500/10 border-slate-500/40',
+  strokeColor: '#94a3b8',
+  fillStyle: { backgroundColor: 'rgba(100,116,139,0.1)', borderColor: 'rgba(100,116,139,0.4)' },
   label: 'Agent',
 };
 
@@ -54,19 +57,19 @@ function getClassColor(agent: MaoAgentProjection): AgentClassColor {
   return AGENT_CLASS_COLORS[agent.agent_class ?? ''] ?? FALLBACK_CLASS_COLOR;
 }
 
-function tileSizeClasses(densityMode: MaoDensityMode): string {
+function tileSizeStyle(densityMode: MaoDensityMode): CSSProperties {
   switch (densityMode) {
     case 'D0':
     case 'D1':
-      return 'min-w-64 p-4';
+      return { minWidth: '16rem', padding: 'var(--nous-space-2xl)' };
     case 'D2':
-      return 'min-w-48 p-3';
+      return { minWidth: '12rem', padding: 'var(--nous-space-xl)' };
     case 'D3':
-      return 'min-w-16 p-1.5';
+      return { minWidth: '4rem', padding: '6px' };
     case 'D4':
-      return 'w-6 h-6';
+      return { width: '1.5rem', height: '1.5rem' };
     default:
-      return 'min-w-48 p-3';
+      return { minWidth: '12rem', padding: 'var(--nous-space-xl)' };
   }
 }
 
@@ -79,7 +82,7 @@ function UrgentIcon() {
       viewBox="0 0 8 8"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className="text-red-500 shrink-0"
+      style={{ color: '#ef4444', flexShrink: 0 }}
       aria-hidden="true"
     >
       <circle cx="4" cy="4" r="4" fill="currentColor" />
@@ -109,7 +112,13 @@ export function MaoWorkflowGroupCard({
   if (densityMode === 'D4') {
     return (
       <div
-        className={`relative rounded border ${classColor.fill} p-1`}
+        style={{
+          position: 'relative',
+          borderRadius: 'var(--nous-radius-xs)',
+          border: '1px solid',
+          padding: 'var(--nous-space-2xs)',
+          ...classColor.fillStyle,
+        }}
         data-testid="workflow-group-card"
       >
         {/* Orchestrator tile — D4 with hover-expand to D3 */}
@@ -119,22 +128,32 @@ export function MaoWorkflowGroupCard({
           const orchUrgent = orchestrator.urgency_level === 'urgent';
 
           if (isHovered) {
-            // Hover-expand: render D3 compact markup
             return (
               <button
                 type="button"
                 data-agent-id={orchestrator.agent_id}
                 onClick={() => onSelectAgent(orchestrator)}
-                className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium transition-colors hover:bg-muted/30 ${
-                  selectedAgentId === orchestrator.agent_id ? 'ring-1 ring-primary' : ''
-                } ${orchUrgent ? 'border-2 border-red-500' : ''} ${orchVisuals.pulse}`}
+                className={orchVisuals.pulse || undefined}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 'var(--nous-space-2xs)',
+                  borderRadius: 'var(--nous-radius-xs)',
+                  paddingInline: 'var(--nous-space-2xs)',
+                  paddingBlock: '2px',
+                  fontSize: 'var(--nous-font-size-xs)',
+                  fontWeight: 500,
+                  transition: 'background-color 0.15s',
+                  ...(selectedAgentId === orchestrator.agent_id ? { boxShadow: '0 0 0 1px var(--nous-accent)' } : {}),
+                  ...(orchUrgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+                }}
                 aria-label={resolveAgentLabel(orchestrator)}
                 onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
                 onMouseLeave={() => setHoveredId(null)}
                 data-testid="hover-expand-tile"
               >
-                <span className={`inline-block w-2 h-2 rounded-full ${orchVisuals.dot}`} />
-                <span className="truncate max-w-24">
+                <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', ...orchVisuals.dotStyle }} />
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '6rem' }}>
                   {resolveAgentLabel(orchestrator)}
                 </span>
                 {orchUrgent && <UrgentIcon />}
@@ -147,9 +166,15 @@ export function MaoWorkflowGroupCard({
               type="button"
               data-agent-id={orchestrator.agent_id}
               onClick={() => onSelectAgent(orchestrator)}
-              className={`w-6 h-6 rounded ${orchVisuals.dot} ${
-                selectedAgentId === orchestrator.agent_id ? 'ring-2 ring-primary' : ''
-              } ${orchUrgent ? 'ring-2 ring-red-500' : ''} ${orchVisuals.pulse}`}
+              className={orchVisuals.pulse || undefined}
+              style={{
+                width: '1.5rem',
+                height: '1.5rem',
+                borderRadius: 'var(--nous-radius-xs)',
+                ...orchVisuals.dotStyle,
+                ...(selectedAgentId === orchestrator.agent_id ? { boxShadow: '0 0 0 2px var(--nous-accent)' } : {}),
+                ...(orchUrgent ? { boxShadow: '0 0 0 2px #ef4444' } : {}),
+              }}
               aria-label={resolveAgentLabel(orchestrator)}
               onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
               onMouseLeave={() => setHoveredId(null)}
@@ -157,30 +182,39 @@ export function MaoWorkflowGroupCard({
           );
         })()}
 
-        <div className="flex flex-wrap gap-0.5 mt-0.5">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2px', marginTop: '2px' }}>
           {workers.map((w) => {
             const isHovered = hoveredId === w.agent_id;
             const wVisuals = getStateVisuals(w.state);
             const wUrgent = w.urgency_level === 'urgent';
 
             if (isHovered) {
-              // Hover-expand: render D3 compact markup
               return (
-                <div key={w.agent_id} className="relative">
+                <div key={w.agent_id} style={{ position: 'relative' }}>
                   <button
                     type="button"
                     data-agent-id={w.agent_id}
                     onClick={() => onSelectAgent(w)}
-                    className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors hover:bg-muted/30 ${
-                      selectedAgentId === w.agent_id ? 'ring-1 ring-primary' : ''
-                    } ${wUrgent ? 'border-2 border-red-500' : ''} ${wVisuals.pulse}`}
+                    className={wVisuals.pulse || undefined}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 'var(--nous-space-2xs)',
+                      borderRadius: 'var(--nous-radius-xs)',
+                      paddingInline: 'var(--nous-space-2xs)',
+                      paddingBlock: '2px',
+                      fontSize: 'var(--nous-font-size-xs)',
+                      transition: 'background-color 0.15s',
+                      ...(selectedAgentId === w.agent_id ? { boxShadow: '0 0 0 1px var(--nous-accent)' } : {}),
+                      ...(wUrgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+                    }}
                     aria-label={resolveAgentLabel(w)}
                     onMouseEnter={() => setHoveredId(w.agent_id)}
                     onMouseLeave={() => setHoveredId(null)}
                     data-testid="hover-expand-tile"
                   >
-                    <span className={`inline-block w-2 h-2 rounded-full ${wVisuals.dot}`} />
-                    <span className="truncate max-w-24 text-[10px]">{resolveAgentLabel(w)}</span>
+                    <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', ...wVisuals.dotStyle }} />
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '6rem', fontSize: '10px' }}>{resolveAgentLabel(w)}</span>
                     {wUrgent && <UrgentIcon />}
                   </button>
                 </div>
@@ -188,14 +222,20 @@ export function MaoWorkflowGroupCard({
             }
 
             return (
-              <div key={w.agent_id} className="relative">
+              <div key={w.agent_id} style={{ position: 'relative' }}>
                 <button
                   type="button"
                   data-agent-id={w.agent_id}
                   onClick={() => onSelectAgent(w)}
-                  className={`w-6 h-6 rounded ${wVisuals.dot} ${
-                    selectedAgentId === w.agent_id ? 'ring-2 ring-primary' : ''
-                  } ${wUrgent ? 'ring-2 ring-red-500' : ''} ${wVisuals.pulse}`}
+                  className={wVisuals.pulse || undefined}
+                  style={{
+                    width: '1.5rem',
+                    height: '1.5rem',
+                    borderRadius: 'var(--nous-radius-xs)',
+                    ...wVisuals.dotStyle,
+                    ...(selectedAgentId === w.agent_id ? { boxShadow: '0 0 0 2px var(--nous-accent)' } : {}),
+                    ...(wUrgent ? { boxShadow: '0 0 0 2px #ef4444' } : {}),
+                  }}
                   aria-label={resolveAgentLabel(w)}
                   onMouseEnter={() => setHoveredId(w.agent_id)}
                   onMouseLeave={() => setHoveredId(null)}
@@ -204,7 +244,7 @@ export function MaoWorkflowGroupCard({
             );
           })}
         </div>
-        <span className="text-[10px] text-muted-foreground">
+        <span style={{ fontSize: '10px', color: 'var(--nous-fg-muted)' }}>
           {workers.length + 1}
         </span>
       </div>
@@ -214,7 +254,12 @@ export function MaoWorkflowGroupCard({
   if (densityMode === 'D3') {
     return (
       <div
-        className={`rounded border ${classColor.fill} p-1.5`}
+        style={{
+          borderRadius: 'var(--nous-radius-xs)',
+          border: '1px solid',
+          padding: '6px',
+          ...classColor.fillStyle,
+        }}
         data-testid="workflow-group-card"
       >
         {(() => {
@@ -225,15 +270,26 @@ export function MaoWorkflowGroupCard({
               type="button"
               data-agent-id={orchestrator.agent_id}
               onClick={() => onSelectAgent(orchestrator)}
-              className={`flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium transition-colors hover:bg-muted/30 ${
-                selectedAgentId === orchestrator.agent_id ? 'ring-1 ring-primary' : ''
-              } ${orchUrgent ? 'border-2 border-red-500' : ''} ${orchVisuals.pulse}`}
+              className={orchVisuals.pulse || undefined}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--nous-space-2xs)',
+                borderRadius: 'var(--nous-radius-xs)',
+                paddingInline: 'var(--nous-space-2xs)',
+                paddingBlock: '2px',
+                fontSize: 'var(--nous-font-size-xs)',
+                fontWeight: 500,
+                transition: 'background-color 0.15s',
+                ...(selectedAgentId === orchestrator.agent_id ? { boxShadow: '0 0 0 1px var(--nous-accent)' } : {}),
+                ...(orchUrgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+              }}
               aria-label={resolveAgentLabel(orchestrator)}
               onMouseEnter={() => setHoveredId(orchestrator.agent_id)}
               onMouseLeave={() => setHoveredId(null)}
             >
-              <span className={`inline-block w-2 h-2 rounded-full ${orchVisuals.dot}`} />
-              <span className="truncate max-w-24">
+              <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', ...orchVisuals.dotStyle }} />
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '6rem' }}>
                 {hoveredId === orchestrator.agent_id
                   ? resolveAgentLabel(orchestrator)
                   : resolveAgentLabel(orchestrator).slice(0, 12)}
@@ -244,7 +300,7 @@ export function MaoWorkflowGroupCard({
             </button>
           );
         })()}
-        <div className="flex flex-wrap gap-1 mt-1">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-2xs)', marginTop: 'var(--nous-space-2xs)' }}>
           {workers.map((w) => {
             const wVisuals = getStateVisuals(w.state);
             const wUrgent = w.urgency_level === 'urgent';
@@ -254,16 +310,26 @@ export function MaoWorkflowGroupCard({
                 type="button"
                 data-agent-id={w.agent_id}
                 onClick={() => onSelectAgent(w)}
-                className={`inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors hover:bg-muted/30 ${
-                  selectedAgentId === w.agent_id ? 'ring-1 ring-primary' : ''
-                } ${wUrgent ? 'border-2 border-red-500' : ''} ${wVisuals.pulse}`}
+                className={wVisuals.pulse || undefined}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 'var(--nous-space-2xs)',
+                  borderRadius: 'var(--nous-radius-xs)',
+                  paddingInline: 'var(--nous-space-2xs)',
+                  paddingBlock: '2px',
+                  fontSize: 'var(--nous-font-size-xs)',
+                  transition: 'background-color 0.15s',
+                  ...(selectedAgentId === w.agent_id ? { boxShadow: '0 0 0 1px var(--nous-accent)' } : {}),
+                  ...(wUrgent ? { borderWidth: '2px', borderStyle: 'solid', borderColor: '#ef4444' } : {}),
+                }}
                 aria-label={resolveAgentLabel(w)}
                 onMouseEnter={() => setHoveredId(w.agent_id)}
                 onMouseLeave={() => setHoveredId(null)}
               >
-                <span className={`inline-block w-2 h-2 rounded-full ${wVisuals.dot}`} />
+                <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', ...wVisuals.dotStyle }} />
                 {hoveredId === w.agent_id && (
-                  <span className="truncate max-w-24 text-[10px]">{resolveAgentLabel(w)}</span>
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '6rem', fontSize: '10px' }}>{resolveAgentLabel(w)}</span>
                 )}
                 {wUrgent && (
                   <span data-testid="urgent-indicator"><UrgentIcon /></span>
@@ -278,38 +344,52 @@ export function MaoWorkflowGroupCard({
 
   // D0, D1, D2 — full card rendering
   const isLarge = densityMode === 'D1' || densityMode === 'D0';
-  const tileSize = tileSizeClasses(densityMode);
+  const tileSize = tileSizeStyle(densityMode);
 
   return (
     <div
-      className={`rounded-lg border ${classColor.fill} ${isLarge ? 'p-4' : 'p-3'}`}
+      style={{
+        borderRadius: 'var(--nous-radius-md)',
+        border: '1px solid',
+        padding: isLarge ? 'var(--nous-space-2xl)' : 'var(--nous-space-xl)',
+        ...classColor.fillStyle,
+      }}
       data-testid="workflow-group-card"
     >
       {/* Orchestrator — header */}
       {(() => {
         const orchVisuals = getStateVisuals(orchestrator.state);
+        const isSelected = selectedAgentId === orchestrator.agent_id;
         return (
           <button
             type="button"
             data-agent-id={orchestrator.agent_id}
             onClick={() => onSelectAgent(orchestrator)}
-            className={`w-full rounded-lg border p-3 text-left transition-colors hover:bg-muted/20 ${
-              selectedAgentId === orchestrator.agent_id
-                ? 'border-primary bg-primary/10'
-                : 'border-border bg-background'
-            } ${tileSize} ${orchVisuals.pulse}`}
+            className={orchVisuals.pulse || undefined}
+            style={{
+              width: '100%',
+              borderRadius: 'var(--nous-radius-md)',
+              border: '1px solid',
+              padding: 'var(--nous-space-xl)',
+              textAlign: 'left',
+              transition: 'background-color 0.15s',
+              ...(isSelected
+                ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                : { borderColor: 'var(--nous-border-subtle)', backgroundColor: 'var(--nous-bg)' }),
+              ...tileSize,
+            }}
             aria-label={resolveAgentLabel(orchestrator)}
           >
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <div className="truncate text-sm font-medium">
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }}>
                   {resolveAgentLabel(orchestrator)}
                 </div>
-                <div className="mt-1 text-xs text-muted-foreground">
+                <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                   {orchestrator.state}
                 </div>
               </div>
-              <span className={`inline-block w-2.5 h-2.5 rounded-full mt-1 ${orchVisuals.dot}`} />
+              <span style={{ display: 'inline-block', width: '0.625rem', height: '0.625rem', borderRadius: '9999px', marginTop: 'var(--nous-space-2xs)', ...orchVisuals.dotStyle }} />
             </div>
           </button>
         );
@@ -317,32 +397,40 @@ export function MaoWorkflowGroupCard({
 
       {/* Workers — horizontal flex-wrap */}
       {workers.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-2" data-testid="workers-container">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)', marginTop: 'var(--nous-space-sm)' }} data-testid="workers-container">
           {workers.map((w) => {
             const wVisuals = getStateVisuals(w.state);
+            const isSelected = selectedAgentId === w.agent_id;
             return (
               <button
                 key={w.agent_id}
                 type="button"
                 data-agent-id={w.agent_id}
                 onClick={() => onSelectAgent(w)}
-                className={`rounded-lg border p-2 text-left transition-colors hover:bg-muted/20 ${
-                  selectedAgentId === w.agent_id
-                    ? 'border-primary bg-primary/10'
-                    : 'border-border bg-background'
-                } ${tileSize} ${wVisuals.pulse}`}
+                className={wVisuals.pulse || undefined}
+                style={{
+                  borderRadius: 'var(--nous-radius-md)',
+                  border: '1px solid',
+                  padding: 'var(--nous-space-sm)',
+                  textAlign: 'left',
+                  transition: 'background-color 0.15s',
+                  ...(isSelected
+                    ? { borderColor: 'var(--nous-accent)', backgroundColor: 'rgba(0,122,204,0.1)' }
+                    : { borderColor: 'var(--nous-border-subtle)', backgroundColor: 'var(--nous-bg)' }),
+                  ...tileSize,
+                }}
                 aria-label={resolveAgentLabel(w)}
               >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 'var(--nous-space-sm)' }}>
+                  <div style={{ minWidth: 0 }}>
+                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 'var(--nous-font-size-sm)', fontWeight: 500 }}>
                       {resolveAgentLabel(w)}
                     </div>
-                    <div className="mt-1 text-xs text-muted-foreground">
+                    <div style={{ marginTop: 'var(--nous-space-2xs)', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                       {w.state}
                     </div>
                   </div>
-                  <span className={`inline-block w-2 h-2 rounded-full mt-1 ${wVisuals.dot}`} />
+                  <span style={{ display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '9999px', marginTop: 'var(--nous-space-2xs)', ...wVisuals.dotStyle }} />
                 </div>
               </button>
             );

--- a/self/ui/src/components/shell/CollapsibleObserveEdge.tsx
+++ b/self/ui/src/components/shell/CollapsibleObserveEdge.tsx
@@ -68,6 +68,8 @@ export function CollapsibleObserveEdge({
                         top: '50%',
                         left: 0,
                         transform: 'translateY(-50%)',
+                        zIndex: 5,
+                        height: '100%',
                     } : {}),
                 }}
             >

--- a/self/ui/src/components/shell/ObservePanel.tsx
+++ b/self/ui/src/components/shell/ObservePanel.tsx
@@ -10,6 +10,16 @@ import type { ObservePanelProps, ObserveRoute } from './types'
 const OBSERVE_ROUTE_MAP: Record<string, ObserveRoute> = {
   workflows: 'mao',
   'workflow-detail': 'mao',
+  threads: 'mao',
+  skills: 'mao',
+  apps: 'mao',
+  dashboard: 'mao',
+  'org-chart': 'mao',
+  inbox: 'mao',
+  tasks: 'mao',
+  'task-detail': 'mao',
+  agents: 'mao',
+  'agent-detail': 'mao',
   'system-activity': 'system-activity',
 }
 

--- a/self/ui/src/components/shell/ObservePanel.tsx
+++ b/self/ui/src/components/shell/ObservePanel.tsx
@@ -6,27 +6,16 @@ import { MaoPanel } from '../mao'
 import { SystemActivitySurface } from './SystemActivitySurface'
 import type { ObservePanelProps, ObserveRoute } from './types'
 
-/** Map content routes to observe sub-panel routes */
-const OBSERVE_ROUTE_MAP: Record<string, ObserveRoute> = {
-  workflows: 'mao',
-  'workflow-detail': 'mao',
-  threads: 'mao',
-  skills: 'mao',
-  apps: 'mao',
-  dashboard: 'mao',
-  'org-chart': 'mao',
-  inbox: 'mao',
-  tasks: 'mao',
-  'task-detail': 'mao',
-  agents: 'mao',
-  'agent-detail': 'mao',
+/** Routes that get special observe content (non-MAO). Everything else defaults to MAO. */
+const OBSERVE_ROUTE_OVERRIDES: Record<string, ObserveRoute> = {
+  home: 'default',
   'system-activity': 'system-activity',
 }
 
 export function ObservePanel(props: ObservePanelProps) {
   const { activeRoute } = useShellContext()
 
-  const observeRoute: ObserveRoute = OBSERVE_ROUTE_MAP[activeRoute] ?? 'default'
+  const observeRoute: ObserveRoute = OBSERVE_ROUTE_OVERRIDES[activeRoute] ?? 'mao'
 
   return (
     <div

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -201,7 +201,7 @@ export function SimpleShellLayout({
 
             <div
                 data-shell-area="observe"
-                style={{ gridArea: 'observe', overflow: 'hidden' }}
+                style={{ gridArea: 'observe', overflow: 'hidden', position: 'relative', zIndex: 1 }}
             >
                 <CollapsibleObserveEdge
                     width={observeWidth}

--- a/self/ui/src/components/shell/__tests__/ObservePanel.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ObservePanel.test.tsx
@@ -202,4 +202,22 @@ describe('ObservePanel', () => {
     )
     expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
   })
+
+  it('renders MaoOperatingSurface for dynamic sidebar routeIds (e.g. campaign-1)', () => {
+    render(
+      <ShellProvider activeRoute="campaign-1">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface for unknown routes (defaults to mao)', () => {
+    render(
+      <ShellProvider activeRoute="some-unknown-route">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
 })

--- a/self/ui/src/components/shell/__tests__/ObservePanel.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ObservePanel.test.tsx
@@ -113,12 +113,93 @@ describe('ObservePanel', () => {
     expect(screen.getByText('No observe content for this view')).toBeTruthy()
   })
 
-  it('renders default placeholder when activeRoute is skills', () => {
+  it('renders MaoOperatingSurface when activeRoute is skills', () => {
     render(
       <ShellProvider activeRoute="skills">
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('No observe content for this view')).toBeTruthy()
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is tasks', () => {
+    render(
+      <ShellProvider activeRoute="tasks">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is agents', () => {
+    render(
+      <ShellProvider activeRoute="agents">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is agent-detail', () => {
+    render(
+      <ShellProvider activeRoute="agent-detail">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is task-detail', () => {
+    render(
+      <ShellProvider activeRoute="task-detail">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is threads', () => {
+    render(
+      <ShellProvider activeRoute="threads">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is apps', () => {
+    render(
+      <ShellProvider activeRoute="apps">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is dashboard', () => {
+    render(
+      <ShellProvider activeRoute="dashboard">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is org-chart', () => {
+    render(
+      <ShellProvider activeRoute="org-chart">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+  })
+
+  it('renders MaoOperatingSurface when activeRoute is inbox', () => {
+    render(
+      <ShellProvider activeRoute="inbox">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
   })
 })

--- a/self/ui/src/styles/tokens.css
+++ b/self/ui/src/styles/tokens.css
@@ -88,6 +88,18 @@
   --nous-state-approved-fill:      #0d6e5e;
   --nous-state-needs-revision-fill:#6b3d99;
 
+  /* ── Agent / node state — tone (MAO surfaces) ────────────────────────── */
+  --nous-state-active-tone-border:   color-mix(in srgb, var(--nous-state-active) 40%, transparent);
+  --nous-state-active-tone-bg:       color-mix(in srgb, var(--nous-state-active) 10%, transparent);
+  --nous-state-waiting-tone-border:  color-mix(in srgb, var(--nous-state-waiting) 40%, transparent);
+  --nous-state-waiting-tone-bg:      color-mix(in srgb, var(--nous-state-waiting) 10%, transparent);
+  --nous-state-blocked-tone-border:  color-mix(in srgb, var(--nous-state-blocked) 40%, transparent);
+  --nous-state-blocked-tone-bg:      color-mix(in srgb, var(--nous-state-blocked) 10%, transparent);
+  --nous-state-idle-tone-border:     color-mix(in srgb, var(--nous-state-idle) 40%, transparent);
+  --nous-state-idle-tone-bg:         color-mix(in srgb, var(--nous-state-idle) 10%, transparent);
+  --nous-state-complete-tone-border: color-mix(in srgb, var(--nous-state-complete) 40%, transparent);
+  --nous-state-complete-tone-bg:     color-mix(in srgb, var(--nous-state-complete) 10%, transparent);
+
   /* ── Alert colours ───────────────────────────────────────────────────── */
   --nous-alert-critical: #ff2d55;
   --nous-alert-error:    #ff453a;


### PR DESCRIPTION
## Summary
- All operational routes now show MAO observe content in the details panel (only `home` shows default)
- All 13 MAO component files migrated from Tailwind `className` to inline styles with CSS custom properties
- 10 new `--nous-state-*-tone-{border,bg}` tokens using `color-mix()`
- `mao-state-utils.ts` API returns `CSSProperties` objects instead of Tailwind strings
- Zero Tailwind utility classes remaining in `self/ui/src/components/mao/`

## Changes
- **SP 1.1** — Foundation + route wiring (tokens, state-utils migration, route map)
- **SP 1.2** — Tailwind-to-inline migration across 13 MAO files (leaf → composite → root)
- **BT fixes** — Link style prop, tab auto-switch on project load, default-to-MAO for unknown routes, observe expand reliability

## Test plan
- [x] 17 ObservePanel tests (route mapping + dynamic routeIds)
- [x] 14 mao-state-utils tests (all 12 lifecycle states + CLUSTER_STATE_ORDER)
- [x] 163 MAO component tests (inline style assertions)
- [x] CI green (build + typecheck + lint + test)
- [x] BT approved by Principal

🤖 Generated with [Claude Code](https://claude.com/claude-code)