### PR TITLE
feat(ui): workflow navigation and creation — WR-123

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -794,6 +794,7 @@ function DesktopShellWithProject({
     <ShellProvider
       mode={mode}
       activeRoute={activeRoute}
+      navigationParams={navigationParams}
       navigation={navigation}
       navigate={navigate}
       goBack={goBack}
@@ -880,7 +881,7 @@ const TASK_DETAIL_PREFIX = 'task-detail::'
 const WORKFLOW_DETAIL_PREFIX = 'workflow-detail::'
 
 function DesktopAssetSidebarConnected() {
-  const { activeProjectId, activeRoute, navigate } = useShellCtx()
+  const { activeProjectId, activeRoute, navigationParams, navigate } = useShellCtx()
   const { data: projectList } = trpc.projects.list.useQuery()
   const tasksApi = useTasks({ projectId: activeProjectId })
   const workflowsApi = useWorkflows({ projectId: activeProjectId })
@@ -892,9 +893,17 @@ function DesktopAssetSidebarConnected() {
   const [sidebarSelection, setSidebarSelection] = useState(activeRoute)
 
   // Sync when activeRoute changes externally (e.g. top-nav click, goBack)
+  // Reconstruct the full encoded routeId from params when navigating within
+  // same-route groups (e.g. goBack restoring workflow-detail with definitionId).
   useEffect(() => {
-    setSidebarSelection(activeRoute)
-  }, [activeRoute])
+    if (activeRoute.startsWith('workflow-detail') && navigationParams?.definitionId) {
+      setSidebarSelection(`${WORKFLOW_DETAIL_PREFIX}${navigationParams.definitionId}`)
+    } else if (activeRoute.startsWith('task-detail') && navigationParams?.taskId) {
+      setSidebarSelection(`${TASK_DETAIL_PREFIX}${navigationParams.taskId}`)
+    } else {
+      setSidebarSelection(activeRoute)
+    }
+  }, [activeRoute, navigationParams])
 
   // Wrap navigate to parse task-detail::<taskId> encoding from sidebar items
   // and forward as navigate('task-detail', { taskId }) with params.

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ import { buildDesktopCommands } from './desktop-command-config'
 import { DESKTOP_TOP_NAV, buildDesktopSidebarSections } from './desktop-sidebar-config'
 import { BASE_SIMPLE_MODE_ROUTES } from './desktop-routes'
 import { useTasks, buildTasksSection } from '@nous/ui/hooks/useTasks'
+import { useWorkflows, buildWorkflowsSection } from '@nous/ui/hooks/useWorkflows'
 import { SettingsRoute } from './desktop-settings-route'
 
 import 'dockview-react/dist/styles/dockview.css'
@@ -876,11 +877,13 @@ function DesktopSimpleShell({
 // ─── Desktop Project Rail (wired to tRPC) ──────────────────────────────────
 
 const TASK_DETAIL_PREFIX = 'task-detail::'
+const WORKFLOW_DETAIL_PREFIX = 'workflow-detail::'
 
 function DesktopAssetSidebarConnected() {
   const { activeProjectId, activeRoute, navigate } = useShellCtx()
   const { data: projectList } = trpc.projects.list.useQuery()
   const tasksApi = useTasks({ projectId: activeProjectId })
+  const workflowsApi = useWorkflows({ projectId: activeProjectId })
 
   // Track the raw sidebar routeId for highlight state.
   // Encoded items like "task-detail::taskId" resolve to activeRoute "task-detail"
@@ -900,6 +903,9 @@ function DesktopAssetSidebarConnected() {
     if (routeId.startsWith(TASK_DETAIL_PREFIX)) {
       const taskId = routeId.slice(TASK_DETAIL_PREFIX.length)
       navigate('task-detail', { taskId })
+    } else if (routeId.startsWith(WORKFLOW_DETAIL_PREFIX)) {
+      const definitionId = routeId.slice(WORKFLOW_DETAIL_PREFIX.length)
+      navigate('workflow-detail', { definitionId })
     } else {
       navigate(routeId)
     }
@@ -916,9 +922,20 @@ function DesktopAssetSidebarConnected() {
     [tasksApi.tasks, tasksApi.tasksLoading, tasksApi.tasksError, navigate, handleNavigate],
   )
 
+  const workflowsSection = useMemo(
+    () => buildWorkflowsSection({
+      workflows: workflowsApi.workflows,
+      loading: workflowsApi.workflowsLoading,
+      error: workflowsApi.workflowsError,
+      onAdd: () => navigate('workflow-detail'),
+      navigate: handleNavigate,
+    }),
+    [workflowsApi.workflows, workflowsApi.workflowsLoading, workflowsApi.workflowsError, navigate, handleNavigate],
+  )
+
   const sections = useMemo(
-    () => buildDesktopSidebarSections({ tasksSection }),
-    [tasksSection],
+    () => buildDesktopSidebarSections({ tasksSection, workflowsSection }),
+    [tasksSection, workflowsSection],
   )
 
   const projectName = useMemo(() => {

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -927,10 +927,16 @@ function DesktopAssetSidebarConnected() {
       workflows: workflowsApi.workflows,
       loading: workflowsApi.workflowsLoading,
       error: workflowsApi.workflowsError,
-      onAdd: () => navigate('workflow-detail'),
+      onAdd: async () => {
+        if (!activeProjectId) return
+        const newId = await workflowsApi.createWorkflow(activeProjectId)
+        if (newId) {
+          navigate('workflow-detail', { definitionId: newId })
+        }
+      },
       navigate: handleNavigate,
     }),
-    [workflowsApi.workflows, workflowsApi.workflowsLoading, workflowsApi.workflowsError, navigate, handleNavigate],
+    [workflowsApi.workflows, workflowsApi.workflowsLoading, workflowsApi.workflowsError, workflowsApi.createWorkflow, activeProjectId, navigate, handleNavigate],
   )
 
   const sections = useMemo(

--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -935,8 +935,11 @@ function DesktopAssetSidebarConnected() {
         }
       },
       navigate: handleNavigate,
+      onItemRename: (itemId, newName) => {
+        void workflowsApi.renameWorkflow(itemId, newName)
+      },
     }),
-    [workflowsApi.workflows, workflowsApi.workflowsLoading, workflowsApi.workflowsError, workflowsApi.createWorkflow, activeProjectId, navigate, handleNavigate],
+    [workflowsApi.workflows, workflowsApi.workflowsLoading, workflowsApi.workflowsError, workflowsApi.createWorkflow, workflowsApi.renameWorkflow, activeProjectId, navigate, handleNavigate],
   )
 
   const sections = useMemo(

--- a/self/apps/desktop/src/renderer/src/desktop-routes.tsx
+++ b/self/apps/desktop/src/renderer/src/desktop-routes.tsx
@@ -11,7 +11,7 @@ import {
   STUB_SKILLS,
   STUB_APPS,
 } from '@nous/ui'
-import { TaskDetailView, TaskCreateForm } from '@nous/ui/panels'
+import { TaskDetailView, TaskCreateForm, WorkflowBuilderPanel } from '@nous/ui/panels'
 
 // ─── Static route definitions ─────────────────────────────────────────────
 
@@ -24,7 +24,7 @@ export const BASE_SIMPLE_MODE_ROUTES: Record<string, React.ComponentType<Content
   dashboard: (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Dashboard" />,
   'org-chart': (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Org Chart" />,
   inbox: (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Inbox" />,
-  'workflow-detail': (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Workflow Detail" />,
+  'workflow-detail': WorkflowBuilderPanel as unknown as React.ComponentType<ContentRouterRenderProps>,
   tasks: (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Tasks" />,
   'task-detail': TaskDetailView,
   'task-create': TaskCreateForm,

--- a/self/apps/desktop/src/renderer/src/desktop-sidebar-config.tsx
+++ b/self/apps/desktop/src/renderer/src/desktop-sidebar-config.tsx
@@ -25,9 +25,10 @@ export const DESKTOP_TOP_NAV: SidebarTopNavItem[] = [
  */
 export function buildDesktopSidebarSections(params?: {
   tasksSection?: AssetSection
+  workflowsSection?: AssetSection
 }): AssetSection[] {
   return [
-    {
+    params?.workflowsSection ?? {
       id: 'workflows',
       label: 'WORKFLOWS',
       items: STUB_CAMPAIGNS,

--- a/self/apps/shared-server/src/trpc/routers/projects.ts
+++ b/self/apps/shared-server/src/trpc/routers/projects.ts
@@ -1510,4 +1510,41 @@ export const projectsRouter = router({
 
       return { deleted };
     }),
+
+  /** Rename a workflow definition by ID. */
+  renameWorkflowDefinition: publicProcedure
+    .input(
+      z.object({
+        projectId: ProjectIdSchema,
+        definitionId: z.string().min(1),
+        name: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const project = await getProjectOrThrow(ctx, input.projectId);
+      const currentDefinitions = getWorkflowDefinitions(project);
+      const target = currentDefinitions.find((d) => d.id === input.definitionId);
+
+      if (!target) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Workflow definition ${input.definitionId} not found`,
+        });
+      }
+
+      const nextDefinitions = currentDefinitions.map((d) =>
+        d.id === input.definitionId ? { ...d, name: input.name } : d,
+      );
+
+      await ctx.projectStore.update(input.projectId, {
+        workflow: {
+          definitions: nextDefinitions,
+          packageBindings: project.workflow?.packageBindings ?? [],
+          defaultWorkflowDefinitionId: project.workflow?.defaultWorkflowDefinitionId,
+          specYamlStore: project.workflow?.specYamlStore ?? {},
+        },
+      });
+
+      return { renamed: true };
+    }),
 });

--- a/self/ui/package.json
+++ b/self/ui/package.json
@@ -16,6 +16,7 @@
     "./styles/components": "./src/styles/components.css",
     "./styles/nous-dark": "./src/styles/nous-dark.css",
     "./hooks/useTasks": "./src/hooks/useTasks.ts",
+    "./hooks/useWorkflows": "./src/hooks/useWorkflows.ts",
     "./lib/cn": "./src/lib/cn.ts"
   },
   "dependencies": {

--- a/self/ui/src/components/shell/AssetSidebar.tsx
+++ b/self/ui/src/components/shell/AssetSidebar.tsx
@@ -79,27 +79,40 @@ function SidebarContextMenu({
         return () => document.removeEventListener('keydown', handler)
     }, [onClose])
 
-    const handleRename = React.useCallback(() => {
-        const result = window.prompt('Rename workflow', itemLabel)
-        if (result !== null && result.trim() !== '') {
-            onRename(itemId, result.trim())
+    const [isRenaming, setIsRenaming] = React.useState(false)
+    const [renameValue, setRenameValue] = React.useState(itemLabel)
+    const renameInputRef = React.useRef<HTMLInputElement>(null)
+
+    React.useEffect(() => {
+        if (isRenaming) {
+            requestAnimationFrame(() => {
+                renameInputRef.current?.focus()
+                renameInputRef.current?.select()
+            })
+        }
+    }, [isRenaming])
+
+    const commitRename = React.useCallback(() => {
+        const trimmed = renameValue.trim()
+        if (trimmed !== '' && trimmed !== itemLabel) {
+            onRename(itemId, trimmed)
         }
         onClose()
-    }, [itemId, itemLabel, onRename, onClose])
+    }, [renameValue, itemLabel, itemId, onRename, onClose])
 
     return createPortal(
         <div
             ref={menuRef}
             style={{
                 position: 'fixed',
-                zIndex: 50,
+                zIndex: 99999,
                 left: clampedPosition.x,
                 top: clampedPosition.y,
                 background: 'var(--nous-bg-elevated)',
                 border: '1px solid var(--nous-border)',
                 borderRadius: 'var(--nous-radius-sm)',
                 padding: '4px 0',
-                minWidth: 140,
+                minWidth: 180,
                 boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
                 fontSize: 'var(--nous-font-size-xs)',
                 color: 'var(--nous-fg)',
@@ -108,27 +121,55 @@ function SidebarContextMenu({
             role="menu"
             aria-label="Sidebar item context menu"
         >
-            <button
-                type="button"
-                style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    padding: '6px 12px',
-                    cursor: 'pointer',
-                    background: 'transparent',
-                    border: 'none',
-                    color: 'inherit',
-                    fontSize: 'inherit',
-                    width: '100%',
-                    textAlign: 'left',
-                }}
-                onClick={handleRename}
-                role="menuitem"
-                data-testid="context-menu-rename"
-            >
-                Rename
-            </button>
+            {isRenaming ? (
+                <div style={{ padding: '4px 8px' }}>
+                    <input
+                        ref={renameInputRef}
+                        type="text"
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onKeyDown={(e) => {
+                            e.stopPropagation()
+                            if (e.key === 'Enter') { e.preventDefault(); commitRename() }
+                            if (e.key === 'Escape') { e.preventDefault(); onClose() }
+                        }}
+                        onBlur={commitRename}
+                        style={{
+                            width: '100%',
+                            background: 'var(--nous-bg)',
+                            border: '1px solid var(--nous-border)',
+                            borderRadius: 'var(--nous-radius-sm)',
+                            padding: '4px 8px',
+                            color: 'var(--nous-fg)',
+                            fontSize: 'inherit',
+                            outline: 'none',
+                        }}
+                        data-testid="context-menu-rename-input"
+                    />
+                </div>
+            ) : (
+                <button
+                    type="button"
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        padding: '6px 12px',
+                        cursor: 'pointer',
+                        background: 'transparent',
+                        border: 'none',
+                        color: 'inherit',
+                        fontSize: 'inherit',
+                        width: '100%',
+                        textAlign: 'left',
+                    }}
+                    onClick={() => setIsRenaming(true)}
+                    role="menuitem"
+                    data-testid="context-menu-rename"
+                >
+                    Rename
+                </button>
+            )}
         </div>,
         document.body,
     )

--- a/self/ui/src/components/shell/AssetSidebar.tsx
+++ b/self/ui/src/components/shell/AssetSidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
+import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
-import { ChevronDown, Settings, Plus, PanelLeftClose } from 'lucide-react'
+import { ChevronDown, Settings, Plus, PanelLeftClose, MoreHorizontal } from 'lucide-react'
 import type {
     AssetSection,
     AssetSidebarProps,
@@ -27,6 +28,113 @@ function writeCollapseState(sectionId: string, collapsed: boolean): void {
 }
 
 // ---------------------------------------------------------------------------
+// SidebarContextMenu — portal-based context menu (follows NodeContextMenu pattern)
+// ---------------------------------------------------------------------------
+
+function SidebarContextMenu({
+    position,
+    itemId,
+    itemLabel,
+    onRename,
+    onClose,
+}: {
+    position: { x: number; y: number }
+    itemId: string
+    itemLabel: string
+    onRename: (itemId: string, newName: string) => void
+    onClose: () => void
+}) {
+    const menuRef = React.useRef<HTMLDivElement>(null)
+    const [clampedPosition, setClampedPosition] = React.useState(position)
+
+    // Clamp position to viewport bounds after render
+    React.useEffect(() => {
+        if (!menuRef.current) return
+        const rect = menuRef.current.getBoundingClientRect()
+        setClampedPosition({
+            x: Math.min(position.x, window.innerWidth - rect.width - 8),
+            y: Math.min(position.y, window.innerHeight - rect.height - 8),
+        })
+    }, [position])
+
+    // Click outside dismissal
+    React.useEffect(() => {
+        const handler = (e: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+                onClose()
+            }
+        }
+        document.addEventListener('mousedown', handler)
+        return () => document.removeEventListener('mousedown', handler)
+    }, [onClose])
+
+    // Escape key dismissal
+    React.useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose()
+            }
+        }
+        document.addEventListener('keydown', handler)
+        return () => document.removeEventListener('keydown', handler)
+    }, [onClose])
+
+    const handleRename = React.useCallback(() => {
+        const result = window.prompt('Rename workflow', itemLabel)
+        if (result !== null && result.trim() !== '') {
+            onRename(itemId, result.trim())
+        }
+        onClose()
+    }, [itemId, itemLabel, onRename, onClose])
+
+    return createPortal(
+        <div
+            ref={menuRef}
+            style={{
+                position: 'fixed',
+                zIndex: 50,
+                left: clampedPosition.x,
+                top: clampedPosition.y,
+                background: 'var(--nous-bg-elevated)',
+                border: '1px solid var(--nous-border)',
+                borderRadius: 'var(--nous-radius-sm)',
+                padding: '4px 0',
+                minWidth: 140,
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+                fontSize: 'var(--nous-font-size-xs)',
+                color: 'var(--nous-fg)',
+            }}
+            data-testid="sidebar-context-menu"
+            role="menu"
+            aria-label="Sidebar item context menu"
+        >
+            <button
+                type="button"
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '6px 12px',
+                    cursor: 'pointer',
+                    background: 'transparent',
+                    border: 'none',
+                    color: 'inherit',
+                    fontSize: 'inherit',
+                    width: '100%',
+                    textAlign: 'left',
+                }}
+                onClick={handleRename}
+                role="menuitem"
+                data-testid="context-menu-rename"
+            >
+                Rename
+            </button>
+        </div>,
+        document.body,
+    )
+}
+
+// ---------------------------------------------------------------------------
 // ListItem — single composable button for all sidebar items
 // ---------------------------------------------------------------------------
 
@@ -41,6 +149,7 @@ function ListItem({
     disabled,
     onNavigate,
     onItemRename,
+    onContextMenu: onContextMenuProp,
 }: {
     id: string
     label: string
@@ -52,71 +161,27 @@ function ListItem({
     disabled?: boolean
     onNavigate: (routeId: string) => void
     onItemRename?: (itemId: string, newName: string) => void
+    onContextMenu?: (info: { itemId: string; itemLabel: string; x: number; y: number }) => void
 }) {
     const [hovered, setHovered] = React.useState(false)
-    const [isEditing, setIsEditing] = React.useState(false)
-    const [editValue, setEditValue] = React.useState(label)
-    const inputRef = React.useRef<HTMLInputElement>(null)
-    const clickTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-
-    React.useEffect(() => {
-        if (isEditing && inputRef.current) {
-            inputRef.current.focus()
-            inputRef.current.select()
-        }
-    }, [isEditing])
-
-    const commitRename = React.useCallback(() => {
-        const trimmed = editValue.trim()
-        setIsEditing(false)
-        if (trimmed && trimmed !== label && onItemRename) {
-            onItemRename(id, trimmed)
-        } else {
-            setEditValue(label)
-        }
-    }, [editValue, label, id, onItemRename])
-
-    const cancelRename = React.useCallback(() => {
-        setIsEditing(false)
-        setEditValue(label)
-    }, [label])
 
     const handleClick = React.useCallback(() => {
-        if (disabled || isEditing) return
-        if (onItemRename) {
-            // Delay single click to allow double-click disambiguation
-            if (clickTimerRef.current) {
-                clearTimeout(clickTimerRef.current)
-                clickTimerRef.current = null
-            }
-            clickTimerRef.current = setTimeout(() => {
-                clickTimerRef.current = null
-                onNavigate(routeId)
-            }, 250)
-        } else {
-            onNavigate(routeId)
-        }
-    }, [disabled, isEditing, onItemRename, onNavigate, routeId])
+        if (disabled) return
+        onNavigate(routeId)
+    }, [disabled, onNavigate, routeId])
 
-    const handleDoubleClick = React.useCallback(() => {
-        if (disabled || !onItemRename) return
-        // Cancel pending single-click navigation
-        if (clickTimerRef.current) {
-            clearTimeout(clickTimerRef.current)
-            clickTimerRef.current = null
-        }
-        setEditValue(label)
-        setIsEditing(true)
-    }, [disabled, onItemRename, label])
+    const handleContextMenu = React.useCallback((e: React.MouseEvent) => {
+        if (!onContextMenuProp || !onItemRename) return
+        e.preventDefault()
+        onContextMenuProp({ itemId: id, itemLabel: label, x: e.clientX, y: e.clientY })
+    }, [onContextMenuProp, onItemRename, id, label])
 
-    // Cleanup timer on unmount
-    React.useEffect(() => {
-        return () => {
-            if (clickTimerRef.current) {
-                clearTimeout(clickTimerRef.current)
-            }
-        }
-    }, [])
+    const handleDotsClick = React.useCallback((e: React.MouseEvent) => {
+        e.stopPropagation()
+        if (!onContextMenuProp) return
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+        onContextMenuProp({ itemId: id, itemLabel: label, x: rect.left, y: rect.bottom })
+    }, [onContextMenuProp, id, label])
 
     return (
         <button
@@ -126,7 +191,7 @@ function ListItem({
             aria-current={isActive ? 'page' : undefined}
             disabled={disabled}
             onClick={handleClick}
-            onDoubleClick={handleDoubleClick}
+            onContextMenu={handleContextMenu}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
             style={{
@@ -154,42 +219,25 @@ function ListItem({
                     }
                 </span>
             )}
-            {isEditing ? (
-                <input
-                    ref={inputRef}
-                    data-testid={`rename-input-${id}`}
-                    type="text"
-                    value={editValue}
-                    onChange={(e) => setEditValue(e.target.value)}
-                    onKeyDown={(e) => {
-                        e.stopPropagation()
-                        if (e.key === 'Enter') {
-                            e.preventDefault()
-                            commitRename()
-                        } else if (e.key === 'Escape') {
-                            e.preventDefault()
-                            cancelRename()
-                        }
-                    }}
-                    onBlur={commitRename}
-                    onClick={(e) => e.stopPropagation()}
-                    onDoubleClick={(e) => e.stopPropagation()}
+            <span style={s.listItemLabel}>{label}</span>
+            {onItemRename && hovered && (
+                <span
+                    data-testid={`dots-button-${id}`}
+                    role="button"
+                    tabIndex={-1}
+                    onClick={handleDotsClick}
                     style={{
-                        flex: '1 1 0%',
-                        minWidth: 0,
-                        fontFamily: 'var(--nous-font-family)',
-                        fontSize: 'var(--nous-font-size-md)',
-                        color: 'inherit',
-                        background: 'transparent',
-                        border: 'none',
-                        outline: 'none',
-                        padding: 0,
-                        margin: 0,
-                        lineHeight: 'inherit',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        flexShrink: 0,
+                        marginLeft: 'auto',
+                        padding: 2,
+                        cursor: 'pointer',
+                        color: 'var(--nous-text-tertiary)',
                     }}
-                />
-            ) : (
-                <span style={s.listItemLabel}>{label}</span>
+                >
+                    <MoreHorizontal size={14} />
+                </span>
             )}
             {badge ? <span style={s.listItemBadge} /> : null}
         </button>
@@ -277,12 +325,25 @@ function AssetSectionBlock({
     const [isCollapsed, setIsCollapsed] = React.useState(() =>
         readCollapseState(section.id, section.defaultCollapsed ?? false),
     )
+    const [contextMenu, setContextMenu] = React.useState<{
+        itemId: string
+        itemLabel: string
+        position: { x: number; y: number }
+    } | null>(null)
 
     const toggleCollapse = () => {
         const next = !isCollapsed
         setIsCollapsed(next)
         writeCollapseState(section.id, next)
     }
+
+    const handleOpenContextMenu = React.useCallback((info: { itemId: string; itemLabel: string; x: number; y: number }) => {
+        setContextMenu({ itemId: info.itemId, itemLabel: info.itemLabel, position: { x: info.x, y: info.y } })
+    }, [])
+
+    const handleCloseContextMenu = React.useCallback(() => {
+        setContextMenu(null)
+    }, [])
 
     return (
         <div data-asset-section={section.id}>
@@ -308,10 +369,20 @@ function AssetSectionBlock({
                             disabled={!!section.disabled}
                             onNavigate={onNavigate}
                             onItemRename={section.onItemRename}
+                            onContextMenu={section.onItemRename ? handleOpenContextMenu : undefined}
                         />
                     ))}
                 </div>
             </div>
+            {contextMenu && section.onItemRename && (
+                <SidebarContextMenu
+                    position={contextMenu.position}
+                    itemId={contextMenu.itemId}
+                    itemLabel={contextMenu.itemLabel}
+                    onRename={section.onItemRename}
+                    onClose={handleCloseContextMenu}
+                />
+            )}
         </div>
     )
 }

--- a/self/ui/src/components/shell/AssetSidebar.tsx
+++ b/self/ui/src/components/shell/AssetSidebar.tsx
@@ -40,6 +40,7 @@ function ListItem({
     isActive,
     disabled,
     onNavigate,
+    onItemRename,
 }: {
     id: string
     label: string
@@ -50,8 +51,72 @@ function ListItem({
     isActive: boolean
     disabled?: boolean
     onNavigate: (routeId: string) => void
+    onItemRename?: (itemId: string, newName: string) => void
 }) {
     const [hovered, setHovered] = React.useState(false)
+    const [isEditing, setIsEditing] = React.useState(false)
+    const [editValue, setEditValue] = React.useState(label)
+    const inputRef = React.useRef<HTMLInputElement>(null)
+    const clickTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    React.useEffect(() => {
+        if (isEditing && inputRef.current) {
+            inputRef.current.focus()
+            inputRef.current.select()
+        }
+    }, [isEditing])
+
+    const commitRename = React.useCallback(() => {
+        const trimmed = editValue.trim()
+        setIsEditing(false)
+        if (trimmed && trimmed !== label && onItemRename) {
+            onItemRename(id, trimmed)
+        } else {
+            setEditValue(label)
+        }
+    }, [editValue, label, id, onItemRename])
+
+    const cancelRename = React.useCallback(() => {
+        setIsEditing(false)
+        setEditValue(label)
+    }, [label])
+
+    const handleClick = React.useCallback(() => {
+        if (disabled || isEditing) return
+        if (onItemRename) {
+            // Delay single click to allow double-click disambiguation
+            if (clickTimerRef.current) {
+                clearTimeout(clickTimerRef.current)
+                clickTimerRef.current = null
+            }
+            clickTimerRef.current = setTimeout(() => {
+                clickTimerRef.current = null
+                onNavigate(routeId)
+            }, 250)
+        } else {
+            onNavigate(routeId)
+        }
+    }, [disabled, isEditing, onItemRename, onNavigate, routeId])
+
+    const handleDoubleClick = React.useCallback(() => {
+        if (disabled || !onItemRename) return
+        // Cancel pending single-click navigation
+        if (clickTimerRef.current) {
+            clearTimeout(clickTimerRef.current)
+            clickTimerRef.current = null
+        }
+        setEditValue(label)
+        setIsEditing(true)
+    }, [disabled, onItemRename, label])
+
+    // Cleanup timer on unmount
+    React.useEffect(() => {
+        return () => {
+            if (clickTimerRef.current) {
+                clearTimeout(clickTimerRef.current)
+            }
+        }
+    }, [])
 
     return (
         <button
@@ -60,7 +125,8 @@ function ListItem({
             data-state={isActive ? 'active' : 'inactive'}
             aria-current={isActive ? 'page' : undefined}
             disabled={disabled}
-            onClick={() => !disabled && onNavigate(routeId)}
+            onClick={handleClick}
+            onDoubleClick={handleDoubleClick}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
             style={{
@@ -88,7 +154,43 @@ function ListItem({
                     }
                 </span>
             )}
-            <span style={s.listItemLabel}>{label}</span>
+            {isEditing ? (
+                <input
+                    ref={inputRef}
+                    data-testid={`rename-input-${id}`}
+                    type="text"
+                    value={editValue}
+                    onChange={(e) => setEditValue(e.target.value)}
+                    onKeyDown={(e) => {
+                        e.stopPropagation()
+                        if (e.key === 'Enter') {
+                            e.preventDefault()
+                            commitRename()
+                        } else if (e.key === 'Escape') {
+                            e.preventDefault()
+                            cancelRename()
+                        }
+                    }}
+                    onBlur={commitRename}
+                    onClick={(e) => e.stopPropagation()}
+                    onDoubleClick={(e) => e.stopPropagation()}
+                    style={{
+                        flex: '1 1 0%',
+                        minWidth: 0,
+                        fontFamily: 'var(--nous-font-family)',
+                        fontSize: 'var(--nous-font-size-md)',
+                        color: 'inherit',
+                        background: 'transparent',
+                        border: 'none',
+                        outline: 'none',
+                        padding: 0,
+                        margin: 0,
+                        lineHeight: 'inherit',
+                    }}
+                />
+            ) : (
+                <span style={s.listItemLabel}>{label}</span>
+            )}
             {badge ? <span style={s.listItemBadge} /> : null}
         </button>
     )
@@ -205,6 +307,7 @@ function AssetSectionBlock({
                             isActive={item.routeId === activeRoute}
                             disabled={!!section.disabled}
                             onNavigate={onNavigate}
+                            onItemRename={section.onItemRename}
                         />
                     ))}
                 </div>

--- a/self/ui/src/components/shell/ContentRouter.tsx
+++ b/self/ui/src/components/shell/ContentRouter.tsx
@@ -19,6 +19,12 @@ export interface ContentRouterProps
   navigationParams?: Record<string, unknown>
 }
 
+type StackEntry = { route: string; params?: Record<string, unknown> }
+
+function stackEntryEquals(a: StackEntry, b: StackEntry): boolean {
+  return a.route === b.route && JSON.stringify(a.params) === JSON.stringify(b.params)
+}
+
 export function ContentRouter({
   activeRoute,
   routes,
@@ -28,10 +34,10 @@ export function ContentRouter({
   style,
   ...props
 }: ContentRouterProps) {
-  const [stack, setStack] = React.useState<string[]>(activeRoute ? [activeRoute] : [])
-  const [navigationParams, setNavigationParams] = React.useState<Record<string, unknown> | undefined>(undefined)
+  const [stack, setStack] = React.useState<StackEntry[]>(activeRoute ? [{ route: activeRoute, params: externalParams }] : [])
+  const [navigationParams, setNavigationParams] = React.useState<Record<string, unknown> | undefined>(externalParams)
   const stackRef = React.useRef(stack)
-  const lastPropRouteRef = React.useRef(activeRoute)
+  const lastPropEntryRef = React.useRef<StackEntry>({ route: activeRoute, params: externalParams })
 
   React.useEffect(() => {
     stackRef.current = stack
@@ -40,17 +46,19 @@ export function ContentRouter({
   React.useEffect(() => {
     if (!activeRoute) return
 
-    // Same route — only update params (e.g. switching items within the same group)
-    if (activeRoute === lastPropRouteRef.current) {
-      setNavigationParams(externalParams)
+    const incoming: StackEntry = { route: activeRoute, params: externalParams }
+
+    // Same route + same params — no-op
+    if (stackEntryEquals(incoming, lastPropEntryRef.current)) {
       return
     }
 
+    const top = stackRef.current[stackRef.current.length - 1]
     const nextStack =
-      stackRef.current.at(-1) === activeRoute
+      top && stackEntryEquals(top, incoming)
         ? stackRef.current
-        : [...stackRef.current, activeRoute]
-    lastPropRouteRef.current = activeRoute
+        : [...stackRef.current, incoming]
+    lastPropEntryRef.current = incoming
     stackRef.current = nextStack
     setStack(nextStack)
     setNavigationParams(externalParams)
@@ -61,8 +69,9 @@ export function ContentRouter({
       return
     }
 
-    const nextStack = [...stackRef.current, routeId]
-    lastPropRouteRef.current = routeId
+    const entry: StackEntry = { route: routeId, params }
+    const nextStack = [...stackRef.current, entry]
+    lastPropEntryRef.current = entry
     stackRef.current = nextStack
     setStack(nextStack)
     setNavigationParams(params)
@@ -75,18 +84,20 @@ export function ContentRouter({
     }
 
     const nextStack = stackRef.current.slice(0, -1)
-    const nextRoute = nextStack[nextStack.length - 1] ?? ''
-    lastPropRouteRef.current = nextRoute
+    const previousEntry = nextStack[nextStack.length - 1]
+    const nextRoute = previousEntry?.route ?? ''
+    const restoredParams = previousEntry?.params
+    lastPropEntryRef.current = previousEntry ?? { route: '' }
     stackRef.current = nextStack
     setStack(nextStack)
-    setNavigationParams(undefined)
+    setNavigationParams(restoredParams)
 
     if (nextRoute) {
-      onNavigate?.(nextRoute)
+      onNavigate?.(nextRoute, restoredParams)
     }
   }
 
-  const currentRoute = stack[stack.length - 1] ?? ''
+  const currentRoute = stack[stack.length - 1]?.route ?? ''
   const ActiveRoute = routes[currentRoute]
   const canGoBack = stack.length > 1
 

--- a/self/ui/src/components/shell/ShellContext.tsx
+++ b/self/ui/src/components/shell/ShellContext.tsx
@@ -23,6 +23,7 @@ export interface ShellProviderProps extends PropsWithChildren {
   mode?: ShellMode
   breakpoint?: ShellBreakpoint
   activeRoute?: string
+  navigationParams?: Record<string, unknown>
   navigation?: NavigationState
   conversation?: ShellContextValue['conversation']
   activeProjectId?: string | null
@@ -38,6 +39,7 @@ export function ShellProvider({
   mode = 'simple',
   breakpoint = 'full',
   activeRoute = DEFAULT_ACTIVE_ROUTE,
+  navigationParams,
   navigation,
   conversation = defaultConversationContext,
   activeProjectId = null,
@@ -51,6 +53,7 @@ export function ShellProvider({
     mode,
     breakpoint,
     activeRoute: resolvedActiveRoute,
+    navigationParams,
     navigation: navigation ?? {
       ...DEFAULT_NAVIGATION,
       activeRoute: resolvedActiveRoute,

--- a/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
+++ b/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
@@ -299,3 +299,175 @@ describe('AssetSidebar — Live Tasks Section', () => {
     expect(ids).toEqual(['workflows', 'tasks', 'teams', 'agents'])
   })
 })
+
+describe('AssetSidebar — Inline Rename', () => {
+  const onItemRename = vi.fn()
+
+  const RENAME_SECTIONS: AssetSection[] = [
+    {
+      id: 'workflows',
+      label: 'WORKFLOWS',
+      collapsible: true,
+      items: [
+        { id: 'wf-1', label: 'Flow A', routeId: 'workflow-a' },
+        { id: 'wf-2', label: 'Flow B', routeId: 'workflow-b' },
+      ],
+      onItemRename,
+    },
+  ]
+
+  const NO_RENAME_SECTIONS: AssetSection[] = [
+    {
+      id: 'workflows',
+      label: 'WORKFLOWS',
+      collapsible: true,
+      items: [
+        { id: 'wf-1', label: 'Flow A', routeId: 'workflow-a' },
+      ],
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('double-click on item label enters edit mode with input pre-filled', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+    expect(item).toBeTruthy()
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      await flush()
+    })
+
+    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('Flow A')
+  })
+
+  it('pressing Enter commits rename and calls onItemRename', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      await flush()
+    })
+
+    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    // Change value using native input value setter to trigger React's onChange
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype, 'value',
+    )!.set!
+    await act(async () => {
+      nativeInputValueSetter.call(input, 'Renamed Flow')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      await flush()
+    })
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      await flush()
+    })
+
+    expect(onItemRename).toHaveBeenCalledWith('wf-1', 'Renamed Flow')
+  })
+
+  it('pressing Escape cancels edit mode without calling onItemRename', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      await flush()
+    })
+
+    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      await flush()
+    })
+
+    expect(onItemRename).not.toHaveBeenCalled()
+    // Label should be restored
+    const label = container.querySelector('[data-list-item="wf-1"]')?.querySelector('span')
+    expect(label?.textContent).toBe('Flow A')
+  })
+
+  it('blur commits rename', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      await flush()
+    })
+
+    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype, 'value',
+    )!.set!
+    await act(async () => {
+      nativeInputValueSetter.call(input, 'Blur Renamed')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      await flush()
+    })
+
+    await act(async () => {
+      // React listens on focusout (which bubbles), not blur
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+      await flush()
+    })
+
+    expect(onItemRename).toHaveBeenCalledWith('wf-1', 'Blur Renamed')
+  })
+
+  it('empty input on blur cancels rename', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      await flush()
+    })
+
+    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype, 'value',
+    )!.set!
+    await act(async () => {
+      nativeInputValueSetter.call(input, '')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      await flush()
+    })
+
+    await act(async () => {
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+      await flush()
+    })
+
+    expect(onItemRename).not.toHaveBeenCalled()
+  })
+
+  it('items without onItemRename do not enter edit mode on double-click', async () => {
+    await renderSidebar({ sections: NO_RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      await flush()
+    })
+
+    const input = container.querySelector('[data-testid="rename-input-wf-1"]')
+    expect(input).toBeNull()
+  })
+})

--- a/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
+++ b/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
@@ -376,9 +376,7 @@ describe('AssetSidebar — Context Menu Rename', () => {
     expect(renameBtn?.textContent).toContain('Rename')
   })
 
-  it('clicking Rename in context menu triggers window.prompt and calls onItemRename', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('New Name')
-
+  it('clicking Rename shows inline input that commits on Enter', async () => {
     await renderSidebar({ sections: RENAME_SECTIONS })
     const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
 
@@ -395,15 +393,27 @@ describe('AssetSidebar — Context Menu Rename', () => {
       await flush()
     })
 
-    expect(promptSpy).toHaveBeenCalledWith('Rename workflow', 'Flow A')
+    const input = document.querySelector('[data-testid="context-menu-rename-input"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('Flow A')
+
+    await act(async () => {
+      // Simulate typing a new name
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      nativeInputValueSetter.call(input, 'New Name')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      await flush()
+    })
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      await flush()
+    })
+
     expect(onItemRename).toHaveBeenCalledWith('wf-1', 'New Name')
-
-    promptSpy.mockRestore()
   })
 
-  it('cancelling prompt does not call onItemRename', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
-
+  it('pressing Escape in rename input cancels without calling onItemRename', async () => {
     await renderSidebar({ sections: RENAME_SECTIONS })
     const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
 
@@ -419,14 +429,18 @@ describe('AssetSidebar — Context Menu Rename', () => {
       await flush()
     })
 
-    expect(onItemRename).not.toHaveBeenCalled()
+    const input = document.querySelector('[data-testid="context-menu-rename-input"]') as HTMLInputElement
+    expect(input).toBeTruthy()
 
-    promptSpy.mockRestore()
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      await flush()
+    })
+
+    expect(onItemRename).not.toHaveBeenCalled()
   })
 
-  it('window.prompt returning empty string does not call onItemRename', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('  ')
-
+  it('submitting unchanged name does not call onItemRename', async () => {
     await renderSidebar({ sections: RENAME_SECTIONS })
     const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
 
@@ -442,9 +456,15 @@ describe('AssetSidebar — Context Menu Rename', () => {
       await flush()
     })
 
-    expect(onItemRename).not.toHaveBeenCalled()
+    const input = document.querySelector('[data-testid="context-menu-rename-input"]') as HTMLInputElement
 
-    promptSpy.mockRestore()
+    // Submit without changing the value
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      await flush()
+    })
+
+    expect(onItemRename).not.toHaveBeenCalled()
   })
 
   it('context menu closes on Escape', async () => {

--- a/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
+++ b/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
@@ -300,7 +300,7 @@ describe('AssetSidebar — Live Tasks Section', () => {
   })
 })
 
-describe('AssetSidebar — Inline Rename', () => {
+describe('AssetSidebar — Context Menu Rename', () => {
   const onItemRename = vi.fn()
 
   const RENAME_SECTIONS: AssetSection[] = [
@@ -331,143 +331,151 @@ describe('AssetSidebar — Inline Rename', () => {
     vi.clearAllMocks()
   })
 
-  it('double-click on item label enters edit mode with input pre-filled', async () => {
+  it('three-dots button appears on hover for items with onItemRename', async () => {
     await renderSidebar({ sections: RENAME_SECTIONS })
     const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
     expect(item).toBeTruthy()
 
+    // Before hover, no dots button
+    expect(container.querySelector('[data-testid="dots-button-wf-1"]')).toBeNull()
+
+    // Hover — use pointerover + mouseover (React listens on mouseover for onMouseEnter)
     await act(async () => {
-      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      item.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
       await flush()
     })
 
-    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
-    expect(input).toBeTruthy()
-    expect(input.value).toBe('Flow A')
+    expect(container.querySelector('[data-testid="dots-button-wf-1"]')).toBeTruthy()
   })
 
-  it('pressing Enter commits rename and calls onItemRename', async () => {
-    await renderSidebar({ sections: RENAME_SECTIONS })
-    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
-
-    await act(async () => {
-      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
-      await flush()
-    })
-
-    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
-    expect(input).toBeTruthy()
-
-    // Change value using native input value setter to trigger React's onChange
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype, 'value',
-    )!.set!
-    await act(async () => {
-      nativeInputValueSetter.call(input, 'Renamed Flow')
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      await flush()
-    })
-
-    await act(async () => {
-      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
-      await flush()
-    })
-
-    expect(onItemRename).toHaveBeenCalledWith('wf-1', 'Renamed Flow')
-  })
-
-  it('pressing Escape cancels edit mode without calling onItemRename', async () => {
-    await renderSidebar({ sections: RENAME_SECTIONS })
-    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
-
-    await act(async () => {
-      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
-      await flush()
-    })
-
-    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
-    expect(input).toBeTruthy()
-
-    await act(async () => {
-      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
-      await flush()
-    })
-
-    expect(onItemRename).not.toHaveBeenCalled()
-    // Label should be restored
-    const label = container.querySelector('[data-list-item="wf-1"]')?.querySelector('span')
-    expect(label?.textContent).toBe('Flow A')
-  })
-
-  it('blur commits rename', async () => {
-    await renderSidebar({ sections: RENAME_SECTIONS })
-    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
-
-    await act(async () => {
-      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
-      await flush()
-    })
-
-    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
-    expect(input).toBeTruthy()
-
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype, 'value',
-    )!.set!
-    await act(async () => {
-      nativeInputValueSetter.call(input, 'Blur Renamed')
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      await flush()
-    })
-
-    await act(async () => {
-      // React listens on focusout (which bubbles), not blur
-      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
-      await flush()
-    })
-
-    expect(onItemRename).toHaveBeenCalledWith('wf-1', 'Blur Renamed')
-  })
-
-  it('empty input on blur cancels rename', async () => {
-    await renderSidebar({ sections: RENAME_SECTIONS })
-    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
-
-    await act(async () => {
-      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
-      await flush()
-    })
-
-    const input = container.querySelector('[data-testid="rename-input-wf-1"]') as HTMLInputElement
-    expect(input).toBeTruthy()
-
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype, 'value',
-    )!.set!
-    await act(async () => {
-      nativeInputValueSetter.call(input, '')
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      await flush()
-    })
-
-    await act(async () => {
-      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
-      await flush()
-    })
-
-    expect(onItemRename).not.toHaveBeenCalled()
-  })
-
-  it('items without onItemRename do not enter edit mode on double-click', async () => {
+  it('three-dots button does not appear for items without onItemRename', async () => {
     await renderSidebar({ sections: NO_RENAME_SECTIONS })
     const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
 
     await act(async () => {
-      item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+      item.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
       await flush()
     })
 
-    const input = container.querySelector('[data-testid="rename-input-wf-1"]')
-    expect(input).toBeNull()
+    expect(container.querySelector('[data-testid="dots-button-wf-1"]')).toBeNull()
+  })
+
+  it('right-click opens context menu with Rename option', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 200 }))
+      await flush()
+    })
+
+    const contextMenu = document.querySelector('[data-testid="sidebar-context-menu"]')
+    expect(contextMenu).toBeTruthy()
+    const renameBtn = document.querySelector('[data-testid="context-menu-rename"]')
+    expect(renameBtn).toBeTruthy()
+    expect(renameBtn?.textContent).toContain('Rename')
+  })
+
+  it('clicking Rename in context menu triggers window.prompt and calls onItemRename', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('New Name')
+
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 200 }))
+      await flush()
+    })
+
+    const renameBtn = document.querySelector('[data-testid="context-menu-rename"]') as HTMLElement
+    expect(renameBtn).toBeTruthy()
+
+    await act(async () => {
+      renameBtn.click()
+      await flush()
+    })
+
+    expect(promptSpy).toHaveBeenCalledWith('Rename workflow', 'Flow A')
+    expect(onItemRename).toHaveBeenCalledWith('wf-1', 'New Name')
+
+    promptSpy.mockRestore()
+  })
+
+  it('cancelling prompt does not call onItemRename', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 200 }))
+      await flush()
+    })
+
+    const renameBtn = document.querySelector('[data-testid="context-menu-rename"]') as HTMLElement
+
+    await act(async () => {
+      renameBtn.click()
+      await flush()
+    })
+
+    expect(onItemRename).not.toHaveBeenCalled()
+
+    promptSpy.mockRestore()
+  })
+
+  it('window.prompt returning empty string does not call onItemRename', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('  ')
+
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 200 }))
+      await flush()
+    })
+
+    const renameBtn = document.querySelector('[data-testid="context-menu-rename"]') as HTMLElement
+
+    await act(async () => {
+      renameBtn.click()
+      await flush()
+    })
+
+    expect(onItemRename).not.toHaveBeenCalled()
+
+    promptSpy.mockRestore()
+  })
+
+  it('context menu closes on Escape', async () => {
+    await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLElement
+
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 200 }))
+      await flush()
+    })
+
+    expect(document.querySelector('[data-testid="sidebar-context-menu"]')).toBeTruthy()
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      await flush()
+    })
+
+    expect(document.querySelector('[data-testid="sidebar-context-menu"]')).toBeNull()
+  })
+
+  it('single-click navigates immediately (no delay) when onItemRename is provided', async () => {
+    const props = await renderSidebar({ sections: RENAME_SECTIONS })
+    const item = container.querySelector('[data-list-item="wf-1"]') as HTMLButtonElement
+
+    await act(async () => {
+      item.click()
+      await flush()
+    })
+
+    // Should navigate immediately — no setTimeout delay
+    expect(props.onNavigate).toHaveBeenCalledWith('workflow-a')
   })
 })

--- a/self/ui/src/components/shell/__tests__/ContentRouter.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ContentRouter.test.tsx
@@ -32,9 +32,14 @@ function DetailsRoute() {
   return <div>Details screen</div>
 }
 
+function ParamRoute({ params }: ContentRouterRenderProps) {
+  return <div data-testid="param-route">Param: {params?.definitionId as string ?? 'none'}</div>
+}
+
 const routes = {
   home: HomeRoute,
   details: DetailsRoute,
+  'workflow-detail': ParamRoute,
 }
 
 async function renderRouter(
@@ -108,7 +113,7 @@ describe('ContentRouter', () => {
     })
 
     expect(container.textContent).toContain('Open details')
-    expect(onNavigate).toHaveBeenCalledWith('home')
+    expect(onNavigate).toHaveBeenCalledWith('home', undefined)
   })
 
   it('renders nothing when the active route is unknown', async () => {
@@ -117,5 +122,91 @@ describe('ContentRouter', () => {
     })
 
     expect(container.textContent?.trim()).toBe('')
+  })
+
+  it('pushes distinct stack entries for same route with different params', async () => {
+    const onNavigate = vi.fn()
+
+    // Render with workflow-detail and params A
+    await renderRouter({
+      activeRoute: 'workflow-detail',
+      navigationParams: { definitionId: 'a' },
+      onNavigate,
+    })
+
+    expect(container.textContent).toContain('Param: a')
+
+    // Re-render with same route but different params
+    await act(async () => {
+      root.render(
+        <ContentRouter
+          activeRoute="workflow-detail"
+          navigationParams={{ definitionId: 'b' }}
+          routes={routes}
+          onNavigate={onNavigate}
+        />,
+      )
+      await flush()
+    })
+
+    expect(container.textContent).toContain('Param: b')
+
+    // Back button should appear (stack has 2 entries)
+    const backButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Back'),
+    )
+    expect(backButton).toBeTruthy()
+
+    // Click Back
+    await act(async () => {
+      backButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await flush()
+    })
+
+    // Should restore params A
+    expect(container.textContent).toContain('Param: a')
+    expect(onNavigate).toHaveBeenCalledWith('workflow-detail', { definitionId: 'a' })
+  })
+
+  it('does not push duplicate when route and params both match', async () => {
+    const onNavigate = vi.fn()
+
+    await renderRouter({
+      activeRoute: 'workflow-detail',
+      navigationParams: { definitionId: 'a' },
+      onNavigate,
+    })
+
+    // Re-render with identical route and params
+    await act(async () => {
+      root.render(
+        <ContentRouter
+          activeRoute="workflow-detail"
+          navigationParams={{ definitionId: 'a' }}
+          routes={routes}
+          onNavigate={onNavigate}
+        />,
+      )
+      await flush()
+    })
+
+    // Back button should NOT appear (stack did not grow)
+    const backButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Back'),
+    )
+    expect(backButton).toBeFalsy()
+  })
+
+  it('goBack on single-entry stack is a no-op', async () => {
+    const onNavigate = vi.fn()
+
+    await renderRouter({ onNavigate })
+
+    // No back button should be present
+    const backButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Back'),
+    )
+    expect(backButton).toBeFalsy()
+    expect(onNavigate).not.toHaveBeenCalled()
   })
 })

--- a/self/ui/src/components/shell/types.ts
+++ b/self/ui/src/components/shell/types.ts
@@ -96,6 +96,7 @@ export interface ShellContextValue {
   mode: ShellMode
   breakpoint: ShellBreakpoint
   activeRoute: string
+  navigationParams?: Record<string, unknown>
   navigation: NavigationState
   conversation: ConversationContext
   activeProjectId: string | null

--- a/self/ui/src/components/shell/types.ts
+++ b/self/ui/src/components/shell/types.ts
@@ -349,6 +349,10 @@ export const AssetSectionSchema = z.object({
     (value) => typeof value === 'function',
     'onSettings function is required',
   ).optional(),
+  onItemRename: z.custom<(itemId: string, newName: string) => void>(
+    (value) => typeof value === 'function',
+    'onItemRename function is required',
+  ).optional(),
 })
 export type AssetSection = z.infer<typeof AssetSectionSchema>
 

--- a/self/ui/src/data/stub-catalog.tsx
+++ b/self/ui/src/data/stub-catalog.tsx
@@ -34,8 +34,8 @@ export const STUB_APPS: CatalogItem[] = [
 
 /** @todo stub data placeholding for proper build out */
 export const STUB_CAMPAIGNS: AssetSectionItem[] = [
-  { id: 'campaign-1', label: 'Marketing Campaigns', indicatorColor: '#4CAF50', routeId: 'campaign-1' },
-  { id: 'campaign-2', label: 'Product Management', indicatorColor: '#66BB6A', routeId: 'campaign-2' },
+  { id: 'wf-stub-1', label: 'Marketing Campaigns', indicatorColor: '#4CAF50', routeId: 'workflow-detail::wf-stub-1' },
+  { id: 'wf-stub-2', label: 'Product Management', indicatorColor: '#66BB6A', routeId: 'workflow-detail::wf-stub-2' },
 ]
 
 /** @todo stub data placeholding for proper build out */

--- a/self/ui/src/hooks/__tests__/useWorkflows.test.ts
+++ b/self/ui/src/hooks/__tests__/useWorkflows.test.ts
@@ -1,7 +1,34 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
 import { buildWorkflowsSection } from '../useWorkflows'
+
+// ─── tRPC mock for useWorkflows hook ────────────────────────────────────────
+
+const mockMutateAsync = vi.fn()
+const mockInvalidate = vi.fn()
+
+vi.mock('@nous/transport', () => ({
+  trpc: {
+    projects: {
+      listWorkflowDefinitions: {
+        useQuery: vi.fn().mockReturnValue({ data: [], isLoading: false, error: null }),
+      },
+      saveWorkflowSpec: {
+        useMutation: () => ({ mutateAsync: mockMutateAsync }),
+      },
+    },
+    useUtils: () => ({
+      projects: {
+        listWorkflowDefinitions: { invalidate: mockInvalidate },
+      },
+    }),
+  },
+}))
+
+import { useWorkflows } from '../useWorkflows'
+import type { UseWorkflowsReturn } from '../useWorkflows'
 
 // --- buildWorkflowsSection tests (pure function, no React hooks needed) ---
 
@@ -102,5 +129,67 @@ describe('buildWorkflowsSection', () => {
 
     expect(section.collapsible).toBe(true)
     expect(section.disabled).toBe(false)
+  })
+})
+
+// --- createWorkflow tests (React hook, needs renderHook) ---
+
+describe('useWorkflows — createWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('UseWorkflowsReturn includes createWorkflow', () => {
+    // Type-level assertion — if this compiles, the interface is correct
+    const _check: UseWorkflowsReturn['createWorkflow'] extends (projectId: string) => Promise<string | null> ? true : never = true
+    expect(_check).toBe(true)
+  })
+
+  it('calls saveWorkflowSpec and returns definitionId', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ definitionId: 'new-def-123' })
+
+    const { result } = renderHook(() => useWorkflows({ projectId: 'proj-1' }))
+
+    let returnedId: string | null = null
+    await act(async () => {
+      returnedId = await result.current.createWorkflow('proj-1')
+    })
+
+    expect(returnedId).toBe('new-def-123')
+    expect(mockMutateAsync).toHaveBeenCalledOnce()
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      specYaml: expect.stringContaining('name: Untitled Workflow'),
+    })
+    // Verify the YAML includes a nous.agent.claude node
+    const calledYaml = mockMutateAsync.mock.calls[0][0].specYaml as string
+    expect(calledYaml).toContain('type: nous.agent.claude')
+    expect(calledYaml).toContain('nodes:')
+    expect(calledYaml).toContain('connections: []')
+
+    // Verify invalidation was called
+    expect(mockInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' })
+  })
+
+  it('returns null on mutation error', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('Save failed'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useWorkflows({ projectId: 'proj-1' }))
+
+    let returnedId: string | null = 'not-null'
+    await act(async () => {
+      returnedId = await result.current.createWorkflow('proj-1')
+    })
+
+    expect(returnedId).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[useWorkflows] createWorkflow failed:',
+      expect.any(Error),
+    )
+    // Invalidation should NOT be called on error
+    expect(mockInvalidate).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
   })
 })

--- a/self/ui/src/hooks/__tests__/useWorkflows.test.ts
+++ b/self/ui/src/hooks/__tests__/useWorkflows.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { buildWorkflowsSection } from '../useWorkflows'
+
+// --- buildWorkflowsSection tests (pure function, no React hooks needed) ---
+
+describe('buildWorkflowsSection', () => {
+  const mockNavigate = vi.fn()
+  const mockOnAdd = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an AssetSection with id "workflows" and label "WORKFLOWS"', () => {
+    const section = buildWorkflowsSection({
+      workflows: [],
+      loading: false,
+      error: null,
+      onAdd: mockOnAdd,
+      navigate: mockNavigate,
+    })
+
+    expect(section.id).toBe('workflows')
+    expect(section.label).toBe('WORKFLOWS')
+    expect(section.collapsible).toBe(true)
+    expect(section.disabled).toBe(false)
+  })
+
+  it('returns empty items array when no workflows', () => {
+    const section = buildWorkflowsSection({
+      workflows: [],
+      loading: false,
+      error: null,
+      onAdd: mockOnAdd,
+      navigate: mockNavigate,
+    })
+
+    expect(section.items).toEqual([])
+  })
+
+  it('maps workflows to items with workflow-detail::<id> routeIds', () => {
+    const workflows = [
+      { id: 'def-1', name: 'First Workflow' },
+      { id: 'def-2', name: 'Second Workflow' },
+    ]
+
+    const section = buildWorkflowsSection({
+      workflows,
+      loading: false,
+      error: null,
+      onAdd: mockOnAdd,
+      navigate: mockNavigate,
+    })
+
+    expect(section.items).toHaveLength(2)
+    expect(section.items[0].id).toBe('def-1')
+    expect(section.items[0].label).toBe('First Workflow')
+    expect(section.items[0].routeId).toBe('workflow-detail::def-1')
+    expect(section.items[1].id).toBe('def-2')
+    expect(section.items[1].label).toBe('Second Workflow')
+    expect(section.items[1].routeId).toBe('workflow-detail::def-2')
+  })
+
+  it('sets correct indicatorColor for workflow items', () => {
+    const workflows = [{ id: 'def-1', name: 'Test Workflow' }]
+
+    const section = buildWorkflowsSection({
+      workflows,
+      loading: false,
+      error: null,
+      onAdd: mockOnAdd,
+      navigate: mockNavigate,
+    })
+
+    expect(section.items[0].indicatorColor).toBe('#4CAF50')
+  })
+
+  it('wires onAdd callback from params', () => {
+    const section = buildWorkflowsSection({
+      workflows: [],
+      loading: false,
+      error: null,
+      onAdd: mockOnAdd,
+      navigate: mockNavigate,
+    })
+
+    expect(section.onAdd).toBe(mockOnAdd)
+    section.onAdd!()
+    expect(mockOnAdd).toHaveBeenCalledOnce()
+  })
+
+  it('section is collapsible and not disabled', () => {
+    const section = buildWorkflowsSection({
+      workflows: [],
+      loading: false,
+      error: null,
+      onAdd: mockOnAdd,
+      navigate: mockNavigate,
+    })
+
+    expect(section.collapsible).toBe(true)
+    expect(section.disabled).toBe(false)
+  })
+})

--- a/self/ui/src/hooks/__tests__/useWorkflows.test.ts
+++ b/self/ui/src/hooks/__tests__/useWorkflows.test.ts
@@ -9,6 +9,8 @@ import { buildWorkflowsSection } from '../useWorkflows'
 const mockMutateAsync = vi.fn()
 const mockInvalidate = vi.fn()
 
+const mockRenameMutateAsync = vi.fn()
+
 vi.mock('@nous/transport', () => ({
   trpc: {
     projects: {
@@ -17,6 +19,9 @@ vi.mock('@nous/transport', () => ({
       },
       saveWorkflowSpec: {
         useMutation: () => ({ mutateAsync: mockMutateAsync }),
+      },
+      renameWorkflowDefinition: {
+        useMutation: () => ({ mutateAsync: mockRenameMutateAsync }),
       },
     },
     useUtils: () => ({
@@ -185,6 +190,58 @@ describe('useWorkflows — createWorkflow', () => {
     expect(returnedId).toBeNull()
     expect(consoleSpy).toHaveBeenCalledWith(
       '[useWorkflows] createWorkflow failed:',
+      expect.any(Error),
+    )
+    // Invalidation should NOT be called on error
+    expect(mockInvalidate).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
+})
+
+// --- renameWorkflow tests ---
+
+describe('useWorkflows — renameWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('UseWorkflowsReturn includes renameWorkflow', () => {
+    // Type-level assertion — if this compiles, the interface is correct
+    const _check: UseWorkflowsReturn['renameWorkflow'] extends (definitionId: string, name: string) => Promise<void> ? true : never = true
+    expect(_check).toBe(true)
+  })
+
+  it('calls mutation and invalidates query', async () => {
+    mockRenameMutateAsync.mockResolvedValueOnce({ renamed: true })
+
+    const { result } = renderHook(() => useWorkflows({ projectId: 'proj-1' }))
+
+    await act(async () => {
+      await result.current.renameWorkflow('def-123', 'New Name')
+    })
+
+    expect(mockRenameMutateAsync).toHaveBeenCalledOnce()
+    expect(mockRenameMutateAsync).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      definitionId: 'def-123',
+      name: 'New Name',
+    })
+    expect(mockInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' })
+  })
+
+  it('handles error gracefully', async () => {
+    mockRenameMutateAsync.mockRejectedValueOnce(new Error('Rename failed'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useWorkflows({ projectId: 'proj-1' }))
+
+    await act(async () => {
+      await result.current.renameWorkflow('def-123', 'New Name')
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[useWorkflows] renameWorkflow failed:',
       expect.any(Error),
     )
     // Invalidation should NOT be called on error

--- a/self/ui/src/hooks/useWorkflows.ts
+++ b/self/ui/src/hooks/useWorkflows.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCallback } from 'react'
 import { trpc } from '@nous/transport'
 import type { AssetSection } from '../components/shell/types'
 
@@ -13,6 +14,7 @@ export interface UseWorkflowsReturn {
   workflows: Array<{ id: string; name: string }>
   workflowsLoading: boolean
   workflowsError: unknown
+  createWorkflow: (projectId: string) => Promise<string | null>
 }
 
 export function useWorkflows({ projectId }: UseWorkflowsOptions): UseWorkflowsReturn {
@@ -21,10 +23,40 @@ export function useWorkflows({ projectId }: UseWorkflowsOptions): UseWorkflowsRe
     { enabled: !!projectId },
   )
 
+  const saveSpecMutation = trpc.projects.saveWorkflowSpec.useMutation()
+  const utils = trpc.useUtils()
+
+  const createWorkflow = useCallback(async (targetProjectId: string): Promise<string | null> => {
+    const minimalSpecYaml = [
+      'name: Untitled Workflow',
+      'version: 1',
+      'nodes:',
+      '  - id: start',
+      '    name: Start',
+      '    type: nous.agent.claude',
+      '    position: [250, 200]',
+      '    parameters: {}',
+      'connections: []',
+    ].join('\n')
+
+    try {
+      const result = await saveSpecMutation.mutateAsync({
+        projectId: targetProjectId,
+        specYaml: minimalSpecYaml,
+      })
+      void utils.projects.listWorkflowDefinitions.invalidate({ projectId: targetProjectId })
+      return result.definitionId
+    } catch (error) {
+      console.error('[useWorkflows] createWorkflow failed:', error)
+      return null
+    }
+  }, [saveSpecMutation, utils])
+
   return {
     workflows: data ?? [],
     workflowsLoading: isLoading,
     workflowsError: error,
+    createWorkflow,
   }
 }
 

--- a/self/ui/src/hooks/useWorkflows.ts
+++ b/self/ui/src/hooks/useWorkflows.ts
@@ -15,6 +15,7 @@ export interface UseWorkflowsReturn {
   workflowsLoading: boolean
   workflowsError: unknown
   createWorkflow: (projectId: string) => Promise<string | null>
+  renameWorkflow: (definitionId: string, name: string) => Promise<void>
 }
 
 export function useWorkflows({ projectId }: UseWorkflowsOptions): UseWorkflowsReturn {
@@ -24,6 +25,7 @@ export function useWorkflows({ projectId }: UseWorkflowsOptions): UseWorkflowsRe
   )
 
   const saveSpecMutation = trpc.projects.saveWorkflowSpec.useMutation()
+  const renameWorkflowMutation = trpc.projects.renameWorkflowDefinition.useMutation()
   const utils = trpc.useUtils()
 
   const createWorkflow = useCallback(async (targetProjectId: string): Promise<string | null> => {
@@ -52,11 +54,22 @@ export function useWorkflows({ projectId }: UseWorkflowsOptions): UseWorkflowsRe
     }
   }, [saveSpecMutation, utils])
 
+  const renameWorkflow = useCallback(async (definitionId: string, name: string) => {
+    if (!projectId) return
+    try {
+      await renameWorkflowMutation.mutateAsync({ projectId, definitionId, name })
+      void utils.projects.listWorkflowDefinitions.invalidate({ projectId })
+    } catch (error) {
+      console.error('[useWorkflows] renameWorkflow failed:', error)
+    }
+  }, [projectId, renameWorkflowMutation, utils])
+
   return {
     workflows: data ?? [],
     workflowsLoading: isLoading,
     workflowsError: error,
     createWorkflow,
+    renameWorkflow,
   }
 }
 
@@ -68,6 +81,7 @@ export function buildWorkflowsSection(params: {
   error: unknown
   onAdd: () => void
   navigate: (routeId: string, navParams?: Record<string, unknown>) => void
+  onItemRename?: (itemId: string, newName: string) => void
 }): AssetSection {
   return {
     id: 'workflows',
@@ -81,5 +95,6 @@ export function buildWorkflowsSection(params: {
     collapsible: true,
     disabled: false,
     onAdd: params.onAdd,
+    onItemRename: params.onItemRename,
   }
 }

--- a/self/ui/src/hooks/useWorkflows.ts
+++ b/self/ui/src/hooks/useWorkflows.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { trpc } from '@nous/transport'
+import type { AssetSection } from '../components/shell/types'
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+export interface UseWorkflowsOptions {
+  projectId: string | null
+}
+
+export interface UseWorkflowsReturn {
+  workflows: Array<{ id: string; name: string }>
+  workflowsLoading: boolean
+  workflowsError: unknown
+}
+
+export function useWorkflows({ projectId }: UseWorkflowsOptions): UseWorkflowsReturn {
+  const { data, isLoading, error } = trpc.projects.listWorkflowDefinitions.useQuery(
+    { projectId: projectId! },
+    { enabled: !!projectId },
+  )
+
+  return {
+    workflows: data ?? [],
+    workflowsLoading: isLoading,
+    workflowsError: error,
+  }
+}
+
+// ─── buildWorkflowsSection helper ────────────────────────────────────────────
+
+export function buildWorkflowsSection(params: {
+  workflows: Array<{ id: string; name: string }>
+  loading: boolean
+  error: unknown
+  onAdd: () => void
+  navigate: (routeId: string, navParams?: Record<string, unknown>) => void
+}): AssetSection {
+  return {
+    id: 'workflows',
+    label: 'WORKFLOWS',
+    items: params.workflows.map((wf) => ({
+      id: wf.id,
+      label: wf.name,
+      indicatorColor: '#4CAF50',
+      routeId: `workflow-detail::${wf.id}`,
+    })),
+    collapsible: true,
+    disabled: false,
+    onAdd: params.onAdd,
+  }
+}

--- a/self/ui/src/panels/workflow-builder/BuilderToolbar.tsx
+++ b/self/ui/src/panels/workflow-builder/BuilderToolbar.tsx
@@ -27,6 +27,8 @@ export interface BuilderToolbarProps {
   validationErrorCount?: number
   /** Whether the validation panel is currently open. */
   isValidationPanelOpen?: boolean
+  /** Delete workflow handler. Shown conditionally (simple mode). */
+  onDelete?: () => void
 }
 
 const MODES: { value: BuilderMode; label: string; icon: string }[] = [
@@ -119,6 +121,7 @@ export function BuilderToolbar({
   isSaving = false,
   validationErrorCount = 0,
   isValidationPanelOpen = false,
+  onDelete,
 }: BuilderToolbarProps) {
   const { zoomIn, zoomOut, fitView } = useReactFlow()
   const { mode: currentMode } = useBuilderMode()
@@ -236,6 +239,21 @@ export function BuilderToolbar({
           onClick={onNewWorkflow}
         >
           <i className="codicon codicon-new-file" style={{ fontSize: 14 }} />
+        </button>
+      )}
+
+      {/* ── Delete Workflow ── */}
+      {onDelete && (
+        <button
+          type="button"
+          title="Delete workflow"
+          aria-label="Delete workflow"
+          data-testid="toolbar-delete"
+          style={isAuthoring ? buttonBaseStyle : disabledButtonStyle}
+          disabled={!isAuthoring}
+          onClick={onDelete}
+        >
+          <i className="codicon codicon-trash" style={{ fontSize: 14 }} />
         </button>
       )}
 

--- a/self/ui/src/panels/workflow-builder/BuilderToolbar.tsx
+++ b/self/ui/src/panels/workflow-builder/BuilderToolbar.tsx
@@ -13,8 +13,6 @@ export interface BuilderToolbarProps {
   canRedo?: boolean
   /** Save handler. */
   onSave?: () => void
-  /** Save As handler (creates new workflow definition). */
-  onSaveAs?: () => void
   /** New Workflow handler (resets to empty state). */
   onNewWorkflow?: () => void
   /** Toggle validation panel and trigger re-validation. */
@@ -114,7 +112,6 @@ export function BuilderToolbar({
   canUndo = false,
   canRedo = false,
   onSave,
-  onSaveAs,
   onNewWorkflow,
   onValidate,
   isDirty = false,
@@ -211,21 +208,6 @@ export function BuilderToolbar({
       >
         <i className="codicon codicon-save" style={{ fontSize: 14 }} />
       </button>
-
-      {/* ── Save As ── */}
-      {onSaveAs && (
-        <button
-          type="button"
-          title="Save as new workflow"
-          aria-label="Save as new workflow"
-          data-testid="toolbar-save-as"
-          style={isAuthoring && !isSaving ? buttonBaseStyle : disabledButtonStyle}
-          disabled={!isAuthoring || isSaving}
-          onClick={onSaveAs}
-        >
-          <i className="codicon codicon-save-as" style={{ fontSize: 14 }} />
-        </button>
-      )}
 
       {/* ── New Workflow ── */}
       {onNewWorkflow && (

--- a/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
+++ b/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
@@ -199,7 +199,7 @@ const CanvasDropTarget = forwardRef<
   // ─── Save handlers with inline naming ──────────────────────────────────
 
   const [showNameInput, setShowNameInput] = useState(false)
-  const [pendingNameAction, setPendingNameAction] = useState<'save' | 'saveAs' | null>(null)
+  const [pendingNameAction, setPendingNameAction] = useState<'save' | null>(null)
   const [nameInputValue, setNameInputValue] = useState('Untitled Workflow')
   const nameInputRef = useRef<HTMLInputElement>(null)
 
@@ -214,12 +214,8 @@ const CanvasDropTarget = forwardRef<
     const name = nameInputValue.trim() || 'Untitled Workflow'
     setShowNameInput(false)
     setPendingNameAction(null)
-    if (pendingNameAction === 'saveAs') {
-      void saveAsNew(name)
-    } else {
-      void saveToServer(name)
-    }
-  }, [nameInputValue, pendingNameAction, saveAsNew, saveToServer])
+    void saveToServer(name)
+  }, [nameInputValue, saveToServer])
 
   const handleSave = useCallback(() => {
     if (projectId) {
@@ -235,11 +231,6 @@ const CanvasDropTarget = forwardRef<
       markClean()
     }
   }, [projectId, currentDefinitionId, saveToServer, getCurrentSpec, markClean])
-
-  const handleSaveAs = useCallback(() => {
-    setPendingNameAction('saveAs')
-    setShowNameInput(true)
-  }, [])
 
   const handleNewWorkflow = useCallback(() => {
     resetToEmpty()
@@ -588,7 +579,6 @@ const CanvasDropTarget = forwardRef<
         canUndo={canUndo}
         canRedo={canRedo}
         onSave={handleSave}
-        onSaveAs={projectId ? handleSaveAs : undefined}
         onNewWorkflow={projectId ? handleNewWorkflow : undefined}
         onValidate={handleValidate}
         isDirty={isDirty}
@@ -662,7 +652,7 @@ const CanvasDropTarget = forwardRef<
           onMouseDown={(e) => e.stopPropagation()}
         >
           <div style={{ fontSize: 'var(--nous-font-size-sm)', fontWeight: 600, color: 'var(--nous-fg)', marginBottom: 'var(--nous-space-sm)' }}>
-            {pendingNameAction === 'saveAs' ? 'Save As New Workflow' : 'Name Your Workflow'}
+            {'Name Your Workflow'}
           </div>
           <input
             ref={nameInputRef}

--- a/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
+++ b/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useCallback, useContext, useRef, useState, useEffect, useImperativeHandle, forwardRef } from 'react'
+import { createPortal } from 'react-dom'
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -641,10 +642,10 @@ const CanvasDropTarget = forwardRef<
         </div>
       )}
       {/* Inline workflow naming dialog */}
-      {showNameInput && (
+      {showNameInput && createPortal(
         <div
           style={{
-            position: 'absolute',
+            position: 'fixed',
             top: '50%',
             left: '50%',
             transform: 'translate(-50%, -50%)',
@@ -722,7 +723,8 @@ const CanvasDropTarget = forwardRef<
               Save
             </button>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
       {/* Authoring-only UI — hidden in monitor mode */}
       {mode !== 'monitoring' && (
@@ -921,6 +923,9 @@ export function WorkflowBuilderPanel(
   const propProjectId = 'projectId' in props ? props.projectId : undefined
   const workflowDefinitionId = 'workflowDefinitionId' in props ? props.workflowDefinitionId : undefined
 
+  // ContentRouter always passes navigate/goBack/canGoBack; dockview never does.
+  const isSimpleMode = 'navigate' in props
+
   // Desktop panels are mounted via dockview without explicit props.
   // Fall back to ShellContext.activeProjectId when no projectId prop is provided.
   // useContext returns null when no ShellProvider is present (e.g. in tests/storybook).
@@ -941,7 +946,7 @@ export function WorkflowBuilderPanel(
         className={className}
         projectId={effectiveProjectId}
         workflowDefinitionId={effectiveDefinitionId}
-        hideWorkflowPicker={!!navParams}
+        hideWorkflowPicker={isSimpleMode}
       />
     </div>
   )

--- a/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
+++ b/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
@@ -63,6 +63,7 @@ const CanvasDropTarget = forwardRef<
     onFocusedNodeChange: (nodeId: string | null) => void
     projectId?: string
     workflowDefinitionId?: string
+    hideWorkflowPicker?: boolean
   }
 >(function CanvasDropTarget({
   canvasRef,
@@ -70,6 +71,7 @@ const CanvasDropTarget = forwardRef<
   onFocusedNodeChange,
   projectId,
   workflowDefinitionId,
+  hideWorkflowPicker,
 }, ref) {
   const { mode, setMode } = useBuilderMode()
   const workflowApi = useWorkflowApi({ projectId })
@@ -592,6 +594,11 @@ const CanvasDropTarget = forwardRef<
         isSaving={isSaving}
         validationErrorCount={validationErrors.length}
         isValidationPanelOpen={isValidationPanelOpen}
+        onDelete={hideWorkflowPicker && currentDefinitionId ? () => {
+          if (window.confirm('Delete this workflow? This cannot be undone.')) {
+            void handleDeleteWorkflow(currentDefinitionId)
+          }
+        } : undefined}
       />
       {/* Construction watching mode indicator */}
       {isWatchingConstruction && (
@@ -721,7 +728,7 @@ const CanvasDropTarget = forwardRef<
       {mode !== 'monitoring' && (
         <>
           <NodePalette containerRef={canvasRef} />
-          {projectId && (
+          {projectId && !hideWorkflowPicker && (
             <WorkflowPicker
               projectId={projectId}
               currentDefinitionId={currentDefinitionId}
@@ -853,10 +860,11 @@ const CanvasDropTarget = forwardRef<
   )
 })
 
-function WorkflowBuilderCanvas({ className, projectId, workflowDefinitionId }: {
+function WorkflowBuilderCanvas({ className, projectId, workflowDefinitionId, hideWorkflowPicker }: {
   className?: string
   projectId?: string
   workflowDefinitionId?: string
+  hideWorkflowPicker?: boolean
 }) {
   const canvasRef = useRef<HTMLDivElement | null>(null)
   const dropTargetRef = useRef<CanvasDropTargetHandle>(null)
@@ -896,6 +904,7 @@ function WorkflowBuilderCanvas({ className, projectId, workflowDefinitionId }: {
             onFocusedNodeChange={handleFocusedNodeChange}
             projectId={projectId}
             workflowDefinitionId={workflowDefinitionId}
+            hideWorkflowPicker={hideWorkflowPicker}
           />
         </ReactFlowProvider>
       </BuilderModeProvider>
@@ -932,6 +941,7 @@ export function WorkflowBuilderPanel(
         className={className}
         projectId={effectiveProjectId}
         workflowDefinitionId={effectiveDefinitionId}
+        hideWorkflowPicker={!!navParams}
       />
     </div>
   )

--- a/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
+++ b/self/ui/src/panels/workflow-builder/WorkflowBuilderPanel.tsx
@@ -927,10 +927,12 @@ export function WorkflowBuilderPanel(
   const effectiveDefinitionId = navDefinitionId ?? workflowDefinitionId
 
   return (
-    <WorkflowBuilderCanvas
-      className={className}
-      projectId={effectiveProjectId}
-      workflowDefinitionId={effectiveDefinitionId}
-    />
+    <div style={{ height: '100%' }}>
+      <WorkflowBuilderCanvas
+        className={className}
+        projectId={effectiveProjectId}
+        workflowDefinitionId={effectiveDefinitionId}
+      />
+    </div>
   )
 }

--- a/self/ui/src/panels/workflow-builder/__tests__/BuilderToolbar.test.tsx
+++ b/self/ui/src/panels/workflow-builder/__tests__/BuilderToolbar.test.tsx
@@ -39,13 +39,12 @@ describe('BuilderToolbar — Persistence actions', () => {
       expect(saveBtn.hasAttribute('disabled')).toBe(true)
     })
 
-    it('new props onSaveAs, onNewWorkflow, isSaving are accepted', () => {
+    it('new props onNewWorkflow, isSaving are accepted', () => {
       // Renders without error
       expect(() => {
         render(
           <BuilderToolbar
             {...defaultProps}
-            onSaveAs={vi.fn()}
             onNewWorkflow={vi.fn()}
             isSaving={false}
           />,
@@ -64,14 +63,6 @@ describe('BuilderToolbar — Persistence actions', () => {
       expect(saveBtn.getAttribute('title')).not.toContain('Phase 3')
     })
 
-    it('"Save As" button renders and calls onSaveAs on click', () => {
-      const onSaveAs = vi.fn()
-      render(<BuilderToolbar {...defaultProps} onSaveAs={onSaveAs} />)
-      const saveAsBtn = screen.getByTestId('toolbar-save-as')
-      fireEvent.click(saveAsBtn)
-      expect(onSaveAs).toHaveBeenCalledTimes(1)
-    })
-
     it('"New Workflow" button renders and calls onNewWorkflow on click', () => {
       const onNewWorkflow = vi.fn()
       render(<BuilderToolbar {...defaultProps} onNewWorkflow={onNewWorkflow} />)
@@ -80,34 +71,19 @@ describe('BuilderToolbar — Persistence actions', () => {
       expect(onNewWorkflow).toHaveBeenCalledTimes(1)
     })
 
-    it('Save and Save As disabled when isSaving is true', () => {
+    it('Save disabled when isSaving is true', () => {
       render(
         <BuilderToolbar
           {...defaultProps}
           isDirty={true}
           isSaving={true}
-          onSaveAs={vi.fn()}
         />,
       )
       expect(screen.getByTestId('toolbar-save').hasAttribute('disabled')).toBe(true)
-      expect(screen.getByTestId('toolbar-save-as').hasAttribute('disabled')).toBe(true)
     })
 
-    it('Save As button not disabled when isDirty is false (always available in authoring)', () => {
-      render(
-        <BuilderToolbar
-          {...defaultProps}
-          isDirty={false}
-          isSaving={false}
-          onSaveAs={vi.fn()}
-        />,
-      )
-      expect(screen.getByTestId('toolbar-save-as').hasAttribute('disabled')).toBe(false)
-    })
-
-    it('Save As and New Workflow buttons hidden when callbacks not provided', () => {
+    it('New Workflow button hidden when callback not provided', () => {
       render(<BuilderToolbar {...defaultProps} />)
-      expect(screen.queryByTestId('toolbar-save-as')).toBeNull()
       expect(screen.queryByTestId('toolbar-new-workflow')).toBeNull()
     })
   })

--- a/self/ui/src/panels/workflow-builder/__tests__/BuilderToolbar.test.tsx
+++ b/self/ui/src/panels/workflow-builder/__tests__/BuilderToolbar.test.tsx
@@ -112,3 +112,45 @@ describe('BuilderToolbar — Persistence actions', () => {
     })
   })
 })
+
+describe('BuilderToolbar — Delete action', () => {
+  // Tier 1 — Contract
+
+  describe('Tier 1 — Contract', () => {
+    it('onDelete prop is accepted without error', () => {
+      expect(() => {
+        render(<BuilderToolbar {...defaultProps} onDelete={vi.fn()} />)
+      }).not.toThrow()
+    })
+
+    it('delete button not rendered when onDelete is undefined', () => {
+      render(<BuilderToolbar {...defaultProps} />)
+      expect(screen.queryByTestId('toolbar-delete')).toBeNull()
+    })
+  })
+
+  // Tier 2 — Behavior
+
+  describe('Tier 2 — Behavior', () => {
+    it('delete button renders when onDelete is provided', () => {
+      render(<BuilderToolbar {...defaultProps} onDelete={vi.fn()} />)
+      expect(screen.getByTestId('toolbar-delete')).toBeDefined()
+    })
+
+    it('delete button calls onDelete on click', () => {
+      const onDelete = vi.fn()
+      render(<BuilderToolbar {...defaultProps} onDelete={onDelete} />)
+      fireEvent.click(screen.getByTestId('toolbar-delete'))
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('delete button is enabled in authoring mode (context mock default)', () => {
+      // The module-level mock sets useBuilderMode to return 'authoring' mode.
+      // In authoring mode, the delete button should be enabled.
+      const onDelete = vi.fn()
+      render(<BuilderToolbar {...defaultProps} onDelete={onDelete} />)
+      const deleteBtn = screen.getByTestId('toolbar-delete')
+      expect(deleteBtn.hasAttribute('disabled')).toBe(false)
+    })
+  })
+})

--- a/self/ui/src/panels/workflow-builder/__tests__/WorkflowBuilderPanel.test.tsx
+++ b/self/ui/src/panels/workflow-builder/__tests__/WorkflowBuilderPanel.test.tsx
@@ -123,6 +123,51 @@ describe('WorkflowBuilderPanel', () => {
     })
   })
 
+  // ─── Tier 2 — Phase 1.3 ContentRouter Integration ─────────────────────────
+
+  describe('Tier 2 — Phase 1.3 ContentRouter Integration', () => {
+    it('hides WorkflowPicker when rendered with ContentRouter props (no params)', () => {
+      // ContentRouter always passes navigate/goBack/canGoBack — dockview never does.
+      // When these props are present, hideWorkflowPicker should be true and
+      // WorkflowPicker must not render, even without params.
+      // Cast to any — ContentRouter injects navigate/goBack/canGoBack at runtime
+      // but they are not part of the static type union.
+      const ContentRouterProps = {
+        navigate: vi.fn(),
+        goBack: vi.fn(),
+        canGoBack: false,
+      } as Record<string, unknown>
+      const { container } = render(
+        <WorkflowBuilderPanel {...ContentRouterProps} />,
+      )
+      expect(container.querySelector('[data-testid="workflow-picker"]')).toBeNull()
+    })
+
+    it('name dialog renders in portal (document.body)', () => {
+      // Render the panel with a projectId so that Save triggers the name dialog
+      // (first save with no currentDefinitionId prompts for a name).
+      const { container } = render(
+        <WorkflowBuilderPanel projectId="proj-123" />,
+      )
+
+      // Before saving, the name dialog should not exist anywhere
+      expect(document.body.querySelector('[data-testid="workflow-name-dialog"]')).toBeNull()
+
+      // Trigger save via Ctrl+S keyboard shortcut — this bypasses the
+      // disabled Save button and invokes handleSave directly. With projectId
+      // set and no currentDefinitionId, handleSave opens the name dialog.
+      fireEvent.keyDown(window, { key: 's', ctrlKey: true })
+
+      // The name dialog should be in document.body (via createPortal), not
+      // inside the panel's own DOM tree.
+      const dialog = document.body.querySelector('[data-testid="workflow-name-dialog"]')
+      expect(dialog).toBeTruthy()
+
+      // Verify it is NOT inside the panel container
+      expect(container.querySelector('[data-testid="workflow-name-dialog"]')).toBeNull()
+    })
+  })
+
   // ─── Tier 3 — Phase 2 Authoring Flow ─────────────────────────────────────
 
   describe('Tier 3 — Phase 2 Authoring Flow', () => {

--- a/self/ui/src/panels/workflow-builder/__tests__/useBuilderState.test.ts
+++ b/self/ui/src/panels/workflow-builder/__tests__/useBuilderState.test.ts
@@ -947,4 +947,148 @@ connections: []
       })
     })
   })
+
+  // ─── Phase 1.2 — Workflow navigation fixes ────────────────────────────────
+
+  describe('Phase 1.2 — Navigation re-fetch and reset', () => {
+    beforeEach(() => {
+      mockMutateAsync.mockReset()
+      mockFetch.mockReset()
+      mockFetch.mockResolvedValue({ specYaml: undefined })
+      mockListWorkflowDefinitionsResult.data = []
+      mockListWorkflowDefinitionsResult.isLoading = false
+    })
+
+    // Tier 2 — Behavior
+
+    it('re-fetches when workflowDefinitionId changes from id-A to id-B', async () => {
+      const TEST_SPEC_A = `
+name: Workflow A
+version: 1
+nodes:
+  - id: trigger-a
+    name: Trigger A
+    type: nous.trigger.webhook
+    position: [100, 50]
+connections: []
+`
+      const TEST_SPEC_B = `
+name: Workflow B
+version: 1
+nodes:
+  - id: trigger-b
+    name: Trigger B
+    type: nous.trigger.webhook
+    position: [200, 50]
+connections: []
+`
+      mockFetch
+        .mockResolvedValueOnce({ specYaml: TEST_SPEC_A })
+        .mockResolvedValueOnce({ specYaml: TEST_SPEC_B })
+
+      const { result, rerender } = renderHook(
+        ({ defId }: { defId?: string }) =>
+          useBuilderState('authoring', { projectId: 'proj-1', workflowDefinitionId: defId }),
+        { initialProps: { defId: 'id-A' } },
+      )
+
+      // Wait for first fetch
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: 'proj-1', definitionId: 'id-A' }),
+      )
+
+      // Change to id-B
+      rerender({ defId: 'id-B' })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        expect.objectContaining({ projectId: 'proj-1', definitionId: 'id-B' }),
+      )
+    })
+
+    it('calls resetToEmpty when workflowDefinitionId transitions to undefined', async () => {
+      const TEST_SPEC = `
+name: Workflow
+version: 1
+nodes:
+  - id: trigger-1
+    name: Trigger
+    type: nous.trigger.webhook
+    position: [100, 50]
+connections: []
+`
+      mockFetch.mockResolvedValue({ specYaml: TEST_SPEC })
+
+      const { result, rerender } = renderHook(
+        ({ defId }: { defId?: string }) =>
+          useBuilderState('authoring', { projectId: 'proj-1', workflowDefinitionId: defId }),
+        { initialProps: { defId: 'id-A' as string | undefined } },
+      )
+
+      // Wait for fetch
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      expect(result.current.nodes.length).toBeGreaterThan(0)
+
+      // Transition to undefined (+ button)
+      rerender({ defId: undefined })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      // Should have reset to empty
+      expect(result.current.nodes).toHaveLength(0)
+      expect(result.current.edges).toHaveLength(0)
+      expect(result.current.currentDefinitionId).toBeNull()
+    })
+
+    it('does not call resetToEmpty on initial mount with undefined', () => {
+      const { result } = renderHook(() =>
+        useBuilderState('authoring', { projectId: 'proj-1' }),
+      )
+
+      // Should start empty (no default configured) — not reset from demo
+      expect(result.current.nodes).toHaveLength(0)
+      expect(result.current.edges).toHaveLength(0)
+    })
+
+    // Tier 3 — Edge Case
+
+    it('does not re-fetch when rerendered with same workflowDefinitionId', async () => {
+      mockFetch.mockResolvedValue({ specYaml: undefined })
+
+      const { rerender } = renderHook(
+        ({ defId }: { defId?: string }) =>
+          useBuilderState('authoring', { projectId: 'proj-1', workflowDefinitionId: defId }),
+        { initialProps: { defId: 'id-A' } },
+      )
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Rerender with same ID
+      rerender({ defId: 'id-A' })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+
+      // Should still only have been called once
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/self/ui/src/panels/workflow-builder/hooks/useBuilderState.ts
+++ b/self/ui/src/panels/workflow-builder/hooks/useBuilderState.ts
@@ -649,34 +649,35 @@ export function useBuilderState(
     [sync, undoRedo, utils],
   )
 
-  const initFetchedRef = useRef(false)
+  const prevDefIdRef = useRef<string | undefined>(undefined)
 
-  // Path 1: Explicit workflowDefinitionId — fetch that specific definition
+  // Path 1: Explicit workflowDefinitionId — fetch when it changes
   useEffect(() => {
-    if (initFetchedRef.current) return
     if (!projectId || !workflowDefinitionId) return
-    initFetchedRef.current = true
+    if (prevDefIdRef.current === workflowDefinitionId) return
+    prevDefIdRef.current = workflowDefinitionId
     fetchAndLoadDefinition(projectId, workflowDefinitionId)
   }, [projectId, workflowDefinitionId, fetchAndLoadDefinition])
 
   // Path 2: projectId but no workflowDefinitionId — check for project default
-  // Also re-checks when panel is kept mounted (dockview caching) and the user
-  // saves a workflow for the first time (listQuery updates with a new default).
   const defaultQuery = trpc.projects.listWorkflowDefinitions.useQuery(
     { projectId: projectId! },
     { enabled: !!projectId && !workflowDefinitionId },
   )
 
+  const defaultFetchedRef = useRef(false)
+
   useEffect(() => {
-    if (initFetchedRef.current) return
-    if (!projectId || workflowDefinitionId) return
+    if (workflowDefinitionId) return  // Path 1 handles explicit IDs
+    if (!projectId) return
     if (defaultQuery.isLoading || !defaultQuery.data) return
+    if (defaultFetchedRef.current) return  // Only load default once per mount
 
     const defaultDef = defaultQuery.data.find(
       (d: { id: string; isDefault?: boolean }) => d.isDefault,
     )
     if (defaultDef && defaultDef.id !== currentDefId) {
-      initFetchedRef.current = true
+      defaultFetchedRef.current = true
       fetchAndLoadDefinition(projectId, defaultDef.id)
     }
     // If no default found, stay with empty state (correct for new projects)
@@ -768,6 +769,14 @@ export function useBuilderState(
     setValidationErrors([])
     specMetaRef.current = { ...DEFAULT_SPEC_META }
   }, [undoRedo])
+
+  // Path 1b: workflowDefinitionId transitions to undefined → reset to empty
+  useEffect(() => {
+    if (workflowDefinitionId !== undefined) return
+    if (prevDefIdRef.current === undefined) return // no transition — initial mount or already undefined
+    prevDefIdRef.current = undefined
+    resetToEmpty()
+  }, [workflowDefinitionId, resetToEmpty])
 
   // ─── Undo / Redo ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Wire WORKFLOWS sidebar items to WorkflowBuilderPanel via ContentRouter simple mode routing, mirroring the task-detail pattern precisely for future factory extraction
- Add `useWorkflows` hook with tRPC `listWorkflowDefinitions` query, `createWorkflow` mutation (auto-creates "Untitled Workflow"), and `renameWorkflow` mutation
- Fix `useBuilderState` re-navigation guard (`initFetchedRef` → `prevDefIdRef`) enabling workflow swapping and + button reset-to-empty
- Hide `WorkflowPicker` in simple mode (sidebar handles navigation), add delete button to `BuilderToolbar`
- Portal name dialog out of ReactFlow DOM tree to fix input event capture issues
- Add context menu rename to `AssetSidebar` (right-click + three-dots hover button) with inline input — generic, reusable for other entity types
- Fix ContentRouter navigation stack to track params for same-route back navigation (workflow A → B → C → back works)
- Add `renameWorkflowDefinition` tRPC endpoint
- Remove Save As button (replaced by sidebar rename)

## Test plan

- [ ] Click workflow item in sidebar → loads WorkflowBuilderPanel with correct definition
- [ ] Click + button → auto-creates "Untitled Workflow", appears in sidebar, builder loads it
- [ ] Click between workflows → builder reloads with each selection
- [ ] Back button → navigates through workflow history (C → B → A)
- [ ] Right-click workflow → context menu with "Rename" → inline input → Enter commits
- [ ] Three-dots hover button → same context menu
- [ ] Delete button in toolbar → confirms and deletes workflow
- [ ] Task navigation, top-nav, developer mode dockview — no regressions
- [ ] 4529+ tests pass, build clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)