### PR TITLE
feat(ollama): WR-132.1 — endpoint config, IPC bridge, download progress

### DIFF
--- a/self/apps/desktop/src/preload/index.ts
+++ b/self/apps/desktop/src/preload/index.ts
@@ -97,6 +97,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.removeListener('ollama:stateChanged', listener)
       }
     },
+    install: (): Promise<unknown> => ipcRenderer.invoke('ollama:install'),
+    onInstallProgress: (
+      callback: (progress: { phase: string; message?: string }) => void,
+    ): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, progress: { phase: string; message?: string }) =>
+        callback(progress)
+      ipcRenderer.on('ollama:install-progress', listener)
+      return () => {
+        ipcRenderer.removeListener('ollama:install-progress', listener)
+      }
+    },
+    checkUpdate: (): Promise<unknown> => ipcRenderer.invoke('ollama:checkUpdate'),
+    update: (): Promise<unknown> => ipcRenderer.invoke('ollama:update'),
+    getVersion: (): Promise<unknown> => ipcRenderer.invoke('ollama:getVersion'),
   },
   mode: {
     get: (): Promise<string | null> => ipcRenderer.invoke('mode:get'),

--- a/self/apps/desktop/src/renderer/src/env.d.ts
+++ b/self/apps/desktop/src/renderer/src/env.d.ts
@@ -76,6 +76,11 @@ interface ElectronAPI {
     pullModel: (modelId: string) => Promise<void>
     onPullProgress: (callback: (progress: OllamaModelPullProgress) => void) => () => void
     onStateChange: (callback: (status: OllamaStatus) => void) => () => void
+    install: () => Promise<unknown>
+    onInstallProgress: (callback: (progress: { phase: string; message?: string }) => void) => () => void
+    checkUpdate: () => Promise<unknown>
+    update: () => Promise<unknown>
+    getVersion: () => Promise<unknown>
   }
 }
 

--- a/self/apps/desktop/src/renderer/src/test-setup.ts
+++ b/self/apps/desktop/src/renderer/src/test-setup.ts
@@ -213,6 +213,15 @@ export function createElectronAPIMock() {
           ollamaStateListeners.delete(callback)
         }
       }),
+      install: vi.fn(async (): Promise<unknown> => ({ success: true })),
+      onInstallProgress: vi.fn(
+        (_callback: (progress: { phase: string; message?: string }) => void) => {
+          return () => {}
+        },
+      ),
+      checkUpdate: vi.fn(async (): Promise<unknown> => ({})),
+      update: vi.fn(async (): Promise<unknown> => ({})),
+      getVersion: vi.fn(async (): Promise<unknown> => null),
     },
   } satisfies ElectronAPI
 

--- a/self/apps/shared-server/__tests__/ollama-config-propagation.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-config-propagation.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for config propagation to all hardcoded endpoint locations.
+ *
+ * Verifies:
+ * - getOllamaEndpointFromContext returns default when no providers in config
+ * - getOllamaEndpointFromContext returns default when Ollama provider has no endpoint
+ * - getOllamaEndpointFromContext returns custom endpoint when configured
+ * - listModels uses config-sourced endpoint (mock fetch, verify URL)
+ * - health check uses config-sourced endpoint (mock fetch, verify URL)
+ * - buildOllamaProviderConfig with no endpoint argument uses default
+ * - buildOllamaProviderConfig with endpoint argument uses that value
+ * - Multiple providers — finds the correct one by OLLAMA_WELL_KNOWN_PROVIDER_ID
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const OLLAMA_WELL_KNOWN_PROVIDER_ID = '10000000-0000-0000-0000-000000000003';
+const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+
+// Mock bootstrap
+const upsertProviderConfigMock = vi.fn();
+vi.mock('../src/bootstrap', () => ({
+  OLLAMA_WELL_KNOWN_PROVIDER_ID,
+  buildOllamaProviderConfig: vi.fn((modelId: string, _pid?: string, endpoint?: string) => ({
+    id: OLLAMA_WELL_KNOWN_PROVIDER_ID,
+    name: 'ollama',
+    type: 'text',
+    endpoint: endpoint ?? DEFAULT_OLLAMA_BASE_URL,
+    modelId,
+    isLocal: true,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'local_text',
+  })),
+  upsertProviderConfig: upsertProviderConfigMock,
+}));
+
+// Mock ollama-detection
+vi.mock('../src/ollama-detection', () => ({
+  pullOllamaModel: vi.fn(),
+  deleteOllamaModel: vi.fn(),
+}));
+
+function createMockContext(providers?: Array<Record<string, unknown>>) {
+  return {
+    config: {
+      get: () => ({ providers: providers ?? [] }),
+      update: vi.fn(),
+    },
+    eventBus: {
+      publish: vi.fn(),
+    },
+    providerRegistry: {
+      registerProvider: vi.fn(),
+    },
+    documentStore: {
+      query: vi.fn().mockResolvedValue([]),
+    },
+    healthAggregator: {
+      getSystemStatus: vi.fn(),
+      getProviderHealth: vi.fn(),
+      getAgentStatus: vi.fn(),
+    },
+  } as any;
+}
+
+describe('getOllamaEndpointFromContext', () => {
+  let getOllamaEndpointFromContext: typeof import('../src/ollama-config').getOllamaEndpointFromContext;
+
+  beforeEach(async () => {
+    const mod = await import('../src/ollama-config');
+    getOllamaEndpointFromContext = mod.getOllamaEndpointFromContext;
+  });
+
+  it('returns default when config has no providers array', () => {
+    const ctx = { config: { get: () => ({}) } } as any;
+    expect(getOllamaEndpointFromContext(ctx)).toBe(DEFAULT_OLLAMA_BASE_URL);
+  });
+
+  it('returns default when providers is empty', () => {
+    const ctx = createMockContext([]);
+    expect(getOllamaEndpointFromContext(ctx)).toBe(DEFAULT_OLLAMA_BASE_URL);
+  });
+
+  it('returns default when Ollama provider exists but has no endpoint field', () => {
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true },
+    ]);
+    expect(getOllamaEndpointFromContext(ctx)).toBe(DEFAULT_OLLAMA_BASE_URL);
+  });
+
+  it('returns custom endpoint when Ollama provider has endpoint set', () => {
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, endpoint: 'http://custom:8080' },
+    ]);
+    expect(getOllamaEndpointFromContext(ctx)).toBe('http://custom:8080');
+  });
+
+  it('finds correct provider by OLLAMA_WELL_KNOWN_PROVIDER_ID among multiple providers', () => {
+    const ctx = createMockContext([
+      { id: '10000000-0000-0000-0000-000000000001', isLocal: false, endpoint: 'https://api.anthropic.com' },
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, endpoint: 'http://remote-ollama:11434' },
+      { id: '10000000-0000-0000-0000-000000000002', isLocal: false, endpoint: 'https://api.openai.com' },
+    ]);
+    expect(getOllamaEndpointFromContext(ctx)).toBe('http://remote-ollama:11434');
+  });
+});
+
+describe('listModels uses config-sourced endpoint', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('fetches from custom endpoint, not hardcoded', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [] }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const { initTRPC } = await import('@trpc/server');
+    const { ollamaRouter } = await import('../src/trpc/routers/ollama');
+    const t = initTRPC.context<any>().create();
+
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, endpoint: 'http://custom:9090' },
+    ]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+    await caller.listModels();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://custom:9090/api/tags',
+      expect.any(Object),
+    );
+  });
+});
+
+describe('health check uses config-sourced endpoint', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('probes custom endpoint, not hardcoded', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [] }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const { initTRPC } = await import('@trpc/server');
+    const { healthRouter } = await import('../src/trpc/routers/health');
+    const t = initTRPC.context<any>().create();
+
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, endpoint: 'http://custom:7777' },
+    ]);
+    const caller = t.createCallerFactory(healthRouter)(ctx);
+    await caller.check();
+
+    // Verify that the Ollama health check used the custom endpoint
+    const ollamaFetchCall = fetchMock.mock.calls.find(
+      (call: any[]) => typeof call[0] === 'string' && call[0].includes('/api/tags'),
+    );
+    expect(ollamaFetchCall).toBeDefined();
+    expect(ollamaFetchCall![0]).toBe('http://custom:7777/api/tags');
+  });
+});
+
+describe('buildOllamaProviderConfig endpoint parameter', () => {
+  it('uses default endpoint when no endpoint argument', async () => {
+    const { buildOllamaProviderConfig } = await import('../src/bootstrap');
+    const config = buildOllamaProviderConfig('llama3');
+    expect(config.endpoint).toBe(DEFAULT_OLLAMA_BASE_URL);
+  });
+
+  it('uses provided endpoint argument', async () => {
+    const { buildOllamaProviderConfig } = await import('../src/bootstrap');
+    const config = buildOllamaProviderConfig('llama3', undefined, 'http://custom:8080');
+    expect(config.endpoint).toBe('http://custom:8080');
+  });
+});

--- a/self/apps/shared-server/__tests__/ollama-endpoint.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-endpoint.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the Ollama endpoint get/set tRPC procedures.
+ *
+ * Verifies:
+ * - getEndpoint returns default when no Ollama provider configured
+ * - getEndpoint returns custom endpoint when provider has one
+ * - setEndpoint with valid URL persists via upsertProviderConfig
+ * - setEndpoint with null clears the endpoint override (reset to default)
+ * - setEndpoint with invalid URL returns Zod validation error
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const OLLAMA_WELL_KNOWN_PROVIDER_ID = '10000000-0000-0000-0000-000000000003';
+const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+
+const upsertProviderConfigMock = vi.hoisted(() => vi.fn());
+const buildOllamaProviderConfigMock = vi.hoisted(() =>
+  vi.fn((modelId: string, _providerId?: string, endpoint?: string) => ({
+    id: OLLAMA_WELL_KNOWN_PROVIDER_ID,
+    name: 'ollama',
+    type: 'text',
+    endpoint: endpoint ?? DEFAULT_OLLAMA_BASE_URL,
+    modelId,
+    isLocal: true,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'local_text',
+  })),
+);
+
+vi.mock('../src/bootstrap', () => ({
+  OLLAMA_WELL_KNOWN_PROVIDER_ID,
+  buildOllamaProviderConfig: buildOllamaProviderConfigMock,
+  upsertProviderConfig: upsertProviderConfigMock,
+}));
+
+vi.mock('../src/ollama-detection', () => ({
+  pullOllamaModel: vi.fn(),
+  deleteOllamaModel: vi.fn(),
+}));
+
+vi.mock('../src/ollama-config', async () => {
+  const actual = await vi.importActual<typeof import('../src/ollama-config')>('../src/ollama-config');
+  return actual;
+});
+
+function createMockContext(providers?: Array<Record<string, unknown>>) {
+  return {
+    config: {
+      get: () => ({
+        providers: providers ?? [],
+      }),
+      update: vi.fn(),
+    },
+    eventBus: {
+      publish: vi.fn(),
+    },
+    providerRegistry: {
+      registerProvider: vi.fn(),
+    },
+    documentStore: {
+      query: vi.fn(),
+    },
+    healthAggregator: {
+      getSystemStatus: vi.fn(),
+      getProviderHealth: vi.fn(),
+      getAgentStatus: vi.fn(),
+    },
+  } as any;
+}
+
+// Import after mocks are set up
+const { ollamaRouter } = await import('../src/trpc/routers/ollama');
+const { createCallerFactory } = await import('../src/trpc/trpc').then(async (mod) => {
+  // We need to use the router directly via tRPC's createCaller pattern
+  // For unit testing, we'll call the procedures more directly
+  return mod;
+}).catch(() => ({ createCallerFactory: null }));
+
+// Direct procedure testing approach — create a caller from the router
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.context<any>().create();
+
+describe('ollama.getEndpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns default endpoint when no Ollama provider is configured', async () => {
+    const ctx = createMockContext([]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const result = await caller.getEndpoint();
+    expect(result).toEqual({ endpoint: DEFAULT_OLLAMA_BASE_URL });
+  });
+
+  it('returns default endpoint when Ollama provider has no endpoint', async () => {
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true },
+    ]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const result = await caller.getEndpoint();
+    expect(result).toEqual({ endpoint: DEFAULT_OLLAMA_BASE_URL });
+  });
+
+  it('returns custom endpoint when provider has one', async () => {
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, endpoint: 'http://custom:8080' },
+    ]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const result = await caller.getEndpoint();
+    expect(result).toEqual({ endpoint: 'http://custom:8080' });
+  });
+});
+
+describe('ollama.setEndpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    upsertProviderConfigMock.mockResolvedValue(undefined);
+  });
+
+  it('persists valid URL via upsertProviderConfig and returns success', async () => {
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, modelId: 'llama3' },
+    ]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const result = await caller.setEndpoint({ endpoint: 'http://custom:8080' });
+
+    expect(result).toEqual({ success: true });
+    expect(upsertProviderConfigMock).toHaveBeenCalledOnce();
+    const config = upsertProviderConfigMock.mock.calls[0][1];
+    expect(config.endpoint).toBe('http://custom:8080');
+  });
+
+  it('with null clears the endpoint override (reset to default)', async () => {
+    const ctx = createMockContext([
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, endpoint: 'http://custom:8080', modelId: 'llama3' },
+    ]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const result = await caller.setEndpoint({ endpoint: null });
+
+    expect(result).toEqual({ success: true });
+    expect(upsertProviderConfigMock).toHaveBeenCalledOnce();
+    const config = upsertProviderConfigMock.mock.calls[0][1];
+    expect(config.endpoint).toBe(DEFAULT_OLLAMA_BASE_URL);
+  });
+
+  it('rejects invalid URL with Zod validation error', async () => {
+    const ctx = createMockContext([]);
+    const caller = t.createCallerFactory(ollamaRouter)(ctx);
+
+    await expect(
+      caller.setEndpoint({ endpoint: 'not-a-url' }),
+    ).rejects.toThrow();
+  });
+
+  it('round-trip: set custom then get returns custom, then reset then get returns default', async () => {
+    const providers: Array<Record<string, unknown>> = [
+      { id: OLLAMA_WELL_KNOWN_PROVIDER_ID, isLocal: true, modelId: 'llama3' },
+    ];
+
+    // Set custom endpoint
+    let ctx = createMockContext(providers);
+    upsertProviderConfigMock.mockImplementation(async (_ctx: any, config: any) => {
+      providers[0] = { ...providers[0], ...config };
+    });
+
+    let caller = t.createCallerFactory(ollamaRouter)(ctx);
+    await caller.setEndpoint({ endpoint: 'http://custom:9999' });
+
+    // Get — should return custom
+    ctx = createMockContext(providers);
+    caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const afterSet = await caller.getEndpoint();
+    expect(afterSet.endpoint).toBe('http://custom:9999');
+
+    // Reset
+    ctx = createMockContext(providers);
+    caller = t.createCallerFactory(ollamaRouter)(ctx);
+    await caller.setEndpoint({ endpoint: null });
+
+    // Get — should return default
+    ctx = createMockContext(providers);
+    caller = t.createCallerFactory(ollamaRouter)(ctx);
+    const afterReset = await caller.getEndpoint();
+    expect(afterReset.endpoint).toBe(DEFAULT_OLLAMA_BASE_URL);
+  });
+});

--- a/self/apps/shared-server/__tests__/ollama-router.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-router.test.ts
@@ -188,7 +188,7 @@ describe('ollama tRPC router', () => {
       const result = await caller.ollama.pullModel({ model: 'llama3.2:3b' });
 
       expect(result).toEqual({ success: true });
-      expect(mockPullOllamaModel).toHaveBeenCalledWith('llama3.2:3b', expect.objectContaining({ onProgress: expect.any(Function) }));
+      expect(mockPullOllamaModel).toHaveBeenCalledWith('llama3.2:3b', expect.objectContaining({ onProgress: expect.any(Function), baseUrl: expect.any(String) }));
       expect(ctx.eventBus.publish).toHaveBeenCalledWith('ollama:pull-progress', {
         model: 'llama3.2:3b',
         status: 'downloading',
@@ -220,7 +220,7 @@ describe('ollama tRPC router', () => {
       const result = await caller.ollama.deleteModel({ name: 'llama3.2:3b' });
 
       expect(result).toEqual({ success: true });
-      expect(mockDeleteOllamaModel).toHaveBeenCalledWith('llama3.2:3b');
+      expect(mockDeleteOllamaModel).toHaveBeenCalledWith('llama3.2:3b', expect.objectContaining({ baseUrl: expect.any(String) }));
     });
 
     it('throws when deleteOllamaModel errors', async () => {

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -376,12 +376,13 @@ export function buildProviderConfig(
 export function buildOllamaProviderConfig(
   modelId: string,
   providerId: ProviderId = OLLAMA_WELL_KNOWN_PROVIDER_ID,
+  endpoint?: string,
 ): ModelProviderConfig {
   return {
     id: providerId,
     name: 'ollama',
     type: 'text',
-    endpoint: 'http://localhost:11434',
+    endpoint: endpoint ?? 'http://localhost:11434',
     modelId,
     isLocal: true,
     capabilities: ['chat', 'streaming'],

--- a/self/apps/shared-server/src/event-bus/event-sse-handler.ts
+++ b/self/apps/shared-server/src/event-bus/event-sse-handler.ts
@@ -43,6 +43,10 @@ const ALL_CHANNELS: (keyof EventChannelMap)[] = [
   'cost:budget-alert',
   'cost:budget-exceeded',
   'cost:snapshot',
+  'ollama:pull-progress',
+  'ollama:install-progress',
+  'ollama:update-progress',
+  'ollama:version-info',
 ];
 
 const HEARTBEAT_INTERVAL_MS = 30_000;

--- a/self/apps/shared-server/src/ollama-config.ts
+++ b/self/apps/shared-server/src/ollama-config.ts
@@ -1,0 +1,32 @@
+/**
+ * Ollama endpoint configuration helper.
+ *
+ * Provides a shared function for reading the Ollama endpoint from the
+ * NousContext config. All tRPC routers that need the Ollama base URL
+ * call getOllamaEndpointFromContext(ctx) instead of using a hardcoded
+ * constant. Falls back to DEFAULT_OLLAMA_BASE_URL when no custom
+ * endpoint is configured.
+ */
+import type { NousContext } from './context';
+import { OLLAMA_WELL_KNOWN_PROVIDER_ID } from './bootstrap';
+
+export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+
+/**
+ * Read the Ollama endpoint from the current config context.
+ *
+ * Looks up the Ollama provider entry by well-known ID or `isLocal` flag,
+ * then returns the configured endpoint (or the default fallback).
+ *
+ * This is a pure read with no caching — the user may change the endpoint
+ * at any time from settings.
+ */
+export function getOllamaEndpointFromContext(ctx: NousContext): string {
+  const config = ctx.config.get() as {
+    providers?: Array<{ id?: string; endpoint?: string; isLocal?: boolean }>;
+  };
+  const ollamaProvider = config.providers?.find(
+    (p) => p.id === OLLAMA_WELL_KNOWN_PROVIDER_ID || p.isLocal,
+  );
+  return ollamaProvider?.endpoint ?? DEFAULT_OLLAMA_BASE_URL;
+}

--- a/self/apps/shared-server/src/trpc/routers/health.ts
+++ b/self/apps/shared-server/src/trpc/routers/health.ts
@@ -2,6 +2,7 @@
  * Health tRPC router.
  */
 import { router, publicProcedure } from '../trpc';
+import { getOllamaEndpointFromContext } from '../../ollama-config';
 
 export const healthRouter = router({
   check: publicProcedure.query(async ({ ctx }) => {
@@ -24,7 +25,9 @@ export const healthRouter = router({
     const hasLocal = providers.some((p) => p.isLocal);
     if (hasLocal) {
       try {
-        const res = await fetch('http://localhost:11434/api/tags', {
+        const ollamaEndpoint = getOllamaEndpointFromContext(ctx);
+        console.log('[nous:health] ollama probe:', ollamaEndpoint);
+        const res = await fetch(`${ollamaEndpoint}/api/tags`, {
           signal: AbortSignal.timeout(2000),
         });
         components.push({

--- a/self/apps/shared-server/src/trpc/routers/ollama.ts
+++ b/self/apps/shared-server/src/trpc/routers/ollama.ts
@@ -1,15 +1,21 @@
 /**
- * Ollama tRPC router — model lifecycle management (list, pull, delete).
+ * Ollama tRPC router — model lifecycle management (list, pull, delete)
+ * and endpoint configuration (get, set).
  *
- * Proxies to the local Ollama HTTP API (localhost:11434).
+ * Proxies to the local Ollama HTTP API. The base URL is read from the
+ * provider config via getOllamaEndpointFromContext(), falling back to
+ * http://localhost:11434 when no custom endpoint is configured.
+ *
  * Pull progress is emitted via the event bus on the 'ollama:pull-progress'
  * SSE channel so the UI can display live progress.
  */
 import { z } from 'zod';
 import { router, publicProcedure } from '../trpc';
 import { pullOllamaModel, deleteOllamaModel } from '../../ollama-detection';
+import { getOllamaEndpointFromContext, DEFAULT_OLLAMA_BASE_URL } from '../../ollama-config';
+import { OLLAMA_WELL_KNOWN_PROVIDER_ID, buildOllamaProviderConfig, upsertProviderConfig } from '../../bootstrap';
+import type { ModelProviderConfig } from '@nous/shared';
 
-const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
 const OLLAMA_LIST_TIMEOUT_MS = 5000;
 
 /**
@@ -33,9 +39,11 @@ export const ollamaRouter = router({
   /**
    * List installed Ollama models with size and modification date.
    */
-  listModels: publicProcedure.query(async () => {
+  listModels: publicProcedure.query(async ({ ctx }) => {
+    const endpoint = getOllamaEndpointFromContext(ctx);
+    console.log(`[nous:ollama] listModels: using endpoint ${endpoint}`);
     try {
-      const response = await fetch(`${DEFAULT_OLLAMA_BASE_URL}/api/tags`, {
+      const response = await fetch(`${endpoint}/api/tags`, {
         signal: AbortSignal.timeout(OLLAMA_LIST_TIMEOUT_MS),
       });
 
@@ -75,10 +83,12 @@ export const ollamaRouter = router({
   pullModel: publicProcedure
     .input(z.object({ model: z.string().min(1) }))
     .mutation(async ({ input, ctx }) => {
+      const endpoint = getOllamaEndpointFromContext(ctx);
       console.log(`[nous:ollama] pullModel: started ${input.model}`);
 
       try {
         await pullOllamaModel(input.model, {
+          baseUrl: endpoint,
           onProgress: (progress) => {
             ctx.eventBus.publish('ollama:pull-progress', {
               model: input.model,
@@ -107,11 +117,12 @@ export const ollamaRouter = router({
    */
   deleteModel: publicProcedure
     .input(z.object({ name: z.string().min(1) }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
+      const endpoint = getOllamaEndpointFromContext(ctx);
       console.log(`[nous:ollama] deleteModel: deleting ${input.name}`);
 
       try {
-        await deleteOllamaModel(input.name);
+        await deleteOllamaModel(input.name, { baseUrl: endpoint });
         console.log(`[nous:ollama] deleteModel: deleted ${input.name}`);
         return { success: true };
       } catch (err) {
@@ -119,5 +130,49 @@ export const ollamaRouter = router({
         console.log(`[nous:ollama] deleteModel: failed ${input.name} — ${message}`);
         throw err;
       }
+    }),
+
+  /**
+   * Get the currently configured Ollama endpoint (or default).
+   */
+  getEndpoint: publicProcedure.query(async ({ ctx }) => {
+    const endpoint = getOllamaEndpointFromContext(ctx);
+    return { endpoint };
+  }),
+
+  /**
+   * Set (or reset) the Ollama endpoint.
+   *
+   * Pass a valid URL string to set a custom endpoint, or `null` to reset
+   * to the default (http://localhost:11434).
+   */
+  setEndpoint: publicProcedure
+    .input(z.object({ endpoint: z.string().url().nullable() }))
+    .mutation(async ({ ctx, input }) => {
+      const config = ctx.config.get() as {
+        providers?: Array<{ id?: string; endpoint?: string; isLocal?: boolean; modelId?: string }>;
+      };
+      const existingProvider = config.providers?.find(
+        (p) => p.id === OLLAMA_WELL_KNOWN_PROVIDER_ID || p.isLocal,
+      );
+
+      // Build the provider config with the new (or cleared) endpoint
+      const endpointValue = input.endpoint ?? undefined;
+      const baseConfig = existingProvider
+        ? {
+            ...buildOllamaProviderConfig(existingProvider.modelId ?? 'unknown'),
+            ...existingProvider,
+            endpoint: endpointValue ?? DEFAULT_OLLAMA_BASE_URL,
+          }
+        : {
+            ...buildOllamaProviderConfig('unknown'),
+            endpoint: endpointValue ?? DEFAULT_OLLAMA_BASE_URL,
+          };
+
+      await upsertProviderConfig(ctx, baseConfig as ModelProviderConfig);
+
+      const effectiveEndpoint = endpointValue ?? DEFAULT_OLLAMA_BASE_URL;
+      console.log(`[nous:ollama] endpoint configured: ${effectiveEndpoint}`);
+      return { success: true };
     }),
 });

--- a/self/shared/src/event-bus/types.ts
+++ b/self/shared/src/event-bus/types.ts
@@ -275,6 +275,39 @@ export const OllamaPullProgressPayloadSchema = z.object({
 });
 export type OllamaPullProgressPayload = z.infer<typeof OllamaPullProgressPayloadSchema>;
 
+/**
+ * SSE payload for Ollama install progress.
+ * Tracks discrete installation phases (not fake percentages) per RT-2.
+ */
+export const OllamaInstallProgressPayloadSchema = z.object({
+  phase: z.enum(['downloading', 'installing', 'verifying', 'complete', 'error']),
+  message: z.string().optional(),
+});
+export type OllamaInstallProgressPayload = z.infer<typeof OllamaInstallProgressPayloadSchema>;
+
+/**
+ * SSE payload for Ollama update progress.
+ * Tracks discrete update phases with optional version metadata.
+ */
+export const OllamaUpdateProgressPayloadSchema = z.object({
+  phase: z.enum(['checking', 'downloading', 'installing', 'verifying', 'complete', 'error']),
+  currentVersion: z.string().optional(),
+  targetVersion: z.string().optional(),
+  message: z.string().optional(),
+});
+export type OllamaUpdateProgressPayload = z.infer<typeof OllamaUpdateProgressPayloadSchema>;
+
+/**
+ * SSE payload for Ollama version info.
+ * Reports detected version and minimum-version compliance.
+ */
+export const OllamaVersionInfoPayloadSchema = z.object({
+  version: z.string(),
+  meetsMinimum: z.boolean(),
+  minimumVersion: z.string().optional(),
+});
+export type OllamaVersionInfoPayload = z.infer<typeof OllamaVersionInfoPayloadSchema>;
+
 // --- Channel Map ---
 
 export interface EventChannelMap {
@@ -308,6 +341,9 @@ export interface EventChannelMap {
   'cost:budget-exceeded': BudgetExceededPayload;
   'cost:snapshot': CostSnapshotPayload;
   'ollama:pull-progress': OllamaPullProgressPayload;
+  'ollama:install-progress': OllamaInstallProgressPayload;
+  'ollama:update-progress': OllamaUpdateProgressPayload;
+  'ollama:version-info': OllamaVersionInfoPayload;
 }
 
 /**

--- a/self/transport/src/hooks/__tests__/usePreferencesApi.test.ts
+++ b/self/transport/src/hooks/__tests__/usePreferencesApi.test.ts
@@ -22,6 +22,7 @@ const mockMutateAsync = {
   resetWizard: vi.fn(),
   pullOllamaModel: vi.fn(),
   deleteOllamaModel: vi.fn(),
+  setOllamaEndpoint: vi.fn(),
 }
 
 vi.mock('../../client', () => ({
@@ -36,6 +37,7 @@ vi.mock('../../client', () => ({
       },
       ollama: {
         listModels: { fetch: mockFetch.listOllamaModels },
+        getEndpoint: { fetch: vi.fn().mockResolvedValue({ endpoint: 'http://localhost:11434' }) },
       },
     }),
     preferences: {
@@ -51,6 +53,7 @@ vi.mock('../../client', () => ({
     ollama: {
       pullModel: { useMutation: () => ({ mutateAsync: mockMutateAsync.pullOllamaModel }) },
       deleteModel: { useMutation: () => ({ mutateAsync: mockMutateAsync.deleteOllamaModel }) },
+      setEndpoint: { useMutation: () => ({ mutateAsync: mockMutateAsync.setOllamaEndpoint }) },
     },
   },
 }))

--- a/self/transport/src/hooks/usePreferencesApi.ts
+++ b/self/transport/src/hooks/usePreferencesApi.ts
@@ -20,6 +20,7 @@ export function usePreferencesApi() {
   const resetWizardMutation = trpc.firstRun.resetWizard.useMutation()
   const pullOllamaModel = trpc.ollama.pullModel.useMutation()
   const deleteOllamaModel = trpc.ollama.deleteModel.useMutation()
+  const setOllamaEndpoint = trpc.ollama.setEndpoint.useMutation()
 
   const utilsRef = useRef(utils)
   utilsRef.current = utils
@@ -39,6 +40,8 @@ export function usePreferencesApi() {
   pullOllamaModelRef.current = pullOllamaModel.mutateAsync
   const deleteOllamaModelRef = useRef(deleteOllamaModel.mutateAsync)
   deleteOllamaModelRef.current = deleteOllamaModel.mutateAsync
+  const setOllamaEndpointRef = useRef(setOllamaEndpoint.mutateAsync)
+  setOllamaEndpointRef.current = setOllamaEndpoint.mutateAsync
 
   return useMemo(
     () => ({
@@ -91,6 +94,13 @@ export function usePreferencesApi() {
       },
       deleteOllamaModel: async (name: string) => {
         return deleteOllamaModelRef.current({ name })
+      },
+      // Ollama endpoint configuration
+      getOllamaEndpoint: async () => {
+        return utilsRef.current.ollama.getEndpoint.fetch()
+      },
+      setOllamaEndpoint: async (endpoint: string | null) => {
+        return setOllamaEndpointRef.current({ endpoint })
       },
     }),
     // No dependencies — object is created once per mount.

--- a/self/ui/src/panels/settings/pages/LocalModelsPage.tsx
+++ b/self/ui/src/panels/settings/pages/LocalModelsPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import type { PreferencesApi, OllamaModelEntry, FeedbackState } from '../types'
 import {
   sectionStyle,
@@ -15,8 +15,13 @@ import { formatFeedbackError } from './helpers'
 import { ConfirmDeleteDialog } from '../../../components'
 
 export interface LocalModelsPageProps {
-  api: Pick<PreferencesApi, 'listOllamaModels' | 'pullOllamaModel' | 'deleteOllamaModel' | 'getSystemStatus'>
+  api: Pick<
+    PreferencesApi,
+    'listOllamaModels' | 'pullOllamaModel' | 'deleteOllamaModel' | 'getSystemStatus' | 'getOllamaEndpoint' | 'setOllamaEndpoint'
+  >
 }
+
+const DEFAULT_ENDPOINT = 'http://localhost:11434'
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -25,15 +30,73 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
+function formatSpeed(bytesPerSecond: number): string {
+  if (bytesPerSecond < 1024) return `${bytesPerSecond.toFixed(0)} B/s`
+  if (bytesPerSecond < 1024 * 1024) return `${(bytesPerSecond / 1024).toFixed(1)} KB/s`
+  return `${(bytesPerSecond / (1024 * 1024)).toFixed(1)} MB/s`
+}
+
+/** Sliding window speed calculation (same logic as DownloadProgressPanel). */
+function useSpeedCalculator() {
+  const samplesRef = useRef<Array<{ time: number; bytes: number }>>([])
+  const WINDOW_SIZE = 5
+
+  return useCallback((completed: number): number => {
+    const now = Date.now()
+    samplesRef.current.push({ time: now, bytes: completed })
+    if (samplesRef.current.length > WINDOW_SIZE) {
+      samplesRef.current.shift()
+    }
+    const samples = samplesRef.current
+    if (samples.length < 2) return 0
+    const oldest = samples[0]
+    const newest = samples[samples.length - 1]
+    const elapsed = (newest.time - oldest.time) / 1000
+    if (elapsed <= 0) return 0
+    return (newest.bytes - oldest.bytes) / elapsed
+  }, [])
+}
+
+interface PullProgress {
+  status: string
+  total?: number
+  completed?: number
+  percent?: number
+}
+
 export function LocalModelsPage({ api }: LocalModelsPageProps) {
   const [models, setModels] = useState<OllamaModelEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [ollamaRunning, setOllamaRunning] = useState(false)
   const [pullInput, setPullInput] = useState('')
   const [pulling, setPulling] = useState(false)
-  const [pullStatus, setPullStatus] = useState<string | null>(null)
+  const [pullProgress, setPullProgress] = useState<PullProgress | null>(null)
   const [feedback, setFeedback] = useState<FeedbackState | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<OllamaModelEntry | null>(null)
+
+  // Endpoint config state
+  const [endpointInput, setEndpointInput] = useState(DEFAULT_ENDPOINT)
+  const [endpointLoading, setEndpointLoading] = useState(false)
+  const [endpointSaving, setEndpointSaving] = useState(false)
+  const [endpointFeedback, setEndpointFeedback] = useState<FeedbackState | null>(null)
+
+  const calculateSpeed = useSpeedCalculator()
+  const [downloadSpeed, setDownloadSpeed] = useState(0)
+  const eventSourceRef = useRef<EventSource | null>(null)
+
+  // Load endpoint on mount
+  useEffect(() => {
+    if (!api.getOllamaEndpoint) return
+    setEndpointLoading(true)
+    api.getOllamaEndpoint()
+      .then((result) => {
+        setEndpointInput(result.endpoint)
+      })
+      .catch(() => {
+        // Keep default
+      })
+      .finally(() => setEndpointLoading(false))
+  }, [api])
 
   const loadModels = useCallback(async () => {
     try {
@@ -57,21 +120,74 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     loadModels()
   }, [loadModels])
 
+  // Subscribe to SSE pull-progress events during a pull
+  useEffect(() => {
+    if (!pulling) {
+      setPullProgress(null)
+      setDownloadSpeed(0)
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close()
+        eventSourceRef.current = null
+      }
+      return
+    }
+
+    // Attempt SSE subscription for pull progress
+    try {
+      const es = new EventSource('/api/events')
+      eventSourceRef.current = es
+
+      es.addEventListener('ollama:pull-progress', (event) => {
+        try {
+          const data = JSON.parse(event.data)
+          // Only show progress for the model being pulled
+          if (data.model === pullInput.trim()) {
+            setPullProgress({
+              status: data.status,
+              total: data.total,
+              completed: data.completed,
+              percent: data.percent,
+            })
+            if (typeof data.completed === 'number') {
+              const speed = calculateSpeed(data.completed)
+              setDownloadSpeed(speed)
+            }
+          }
+        } catch {
+          // Ignore malformed events
+        }
+      })
+
+      es.onerror = () => {
+        // SSE not available — fall back to static text
+        es.close()
+        eventSourceRef.current = null
+      }
+    } catch {
+      // SSE not supported — fall back to static text
+    }
+
+    return () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close()
+        eventSourceRef.current = null
+      }
+    }
+  }, [pulling, pullInput, calculateSpeed])
+
   const handlePull = async () => {
     if (!pullInput.trim() || pulling || !api.pullOllamaModel) return
 
     setPulling(true)
-    setPullStatus('Pulling...')
+    setPullProgress(null)
     setFeedback(null)
 
     try {
       await api.pullOllamaModel(pullInput.trim())
-      setPullStatus(null)
       setPullInput('')
       setFeedback({ message: `Successfully pulled ${pullInput.trim()}`, success: true })
       await loadModels()
     } catch (err) {
-      setPullStatus(null)
       setFeedback(formatFeedbackError(err))
     } finally {
       setPulling(false)
@@ -94,6 +210,37 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     }
   }
 
+  const handleSaveEndpoint = async () => {
+    if (!api.setOllamaEndpoint || endpointSaving) return
+    setEndpointSaving(true)
+    setEndpointFeedback(null)
+
+    try {
+      await api.setOllamaEndpoint(endpointInput.trim())
+      setEndpointFeedback({ message: 'Endpoint saved', success: true })
+    } catch (err) {
+      setEndpointFeedback(formatFeedbackError(err))
+    } finally {
+      setEndpointSaving(false)
+    }
+  }
+
+  const handleResetEndpoint = async () => {
+    if (!api.setOllamaEndpoint || endpointSaving) return
+    setEndpointSaving(true)
+    setEndpointFeedback(null)
+
+    try {
+      await api.setOllamaEndpoint(null)
+      setEndpointInput(DEFAULT_ENDPOINT)
+      setEndpointFeedback({ message: 'Endpoint reset to default', success: true })
+    } catch (err) {
+      setEndpointFeedback(formatFeedbackError(err))
+    } finally {
+      setEndpointSaving(false)
+    }
+  }
+
   if (loading) {
     return (
       <div data-testid="settings-page-local-models">
@@ -105,11 +252,111 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     )
   }
 
+  // Render pull progress inline
+  const renderPullStatus = () => {
+    if (!pulling) return null
+
+    if (pullProgress && typeof pullProgress.percent === 'number') {
+      const pct = Math.min(100, Math.max(0, pullProgress.percent))
+      return (
+        <div data-testid="pull-progress" style={{ width: '100%', marginTop: 'var(--nous-space-xs)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)', marginBottom: '4px' }}>
+            <span>{pullProgress.status}</span>
+            <span>
+              {pullProgress.completed != null && pullProgress.total != null
+                ? `${formatSize(pullProgress.completed)} / ${formatSize(pullProgress.total)}`
+                : ''}
+              {downloadSpeed > 0 ? ` - ${formatSpeed(downloadSpeed)}` : ''}
+              {` - ${pct.toFixed(1)}%`}
+            </span>
+          </div>
+          <div
+            style={{
+              width: '100%',
+              height: '6px',
+              background: 'var(--nous-bg-subtle, #333)',
+              borderRadius: '3px',
+              overflow: 'hidden',
+            }}
+            data-testid="pull-progress-bar"
+          >
+            <div
+              style={{
+                width: `${pct}%`,
+                height: '100%',
+                background: 'var(--nous-accent, #4a9eff)',
+                borderRadius: '3px',
+                transition: 'width 0.3s ease',
+              }}
+            />
+          </div>
+        </div>
+      )
+    }
+
+    // Fallback to static text when no SSE events arrive
+    return (
+      <div style={helperTextStyle} data-testid="pull-status">
+        Pulling...
+      </div>
+    )
+  }
+
   if (!ollamaRunning) {
     return (
       <div data-testid="settings-page-local-models">
         <div style={sectionStyle}>
           <div style={sectionTitleStyle}>Local Models</div>
+
+          {/* Endpoint config — always visible, even when Ollama is not running */}
+          {api.getOllamaEndpoint && (
+            <div style={{ ...cardStyle, marginBottom: 'var(--nous-space-md)' }} data-testid="endpoint-config">
+              <div style={{ fontSize: 'var(--nous-font-size-sm)', fontWeight: 'var(--nous-font-weight-semibold)' as never, color: 'var(--nous-fg)', marginBottom: 'var(--nous-space-xs)' }}>
+                Ollama Endpoint
+              </div>
+              <div style={{ display: 'flex', gap: 'var(--nous-space-sm)', alignItems: 'center', flexWrap: 'wrap' }}>
+                <input
+                  type="url"
+                  value={endpointInput}
+                  onChange={(e) => setEndpointInput(e.target.value)}
+                  placeholder={DEFAULT_ENDPOINT}
+                  disabled={endpointLoading || endpointSaving}
+                  style={{ ...inputStyle, minWidth: '260px' }}
+                  data-testid="endpoint-input"
+                />
+                <button
+                  style={{
+                    ...btnStyle('primary'),
+                    opacity: endpointSaving ? 0.5 : 1,
+                    cursor: endpointSaving ? 'not-allowed' : 'pointer',
+                  }}
+                  onClick={handleSaveEndpoint}
+                  disabled={endpointSaving}
+                  data-testid="endpoint-save-button"
+                >
+                  Save
+                </button>
+                <button
+                  style={{
+                    ...btnStyle('ghost'),
+                    opacity: endpointSaving ? 0.5 : 1,
+                    cursor: endpointSaving ? 'not-allowed' : 'pointer',
+                  }}
+                  onClick={handleResetEndpoint}
+                  disabled={endpointSaving}
+                  data-testid="endpoint-reset-button"
+                >
+                  Reset to Default
+                </button>
+              </div>
+              {endpointFeedback && (
+                <div style={{ ...feedbackStyle(endpointFeedback.success), marginTop: 'var(--nous-space-xs)' }}>
+                  {endpointFeedback.message}
+                </div>
+              )}
+            </div>
+          )}
+
           <div style={cardStyle}>
             <div style={feedbackStyle(false)}>
               Ollama is not running. Start Ollama to manage local models.
@@ -124,6 +371,55 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     <div data-testid="settings-page-local-models">
       <div style={sectionStyle}>
         <div style={sectionTitleStyle}>Local Models</div>
+
+        {/* Endpoint config */}
+        {api.getOllamaEndpoint && (
+          <div style={{ ...cardStyle, marginBottom: 'var(--nous-space-md)' }} data-testid="endpoint-config">
+            <div style={{ fontSize: 'var(--nous-font-size-sm)', fontWeight: 'var(--nous-font-weight-semibold)' as never, color: 'var(--nous-fg)', marginBottom: 'var(--nous-space-xs)' }}>
+              Ollama Endpoint
+            </div>
+            <div style={{ display: 'flex', gap: 'var(--nous-space-sm)', alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                type="url"
+                value={endpointInput}
+                onChange={(e) => setEndpointInput(e.target.value)}
+                placeholder={DEFAULT_ENDPOINT}
+                disabled={endpointLoading || endpointSaving}
+                style={{ ...inputStyle, minWidth: '260px' }}
+                data-testid="endpoint-input"
+              />
+              <button
+                style={{
+                  ...btnStyle('primary'),
+                  opacity: endpointSaving ? 0.5 : 1,
+                  cursor: endpointSaving ? 'not-allowed' : 'pointer',
+                }}
+                onClick={handleSaveEndpoint}
+                disabled={endpointSaving}
+                data-testid="endpoint-save-button"
+              >
+                Save
+              </button>
+              <button
+                style={{
+                  ...btnStyle('ghost'),
+                  opacity: endpointSaving ? 0.5 : 1,
+                  cursor: endpointSaving ? 'not-allowed' : 'pointer',
+                }}
+                onClick={handleResetEndpoint}
+                disabled={endpointSaving}
+                data-testid="endpoint-reset-button"
+              >
+                Reset to Default
+              </button>
+            </div>
+            {endpointFeedback && (
+              <div style={{ ...feedbackStyle(endpointFeedback.success), marginTop: 'var(--nous-space-xs)' }}>
+                {endpointFeedback.message}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Pull section */}
         <div style={{ ...cardStyle, display: 'flex', gap: 'var(--nous-space-sm)', alignItems: 'center', flexWrap: 'wrap' }}>
@@ -149,11 +445,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
           >
             {pulling ? 'Pulling...' : 'Pull Model'}
           </button>
-          {pullStatus && (
-            <div style={helperTextStyle} data-testid="pull-status">
-              {pullStatus}
-            </div>
-          )}
+          {renderPullStatus()}
         </div>
 
         {/* Feedback */}

--- a/self/ui/src/panels/settings/pages/LocalModelsPage.tsx
+++ b/self/ui/src/panels/settings/pages/LocalModelsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { PreferencesApi, OllamaModelEntry, FeedbackState } from '../types'
+import { useEventSubscription } from '@nous/transport'
 import {
   sectionStyle,
   sectionTitleStyle,
@@ -82,7 +83,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
 
   const calculateSpeed = useSpeedCalculator()
   const [downloadSpeed, setDownloadSpeed] = useState(0)
-  const eventSourceRef = useRef<EventSource | null>(null)
+  const pullingModelRef = useRef('')
 
   // Load endpoint on mount
   useEffect(() => {
@@ -120,77 +121,49 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     loadModels()
   }, [loadModels])
 
-  // Subscribe to SSE pull-progress events during a pull
-  useEffect(() => {
-    if (!pulling) {
-      setPullProgress(null)
-      setDownloadSpeed(0)
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close()
-        eventSourceRef.current = null
-      }
-      return
-    }
-
-    // Attempt SSE subscription for pull progress
-    try {
-      const es = new EventSource('/api/events')
-      eventSourceRef.current = es
-
-      es.addEventListener('ollama:pull-progress', (event) => {
-        try {
-          const data = JSON.parse(event.data)
-          // Only show progress for the model being pulled
-          if (data.model === pullInput.trim()) {
-            setPullProgress({
-              status: data.status,
-              total: data.total,
-              completed: data.completed,
-              percent: data.percent,
-            })
-            if (typeof data.completed === 'number') {
-              const speed = calculateSpeed(data.completed)
-              setDownloadSpeed(speed)
-            }
-          }
-        } catch {
-          // Ignore malformed events
+  // Subscribe to SSE pull-progress events via transport hook
+  useEventSubscription({
+    channels: ['ollama:pull-progress'],
+    enabled: pulling,
+    onEvent: useCallback((_channel: string, payload: unknown) => {
+      const data = payload as { model?: string; status?: string; total?: number; completed?: number; percent?: number }
+      if (data.model && data.model === pullingModelRef.current) {
+        setPullProgress({
+          status: data.status ?? 'downloading',
+          total: data.total,
+          completed: data.completed,
+          percent: data.percent,
+        })
+        if (typeof data.completed === 'number') {
+          const speed = calculateSpeed(data.completed)
+          setDownloadSpeed(speed)
         }
-      })
-
-      es.onerror = () => {
-        // SSE not available — fall back to static text
-        es.close()
-        eventSourceRef.current = null
       }
-    } catch {
-      // SSE not supported — fall back to static text
-    }
-
-    return () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close()
-        eventSourceRef.current = null
-      }
-    }
-  }, [pulling, pullInput, calculateSpeed])
+    }, [calculateSpeed]),
+  })
 
   const handlePull = async () => {
     if (!pullInput.trim() || pulling || !api.pullOllamaModel) return
 
+    const modelName = pullInput.trim()
+    pullingModelRef.current = modelName
     setPulling(true)
     setPullProgress(null)
+    setDownloadSpeed(0)
     setFeedback(null)
 
     try {
-      await api.pullOllamaModel(pullInput.trim())
+      await api.pullOllamaModel(modelName)
       setPullInput('')
-      setFeedback({ message: `Successfully pulled ${pullInput.trim()}`, success: true })
+      setFeedback({ message: `Successfully downloaded ${modelName}`, success: true })
       await loadModels()
     } catch (err) {
       setFeedback(formatFeedbackError(err))
     } finally {
       setPulling(false)
+      setPullProgress(null)
+      setDownloadSpeed(0)
+      pullingModelRef.current = ''
     }
   }
 
@@ -218,6 +191,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     try {
       await api.setOllamaEndpoint(endpointInput.trim())
       setEndpointFeedback({ message: 'Endpoint saved', success: true })
+      await loadModels()
     } catch (err) {
       setEndpointFeedback(formatFeedbackError(err))
     } finally {
@@ -234,6 +208,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
       await api.setOllamaEndpoint(null)
       setEndpointInput(DEFAULT_ENDPOINT)
       setEndpointFeedback({ message: 'Endpoint reset to default', success: true })
+      await loadModels()
     } catch (err) {
       setEndpointFeedback(formatFeedbackError(err))
     } finally {
@@ -297,7 +272,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
     // Fallback to static text when no SSE events arrive
     return (
       <div style={helperTextStyle} data-testid="pull-status">
-        Pulling...
+        Downloading...
       </div>
     )
   }
@@ -428,7 +403,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
             value={pullInput}
             onChange={(e) => setPullInput(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handlePull() }}
-            placeholder="Model name (e.g. llama3.2)"
+            placeholder="Model name (e.g., llama3.2)"
             disabled={pulling}
             style={{ ...inputStyle, minWidth: '200px' }}
             data-testid="pull-model-input"
@@ -443,7 +418,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
             disabled={!pullInput.trim() || pulling}
             data-testid="pull-model-button"
           >
-            {pulling ? 'Pulling...' : 'Pull Model'}
+            {pulling ? 'Downloading...' : 'Download Model'}
           </button>
           {renderPullStatus()}
         </div>
@@ -458,7 +433,7 @@ export function LocalModelsPage({ api }: LocalModelsPageProps) {
         {/* Model cards */}
         {models.length === 0 ? (
           <div style={{ ...helperTextStyle, marginTop: 'var(--nous-space-md)' }}>
-            No models installed. Pull a model to get started.
+            No models installed. Download a model to get started.
           </div>
         ) : (
           models.map((model) => (

--- a/self/ui/src/panels/settings/pages/__tests__/LocalModelsPage-progress.test.tsx
+++ b/self/ui/src/panels/settings/pages/__tests__/LocalModelsPage-progress.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for pull progress rendering in LocalModelsPage.
+ *
+ * Verifies:
+ * - During a pull, progress bar is rendered instead of static "Pulling..." text
+ * - Progress updates (percent, bytes, speed) are reflected in the UI
+ * - Fallback to "Pulling..." when no SSE events arrive
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { LocalModelsPage } from '../LocalModelsPage';
+import type { PreferencesApi } from '../../types';
+
+// Mock EventSource
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  listeners: Record<string, ((event: MessageEvent) => void)[]> = {};
+  onerror: ((event: Event) => void) | null = null;
+  readyState = 0;
+
+  constructor(_url: string) {
+    MockEventSource.instances.push(this);
+    this.readyState = 1; // OPEN
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (!this.listeners[type]) this.listeners[type] = [];
+    this.listeners[type].push(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (this.listeners[type]) {
+      this.listeners[type] = this.listeners[type].filter((l) => l !== listener);
+    }
+  }
+
+  close() {
+    this.readyState = 2; // CLOSED
+  }
+
+  // Test helper: simulate an event
+  emit(type: string, data: unknown) {
+    const event = new MessageEvent(type, { data: JSON.stringify(data) });
+    this.listeners[type]?.forEach((l) => l(event));
+  }
+}
+
+function createMockApi(overrides?: Partial<PreferencesApi>): any {
+  return {
+    getSystemStatus: vi.fn().mockResolvedValue({
+      ollama: { running: true, models: ['llama3'] },
+      configuredProviders: [],
+      credentialVaultHealthy: true,
+    }),
+    listOllamaModels: vi.fn().mockResolvedValue({
+      models: [{ name: 'llama3', size: 4_000_000_000, modifiedAt: '2024-01-01T00:00:00Z' }],
+    }),
+    pullOllamaModel: vi.fn().mockImplementation(() => new Promise(() => {
+      // Never resolve — simulate an ongoing pull
+    })),
+    deleteOllamaModel: vi.fn().mockResolvedValue({ success: true }),
+    getOllamaEndpoint: vi.fn().mockResolvedValue({ endpoint: 'http://localhost:11434' }),
+    setOllamaEndpoint: vi.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  };
+}
+
+describe('LocalModelsPage pull progress', () => {
+  let OriginalEventSource: typeof globalThis.EventSource;
+
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    OriginalEventSource = globalThis.EventSource;
+    (globalThis as any).EventSource = MockEventSource;
+  });
+
+  afterEach(() => {
+    globalThis.EventSource = OriginalEventSource;
+    vi.restoreAllMocks();
+  });
+
+  it('shows "Pulling..." fallback when no SSE events arrive', async () => {
+    const api = createMockApi();
+
+    render(<LocalModelsPage api={api} />);
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByTestId('pull-model-input')).toBeDefined();
+    });
+
+    // Type model name and click pull
+    const input = screen.getByTestId('pull-model-input') as HTMLInputElement;
+    const pullButton = screen.getByTestId('pull-model-button');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'llama3.2' } });
+    });
+    await act(async () => {
+      fireEvent.click(pullButton);
+    });
+
+    // Should show fallback "Pulling..." text
+    await waitFor(() => {
+      expect(screen.getByTestId('pull-status')).toBeDefined();
+      expect(screen.getByTestId('pull-status').textContent).toBe('Pulling...');
+    });
+  });
+
+  it('shows progress bar when SSE events arrive during pull', async () => {
+    const api = createMockApi();
+
+    render(<LocalModelsPage api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pull-model-input')).toBeDefined();
+    });
+
+    const input = screen.getByTestId('pull-model-input') as HTMLInputElement;
+    const pullButton = screen.getByTestId('pull-model-button');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'llama3.2' } });
+    });
+    await act(async () => {
+      fireEvent.click(pullButton);
+    });
+
+    // Get the EventSource instance created during pull
+    const es = MockEventSource.instances[MockEventSource.instances.length - 1];
+    expect(es).toBeDefined();
+
+    // Simulate progress events
+    await act(async () => {
+      es.emit('ollama:pull-progress', {
+        model: 'llama3.2',
+        status: 'downloading',
+        total: 4_000_000_000,
+        completed: 1_000_000_000,
+        percent: 25.0,
+      });
+    });
+
+    // Should now show progress bar instead of "Pulling..."
+    await waitFor(() => {
+      const progressEl = screen.getByTestId('pull-progress');
+      expect(progressEl).toBeDefined();
+      expect(progressEl.textContent).toContain('25.0%');
+      expect(progressEl.textContent).toContain('downloading');
+    });
+
+    // Progress bar element should exist
+    expect(screen.getByTestId('pull-progress-bar')).toBeDefined();
+  });
+
+  it('updates progress display when new events arrive', async () => {
+    const api = createMockApi();
+
+    render(<LocalModelsPage api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pull-model-input')).toBeDefined();
+    });
+
+    const input = screen.getByTestId('pull-model-input') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'llama3.2' } });
+      fireEvent.click(screen.getByTestId('pull-model-button'));
+    });
+
+    const es = MockEventSource.instances[MockEventSource.instances.length - 1];
+
+    // First progress event
+    await act(async () => {
+      es.emit('ollama:pull-progress', {
+        model: 'llama3.2',
+        status: 'downloading',
+        total: 4_000_000_000,
+        completed: 1_000_000_000,
+        percent: 25.0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pull-progress').textContent).toContain('25.0%');
+    });
+
+    // Second progress event — higher percentage
+    await act(async () => {
+      es.emit('ollama:pull-progress', {
+        model: 'llama3.2',
+        status: 'downloading',
+        total: 4_000_000_000,
+        completed: 2_000_000_000,
+        percent: 50.0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pull-progress').textContent).toContain('50.0%');
+    });
+  });
+});

--- a/self/ui/src/panels/settings/pages/__tests__/LocalModelsPage-progress.test.tsx
+++ b/self/ui/src/panels/settings/pages/__tests__/LocalModelsPage-progress.test.tsx
@@ -100,10 +100,10 @@ describe('LocalModelsPage pull progress', () => {
       fireEvent.click(pullButton);
     });
 
-    // Should show fallback "Pulling..." text
+    // Should show fallback "Downloading..." text
     await waitFor(() => {
       expect(screen.getByTestId('pull-status')).toBeDefined();
-      expect(screen.getByTestId('pull-status').textContent).toBe('Pulling...');
+      expect(screen.getByTestId('pull-status').textContent).toBe('Downloading...');
     });
   });
 

--- a/self/ui/src/panels/settings/types.ts
+++ b/self/ui/src/panels/settings/types.ts
@@ -109,6 +109,8 @@ export interface PreferencesApi {
   listOllamaModels?: () => Promise<{ models: OllamaModelEntry[] }>
   pullOllamaModel?: (name: string) => Promise<{ success: boolean }>
   deleteOllamaModel?: (name: string) => Promise<{ success: boolean }>
+  getOllamaEndpoint?: () => Promise<{ endpoint: string }>
+  setOllamaEndpoint?: (endpoint: string | null) => Promise<{ success: boolean }>
 }
 
 // ─── Constants ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Configurable Ollama endpoint with tRPC get/set procedures and settings UI (replaces 4 hardcoded `localhost:11434` locations)
- IPC bridge extensions for install, update, and version channels (foundation for WR-132.2/132.3)
- Download progress bar in Settings > Local Models using SSE event subscription (replaces static "Downloading..." text)
- New shared helper `ollama-config.ts` for endpoint resolution across routers

## Test plan
- [x] Unit tests: 19 new (endpoint config, config propagation, progress rendering)
- [x] Regression: 41 existing tests pass
- [x] TypeScript typecheck clean
- [x] BT: endpoint config save/reset with auto-reload
- [x] BT: download progress bar via SSE
- [x] BT: wizard regression (still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)