### PR TITLE
fix(cortex-core): replace transformGatewayInput with adapter formatRequest — WR-139

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter.test.ts
@@ -105,6 +105,51 @@ describe('createAnthropicAdapter', () => {
       const result = adapter.formatRequest(input);
       expect(result.input.model_profile).toBe('fast');
     });
+
+    it('emits tool_result content block for tool frame with metadata.tool_call_id', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'tool',
+            content: 'search result here',
+            source: 'tool_result',
+            createdAt: '2026-01-01T00:00:00Z',
+            name: 'search',
+            metadata: { tool_call_id: 'toolu_abc123' },
+          },
+        ],
+      };
+      const result = adapter.formatRequest(input);
+      const messages = result.input.messages as Array<{ role: string; content: unknown }>;
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].content).toEqual([
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_abc123',
+          content: 'search result here',
+        },
+      ]);
+    });
+
+    it('falls back to role: user for tool frame without metadata.tool_call_id', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'tool',
+            content: 'tool output',
+            source: 'tool_result',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      };
+      const result = adapter.formatRequest(input);
+      const messages = result.input.messages as Array<{ role: string; content: unknown }>;
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({ role: 'user', content: 'tool output' });
+    });
   });
 
   describe('parseResponse', () => {
@@ -130,6 +175,7 @@ describe('createAnthropicAdapter', () => {
           { type: 'text', text: 'Let me search for that.' },
           {
             type: 'tool_use',
+            id: 'toolu_abc',
             name: 'search',
             input: { query: 'test' },
           },
@@ -139,8 +185,19 @@ describe('createAnthropicAdapter', () => {
       const result = adapter.parseResponse(output, traceId);
       expect(result.response).toBe('Let me search for that.');
       expect(result.toolCalls).toEqual([
-        { name: 'search', params: { query: 'test' } },
+        { name: 'search', params: { query: 'test' }, id: 'toolu_abc' },
       ]);
+    });
+
+    it('preserves tool_use block id in toolCalls', () => {
+      const output = {
+        content: [
+          { type: 'tool_use', id: 'toolu_123', name: 'read_file', input: { path: '/x' } },
+        ],
+        stop_reason: 'tool_use',
+      };
+      const result = adapter.parseResponse(output, traceId);
+      expect(result.toolCalls[0].id).toBe('toolu_123');
     });
 
     it('parses multiple tool_use blocks', () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
@@ -205,6 +205,54 @@ describe('createOllamaAdapter', () => {
       const input = result.input as Record<string, unknown>;
       expect(input.model_profile).toBe('review-standard');
     });
+
+    it('emits tool result message for tool frame with metadata.tool_call_id', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'prompt',
+        context: [
+          {
+            role: 'tool' as const,
+            content: 'weather data',
+            source: 'tool_result' as const,
+            createdAt: new Date().toISOString(),
+            metadata: { tool_call_id: 'call_xyz' },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      // System message + tool result
+      expect(messages).toHaveLength(2);
+      expect(messages[1]).toEqual({
+        role: 'tool',
+        content: 'weather data',
+        tool_call_id: 'call_xyz',
+      });
+    });
+
+    it('falls back to role: user for tool frame without metadata.tool_call_id', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'prompt',
+        context: [makeFrame('tool', 'tool output')],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1]).toEqual({ role: 'user', content: 'tool output' });
+    });
+
+    it('parseResponse returns undefined id for tool calls (Ollama does not provide IDs)', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const output = {
+        content: '',
+        tool_calls: [
+          { function: { name: 'get_weather', arguments: { city: 'NYC' } } },
+        ],
+      };
+      const result = adapter.parseResponse(output, TRACE_ID);
+      expect(result.toolCalls[0].id).toBeUndefined();
+    });
   });
 
   describe('parseResponse', () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/openai-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/openai-adapter.test.ts
@@ -76,6 +76,47 @@ describe('createOpenAiAdapter', () => {
       const messages = input.messages as Array<{ role: string; content: string }>;
       expect(messages[0].content).toBe('Part A.\n\nPart B.');
     });
+
+    it('emits tool result message for tool frame with metadata.tool_call_id', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'tool' as const,
+            content: 'weather data',
+            source: 'tool_result' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+            metadata: { tool_call_id: 'call_xyz' },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      // System message + tool result
+      expect(messages).toHaveLength(2);
+      expect(messages[1]).toEqual({
+        role: 'tool',
+        content: 'weather data',
+        tool_call_id: 'call_xyz',
+      });
+    });
+
+    it('falls back to role: user for tool frame without metadata.tool_call_id', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'tool' as const,
+            content: 'tool output',
+            source: 'tool_result' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1]).toEqual({ role: 'user', content: 'tool output' });
+    });
   });
 
   describe('parseResponse', () => {
@@ -94,6 +135,7 @@ describe('createOpenAiAdapter', () => {
           message: {
             content: '',
             tool_calls: [{
+              id: 'call_456',
               function: {
                 name: 'get_weather',
                 arguments: '{"city":"NYC"}',
@@ -104,8 +146,24 @@ describe('createOpenAiAdapter', () => {
       };
       const result = adapter.parseResponse(output, TRACE_ID);
       expect(result.toolCalls).toEqual([
-        { name: 'get_weather', params: { city: 'NYC' } },
+        { name: 'get_weather', params: { city: 'NYC' }, id: 'call_456' },
       ]);
+    });
+
+    it('preserves tool call id from tool_calls', () => {
+      const output = {
+        choices: [{
+          message: {
+            content: '',
+            tool_calls: [{
+              id: 'call_789',
+              function: { name: 'test', arguments: '{}' },
+            }],
+          },
+        }],
+      };
+      const result = adapter.parseResponse(output, TRACE_ID);
+      expect(result.toolCalls[0].id).toBe('call_789');
     });
 
     it('handles direct content/tool_calls (no choices wrapper)', () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-dispatch-chain.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-dispatch-chain.test.ts
@@ -363,15 +363,16 @@ describe('AgentGateway dispatch chain integration', () => {
     expect(result.status).toBe('completed');
 
     // Verify injected context appeared in the first model invocation's context
+    // Text adapter produces { prompt, context } format with GatewayContextFrame[]
     const firstInvoke = modelProvider.invoke.mock.calls[0][0];
-    const messages = firstInvoke.input.messages as Array<{
+    const context = firstInvoke.input.context as Array<{
       role: string;
       content: string;
     }>;
-    const injectedMessage = messages.find(
-      (msg) => msg.content.includes('Priority update'),
+    const injectedFrame = context.find(
+      (frame) => frame.content.includes('Priority update'),
     );
-    expect(injectedMessage).toBeDefined();
+    expect(injectedFrame).toBeDefined();
   });
 
   it('turn-cycle ack events are emitted to the outbox for each turn', async () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-lifecycle-integration.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-lifecycle-integration.test.ts
@@ -93,15 +93,16 @@ describe('AgentGateway lifecycle integration', () => {
 
     expect(result.status).toBe('completed');
     const secondInvoke = modelProvider.invoke.mock.calls[1][0];
-    const messages = secondInvoke.input.messages as Array<{ role: string; content: string }>;
-    // After transformGatewayInput, child_result frames become messages; filter by content
-    const childMessages = messages.filter(
-      (msg) => msg.content.includes('child-one') || msg.content.includes('child-two'),
+    // Text adapter produces { prompt, context } format with GatewayContextFrame[]
+    const context = secondInvoke.input.context as Array<{ role: string; content: string }>;
+    // After adapter.formatRequest, child_result frames become context entries; filter by content
+    const childFrames = context.filter(
+      (frame) => frame.content.includes('child-one') || frame.content.includes('child-two'),
     );
 
-    expect(childMessages).toHaveLength(2);
-    expect(childMessages[0]?.content).toContain('child-one');
-    expect(childMessages[1]?.content).toContain('child-two');
+    expect(childFrames).toHaveLength(2);
+    expect(childFrames[0]?.content).toContain('child-one');
+    expect(childFrames[1]?.content).toContain('child-two');
   });
 
   it('keeps flag_observation non-terminal while emitting the outbox event', async () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-messaging.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-messaging.test.ts
@@ -70,13 +70,14 @@ describe('AgentGateway messaging', () => {
 
     expect(result.status).toBe('completed');
     const secondInvoke = modelProvider.invoke.mock.calls[1][0];
-    const messages = secondInvoke.input.messages as Array<{ role: string; content: string }>;
-    // After transformGatewayInput, child_result frames become messages; find by content
-    const childMessage = messages.find(
-      (msg) => msg.content.includes('"child": "done"'),
+    // Text adapter produces { prompt, context } format with GatewayContextFrame[]
+    const context = secondInvoke.input.context as Array<{ role: string; content: string }>;
+    // After adapter.formatRequest, child_result frames become context entries; find by content
+    const childFrame = context.find(
+      (frame) => frame.content.includes('"child": "done"'),
     );
 
-    expect(childMessage?.content).toContain('"child": "done"');
-    expect(childMessage?.content.includes('"context"')).toBe(false);
+    expect(childFrame?.content).toContain('"child": "done"');
+    expect(childFrame?.content.includes('"context"')).toBe(false);
   });
 });

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-turn-loop.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-turn-loop.test.ts
@@ -44,10 +44,11 @@ describe('AgentGateway turn loop', () => {
     expect(outbox.events.filter((event) => event.type === 'turn_ack')).toHaveLength(2);
 
     const secondInvoke = modelProvider.invoke.mock.calls[1][0];
-    const secondMessages = secondInvoke.input.messages as Array<{ role: string; content: string }>;
+    // Text adapter produces { prompt, context } format with GatewayContextFrame[]
+    const secondContext = secondInvoke.input.context as Array<{ role: string; content: string }>;
     expect(
-      secondMessages.some((msg) =>
-        msg.content.includes('Supervisor updated the task constraints.'),
+      secondContext.some((frame) =>
+        frame.content.includes('Supervisor updated the task constraints.'),
       ),
     ).toBe(true);
   });

--- a/self/cortex/core/src/__tests__/gateway-runtime/gateway-turn-executor.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/gateway-turn-executor.test.ts
@@ -1,74 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { NousError } from '@nous/shared';
 import { GatewayBackedTurnExecutor } from '../../gateway-runtime/index.js';
-import { transformGatewayInput } from '../../gateway-runtime/gateway-turn-executor.js';
-import { TextModelInputSchema } from '../../../../../subcortex/providers/src/schemas.js';
 
 describe('GatewayBackedTurnExecutor', () => {
-  it('transforms gateway-format input into provider-compatible messages', () => {
-    const transformed = transformGatewayInput({
-      systemPrompt: 'Follow the system instructions',
-      context: [
-        {
-          role: 'user',
-          source: 'initial_context',
-          content: 'First question',
-          createdAt: '2026-03-21T23:00:00.000Z',
-        },
-        {
-          role: 'assistant',
-          source: 'model_output',
-          content: 'First answer',
-          createdAt: '2026-03-21T23:00:01.000Z',
-        },
-        {
-          role: 'tool',
-          source: 'tool_result',
-          content: 'tool output',
-          createdAt: '2026-03-21T23:00:02.000Z',
-        },
-      ],
-      tools: [{ name: 'task_complete' }],
-    });
-
-    expect(transformed).toEqual({
-      messages: [
-        { role: 'system', content: 'Follow the system instructions' },
-        { role: 'user', content: 'First question' },
-        { role: 'assistant', content: 'First answer' },
-        { role: 'user', content: 'tool output' },
-      ],
-      tools: [
-        { name: 'task_complete', description: '', input_schema: {} },
-      ],
-    });
-    expect(TextModelInputSchema.safeParse(transformed).success).toBe(true);
-  });
-
-  it('passes through existing provider input shapes unchanged', () => {
-    const promptInput = { prompt: 'Summarize this' };
-    const messagesInput = {
-      messages: [{ role: 'user', content: 'Already in provider format' }],
-    };
-    const randomInput = { foo: 'bar' };
-
-    expect(transformGatewayInput(promptInput)).toBe(promptInput);
-    expect(transformGatewayInput(messagesInput)).toBe(messagesInput);
-    expect(transformGatewayInput(randomInput)).toBe(randomInput);
-  });
-
-  it('keeps empty system prompts and empty context arrays valid', () => {
-    const transformed = transformGatewayInput({
-      systemPrompt: '',
-      context: [],
-      tools: [],
-    });
-
-    expect(transformed).toEqual({
-      messages: [{ role: 'system', content: '' }],
-    });
-    expect(TextModelInputSchema.safeParse(transformed).success).toBe(true);
-  });
+  // Legacy transformGatewayInput tests removed — function replaced by adapter.formatRequest()
+  // per WR-139.1 Adapter Format Wiring.
 
   it('satisfies the turn/trace seam through a gateway-backed execution path', async () => {
     const traces = new Map<string, unknown>();
@@ -133,20 +69,17 @@ describe('GatewayBackedTurnExecutor', () => {
 
     expect(result.response).toBe('Gateway-backed reply');
     expect(provider.invoke).toHaveBeenCalledOnce();
-    expect(provider.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({
-        input: expect.objectContaining({
-          messages: [
-            expect.objectContaining({
-              role: 'system',
-            }),
-            expect.objectContaining({
-              role: 'user',
-              content: '{\n  "message": "Hello gateway executor"\n}',
-            }),
-          ],
+    // Text adapter produces { prompt, context } format (not { messages })
+    const invokedInput = provider.invoke.mock.calls[0][0].input;
+    expect(invokedInput).toHaveProperty('prompt');
+    expect(invokedInput).toHaveProperty('context');
+    expect(invokedInput.context).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: '{\n  "message": "Hello gateway executor"\n}',
         }),
-      }),
+      ]),
     );
 
     const trace = await executor.getTrace(traceId);

--- a/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
@@ -88,17 +88,34 @@ function formatTools(
 
 function formatMessages(
   context: readonly import('@nous/shared').GatewayContextFrame[],
-): Array<{ role: 'user' | 'assistant'; content: string }> {
-  return context.map((frame) => ({
-    role: frame.role === 'tool' || frame.role === 'system' ? 'user' : frame.role,
-    content: frame.content,
-  }));
+): Array<{ role: 'user' | 'assistant'; content: string | Array<Record<string, unknown>> }> {
+  return context.map((frame) => {
+    // Tool result with tool_call_id metadata → Anthropic tool_result content block
+    if (frame.role === 'tool' && frame.metadata?.tool_call_id) {
+      return {
+        role: 'user' as const,
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: frame.metadata.tool_call_id as string,
+            content: frame.content,
+          },
+        ],
+      };
+    }
+
+    return {
+      role: (frame.role === 'tool' || frame.role === 'system' ? 'user' : frame.role) as 'user' | 'assistant',
+      content: frame.content,
+    };
+  });
 }
 
 // ── Response parsing ────────────────────────────────────────────────
 
 interface AnthropicContentBlock {
   type?: string;
+  id?: string;
   text?: string;
   name?: string;
   input?: unknown;
@@ -161,7 +178,7 @@ function parseAnthropicResponse(
 
   // Parse content blocks
   const textParts: string[] = [];
-  const toolCalls: Array<{ name: string; params: unknown }> = [];
+  const toolCalls: Array<{ name: string; params: unknown; id?: string }> = [];
   const thinkingParts: string[] = [];
 
   for (const block of content) {
@@ -171,7 +188,7 @@ function parseAnthropicResponse(
       textParts.push(block.text);
     } else if (block.type === 'tool_use') {
       if (typeof block.name === 'string') {
-        toolCalls.push({ name: block.name, params: block.input ?? {} });
+        toolCalls.push({ name: block.name, params: block.input ?? {}, id: block.id });
       }
     } else if (block.type === 'thinking' && typeof block.thinking === 'string') {
       thinkingParts.push(block.thinking);

--- a/self/cortex/core/src/agent-gateway/adapters/index.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/index.ts
@@ -37,3 +37,21 @@ export function resolveAdapter(providerType: string): ProviderAdapter {
   if (factory) return factory();
   return createTextAdapter();
 }
+
+/**
+ * Detects provider type from an IModelProvider's config name/type.
+ * Uses the same heuristic as CortexRuntime.resolveProviderType.
+ * Falls back to 'text' for unknown providers.
+ */
+export function resolveProviderTypeFromConfig(provider: { getConfig(): { name?: string; type?: string } }): string {
+  try {
+    const config = provider.getConfig();
+    const name = (config.name ?? config.type ?? '').toLowerCase();
+    if (name.includes('anthropic') || name.includes('claude')) return 'anthropic';
+    if (name.includes('openai') || name.includes('gpt')) return 'openai';
+    if (name.includes('ollama')) return 'ollama';
+    return 'text';
+  } catch {
+    return 'text';
+  }
+}

--- a/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
@@ -243,7 +243,7 @@ export function createOllamaAdapter(modelId?: string): ProviderAdapter {
         : input.systemPrompt;
 
       // Build messages array
-      const messages: Array<{ role: string; content: string }> = [
+      const messages: Array<{ role: string; content: string; tool_call_id?: string }> = [
         { role: 'system', content: systemPrompt },
       ];
 
@@ -254,6 +254,25 @@ export function createOllamaAdapter(modelId?: string): ProviderAdapter {
         // to avoid confusing the model with prior reasoning traces
         if (frame.role === 'assistant') {
           content = stripThinkingFromContext(content);
+        }
+
+        // Tool result with tool_call_id metadata → OpenAI-compatible tool result message
+        if (frame.role === 'tool' && frame.metadata?.tool_call_id) {
+          messages.push({
+            role: 'tool',
+            content,
+            tool_call_id: frame.metadata.tool_call_id as string,
+          });
+          continue;
+        }
+
+        // Fallback: tool frames without metadata degrade to user role
+        if (frame.role === 'tool') {
+          messages.push({
+            role: 'user',
+            content,
+          });
+          continue;
         }
 
         messages.push({

--- a/self/cortex/core/src/agent-gateway/adapters/openai-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/openai-adapter.ts
@@ -18,11 +18,21 @@ export function createOpenAiAdapter(): ProviderAdapter {
         : input.systemPrompt;
 
       const messages = [
-        { role: 'system' as const, content: systemPrompt },
-        ...input.context.map((frame) => ({
-          role: frame.role === 'tool' ? ('user' as const) : frame.role,
-          content: frame.content,
-        })),
+        { role: 'system' as const, content: systemPrompt } as Record<string, unknown>,
+        ...input.context.map((frame) => {
+          // Tool result with tool_call_id metadata → OpenAI tool result message
+          if (frame.role === 'tool' && frame.metadata?.tool_call_id) {
+            return {
+              role: 'tool' as const,
+              content: frame.content,
+              tool_call_id: frame.metadata.tool_call_id as string,
+            };
+          }
+          return {
+            role: frame.role === 'tool' ? ('user' as const) : frame.role,
+            content: frame.content,
+          };
+        }),
       ];
 
       const result: Record<string, unknown> = { messages };
@@ -127,12 +137,13 @@ function parseOpenAiResponse(output: unknown): ParsedModelOutput {
 
 function parseOpenAiToolCalls(
   toolCalls: unknown,
-): Array<{ name: string; params: unknown }> {
+): Array<{ name: string; params: unknown; id?: string }> {
   if (!Array.isArray(toolCalls)) return [];
-  const result: Array<{ name: string; params: unknown }> = [];
+  const result: Array<{ name: string; params: unknown; id?: string }> = [];
   for (const tc of toolCalls) {
     if (tc && typeof tc === 'object' && 'function' in tc) {
-      const fn = (tc as Record<string, unknown>).function;
+      const tcObj = tc as Record<string, unknown>;
+      const fn = tcObj.function;
       if (fn && typeof fn === 'object') {
         const fnObj = fn as Record<string, unknown>;
         const name = typeof fnObj.name === 'string' ? fnObj.name : '';
@@ -140,7 +151,8 @@ function parseOpenAiToolCalls(
         if (typeof fnObj.arguments === 'string') {
           try { params = JSON.parse(fnObj.arguments); } catch { params = {}; }
         }
-        if (name) result.push({ name, params });
+        const id = typeof tcObj.id === 'string' ? tcObj.id : undefined;
+        if (name) result.push({ name, params, id });
       }
     }
   }

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -54,7 +54,8 @@ import {
 } from './lifecycle-hooks.js';
 import { GatewayOutbox } from './outbox.js';
 import { composeSystemPrompt } from './system-prompt-composer.js';
-import { transformGatewayInput } from '../gateway-runtime/gateway-turn-executor.js';
+import { resolveAdapter, resolveProviderTypeFromConfig } from './adapters/index.js';
+import type { ProviderAdapter } from './adapters/types.js';
 
 const DEFAULT_MODEL_ROLE: ModelRole = 'reasoner';
 const DEFAULT_MODEL_REQUIREMENTS = {
@@ -96,6 +97,7 @@ export class AgentGateway implements IAgentGateway {
   private readonly now: () => string;
   private readonly nowMs: () => number;
   private readonly idFactory: () => string;
+  private cachedAdapter: ProviderAdapter | null = null;
 
   constructor(private readonly config: AgentGatewayConfig) {
     this.agentClass = config.agentClass;
@@ -112,6 +114,19 @@ export class AgentGateway implements IAgentGateway {
         'CONFIG_ERROR',
       );
     }
+  }
+
+  /**
+   * Lazily resolves a ProviderAdapter from the provider's config name.
+   * Uses the same heuristic as CortexRuntime.resolveProviderType.
+   * Caches after first resolution for the gateway's lifetime.
+   */
+  private resolveAdapterFromProvider(provider: IModelProvider): ProviderAdapter {
+    if (this.cachedAdapter) return this.cachedAdapter;
+    const providerType = resolveProviderTypeFromConfig(provider);
+    this.cachedAdapter = resolveAdapter(providerType);
+    console.debug('[nous:gateway] adapter resolved', { agentClass: this.agentClass, providerType });
+    return this.cachedAdapter;
   }
 
   getInboxHandle() {
@@ -186,9 +201,10 @@ export class AgentGateway implements IAgentGateway {
 
         const correlation = sequencer.snapshot();
 
-        // ALWAYS use transformGatewayInput — converts { systemPrompt, context, tools }
-        // into provider-compatible format ({ messages, tools }).
-        const providerInput = transformGatewayInput({ systemPrompt, context, tools });
+        // Use adapter.formatRequest() — converts { systemPrompt, context, toolDefinitions }
+        // into provider-specific format (Anthropic, OpenAI, Ollama, or text).
+        const adapter = this.resolveAdapterFromProvider(provider);
+        const formatted = adapter.formatRequest({ systemPrompt, context, toolDefinitions: tools });
 
         // Extract the last user message from context for logging
         const lastUserFrame = [...context].reverse().find(f => f.role === 'user');
@@ -196,13 +212,13 @@ export class AgentGateway implements IAgentGateway {
         console.debug('[nous:gateway] invoke provider', {
           agentClass: this.agentClass,
           hasHarness: !!this.config.harness,
-          inputKeys: Object.keys(providerInput as Record<string, unknown>),
+          inputKeys: Object.keys(formatted.input),
           userMessage: lastUserFrame?.content?.slice(0, 500) ?? '(no user message)',
         });
 
         const modelResponse = await provider.invoke({
           role: this.config.modelRole ?? DEFAULT_MODEL_ROLE,
-          input: providerInput,
+          input: formatted.input,
           projectId,
           traceId,
           agentClass: this.agentClass,
@@ -397,6 +413,7 @@ export class AgentGateway implements IAgentGateway {
     input: AgentInput;
     toolName: string;
     params: unknown;
+    toolCallId?: string;
     budgetTracker: BudgetTracker;
     sequencer: CorrelationSequencer;
     traceId: TraceId;
@@ -422,7 +439,7 @@ export class AgentGateway implements IAgentGateway {
 
   private async handleToolCalls(args: {
     input: AgentInput;
-    toolCalls: Array<{ name: string; params: unknown }>;
+    toolCalls: Array<{ name: string; params: unknown; id?: string }>;
     budgetTracker: BudgetTracker;
     sequencer: CorrelationSequencer;
     traceId: TraceId;
@@ -453,6 +470,7 @@ export class AgentGateway implements IAgentGateway {
           ...args,
           toolName: toolCall.name,
           params: toolCall.params,
+          toolCallId: toolCall.id,
         }));
 
       if (handled.contextFrame) {
@@ -554,6 +572,7 @@ export class AgentGateway implements IAgentGateway {
     input: AgentInput;
     toolName: string;
     params: unknown;
+    toolCallId?: string;
     budgetTracker: BudgetTracker;
     sequencer: CorrelationSequencer;
     traceId: TraceId;
@@ -575,6 +594,7 @@ export class AgentGateway implements IAgentGateway {
           'tool_result',
           stringifyValue(value),
           args.toolName,
+          args.toolCallId ? { tool_call_id: args.toolCallId } : undefined,
         ),
       };
     } catch (error) {
@@ -1326,12 +1346,14 @@ export class AgentGateway implements IAgentGateway {
     source: GatewayContextFrame['source'],
     content: string,
     name?: string,
+    metadata?: Record<string, unknown>,
   ): GatewayContextFrame {
     return GatewayContextFrameSchema.parse({
       role,
       source,
       content,
       name,
+      metadata,
       createdAt: this.now(),
     });
   }

--- a/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
+++ b/self/cortex/core/src/gateway-runtime/gateway-turn-executor.ts
@@ -37,6 +37,8 @@ import type { IWorkmodeAdmissionGuard } from '@nous/shared';
 import { WorkmodeAdmissionGuard } from '../workmode/admission-guard.js';
 import { parseModelOutput } from '../output-parser.js';
 import { GatewayTraceRecorder } from './trace-recorder.js';
+import { resolveAdapter, resolveProviderTypeFromConfig } from '../agent-gateway/adapters/index.js';
+import type { ProviderAdapter } from '../agent-gateway/adapters/types.js';
 
 const DEFAULT_CHAT_BUDGET = {
   maxTurns: 4,
@@ -63,51 +65,28 @@ function isGatewayInput(value: unknown): value is GatewayInputRecord {
   return typeof value.systemPrompt === 'string' && Array.isArray(value.context);
 }
 
-export function transformGatewayInput(input: unknown): unknown {
-  if (!isRecord(input)) {
-    return input;
-  }
-
-  if ('messages' in input || 'prompt' in input) {
-    return input;
-  }
-
-  if (!isGatewayInput(input)) {
-    return input;
-  }
+/**
+ * Converts gateway-format input to provider-specific format using the adapter.
+ * Passes through input that is already in provider format (has messages/prompt).
+ */
+function adaptGatewayInput(input: unknown, adapter: ProviderAdapter): unknown {
+  if (!isRecord(input)) return input;
+  if ('messages' in input || 'prompt' in input) return input;
+  if (!isGatewayInput(input)) return input;
 
   const parsedContext = GatewayContextFrameSchema.array().safeParse(input.context);
-  if (!parsedContext.success) {
-    return input;
-  }
+  if (!parsedContext.success) return input;
 
-  const result: Record<string, unknown> = {
-    messages: [
-      {
-        role: 'system' as const,
-        content: input.systemPrompt,
-      },
-      ...parsedContext.data.map((frame) => ({
-        role: frame.role === 'tool' ? 'user' as const : frame.role,
-        content: frame.content,
-      })),
-    ],
-  };
-
-  // Pass tools through to the provider when present.
-  // Transform from ToolDefinition shape (camelCase: inputSchema) to
-  // provider schema shape (snake_case: input_schema) for TextModelInputSchema.
-  const tools = (input as Record<string, unknown>).tools;
-  if (Array.isArray(tools) && tools.length > 0) {
-    result.tools = tools.map((t: Record<string, unknown>) => ({
-      name: t.name,
-      description: t.description ?? '',
-      input_schema: t.inputSchema ?? t.input_schema ?? {},
-    }));
-  }
-
-  return result;
+  const result = adapter.formatRequest({
+    systemPrompt: input.systemPrompt,
+    context: parsedContext.data,
+    toolDefinitions: Array.isArray((input as Record<string, unknown>).tools)
+      ? (input as Record<string, unknown>).tools as import('@nous/shared').ToolDefinition[]
+      : undefined,
+  });
+  return result.input;
 }
+
 
 interface MwcPipelineLike {
   submit(
@@ -354,12 +333,15 @@ export class GatewayBackedTurnExecutor implements ICoreExecutor {
       return null;
     }
 
+    const providerType = resolveProviderTypeFromConfig(provider);
+    const adapter = resolveAdapter(providerType);
+
     return {
       ...provider,
       invoke: async (request) => {
         const response = await provider.invoke({
           ...request,
-          input: transformGatewayInput(request.input),
+          input: adaptGatewayInput(request.input, adapter),
         });
         const parsedOutput = parseModelOutput(
           response.output,

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -26,7 +26,7 @@ import type {
 } from '@nous/shared';
 import { GatewayContextFrameSchema } from '@nous/shared';
 import { AgentGatewayFactory, createInboxFrame } from '../agent-gateway/index.js';
-import { transformGatewayInput } from './gateway-turn-executor.js';
+import { resolveAdapter, resolveProviderTypeFromConfig } from '../agent-gateway/adapters/index.js';
 import {
   createInternalMcpSurfaceBundle,
   getInternalMcpCatalogEntry,
@@ -885,12 +885,28 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     provider: import('@nous/shared').IModelProvider,
     options?: { synthesizeTaskComplete?: boolean },
   ): import('@nous/shared').IModelProvider {
+    const providerType = resolveProviderTypeFromConfig(provider);
+    const adapter = resolveAdapter(providerType);
+
     return {
       ...provider,
       invoke: async (request) => {
+        const transformedInput = (() => {
+          const input = request.input;
+          if (typeof input !== 'object' || input === null) return input;
+          if ('messages' in input || 'prompt' in input) return input;
+          const rec = input as Record<string, unknown>;
+          if (typeof rec.systemPrompt !== 'string' || !Array.isArray(rec.context)) return input;
+          const result = adapter.formatRequest({
+            systemPrompt: rec.systemPrompt as string,
+            context: rec.context as import('@nous/shared').GatewayContextFrame[],
+            toolDefinitions: Array.isArray(rec.tools) ? rec.tools as import('@nous/shared').ToolDefinition[] : undefined,
+          });
+          return result.input;
+        })();
         const response = await provider.invoke({
           ...request,
-          input: transformGatewayInput(request.input),
+          input: transformedInput,
         });
 
         if (!options?.synthesizeTaskComplete) return response;

--- a/self/cortex/core/src/output-parser.ts
+++ b/self/cortex/core/src/output-parser.ts
@@ -11,7 +11,7 @@ import {
 
 export interface ParsedModelOutput {
   response: string;
-  toolCalls: Array<{ name: string; params: unknown }>;
+  toolCalls: Array<{ name: string; params: unknown; id?: string }>;
   memoryCandidates: MemoryWriteCandidate[];
   contentType?: 'text' | 'openui';
   /** Extended thinking / reasoning trace from the provider. Populated by adapters (SP 1.3). */


### PR DESCRIPTION
## Summary

Replaces the legacy `transformGatewayInput` provider-agnostic shim with the adapter `formatRequest()` pattern, fixing incorrect tool schema and multi-turn tool context formatting for non-Anthropic providers.

## What changed

- **Adapter `formatRequest()` extensions** — each provider adapter (Anthropic, OpenAI, Ollama) now owns its own request formatting, including tool schema shape and tool-result message threading
- **Metadata propagation** — conversation metadata (tool definitions, system prompts, model config) flows through the adapter layer instead of being pre-flattened by a shared transform
- **Legacy removal** — `transformGatewayInput` and its associated provider-switch logic deleted; all callsites migrated to `adapter.formatRequest()`
- **16 files touched** across `cortex-core`, adapter implementations, and gateway wiring

## Why

Tool schemas and tool results were incorrectly formatted for non-Anthropic providers (OpenAI, Ollama). The shared `transformGatewayInput` shim applied Anthropic-shaped transforms universally, causing tool calls to fail or produce malformed payloads on other providers. The adapter pattern lets each provider own its wire format.

## Unblocks

- **WR-146** — workflow-from-chat (depends on correct multi-provider tool dispatch)
- **WR-144** — task execution harness (depends on reliable tool-result threading)

## Sub-phase history

- **WR-139.1** — adapter-format-wiring (PR #219, squash-merged into `fix/wr-139`)

## Test plan

- [x] Gate review passed (synthesis review confirmed correctness)
- [x] BT deferred to post-sprint per Principal directive

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)