### PR TITLE
fix(ui): resolve chat overlay layout shift in full mode (WR-136)

### DIFF
--- a/self/ui/src/components/shell/AssetSidebar.tsx
+++ b/self/ui/src/components/shell/AssetSidebar.tsx
@@ -511,9 +511,11 @@ export function AssetSidebar({
     style,
     ...props
 }: AssetSidebarProps & Omit<React.HTMLAttributes<HTMLDivElement>, 'content'>) {
-    const scrollPaddingBottom = chatStage
-        ? CHAT_STAGE_HEIGHT[chatStage]
-        : CHAT_STAGE_HEIGHT['ambient_large'] // safe default: largest resting state
+    const scrollPaddingBottom = chatStage === 'full'
+        ? 0 // overlay covers sidebar entirely in full mode
+        : chatStage
+            ? CHAT_STAGE_HEIGHT[chatStage]
+            : CHAT_STAGE_HEIGHT['ambient_large'] // safe default: largest resting state
 
     return (
         <div

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -230,7 +230,7 @@ export function SimpleShellLayout({
                     borderRadius: '0px',
                     display: 'flex',
                     flexDirection: 'column',
-                    overflow: 'visible',
+                    overflow: 'hidden',
                     transition: 'height var(--nous-duration-slow) var(--nous-ease-out), background var(--nous-duration-slow) var(--nous-ease-out)',
                 }}
             >

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -158,7 +158,7 @@ export function SimpleShellLayout({
             showObserve ? '5px' : '0px',
             showObserve ? 'var(--shell-observe-width)' : '0px',
         ].join(' '),
-        gridTemplateRows: '1fr',
+        gridTemplateRows: 'minmax(0, 1fr)',
         position: 'relative',
         width: '100%',
         height: '100%',


### PR DESCRIPTION
## Summary
- Fix ~250px vertical content shift when chat transitions to `full` stage
- Root cause: `gridTemplateRows: '1fr'` (= `minmax(auto, 1fr)`) allowed sidebar's `paddingBottom: 100%` (CSS percentage padding resolves against width, not height) to inflate the grid row track beyond the container
- `minmax(0, 1fr)` prevents grid cell min-content from inflating the row
- Skip sidebar bottom padding in `full` mode (overlay covers sidebar entirely)

## Changes
- `SimpleShellLayout.tsx` — `gridTemplateRows: 'minmax(0, 1fr)'` + `overflow: 'hidden'` on overlay
- `AssetSidebar.tsx` — `scrollPaddingBottom: 0` when `chatStage === 'full'`

## Test plan
- [x] No vertical shift when transitioning small → full
- [x] No vertical shift when collapsing full → small (Escape)
- [x] Scroll works in full mode
- [x] Ambient stages render correctly
- [x] ChatInput stays visible at bottom
- [x] Type-check passes (no new errors)

Closes WR-136