### PR TITLE
fix(providers): widen TextModelInputSchema for adapter-formatted input — WR-139 BT hotfix

### DIFF
--- a/self/subcortex/providers/src/anthropic-provider.ts
+++ b/self/subcortex/providers/src/anthropic-provider.ts
@@ -34,7 +34,7 @@ interface AnthropicStreamEvent {
 interface AnthropicFormattedInput {
   system?: string | Array<{ type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }>;
   messages: Array<{ role: 'user' | 'assistant'; content: string }>;
-  tools?: Array<{ name: string; description: string; input_schema: Record<string, unknown> }>;
+  tools?: Array<Record<string, unknown>>;
 }
 
 export class AnthropicProvider implements IModelProvider {

--- a/self/subcortex/providers/src/ollama-provider.ts
+++ b/self/subcortex/providers/src/ollama-provider.ts
@@ -139,8 +139,8 @@ export class OllamaProvider implements IModelProvider {
 
   private validateInput(input: unknown): {
     prompt?: string;
-    messages?: Array<{ role: string; content: string }>;
-    tools?: Array<{ name: string; description: string; input_schema: Record<string, unknown> }>;
+    messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }>;
+    tools?: Array<Record<string, unknown>>;
   } {
     const result = TextModelInputSchema.safeParse(input);
     if (!result.success) {
@@ -156,8 +156,8 @@ export class OllamaProvider implements IModelProvider {
   private buildRequestBody(
     input: {
       prompt?: string;
-      messages?: Array<{ role: string; content: string }>;
-      tools?: Array<{ name: string; description: string; input_schema: Record<string, unknown> }>;
+      messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }>;
+      tools?: Array<Record<string, unknown>>;
     },
   ): Record<string, unknown> {
     const base: Record<string, unknown> = { model: this.config.modelId };
@@ -168,14 +168,19 @@ export class OllamaProvider implements IModelProvider {
 
     // Pass tools to Ollama /api/chat in OpenAI-compatible format
     if (input.tools && input.tools.length > 0) {
-      body.tools = input.tools.map((t) => ({
-        type: 'function',
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema,
-        },
-      }));
+      body.tools = input.tools.map((t: Record<string, unknown>) => {
+        // Already in adapter format: { type: 'function', function: { ... } }
+        if (t.type === 'function' && t.function) return t;
+        // Legacy format: { name, description, input_schema }
+        return {
+          type: 'function',
+          function: {
+            name: t.name,
+            description: t.description,
+            parameters: t.input_schema,
+          },
+        };
+      });
     }
 
     return body;

--- a/self/subcortex/providers/src/openai-provider.ts
+++ b/self/subcortex/providers/src/openai-provider.ts
@@ -202,7 +202,7 @@ export class OpenAiCompatibleProvider implements IModelProvider {
     }
   }
 
-  private validateInput(input: unknown): { prompt?: string; messages?: Array<{ role: string; content: string }> } {
+  private validateInput(input: unknown): { prompt?: string; messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }> } {
     const result = TextModelInputSchema.safeParse(input);
     if (!result.success) {
       const errors = result.error.errors.map((e) => ({
@@ -215,12 +215,13 @@ export class OpenAiCompatibleProvider implements IModelProvider {
   }
 
   private toOpenAiMessages(
-    input: { prompt?: string; messages?: Array<{ role: string; content: string }> },
-  ): Array<{ role: string; content: string }> {
+    input: { prompt?: string; messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }> },
+  ): Array<{ role: string; content: string; tool_call_id?: string }> {
     if (input.messages && input.messages.length > 0) {
       return input.messages.map((m) => ({
-        role: m.role as 'user' | 'assistant' | 'system',
-        content: m.content,
+        role: m.role as 'user' | 'assistant' | 'system' | 'tool',
+        content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        ...(m.tool_call_id ? { tool_call_id: m.tool_call_id } : {}),
       }));
     }
     return [{ role: 'user' as const, content: input.prompt ?? '' }];

--- a/self/subcortex/providers/src/schemas.ts
+++ b/self/subcortex/providers/src/schemas.ts
@@ -5,10 +5,37 @@
  */
 import { z } from 'zod';
 
-const ToolInputSchema = z.object({
+// Legacy tool format: { name, description, input_schema }
+const LegacyToolSchema = z.object({
   name: z.string(),
   description: z.string(),
   input_schema: z.record(z.unknown()),
+});
+
+// Adapter-formatted tool: { type: 'function', function: { name, description, parameters } }
+const AdapterToolSchema = z.object({
+  type: z.literal('function'),
+  function: z.object({
+    name: z.string(),
+    description: z.string(),
+    parameters: z.record(z.unknown()),
+  }),
+});
+
+const ToolInputSchema = z.union([LegacyToolSchema, AdapterToolSchema]);
+
+// Anthropic content blocks: [{ type: 'tool_result', tool_use_id, content }]
+const ContentBlockSchema = z.object({
+  type: z.string(),
+  tool_use_id: z.string().optional(),
+  content: z.string().optional(),
+  text: z.string().optional(),
+}).passthrough();
+
+const MessageSchema = z.object({
+  role: z.enum(['user', 'assistant', 'system', 'tool']),
+  content: z.union([z.string(), z.array(ContentBlockSchema)]),
+  tool_call_id: z.string().optional(),
 });
 
 export const TextModelInputSchema = z.union([
@@ -18,14 +45,11 @@ export const TextModelInputSchema = z.union([
     systemSegments: z.array(z.string()).optional(),
   }),
   z.object({
-    messages: z.array(
-      z.object({
-        role: z.enum(['user', 'assistant', 'system', 'tool']),
-        content: z.string(),
-      }),
-    ),
+    messages: z.array(MessageSchema),
     tools: z.array(ToolInputSchema).optional(),
+    system: z.union([z.string(), z.array(z.unknown())]).optional(),
     systemSegments: z.array(z.string()).optional(),
+    stream: z.boolean().optional(),
   }),
 ]);
 export type TextModelInput = z.infer<typeof TextModelInputSchema>;


### PR DESCRIPTION
## Summary

- BT found ValidationError when Ollama provider received adapter-formatted tool schemas
- `TextModelInputSchema` only accepted `{ name, description, input_schema }` (Anthropic format) but WR-139 adapters now output `{ type: 'function', function: { parameters } }` (OpenAI format)
- Provider-level validation rejected valid adapter output

## Changes

- Widen `TextModelInputSchema` to accept both legacy and adapter tool formats
- Accept `tool_call_id` on messages, `stream` on message-based input
- Update Ollama/OpenAI providers to handle both tool formats and preserve `tool_call_id`
- All adapter + provider tests pass (195/195)

## Test plan

- [ ] Verify Ollama chat works (was broken by ValidationError)
- [ ] Verify Anthropic chat works
- [ ] Verify tool-using conversations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)