### PR TITLE
feat(WR-142.1.1): schema/bridge/runtime collapse — 7→4 model role taxonomy

### DIFF
--- a/scripts/install/src/__tests__/config-generator.test.ts
+++ b/scripts/install/src/__tests__/config-generator.test.ts
@@ -11,14 +11,14 @@ describe('generateDefaultConfig', () => {
     expect(parsed.success).toBe(true);
   });
 
-  it('has Ollama provider and reasoner assignment', () => {
+  it('has Ollama provider and cortex-chat assignment', () => {
     const config = generateDefaultConfig('./data', 'llama3.2:3b');
     expect(config.providers).toHaveLength(1);
     expect(config.providers[0]?.name).toBe('Ollama');
     expect(config.providers[0]?.modelId).toBe('llama3.2:3b');
     expect(config.providers[0]?.id).toBe(expectedOllamaProviderId);
     expect(config.modelRoleAssignments).toHaveLength(1);
-    expect(config.modelRoleAssignments[0]?.role).toBe('reasoner');
+    expect(config.modelRoleAssignments[0]?.role).toBe('cortex-chat');
     expect(config.modelRoleAssignments[0]?.providerId).toBe(expectedOllamaProviderId);
   });
 });

--- a/scripts/install/src/config-generator.ts
+++ b/scripts/install/src/config-generator.ts
@@ -19,7 +19,7 @@ export function generateDefaultConfig(
     profile: DEFAULT_PROFILES['local-only']!,
     pfcTier: 2,
     pfcTierPresets: DEFAULT_PFC_TIER_PRESETS,
-    modelRoleAssignments: [{ role: 'reasoner', providerId: OLLAMA_PROVIDER_ID }],
+    modelRoleAssignments: [{ role: 'cortex-chat', providerId: OLLAMA_PROVIDER_ID }],
     providers: [
       {
         id: OLLAMA_PROVIDER_ID,

--- a/self/apps/desktop/server/main.ts
+++ b/self/apps/desktop/server/main.ts
@@ -17,7 +17,6 @@ import {
   createEventSseHandler,
   detectOllama,
   loadStoredApiKeys,
-  loadModelSelection,
   pullOllamaModel,
   registerStoredProviders,
 } from '@nous/shared-server';
@@ -214,7 +213,6 @@ async function main() {
   });
   await loadStoredApiKeys(context);
   await registerStoredProviders(context);
-  await loadModelSelection(context);
 
   const trpcHandler = createHTTPHandler({
     router: appRouter,

--- a/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardSteps.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardSteps.test.tsx
@@ -452,8 +452,8 @@ describe('Wizard step components', () => {
         {...props}
         selectedModelSpec="ollama:qwen2.5:7b"
         roleAssignments={{
-          orchestrator: 'ollama:qwen2.5:7b',
-          reasoner: 'ollama:qwen2.5:14b',
+          orchestrators: 'ollama:qwen2.5:7b',
+          workers: 'ollama:qwen2.5:14b',
         }}
         ollamaStatus={createPrerequisites().ollama}
         onFinish={vi.fn()}

--- a/self/apps/desktop/src/renderer/src/components/wizard/types.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/types.ts
@@ -13,15 +13,9 @@ import type {
 
 export type FirstRunCurrentStep = FirstRunState['currentStep']
 
-/** ModelRole — mirrors @nous/shared ModelRole enum values. */
-export type ModelRole =
-  | 'orchestrator'
-  | 'reasoner'
-  | 'tool-advisor'
-  | 'summarizer'
-  | 'embedder'
-  | 'reranker'
-  | 'vision'
+export { ModelRoleSchema, MODEL_ROLE_LABELS } from '@nous/shared'
+export type { ModelRole } from '@nous/shared'
+import { ModelRoleSchema, type ModelRole, MODEL_ROLE_LABELS } from '@nous/shared'
 
 type ElectronAPI = Window['electronAPI']
 export type OllamaStatus = Awaited<ReturnType<ElectronAPI['ollama']['getStatus']>>
@@ -66,25 +60,7 @@ export interface WizardStepProps {
   onStepComplete: (nextState: FirstRunState) => void
 }
 
-export const MODEL_ROLES = [
-  'orchestrator',
-  'reasoner',
-  'tool-advisor',
-  'summarizer',
-  'embedder',
-  'reranker',
-  'vision',
-] as const satisfies readonly ModelRole[]
-
-export const MODEL_ROLE_LABELS: Record<ModelRole, string> = {
-  orchestrator: 'Orchestrator',
-  reasoner: 'Reasoner',
-  'tool-advisor': 'Tool Advisor',
-  summarizer: 'Summarizer',
-  embedder: 'Embedder',
-  reranker: 'Reranker',
-  vision: 'Vision',
-}
+export const MODEL_ROLES = ModelRoleSchema.options
 
 export const BACKEND_STEP_TO_WIZARD_STEP: Record<FirstRunCurrentStep, WizardStepId> = {
   ollama_check: 'ollama-setup',

--- a/self/apps/desktop/src/renderer/src/test-setup.ts
+++ b/self/apps/desktop/src/renderer/src/test-setup.ts
@@ -68,23 +68,13 @@ export const DEFAULT_PREREQUISITES: FirstRunPrerequisites = {
     },
     multiModel: [
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         recommendation: {
           modelId: 'qwen2.5:14b',
           modelSpec: 'ollama:qwen2.5:14b',
           displayName: 'Qwen 2.5 14B',
           ramRequiredMB: 16384,
           reason: 'Use the stronger local model for heavier reasoning.',
-        },
-      },
-      {
-        role: 'vision',
-        recommendation: {
-          modelId: 'llama3.2:3b',
-          modelSpec: 'ollama:llama3.2:3b',
-          displayName: 'Llama 3.2 3B',
-          ramRequiredMB: 4096,
-          reason: 'Lightweight support model for specialist roles.',
         },
       },
     ],

--- a/self/apps/shared-server/__tests__/first-run-wizard.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-wizard.test.ts
@@ -22,7 +22,6 @@ const bootstrapMock = vi.hoisted(() => ({
   buildOllamaProviderConfig: vi.fn(),
   buildProviderConfig: vi.fn(),
   parseSelectedModelSpec: vi.fn(),
-  updateReasonerAssignment: vi.fn(),
   updateRoleAssignment: vi.fn(),
   upsertProviderConfig: vi.fn(),
 }));
@@ -76,7 +75,6 @@ vi.mock('../src/bootstrap', () => ({
   buildOllamaProviderConfig: bootstrapMock.buildOllamaProviderConfig,
   buildProviderConfig: bootstrapMock.buildProviderConfig,
   parseSelectedModelSpec: bootstrapMock.parseSelectedModelSpec,
-  updateReasonerAssignment: bootstrapMock.updateReasonerAssignment,
   updateRoleAssignment: bootstrapMock.updateRoleAssignment,
   upsertProviderConfig: bootstrapMock.upsertProviderConfig,
 }));
@@ -253,7 +251,6 @@ describe('first-run wizard router', () => {
     bootstrapMock.buildOllamaProviderConfig.mockReset().mockImplementation(buildOllamaProviderConfigMock);
     bootstrapMock.buildProviderConfig.mockReset().mockImplementation(buildProviderConfigMock);
     bootstrapMock.parseSelectedModelSpec.mockReset().mockImplementation(parseSelectedModelSpecMock);
-    bootstrapMock.updateReasonerAssignment.mockReset().mockResolvedValue(undefined);
     bootstrapMock.updateRoleAssignment.mockReset().mockResolvedValue(undefined);
     bootstrapMock.upsertProviderConfig.mockReset().mockResolvedValue(undefined);
 
@@ -348,8 +345,9 @@ describe('first-run wizard router', () => {
         modelId: 'llama3.2:3b',
       }),
     );
-    expect(bootstrapMock.updateReasonerAssignment).toHaveBeenCalledWith(
+    expect(bootstrapMock.updateRoleAssignment).toHaveBeenCalledWith(
       ctx,
+      'cortex-chat',
       bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
     );
     expect(result).toEqual({
@@ -367,11 +365,11 @@ describe('first-run wizard router', () => {
     const result = await caller.assignRoles({
       assignments: [
         {
-          role: 'orchestrator',
+          role: 'orchestrators',
           modelSpec: 'ollama:llama3.2:3b',
         },
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           modelSpec: 'openai:gpt-4o',
         },
       ],
@@ -381,13 +379,13 @@ describe('first-run wizard router', () => {
     expect(bootstrapMock.updateRoleAssignment).toHaveBeenNthCalledWith(
       1,
       ctx,
-      'orchestrator',
+      'orchestrators',
       bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
     );
     expect(bootstrapMock.updateRoleAssignment).toHaveBeenNthCalledWith(
       2,
       ctx,
-      'reasoner',
+      'cortex-chat',
       bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
     );
     expect(result).toEqual({

--- a/self/apps/shared-server/__tests__/hardware-detection.test.ts
+++ b/self/apps/shared-server/__tests__/hardware-detection.test.ts
@@ -179,7 +179,7 @@ describe('hardware detection', () => {
     expect(result.multiModel).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          role: 'reasoner',
+          role: 'cortex-chat',
           recommendation: expect.objectContaining({
             modelSpec: 'ollama:qwen2.5:14b',
           }),

--- a/self/apps/shared-server/__tests__/preferences-router.test.ts
+++ b/self/apps/shared-server/__tests__/preferences-router.test.ts
@@ -1,18 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ModelRoleSchema } from '@nous/shared';
+
 const SYSTEM_APP_ID = 'nous:system';
-const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
-const MODEL_SELECTION_ID = 'current';
-const MODEL_ROLES = [
-  'orchestrator',
-  'reasoner',
-  'tool-advisor',
-  'summarizer',
-  'embedder',
-  'reranker',
-  'vision',
-] as const;
-type ModelRole = (typeof MODEL_ROLES)[number];
+const MODEL_ROLES = ModelRoleSchema.options;
 
 const detectOllamaMock = vi.hoisted(() => vi.fn());
 const bootstrapConstants = vi.hoisted(() => ({
@@ -30,7 +21,6 @@ const bootstrapMock = vi.hoisted(() => ({
   registerConfiguredProvider: vi.fn(),
   removeConfiguredProvider: vi.fn(),
   updateRoleAssignment: vi.fn(),
-  updateReasonerAssignment: vi.fn(),
   upsertProviderConfig: vi.fn(),
 }));
 
@@ -48,7 +38,6 @@ vi.mock('../src/bootstrap', () => ({
   registerConfiguredProvider: bootstrapMock.registerConfiguredProvider,
   removeConfiguredProvider: bootstrapMock.removeConfiguredProvider,
   updateRoleAssignment: bootstrapMock.updateRoleAssignment,
-  updateReasonerAssignment: bootstrapMock.updateReasonerAssignment,
   upsertProviderConfig: bootstrapMock.upsertProviderConfig,
 }));
 
@@ -263,8 +252,6 @@ describe('preferences router', () => {
     bootstrapMock.removeConfiguredProvider.mockResolvedValue(undefined);
     bootstrapMock.updateRoleAssignment.mockReset();
     bootstrapMock.updateRoleAssignment.mockResolvedValue(undefined);
-    bootstrapMock.updateReasonerAssignment.mockReset();
-    bootstrapMock.updateReasonerAssignment.mockResolvedValue(undefined);
     bootstrapMock.upsertProviderConfig.mockReset();
     bootstrapMock.upsertProviderConfig.mockResolvedValue(undefined);
 
@@ -349,167 +336,6 @@ describe('preferences router', () => {
     });
   });
 
-  describe('setModelSelection', () => {
-    it('persists the selection and applies the runtime provider config immediately', async () => {
-      const { ctx, documentStore } = createMockContext();
-      const preferencesRouter = await loadPreferencesRouter();
-      const caller = preferencesRouter.createCaller(ctx);
-
-      const result = await caller.setModelSelection({
-        principal: 'openai:o3',
-        system: 'anthropic:claude-sonnet-4-20250514',
-      });
-
-      expect(result).toEqual({ success: true });
-      expect(
-        await documentStore.get<{
-          principal: string | null;
-          system: string | null;
-        }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID),
-      ).toEqual({
-        principal: 'openai:o3',
-        system: 'anthropic:claude-sonnet-4-20250514',
-      });
-      expect(bootstrapMock.parseSelectedModelSpec).toHaveBeenCalledWith('openai:o3');
-      expect(bootstrapMock.buildProviderConfig).toHaveBeenCalledWith(
-        'openai',
-        bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
-        'o3',
-      );
-      expect(bootstrapMock.upsertProviderConfig).toHaveBeenCalledWith(
-        ctx,
-        expect.objectContaining({
-          id: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
-          modelId: 'o3',
-          name: 'openai',
-        }),
-      );
-      expect(bootstrapMock.updateReasonerAssignment).toHaveBeenCalledWith(
-        ctx,
-        bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
-      );
-    });
-
-    it('routes ollama selections through the local provider config builder', async () => {
-      const { ctx, documentStore } = createMockContext();
-      const preferencesRouter = await loadPreferencesRouter();
-      const caller = preferencesRouter.createCaller(ctx);
-
-      const result = await caller.setModelSelection({
-        principal: 'ollama:llama3.2:3b',
-      });
-
-      expect(result).toEqual({ success: true });
-      expect(
-        await documentStore.get<{
-          principal: string | null;
-          system: string | null;
-        }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID),
-      ).toEqual({
-        principal: 'ollama:llama3.2:3b',
-        system: null,
-      });
-      expect(bootstrapMock.parseSelectedModelSpec).toHaveBeenCalledWith(
-        'ollama:llama3.2:3b',
-      );
-      expect(bootstrapMock.buildOllamaProviderConfig).toHaveBeenCalledWith(
-        'llama3.2:3b',
-        bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
-      );
-      expect(bootstrapMock.buildProviderConfig).not.toHaveBeenCalled();
-      expect(bootstrapMock.upsertProviderConfig).toHaveBeenCalledWith(
-        ctx,
-        expect.objectContaining({
-          id: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
-          modelId: 'llama3.2:3b',
-          name: 'ollama',
-          isLocal: true,
-          providerClass: 'local_text',
-        }),
-      );
-      expect(bootstrapMock.updateReasonerAssignment).toHaveBeenCalledWith(
-        ctx,
-        bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
-      );
-    });
-
-    it('preserves existing values on partial updates', async () => {
-      const { ctx, documentStore } = createMockContext();
-      const preferencesRouter = await loadPreferencesRouter();
-      const caller = preferencesRouter.createCaller(ctx);
-
-      await documentStore.put(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID, {
-        principal: 'anthropic:claude-opus-4-20250514',
-        system: 'openai:gpt-4o',
-      });
-
-      await caller.setModelSelection({
-        principal: 'anthropic:claude-sonnet-4-20250514',
-      });
-
-      expect(
-        await documentStore.get<{
-          principal: string | null;
-          system: string | null;
-        }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID),
-      ).toEqual({
-        principal: 'anthropic:claude-sonnet-4-20250514',
-        system: 'openai:gpt-4o',
-      });
-    });
-
-    it('skips runtime updates for invalid model specs while preserving the document write', async () => {
-      const { ctx, documentStore } = createMockContext();
-      const preferencesRouter = await loadPreferencesRouter();
-      const caller = preferencesRouter.createCaller(ctx);
-
-      bootstrapMock.parseSelectedModelSpec.mockReturnValueOnce(null);
-
-      const result = await caller.setModelSelection({
-        principal: 'invalid-model-spec',
-      });
-
-      expect(result).toEqual({ success: true });
-      expect(
-        await documentStore.get<{
-          principal: string | null;
-          system: string | null;
-        }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID),
-      ).toEqual({
-        principal: 'invalid-model-spec',
-        system: null,
-      });
-      expect(bootstrapMock.buildProviderConfig).not.toHaveBeenCalled();
-      expect(bootstrapMock.upsertProviderConfig).not.toHaveBeenCalled();
-      expect(bootstrapMock.updateReasonerAssignment).not.toHaveBeenCalled();
-    });
-
-    it('catches runtime update failures and still returns success', async () => {
-      const { ctx, documentStore } = createMockContext();
-      const preferencesRouter = await loadPreferencesRouter();
-      const caller = preferencesRouter.createCaller(ctx);
-
-      bootstrapMock.upsertProviderConfig.mockRejectedValueOnce(new Error('boom'));
-
-      const result = await caller.setModelSelection({
-        principal: 'anthropic:claude-opus-4-20250514',
-      });
-
-      expect(result).toEqual({ success: true });
-      expect(
-        await documentStore.get<{
-          principal: string | null;
-          system: string | null;
-        }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID),
-      ).toEqual({
-        principal: 'anthropic:claude-opus-4-20250514',
-        system: null,
-      });
-      expect(bootstrapMock.updateReasonerAssignment).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalled();
-    });
-  });
-
   describe('getRoleAssignments', () => {
     it('returns all model roles with null when no assignments exist', async () => {
       const { ctx } = createMockContext();
@@ -533,14 +359,14 @@ describe('preferences router', () => {
 
       bootstrapMock.currentRoleAssignment.mockImplementation(
         (_ctx: unknown, role: ModelRole) => {
-          if (role === 'orchestrator') {
+          if (role === 'orchestrators') {
             return {
               role,
               providerId: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
             };
           }
 
-          if (role === 'reasoner') {
+          if (role === 'cortex-chat') {
             return {
               role,
               providerId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
@@ -555,18 +381,15 @@ describe('preferences router', () => {
       const result = await caller.getRoleAssignments();
 
       expect(result).toEqual({
-        orchestrator: {
+        orchestrators: {
           providerId: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
         },
-        reasoner: {
+        'cortex-chat': {
           providerId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
           fallbackProviderId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.anthropic,
         },
-        'tool-advisor': null,
-        summarizer: null,
-        embedder: null,
-        reranker: null,
-        vision: null,
+        'cortex-system': null,
+        workers: null,
       });
     });
   });
@@ -578,7 +401,7 @@ describe('preferences router', () => {
       const caller = preferencesRouter.createCaller(ctx);
 
       const result = await caller.setRoleAssignment({
-        role: 'orchestrator',
+        role: 'orchestrators',
         modelSpec: 'ollama:llama3.2:3b',
       });
 
@@ -598,7 +421,7 @@ describe('preferences router', () => {
       );
       expect(bootstrapMock.updateRoleAssignment).toHaveBeenCalledWith(
         ctx,
-        'orchestrator',
+        'orchestrators',
         bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
       );
     });
@@ -609,7 +432,7 @@ describe('preferences router', () => {
       const caller = preferencesRouter.createCaller(ctx);
 
       const result = await caller.setRoleAssignment({
-        role: 'summarizer',
+        role: 'cortex-chat',
         modelSpec: 'openai:gpt-4o-mini',
       });
 
@@ -622,7 +445,7 @@ describe('preferences router', () => {
       expect(bootstrapMock.buildOllamaProviderConfig).not.toHaveBeenCalled();
       expect(bootstrapMock.updateRoleAssignment).toHaveBeenCalledWith(
         ctx,
-        'summarizer',
+        'cortex-chat',
         bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
       );
     });
@@ -635,7 +458,7 @@ describe('preferences router', () => {
       bootstrapMock.parseSelectedModelSpec.mockReturnValueOnce(null);
 
       const result = await caller.setRoleAssignment({
-        role: 'vision',
+        role: 'workers',
         modelSpec: 'invalid-model-spec',
       });
 

--- a/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
+++ b/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
@@ -9,15 +9,12 @@ import {
   OLLAMA_WELL_KNOWN_PROVIDER_ID,
   WELL_KNOWN_PROVIDER_IDS,
   createNousServices,
-  loadModelSelection,
   loadStoredApiKeys,
   registerStoredProviders,
 } from '../src/bootstrap';
 import { preferencesRouter } from '../src/trpc/routers/preferences';
 
 const SYSTEM_APP_ID = 'nous:system';
-const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
-const MODEL_SELECTION_ID = 'current';
 
 type ConfigState = {
   profile: (typeof DEFAULT_PROFILES)[keyof typeof DEFAULT_PROFILES] & {
@@ -273,65 +270,8 @@ describe('provider lifecycle wiring', () => {
     expect(state.providers[0]!.id).toBe(WELL_KNOWN_PROVIDER_IDS.openai);
     expect(state.modelRoleAssignments).toEqual([
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         providerId: WELL_KNOWN_PROVIDER_IDS.openai,
-      },
-    ]);
-  });
-
-  it('loadModelSelection applies saved model selections to config', async () => {
-    const { ctx, state, documentStore } = createLifecycleContext();
-    process.env.OPENAI_API_KEY = 'sk-test-openai';
-    process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
-
-    await registerStoredProviders(ctx);
-    await documentStore.put(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID, {
-      principal: 'openai:gpt-4o-mini',
-      system: 'anthropic:claude-opus-4-20250514',
-    });
-
-    await loadModelSelection(ctx);
-
-    expect(
-      state.providers.find((provider) => provider.id === WELL_KNOWN_PROVIDER_IDS.openai)
-        ?.modelId,
-    ).toBe('gpt-4o-mini');
-    expect(
-      state.providers.find((provider) => provider.id === WELL_KNOWN_PROVIDER_IDS.anthropic)
-        ?.modelId,
-    ).toBe('claude-opus-4-20250514');
-    expect(state.modelRoleAssignments).toEqual([
-      {
-        role: 'reasoner',
-        providerId: WELL_KNOWN_PROVIDER_IDS.openai,
-        fallbackProviderId: WELL_KNOWN_PROVIDER_IDS.anthropic,
-      },
-    ]);
-  });
-
-  it('loadModelSelection restores persisted ollama selections without cloud credentials', async () => {
-    const { ctx, state, documentStore } = createLifecycleContext();
-
-    await documentStore.put(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID, {
-      principal: 'ollama:llama3.2:3b',
-      system: null,
-    });
-
-    await loadModelSelection(ctx);
-
-    expect(
-      state.providers.find((provider) => provider.id === OLLAMA_WELL_KNOWN_PROVIDER_ID),
-    ).toMatchObject({
-      id: OLLAMA_WELL_KNOWN_PROVIDER_ID,
-      name: 'ollama',
-      modelId: 'llama3.2:3b',
-      isLocal: true,
-      providerClass: 'local_text',
-    });
-    expect(state.modelRoleAssignments).toEqual([
-      {
-        role: 'reasoner',
-        providerId: OLLAMA_WELL_KNOWN_PROVIDER_ID,
       },
     ]);
   });
@@ -353,7 +293,7 @@ describe('provider lifecycle wiring', () => {
     );
     expect(state.modelRoleAssignments).toEqual([
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         providerId: WELL_KNOWN_PROVIDER_IDS.openai,
       },
     ]);

--- a/self/apps/shared-server/__tests__/role-assignment.test.ts
+++ b/self/apps/shared-server/__tests__/role-assignment.test.ts
@@ -4,21 +4,16 @@ import type { ModelRoleAssignment } from '@nous/autonomic-config';
 import {
   OLLAMA_WELL_KNOWN_PROVIDER_ID,
   buildOllamaProviderConfig,
-  currentReasonerAssignment,
   currentRoleAssignment,
   parseSelectedModelSpec,
-  updateReasonerAssignment,
   updateRoleAssignment,
 } from '../src/bootstrap';
 
 const ROLE_PROVIDER_IDS: Record<ModelRole, ProviderId> = {
-  orchestrator: '20000000-0000-0000-0000-000000000001' as ProviderId,
-  reasoner: '20000000-0000-0000-0000-000000000002' as ProviderId,
-  'tool-advisor': '20000000-0000-0000-0000-000000000003' as ProviderId,
-  summarizer: '20000000-0000-0000-0000-000000000004' as ProviderId,
-  embedder: '20000000-0000-0000-0000-000000000005' as ProviderId,
-  reranker: '20000000-0000-0000-0000-000000000006' as ProviderId,
-  vision: '20000000-0000-0000-0000-000000000007' as ProviderId,
+  'cortex-chat': '20000000-0000-0000-0000-000000000001' as ProviderId,
+  'cortex-system': '20000000-0000-0000-0000-000000000002' as ProviderId,
+  orchestrators: '20000000-0000-0000-0000-000000000003' as ProviderId,
+  workers: '20000000-0000-0000-0000-000000000004' as ProviderId,
 };
 const REPLACEMENT_PROVIDER_ID =
   '30000000-0000-0000-0000-000000000001' as ProviderId;
@@ -108,7 +103,7 @@ describe('buildOllamaProviderConfig', () => {
 });
 
 describe('updateRoleAssignment', () => {
-  it('accepts all 7 model roles and stores a separate assignment for each one', async () => {
+  it('accepts all 4 model roles and stores a separate assignment for each one', async () => {
     const { ctx, state } = createMockContext();
 
     for (const role of ModelRoleSchema.options as ModelRole[]) {
@@ -123,66 +118,38 @@ describe('updateRoleAssignment', () => {
 
   it('updates only the targeted role and preserves other assignments', async () => {
     const { ctx, state } = createMockContext([
-      assignmentFor('reasoner'),
-      assignmentFor('orchestrator'),
+      assignmentFor('cortex-chat'),
+      assignmentFor('orchestrators'),
     ]);
 
     await updateRoleAssignment(
       ctx,
-      'orchestrator',
+      'orchestrators',
       REPLACEMENT_PROVIDER_ID,
       FALLBACK_PROVIDER_ID,
     );
 
     expect(state.modelRoleAssignments).toEqual([
-      assignmentFor('reasoner'),
-      assignmentFor('orchestrator', REPLACEMENT_PROVIDER_ID, FALLBACK_PROVIDER_ID),
+      assignmentFor('cortex-chat'),
+      assignmentFor('orchestrators', REPLACEMENT_PROVIDER_ID, FALLBACK_PROVIDER_ID),
     ]);
   });
 
   it('removes only the targeted role when providerId is null', async () => {
     const { ctx, state } = createMockContext([
-      assignmentFor('reasoner'),
-      assignmentFor('orchestrator'),
+      assignmentFor('cortex-chat'),
+      assignmentFor('orchestrators'),
     ]);
 
-    await updateRoleAssignment(ctx, 'orchestrator', null);
+    await updateRoleAssignment(ctx, 'orchestrators', null);
 
-    expect(state.modelRoleAssignments).toEqual([assignmentFor('reasoner')]);
-    expect(currentRoleAssignment(ctx, 'orchestrator')).toBeUndefined();
+    expect(state.modelRoleAssignments).toEqual([assignmentFor('cortex-chat')]);
+    expect(currentRoleAssignment(ctx, 'orchestrators')).toBeUndefined();
   });
 
   it('returns undefined for unassigned roles', () => {
-    const { ctx } = createMockContext([assignmentFor('reasoner')]);
+    const { ctx } = createMockContext([assignmentFor('cortex-chat')]);
 
-    expect(currentRoleAssignment(ctx, 'vision')).toBeUndefined();
-  });
-});
-
-describe('reasoner wrappers', () => {
-  it('updateReasonerAssignment preserves other roles while updating reasoner', async () => {
-    const { ctx, state } = createMockContext([assignmentFor('orchestrator')]);
-
-    await updateReasonerAssignment(
-      ctx,
-      ROLE_PROVIDER_IDS.reasoner,
-      FALLBACK_PROVIDER_ID,
-    );
-
-    expect(state.modelRoleAssignments).toEqual([
-      assignmentFor('orchestrator'),
-      assignmentFor('reasoner', ROLE_PROVIDER_IDS.reasoner, FALLBACK_PROVIDER_ID),
-    ]);
-  });
-
-  it('currentReasonerAssignment reads the reasoner entry from multi-role config', () => {
-    const { ctx } = createMockContext([
-      assignmentFor('orchestrator'),
-      assignmentFor('reasoner', ROLE_PROVIDER_IDS.reasoner, FALLBACK_PROVIDER_ID),
-    ]);
-
-    expect(currentReasonerAssignment(ctx)).toEqual(
-      assignmentFor('reasoner', ROLE_PROVIDER_IDS.reasoner, FALLBACK_PROVIDER_ID),
-    );
+    expect(currentRoleAssignment(ctx, 'workers')).toBeUndefined();
   });
 });

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -148,8 +148,6 @@ type CloudProviderName = 'anthropic' | 'openai';
 type ProviderName = CloudProviderName | 'ollama';
 type ParsedModelSpec = { provider: ProviderName; modelId: string };
 
-const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
-const MODEL_SELECTION_ID = 'current';
 
 const CLOUD_PROVIDER_ENV_VARS: Record<CloudProviderName, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
@@ -211,11 +209,6 @@ export function currentRoleAssignment(
   return config.modelRoleAssignments?.find((assignment) => assignment.role === role);
 }
 
-export function currentReasonerAssignment(
-  ctx: NousContext,
-): ModelRoleAssignment | undefined {
-  return currentRoleAssignment(ctx, 'reasoner');
-}
 
 function sortProvidersForDefault(
   providers: ProviderConfigEntry[],
@@ -279,13 +272,6 @@ export async function updateRoleAssignment(
   );
 }
 
-export async function updateReasonerAssignment(
-  ctx: NousContext,
-  providerId: ProviderId | null,
-  fallbackProviderId?: ProviderId,
-): Promise<void> {
-  await updateRoleAssignment(ctx, 'reasoner', providerId, fallbackProviderId);
-}
 
 async function ensureCloudCompatibleProfile(ctx: NousContext): Promise<void> {
   if (!hasConfiguredCloudKey()) {
@@ -482,7 +468,12 @@ function configWithFallback(base: ConfigManager) {
         }
         return {
           ...c,
-          modelRoleAssignments: [{ role: 'reasoner', providerId: MOCK_PROVIDER_ID }],
+          modelRoleAssignments: [
+            { role: 'cortex-chat', providerId: MOCK_PROVIDER_ID },
+            { role: 'cortex-system', providerId: MOCK_PROVIDER_ID },
+            { role: 'orchestrators', providerId: MOCK_PROVIDER_ID },
+            { role: 'workers', providerId: MOCK_PROVIDER_ID },
+          ],
           providers: [
             {
               id: MOCK_PROVIDER_ID,
@@ -1338,87 +1329,6 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
  * If no selection has been persisted, auto-detection is left in place.
  * Call this after `createNousServices()`.
  */
-export async function loadModelSelection(ctx: NousContext): Promise<void> {
-  try {
-    const saved = await ctx.documentStore.get<{
-      principal: string | null;
-      system: string | null;
-    }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID);
-
-    if (saved) {
-      if (saved.principal) {
-        console.log(
-          `[nous:bootstrap] Loaded principal model selection: ${saved.principal}`,
-        );
-      }
-      if (saved.system) {
-        console.log(
-          `[nous:bootstrap] Loaded system model selection: ${saved.system}`,
-        );
-      }
-    }
-
-    const primarySelection = parseSelectedModelSpec(saved?.principal);
-    const secondarySelection = parseSelectedModelSpec(saved?.system);
-    const primaryProviderId =
-      primarySelection && canApplySelectedModel(primarySelection)
-        ? selectedModelProviderId(primarySelection)
-        : null;
-    const secondaryProviderId =
-      secondarySelection && canApplySelectedModel(secondarySelection)
-        ? selectedModelProviderId(secondarySelection)
-        : null;
-
-    if (primarySelection && primaryProviderId) {
-      await upsertProviderConfig(
-        ctx,
-        buildSelectedProviderConfig(primarySelection, primaryProviderId),
-      );
-    }
-
-    if (
-      secondarySelection &&
-      secondaryProviderId &&
-      (!primarySelection ||
-        secondarySelection.provider !== primarySelection.provider ||
-        secondarySelection.modelId !== primarySelection.modelId)
-    ) {
-      await upsertProviderConfig(
-        ctx,
-        buildSelectedProviderConfig(secondarySelection, secondaryProviderId),
-      );
-    }
-
-    if (primaryProviderId) {
-      await updateReasonerAssignment(
-        ctx,
-        primaryProviderId,
-        secondaryProviderId ?? undefined,
-      );
-      return;
-    }
-
-    if (secondaryProviderId) {
-      await updateReasonerAssignment(
-        ctx,
-        secondaryProviderId,
-      );
-      return;
-    }
-
-    const availableProviders = sortProvidersForDefault(currentProviderEntries(ctx));
-    if (availableProviders.length > 0) {
-      await updateReasonerAssignment(ctx, availableProviders[0]!.id);
-    }
-  } catch {
-    // Model selection not yet persisted — use auto-detect defaults.
-    const availableProviders = sortProvidersForDefault(currentProviderEntries(ctx));
-    if (availableProviders.length > 0) {
-      await updateReasonerAssignment(ctx, availableProviders[0]!.id);
-    }
-  }
-}
-
 /**
  * Loads stored API keys from the credential vault into process.env
  * so the SDK can use them immediately on restart.
@@ -1461,8 +1371,8 @@ export async function registerStoredProviders(ctx: NousContext): Promise<void> {
     );
   }
 
-  if (!currentReasonerAssignment(ctx) && availableProviders.length > 0) {
-    await updateReasonerAssignment(ctx, WELL_KNOWN_PROVIDER_IDS[availableProviders[0]!]);
+  if (!currentRoleAssignment(ctx, 'cortex-chat') && availableProviders.length > 0) {
+    await updateRoleAssignment(ctx, 'cortex-chat', WELL_KNOWN_PROVIDER_IDS[availableProviders[0]!]);
   }
 
   if (availableProviders.length === 0) {
@@ -1485,9 +1395,10 @@ export async function registerConfiguredProvider(
     ),
   );
 
-  const existingAssignment = currentReasonerAssignment(ctx);
-  await updateReasonerAssignment(
+  const existingAssignment = currentRoleAssignment(ctx, 'cortex-chat');
+  await updateRoleAssignment(
     ctx,
+    'cortex-chat',
     WELL_KNOWN_PROVIDER_IDS[provider],
     existingAssignment?.providerId &&
       existingAssignment.providerId !== WELL_KNOWN_PROVIDER_IDS[provider]
@@ -1507,6 +1418,6 @@ export async function removeConfiguredProvider(
   const nextPrimary = remainingProviders[0]?.id ?? null;
   const nextFallback = remainingProviders[1]?.id;
 
-  await updateReasonerAssignment(ctx, nextPrimary, nextFallback);
+  await updateRoleAssignment(ctx, 'cortex-chat', nextPrimary, nextFallback);
   await ensureLocalCompatibleProfile(ctx);
 }

--- a/self/apps/shared-server/src/hardware-detection.ts
+++ b/self/apps/shared-server/src/hardware-detection.ts
@@ -294,55 +294,34 @@ function buildLocalRecommendations(
     tier === 'medium'
       ? [
           {
-            role: 'reasoner',
+            role: 'cortex-chat',
             recommendation: createRecommendation(
               LOCAL_MODEL_CATALOG.medium,
               'Use the stronger local model for reasoning-heavy work.',
             ),
           },
           {
-            role: 'orchestrator',
+            role: 'orchestrators',
             recommendation: createRecommendation(
               LOCAL_MODEL_CATALOG.small,
               'Keep orchestration responsive with a lighter local model.',
-            ),
-          },
-          {
-            role: 'tool-advisor',
-            recommendation: createRecommendation(
-              LOCAL_MODEL_CATALOG.small,
-              'Tool routing benefits from a faster local model on mid-spec systems.',
             ),
           },
         ]
       : tier === 'large'
         ? [
             {
-              role: 'reasoner',
+              role: 'cortex-chat',
               recommendation: createRecommendation(
                 LOCAL_MODEL_CATALOG.large,
                 'High-spec hardware can sustain a larger local reasoner.',
               ),
             },
             {
-              role: 'orchestrator',
+              role: 'orchestrators',
               recommendation: createRecommendation(
                 LOCAL_MODEL_CATALOG.medium,
                 'Use a mid-tier model for orchestration to preserve local responsiveness.',
-              ),
-            },
-            {
-              role: 'summarizer',
-              recommendation: createRecommendation(
-                LOCAL_MODEL_CATALOG.small,
-                'Summarization can stay on a lighter model without sacrificing throughput.',
-              ),
-            },
-            {
-              role: 'vision',
-              recommendation: createRecommendation(
-                LOCAL_MODEL_CATALOG.medium,
-                'Vision tasks benefit from the larger context budget on high-spec systems.',
               ),
             },
           ]
@@ -379,16 +358,8 @@ function buildRemoteRecommendations(spec: HardwareSpec): RecommendationResult {
     singleModel: REMOTE_SINGLE_MODEL,
     multiModel: [
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         recommendation: REMOTE_REASONER_MODEL,
-      },
-      {
-        role: 'vision',
-        recommendation: REMOTE_SUPPORT_MODEL,
-      },
-      {
-        role: 'summarizer',
-        recommendation: REMOTE_SUPPORT_MODEL,
       },
     ],
     hardwareSpec: spec,

--- a/self/apps/shared-server/src/index.ts
+++ b/self/apps/shared-server/src/index.ts
@@ -11,7 +11,6 @@ export {
   OLLAMA_WELL_KNOWN_PROVIDER_ID,
   createNousServices,
   loadStoredApiKeys,
-  loadModelSelection,
   registerStoredProviders,
   WELL_KNOWN_PROVIDER_IDS,
   buildOllamaProviderConfig,

--- a/self/apps/shared-server/src/trpc/routers/config.ts
+++ b/self/apps/shared-server/src/trpc/routers/config.ts
@@ -3,7 +3,7 @@
  */
 import { z } from 'zod';
 import { router, publicProcedure } from '../trpc';
-import { ProviderIdSchema } from '@nous/shared';
+import { ModelRoleSchema, ProviderIdSchema } from '@nous/shared';
 
 export const configRouter = router({
   get: publicProcedure.query(({ ctx }) => {
@@ -15,7 +15,7 @@ export const configRouter = router({
       z.object({
         pfcTier: z.number().min(0).max(5).optional(),
         modelRoleAssignments: z
-          .array(z.object({ role: z.string(), providerId: ProviderIdSchema }))
+          .array(z.object({ role: ModelRoleSchema, providerId: ProviderIdSchema }))
           .optional(),
       }),
     )

--- a/self/apps/shared-server/src/trpc/routers/first-run.ts
+++ b/self/apps/shared-server/src/trpc/routers/first-run.ts
@@ -22,7 +22,6 @@ import {
   buildOllamaProviderConfig,
   buildProviderConfig,
   parseSelectedModelSpec,
-  updateReasonerAssignment,
   updateRoleAssignment,
   upsertProviderConfig,
 } from '../../bootstrap';
@@ -157,7 +156,7 @@ export const firstRunRouter = router({
 
       try {
         await upsertProviderConfig(ctx, selection.providerConfig);
-        await updateReasonerAssignment(ctx, selection.providerId);
+        await updateRoleAssignment(ctx, 'cortex-chat', selection.providerId);
         const state = await markStepComplete(ctx.dataDir, 'provider_config');
 
         return FirstRunActionResultSchema.parse({

--- a/self/apps/shared-server/src/trpc/routers/preferences.ts
+++ b/self/apps/shared-server/src/trpc/routers/preferences.ts
@@ -16,13 +16,10 @@ import {
   registerConfiguredProvider,
   removeConfiguredProvider,
   updateRoleAssignment,
-  updateReasonerAssignment,
   upsertProviderConfig,
 } from '../../bootstrap';
 
 const SYSTEM_APP_ID = 'nous:system';
-const MODEL_SELECTION_COLLECTION = 'nous:model_selection';
-const MODEL_SELECTION_ID = 'current';
 
 const ProviderSchema = z.enum(['anthropic', 'openai']);
 type Provider = z.infer<typeof ProviderSchema>;
@@ -521,72 +518,6 @@ export const preferencesRouter = router({
 
     return { models: [...ollamaModels, ...cloudModels] };
   }),
-
-  getModelSelection: publicProcedure.query(async ({ ctx }) => {
-    const saved = await ctx.documentStore.get<{
-      principal: string | null;
-      system: string | null;
-    }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID);
-
-    return {
-      principal: saved?.principal ?? null,
-      system: saved?.system ?? null,
-    };
-  }),
-
-  setModelSelection: publicProcedure
-    .input(
-      z.object({
-        principal: z.string().optional(),
-        system: z.string().optional(),
-      }),
-    )
-    .mutation(async ({ ctx, input }) => {
-      const existing = await ctx.documentStore.get<{
-        principal: string | null;
-        system: string | null;
-      }>(MODEL_SELECTION_COLLECTION, MODEL_SELECTION_ID);
-
-      const updated = {
-        principal: input.principal ?? existing?.principal ?? null,
-        system: input.system ?? existing?.system ?? null,
-      };
-
-      await ctx.documentStore.put(
-        MODEL_SELECTION_COLLECTION,
-        MODEL_SELECTION_ID,
-        updated,
-      );
-
-      const selectedModel = parseSelectedModelSpec(updated.principal);
-      if (!selectedModel) {
-        if (updated.principal) {
-          console.warn(
-            `[nous:preferences] Cannot parse model spec: ${updated.principal}. Skipping runtime config update.`,
-          );
-        }
-
-        return { success: true };
-      }
-
-      try {
-        const { providerId, providerConfig } = buildProviderSelection(selectedModel);
-
-        await upsertProviderConfig(ctx, providerConfig);
-        await updateReasonerAssignment(ctx, providerId);
-
-        console.info(
-          `[nous:preferences] Updated runtime provider config for ${updated.principal}`,
-        );
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(
-          `[nous:preferences] Failed to update runtime provider config: ${message}`,
-        );
-      }
-
-      return { success: true };
-    }),
 
   getRoleAssignments: publicProcedure.query(async ({ ctx }) => {
     return Object.fromEntries(

--- a/self/apps/web/app/first-run/components/config-review-step.tsx
+++ b/self/apps/web/app/first-run/components/config-review-step.tsx
@@ -72,7 +72,7 @@ export function ConfigReviewStep({ onNext }: ConfigReviewStepProps) {
             })}
             {assignments.length === 0 && providers.length > 0 && (
               <li>
-                reasoner: {providers[0]?.name} ({String(providers[0]?.modelId ?? 'default')})
+                cortex-chat: {providers[0]?.name} ({String(providers[0]?.modelId ?? 'default')})
               </li>
             )}
           </ul>

--- a/self/apps/web/server/__tests__/bootstrap-config-validation.test.ts
+++ b/self/apps/web/server/__tests__/bootstrap-config-validation.test.ts
@@ -41,7 +41,7 @@ describe('bootstrap config validation', () => {
     ) as Record<string, unknown>;
 
     invalidConfig.modelRoleAssignments = [
-      { role: 'reasoner', providerId: 'ollama-default' },
+      { role: 'cortex-chat', providerId: 'ollama-default' },
     ];
     invalidConfig.providers = [
       {

--- a/self/apps/web/server/__tests__/mao-router.test.ts
+++ b/self/apps/web/server/__tests__/mao-router.test.ts
@@ -36,7 +36,7 @@ function createWorkflow(projectId: ProjectId): WorkflowDefinition {
         outputSchemaRef: 'schema://mao-router/draft-output',
         config: {
           type: 'model-call',
-          modelRole: 'reasoner',
+          modelRole: 'cortex-chat',
           promptRef: 'prompt://draft',
         },
       },

--- a/self/apps/web/server/__tests__/projects-router.test.ts
+++ b/self/apps/web/server/__tests__/projects-router.test.ts
@@ -128,7 +128,7 @@ function createWorkflow(projectId: ProjectId, version = '1.0.0'): WorkflowDefini
         outputSchemaRef: 'schema://projects-workflow/draft-output',
         config: {
           type: 'model-call' as const,
-          modelRole: 'reasoner' as const,
+          modelRole: 'cortex-chat' as const,
           promptRef: 'prompt://draft',
         },
       },

--- a/self/apps/web/server/__tests__/trpc-procedures.test.ts
+++ b/self/apps/web/server/__tests__/trpc-procedures.test.ts
@@ -199,7 +199,7 @@ describe('tRPC procedures', () => {
                 outputSchemaRef: 'schema://projects-procedure/draft-output',
                 config: {
                   type: 'model-call',
-                  modelRole: 'reasoner',
+                  modelRole: 'cortex-chat',
                   promptRef: 'prompt://draft',
                 },
               },
@@ -228,7 +228,7 @@ describe('tRPC procedures', () => {
           outputSchemaRef: 'schema://projects-procedure/draft-output',
           config: {
             type: 'model-call' as const,
-            modelRole: 'reasoner' as const,
+            modelRole: 'cortex-chat' as const,
             promptRef: 'prompt://draft-v2',
           },
         },

--- a/self/apps/web/server/bootstrap.ts
+++ b/self/apps/web/server/bootstrap.ts
@@ -7,7 +7,6 @@
 import {
   createNousServices,
   loadStoredApiKeys,
-  loadModelSelection,
   registerStoredProviders,
 } from '@nous/shared-server';
 import type { NousContext } from '@nous/shared-server';
@@ -43,7 +42,6 @@ export async function initializeNousContext(): Promise<NousContext> {
   initPromise = (async () => {
     await loadStoredApiKeys(ctx);
     await registerStoredProviders(ctx);
-    await loadModelSelection(ctx);
     return ctx;
   })();
 

--- a/self/autonomic/config/src/__tests__/config-manager.test.ts
+++ b/self/autonomic/config/src/__tests__/config-manager.test.ts
@@ -140,7 +140,7 @@ describe('ConfigManager', () => {
       const manager = new ConfigManager();
       await expect(
         manager.update('modelRoleAssignments', [
-          { role: 'reasoner', providerId: 'ollama-default' },
+          { role: 'cortex-chat', providerId: 'ollama-default' },
         ] as never),
       ).rejects.toThrow(ConfigError);
     });

--- a/self/autonomic/config/src/__tests__/loader.test.ts
+++ b/self/autonomic/config/src/__tests__/loader.test.ts
@@ -111,7 +111,7 @@ describe('loadConfig', () => {
       ],
       modelRoleAssignments: [
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           providerId: 'ollama-default',
         },
       ],

--- a/self/autonomic/config/src/__tests__/migrate.test.ts
+++ b/self/autonomic/config/src/__tests__/migrate.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { migrateSystemConfigModelRoleAssignments } from '../migrate.js';
+
+describe('migrateSystemConfigModelRoleAssignments', () => {
+  it('(i) remaps 2-entry legacy to 2-entry canonical', () => {
+    const input = {
+      modelRoleAssignments: [
+        { role: 'reasoner', providerId: 'p1' },
+        { role: 'orchestrator', providerId: 'p2' },
+      ],
+    };
+    const result = migrateSystemConfigModelRoleAssignments(input) as any;
+    expect(result.modelRoleAssignments).toEqual([
+      { role: 'cortex-chat', providerId: 'p1' },
+      { role: 'orchestrators', providerId: 'p2' },
+    ]);
+  });
+
+  it('(ii) silently drops capability-only entries', () => {
+    const input = {
+      modelRoleAssignments: [
+        { role: 'tool-advisor', providerId: 'p1' },
+        { role: 'summarizer', providerId: 'p2' },
+      ],
+    };
+    const result = migrateSystemConfigModelRoleAssignments(input) as any;
+    expect(result.modelRoleAssignments).toEqual([]);
+  });
+
+  it('(iii) mixed legacy → 1-entry remapped', () => {
+    const input = {
+      modelRoleAssignments: [
+        { role: 'reasoner', providerId: 'p1' },
+        { role: 'vision', providerId: 'p2' },
+      ],
+    };
+    const result = migrateSystemConfigModelRoleAssignments(input) as any;
+    expect(result.modelRoleAssignments).toEqual([
+      { role: 'cortex-chat', providerId: 'p1' },
+    ]);
+  });
+
+  it('(iv) all-7-legacy → exactly 2 remapped survivors', () => {
+    const input = {
+      modelRoleAssignments: [
+        { role: 'reasoner', providerId: 'p1' },
+        { role: 'orchestrator', providerId: 'p2' },
+        { role: 'tool-advisor', providerId: 'p3' },
+        { role: 'summarizer', providerId: 'p4' },
+        { role: 'embedder', providerId: 'p5' },
+        { role: 'reranker', providerId: 'p6' },
+        { role: 'vision', providerId: 'p7' },
+      ],
+    };
+    const result = migrateSystemConfigModelRoleAssignments(input) as any;
+    expect(result.modelRoleAssignments).toEqual([
+      { role: 'cortex-chat', providerId: 'p1' },
+      { role: 'orchestrators', providerId: 'p2' },
+    ]);
+  });
+
+  it('(v) forward-compat — canonical roles pass through unchanged', () => {
+    const input = {
+      modelRoleAssignments: [
+        { role: 'cortex-chat', providerId: 'p1' },
+      ],
+    };
+    const result = migrateSystemConfigModelRoleAssignments(input) as any;
+    expect(result.modelRoleAssignments).toEqual([
+      { role: 'cortex-chat', providerId: 'p1' },
+    ]);
+  });
+
+  it('passes through non-object input unchanged', () => {
+    expect(migrateSystemConfigModelRoleAssignments(null)).toBeNull();
+    expect(migrateSystemConfigModelRoleAssignments(undefined)).toBeUndefined();
+    expect(migrateSystemConfigModelRoleAssignments(42)).toBe(42);
+  });
+
+  it('passes through object without modelRoleAssignments unchanged', () => {
+    const input = { pfcTier: 3 };
+    expect(migrateSystemConfigModelRoleAssignments(input)).toEqual({ pfcTier: 3 });
+  });
+});

--- a/self/autonomic/config/src/loader.ts
+++ b/self/autonomic/config/src/loader.ts
@@ -10,6 +10,7 @@ import JSON5 from 'json5';
 import { ConfigError } from '@nous/shared';
 import { SystemConfigSchema, type SystemConfig } from './schema.js';
 import { DEFAULT_SYSTEM_CONFIG } from './defaults.js';
+import { migrateSystemConfigModelRoleAssignments } from './migrate.js';
 
 /**
  * Load and validate system configuration.
@@ -43,7 +44,8 @@ export function loadConfig(path?: string): SystemConfig {
     });
   }
 
-  const result = SystemConfigSchema.safeParse(parsed);
+  const migrated = migrateSystemConfigModelRoleAssignments(parsed);
+  const result = SystemConfigSchema.safeParse(migrated);
   if (!result.success) {
     const fieldErrors = result.error.issues.map((issue) => ({
       path: issue.path.join('.'),

--- a/self/autonomic/config/src/migrate.ts
+++ b/self/autonomic/config/src/migrate.ts
@@ -1,0 +1,45 @@
+/**
+ * U2 system config migration — pre-safeParse preprocessing for
+ * ModelRoleAssignment arrays containing legacy 7-role taxonomy literals.
+ *
+ * Called from loader.ts before SystemConfigSchema.safeParse.
+ */
+import { migrateLegacyModelRole } from '@nous/shared';
+
+/**
+ * Migrate legacy model-role assignments in a raw system config blob.
+ *
+ * Rewrites `modelRoleAssignments[].role` values using the shared
+ * migration helper, silently dropping entries whose role maps to `null`
+ * (i.e., the 5 removed capability roles).
+ */
+export function migrateSystemConfigModelRoleAssignments(input: unknown): unknown {
+  if (input === null || input === undefined || typeof input !== 'object') {
+    return input;
+  }
+
+  const obj = input as Record<string, unknown>;
+  if (!Array.isArray(obj.modelRoleAssignments)) {
+    return input;
+  }
+
+  const migrated: unknown[] = [];
+  for (const entry of obj.modelRoleAssignments) {
+    if (entry === null || entry === undefined || typeof entry !== 'object') {
+      migrated.push(entry);
+      continue;
+    }
+
+    const e = entry as Record<string, unknown>;
+    if (typeof e.role !== 'string') {
+      migrated.push(entry);
+      continue;
+    }
+
+    const newRole = migrateLegacyModelRole(e.role);
+    if (newRole === null) continue; // silently drop
+    migrated.push({ ...e, role: newRole });
+  }
+
+  return { ...obj, modelRoleAssignments: migrated };
+}

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-derive.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-derive.test.ts
@@ -1,0 +1,116 @@
+/**
+ * AgentGateway — deriveDefaultModelRole tests.
+ *
+ * Validates the class-aware derive function introduced by WR-142 R7/E5-B.
+ * The derive replaces the former `DEFAULT_MODEL_ROLE = 'reasoner'` constant
+ * with a 4-entry lookup table keyed by AgentClass.
+ *
+ * NOTE: Test cases (c) and (d) use the bare `'Orchestrator'` / `'Worker'`
+ * values from the closed AgentClassSchema enum, NOT the wildcard notation
+ * `'Orchestrator::*'` from the decision docs. The AgentClassSchema is a
+ * closed 4-entry z.enum without subtypes (SDS-F-1 normalization).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createGatewayHarness, createGatewayInput } from './helpers.js';
+
+describe('AgentGateway deriveDefaultModelRole', () => {
+  it('(a) Cortex::Principal derives cortex-chat', async () => {
+    const { gateway, modelProvider } = createGatewayHarness({
+      agentClass: 'Cortex::Principal',
+    });
+
+    const invokeSpy = vi.spyOn(modelProvider, 'invoke');
+
+    await gateway.run(createGatewayInput('test'));
+
+    expect(invokeSpy).toHaveBeenCalled();
+    const invokeCall = invokeSpy.mock.calls[0]![0];
+    expect(invokeCall.role).toBe('cortex-chat');
+  });
+
+  it('(b) Cortex::System derives cortex-system', async () => {
+    const { gateway, modelProvider } = createGatewayHarness({
+      agentClass: 'Cortex::System',
+    });
+
+    const invokeSpy = vi.spyOn(modelProvider, 'invoke');
+
+    await gateway.run(createGatewayInput('test'));
+
+    expect(invokeSpy).toHaveBeenCalled();
+    const invokeCall = invokeSpy.mock.calls[0]![0];
+    expect(invokeCall.role).toBe('cortex-system');
+  });
+
+  it('(c) Orchestrator (bare) derives orchestrators', async () => {
+    const { gateway, modelProvider } = createGatewayHarness({
+      agentClass: 'Orchestrator',
+    });
+
+    const invokeSpy = vi.spyOn(modelProvider, 'invoke');
+
+    await gateway.run(createGatewayInput('test'));
+
+    expect(invokeSpy).toHaveBeenCalled();
+    const invokeCall = invokeSpy.mock.calls[0]![0];
+    expect(invokeCall.role).toBe('orchestrators');
+  });
+
+  it('(d) Worker (bare) derives workers', async () => {
+    const { gateway, modelProvider } = createGatewayHarness({
+      agentClass: 'Worker',
+    });
+
+    const invokeSpy = vi.spyOn(modelProvider, 'invoke');
+
+    await gateway.run(createGatewayInput('test'));
+
+    expect(invokeSpy).toHaveBeenCalled();
+    const invokeCall = invokeSpy.mock.calls[0]![0];
+    expect(invokeCall.role).toBe('workers');
+  });
+
+  it('(e) undefined agentClass falls back to cortex-chat (I5)', async () => {
+    const { gateway, modelProvider } = createGatewayHarness({
+      agentClass: undefined,
+    });
+
+    const invokeSpy = vi.spyOn(modelProvider, 'invoke');
+
+    await gateway.run(createGatewayInput('test'));
+
+    expect(invokeSpy).toHaveBeenCalled();
+    const invokeCall = invokeSpy.mock.calls[0]![0];
+    expect(invokeCall.role).toBe('cortex-chat');
+  });
+
+  it('(f) explicit config.modelRole overrides the derive (I-3)', async () => {
+    const { modelProvider } = createGatewayHarness({
+      agentClass: 'Cortex::Principal',
+    });
+
+    // Create a gateway with explicit modelRole
+    const { AgentGateway } = await import('../../agent-gateway/agent-gateway.js');
+    const { createToolSurface, AGENT_ID, NOW, InMemoryGatewayOutboxSink } = await import('./helpers.js');
+
+    const gateway = new AgentGateway({
+      agentClass: 'Cortex::Principal',
+      agentId: AGENT_ID,
+      toolSurface: createToolSurface(),
+      modelProvider,
+      modelRole: 'orchestrators', // explicit override
+      outbox: new InMemoryGatewayOutboxSink(),
+      now: () => NOW,
+      nowMs: () => Date.parse(NOW),
+      idFactory: () => AGENT_ID,
+    });
+
+    const invokeSpy = vi.spyOn(modelProvider, 'invoke');
+
+    await gateway.run(createGatewayInput('test'));
+
+    expect(invokeSpy).toHaveBeenCalled();
+    const invokeCall = invokeSpy.mock.calls[0]![0];
+    expect(invokeCall.role).toBe('orchestrators');
+  });
+});

--- a/self/cortex/core/src/__tests__/agent-gateway/helpers.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/helpers.ts
@@ -399,6 +399,14 @@ export function createStampedPacket(): GatewayStampedPacket {
   };
 }
 
+export function createGatewayInput(prompt: string): AgentInput {
+  return createBaseInput({
+    taskInstructions: prompt,
+  });
+}
+
+export { InMemoryGatewayOutboxSink };
+
 export function createGatewayHarness(options?: {
   outputs?: unknown[];
   toolSurface?: IScopedMcpToolSurface;
@@ -420,8 +428,12 @@ export function createGatewayHarness(options?: {
   const modelProvider =
     options?.modelProvider ??
     (options?.outputs ? createModelProvider(options.outputs) : createModelProvider(['']));
+  const resolvedAgentClass =
+    options !== undefined && 'agentClass' in options
+      ? options.agentClass
+      : 'Worker';
   const gateway = new AgentGateway({
-    agentClass: options?.agentClass ?? 'Worker',
+    agentClass: resolvedAgentClass,
     agentId: AGENT_ID,
     toolSurface,
     modelProvider,

--- a/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
@@ -333,7 +333,7 @@ describe('Internal MCP capability handlers', () => {
                           executionModel: 'synchronous',
                           config: {
                             type: 'model-call',
-                            modelRole: 'reasoner',
+                            modelRole: 'cortex-chat',
                             promptRef: 'prompt://start',
                           },
                         },

--- a/self/cortex/core/src/__tests__/internal-mcp/lifecycle-handlers.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/lifecycle-handlers.test.ts
@@ -107,7 +107,7 @@ describe('Internal MCP lifecycle handlers', () => {
               executionModel: 'sync',
               config: {
                 type: 'model-call',
-                modelRole: 'reasoner',
+                modelRole: 'cortex-chat',
                 promptRef: 'prompt://complete',
                 outputSchemaRef: 'schema://completion',
               },

--- a/self/cortex/core/src/__tests__/trace-schema.test.ts
+++ b/self/cortex/core/src/__tests__/trace-schema.test.ts
@@ -18,7 +18,7 @@ describe('ExecutionTrace schema', () => {
           modelCalls: [
             {
               providerId: randomUUID(),
-              role: 'reasoner',
+              role: 'cortex-chat',
               durationMs: 100,
             },
           ],

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -56,7 +56,18 @@ import { GatewayOutbox } from './outbox.js';
 import { composeSystemPrompt } from './system-prompt-composer.js';
 import { transformGatewayInput } from '../gateway-runtime/gateway-turn-executor.js';
 
-const DEFAULT_MODEL_ROLE: ModelRole = 'reasoner';
+const DEFAULT_MODEL_ROLE_BY_CLASS: Record<AgentClass, ModelRole> = {
+  'Cortex::Principal': 'cortex-chat',
+  'Cortex::System': 'cortex-system',
+  Orchestrator: 'orchestrators',
+  Worker: 'workers',
+};
+
+function deriveDefaultModelRole(agentClass: AgentClass | undefined): ModelRole {
+  if (!agentClass) return 'cortex-chat'; // I5 first-run fallback
+  return DEFAULT_MODEL_ROLE_BY_CLASS[agentClass];
+}
+
 const DEFAULT_MODEL_REQUIREMENTS = {
   profile: 'review-standard',
   fallbackPolicy: 'block_if_unmet' as const,
@@ -201,7 +212,7 @@ export class AgentGateway implements IAgentGateway {
         });
 
         const modelResponse = await provider.invoke({
-          role: this.config.modelRole ?? DEFAULT_MODEL_ROLE,
+          role: this.config.modelRole ?? deriveDefaultModelRole(this.config.agentClass),
           input: providerInput,
           projectId,
           traceId,
@@ -1300,7 +1311,7 @@ export class AgentGateway implements IAgentGateway {
         DEFAULT_MODEL_REQUIREMENTS,
     };
     const route = await this.config.modelRouter!.routeWithEvidence(
-      this.config.modelRole ?? DEFAULT_MODEL_ROLE,
+      this.config.modelRole ?? deriveDefaultModelRole(this.config.agentClass),
       routeContext,
     );
     const provider = this.config.getProvider!(route.providerId);

--- a/self/shared/src/__tests__/types/enums.test.ts
+++ b/self/shared/src/__tests__/types/enums.test.ts
@@ -42,8 +42,7 @@ describe('PfcTierSchema', () => {
 
 describe('ModelRoleSchema', () => {
   const validRoles = [
-    'orchestrator', 'reasoner', 'tool-advisor', 'summarizer',
-    'embedder', 'reranker', 'vision',
+    'cortex-chat', 'cortex-system', 'orchestrators', 'workers',
   ];
 
   it.each(validRoles)('accepts "%s"', (role) => {
@@ -52,6 +51,15 @@ describe('ModelRoleSchema', () => {
 
   it('rejects invalid role', () => {
     expect(ModelRoleSchema.safeParse('invalid-role').success).toBe(false);
+  });
+
+  const legacyRoles = [
+    'reasoner', 'orchestrator', 'tool-advisor', 'summarizer',
+    'embedder', 'reranker', 'vision',
+  ];
+
+  it.each(legacyRoles)('rejects legacy role "%s"', (role) => {
+    expect(ModelRoleSchema.safeParse(role).success).toBe(false);
   });
 });
 

--- a/self/shared/src/__tests__/types/model-role-migration.test.ts
+++ b/self/shared/src/__tests__/types/model-role-migration.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { migrateLegacyModelRole } from '../../types/model-role-migration.js';
+
+describe('migrateLegacyModelRole', () => {
+  it('remaps "reasoner" to "cortex-chat"', () => {
+    expect(migrateLegacyModelRole('reasoner')).toBe('cortex-chat');
+  });
+
+  it('remaps "orchestrator" to "orchestrators"', () => {
+    expect(migrateLegacyModelRole('orchestrator')).toBe('orchestrators');
+  });
+
+  it.each(['tool-advisor', 'summarizer', 'embedder', 'reranker', 'vision'])(
+    'returns null for dropped literal "%s"',
+    (role) => {
+      expect(migrateLegacyModelRole(role)).toBeNull();
+    },
+  );
+
+  it.each(['cortex-chat', 'cortex-system', 'orchestrators', 'workers'])(
+    'passes through canonical literal "%s" unchanged',
+    (role) => {
+      expect(migrateLegacyModelRole(role)).toBe(role);
+    },
+  );
+
+  it('passes through unrecognized strings unchanged', () => {
+    expect(migrateLegacyModelRole('fantasy-role')).toBe('fantasy-role');
+  });
+
+  it('is idempotent — double-migration does not corrupt', () => {
+    const first = migrateLegacyModelRole('reasoner');
+    expect(first).toBe('cortex-chat');
+    expect(migrateLegacyModelRole(first as string)).toBe('cortex-chat');
+  });
+});

--- a/self/shared/src/__tests__/types/package-documents.test.ts
+++ b/self/shared/src/__tests__/types/package-documents.test.ts
@@ -100,7 +100,7 @@ describe('WorkflowStepFrontmatterSchema', () => {
       executionModel: 'synchronous',
       config: {
         type: 'model-call',
-        modelRole: 'reasoner',
+        modelRole: 'cortex-chat',
         promptRef: 'prompt://draft',
       },
     });
@@ -212,7 +212,7 @@ describe('LoadedWorkflowPackageSchema', () => {
             executionModel: 'synchronous',
             config: {
               type: 'model-call',
-              modelRole: 'reasoner',
+              modelRole: 'cortex-chat',
               promptRef: 'prompt://draft',
             },
           },

--- a/self/shared/src/__tests__/types/project-surface.test.ts
+++ b/self/shared/src/__tests__/types/project-surface.test.ts
@@ -87,7 +87,7 @@ describe('ProjectDashboardSnapshotSchema', () => {
               executionModel: 'synchronous',
               config: {
                 type: 'model-call',
-                modelRole: 'reasoner',
+                modelRole: 'cortex-chat',
                 promptRef: 'prompt://draft',
               },
             },

--- a/self/shared/src/__tests__/types/project.test.ts
+++ b/self/shared/src/__tests__/types/project.test.ts
@@ -42,7 +42,7 @@ describe('NodeSchemaDefinition', () => {
   it('accepts optional modelRole', () => {
     const result = NodeSchemaDefinition.safeParse({
       ...validNode,
-      modelRole: 'vision',
+      modelRole: 'cortex-chat',
     });
     expect(result.success).toBe(true);
   });
@@ -238,7 +238,7 @@ describe('ProjectConfigSchema', () => {
                 executionModel: 'synchronous',
                 config: {
                   type: 'model-call',
-                  modelRole: 'reasoner',
+                  modelRole: 'cortex-chat',
                   promptRef: 'prompt://draft',
                 },
               },
@@ -320,5 +320,68 @@ describe('ProjectWorkflowConfigurationSchema', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+});
+
+// ─── U2 Migration Tests — ProjectConfigSchema.modelAssignments ────────────
+
+describe('ProjectConfigSchema modelAssignments U2 migration', () => {
+  const baseConfig = {
+    id: '550e8400-e29b-41d4-a716-446655440099' as any,
+    name: 'Test Project',
+    type: 'protocol' as const,
+    pfcTier: 2,
+    memoryAccessPolicy: {
+      canReadFrom: 'all' as const,
+      canBeReadBy: 'all' as const,
+      inheritsGlobal: true,
+    },
+    escalationChannels: ['in-app' as const],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  it('(i) remaps reasoner key to cortex-chat', () => {
+    const result = ProjectConfigSchema.safeParse({
+      ...baseConfig,
+      modelAssignments: { reasoner: 'p1' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelAssignments).toEqual({ 'cortex-chat': 'p1' });
+    }
+  });
+
+  it('(ii) remaps orchestrator key to orchestrators', () => {
+    const result = ProjectConfigSchema.safeParse({
+      ...baseConfig,
+      modelAssignments: { orchestrator: 'p1' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelAssignments).toEqual({ orchestrators: 'p1' });
+    }
+  });
+
+  it('(iii) all 7 legacy keys → exactly 2 remapped survivors', () => {
+    const result = ProjectConfigSchema.safeParse({
+      ...baseConfig,
+      modelAssignments: {
+        reasoner: 'p1',
+        orchestrator: 'p2',
+        'tool-advisor': 'p3',
+        summarizer: 'p4',
+        embedder: 'p5',
+        reranker: 'p6',
+        vision: 'p7',
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelAssignments).toEqual({
+        'cortex-chat': 'p1',
+        orchestrators: 'p2',
+      });
+    }
   });
 });

--- a/self/shared/src/__tests__/types/provider.test.ts
+++ b/self/shared/src/__tests__/types/provider.test.ts
@@ -43,7 +43,7 @@ describe('ModelProviderConfigSchema', () => {
 describe('ModelRequestSchema', () => {
   it('accepts a valid request', () => {
     const result = ModelRequestSchema.safeParse({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Analyze this deal' },
       traceId: VALID_UUID,
     });
@@ -53,7 +53,7 @@ describe('ModelRequestSchema', () => {
   it('accepts optional agentClass and abortSignal fields', () => {
     const controller = new AbortController();
     const result = ModelRequestSchema.safeParse({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Analyze this deal' },
       traceId: VALID_UUID,
       agentClass: 'Worker',

--- a/self/shared/src/__tests__/types/workflow-monitoring.test.ts
+++ b/self/shared/src/__tests__/types/workflow-monitoring.test.ts
@@ -38,7 +38,7 @@ const definition = {
       executionModel: 'synchronous',
       config: {
         type: 'model-call',
-        modelRole: 'reasoner',
+        modelRole: 'cortex-chat',
         promptRef: 'prompt://draft',
       },
     },

--- a/self/shared/src/__tests__/types/workflow.test.ts
+++ b/self/shared/src/__tests__/types/workflow.test.ts
@@ -19,6 +19,7 @@ import {
   WorkflowStartResultSchema,
   WorkflowStateSchema,
   WorkflowTransitionInputSchema,
+  WorkflowModelCallNodeConfigSchema,
 } from '../../types/workflow.js';
 
 const PROJECT_ID = '550e8400-e29b-41d4-a716-446655440001';
@@ -82,7 +83,7 @@ const definition = {
       executionModel: 'synchronous',
       config: {
         type: 'model-call',
-        modelRole: 'reasoner',
+        modelRole: 'cortex-chat',
         promptRef: 'prompt://draft',
       },
     },
@@ -463,5 +464,42 @@ describe('Workflow request schemas', () => {
         },
       }).success,
     ).toBe(true);
+  });
+});
+
+// ─── U2 Migration Tests ────────────────────────────────────────────────────
+
+describe('WorkflowModelCallNodeConfigSchema U2 migration', () => {
+  it('(i) remaps modelRole "reasoner" to "cortex-chat"', () => {
+    const result = WorkflowModelCallNodeConfigSchema.safeParse({
+      type: 'model-call',
+      modelRole: 'reasoner',
+      promptRef: 'prompt://test',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelRole).toBe('cortex-chat');
+    }
+  });
+
+  it('(ii) remaps modelRole "orchestrator" to "orchestrators"', () => {
+    const result = WorkflowModelCallNodeConfigSchema.safeParse({
+      type: 'model-call',
+      modelRole: 'orchestrator',
+      promptRef: 'prompt://test',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelRole).toBe('orchestrators');
+    }
+  });
+
+  it('(iii) dropped literal "tool-advisor" causes safeParse failure', () => {
+    const result = WorkflowModelCallNodeConfigSchema.safeParse({
+      type: 'model-call',
+      modelRole: 'tool-advisor',
+      promptRef: 'prompt://test',
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/self/shared/src/types/enums.ts
+++ b/self/shared/src/types/enums.ts
@@ -14,17 +14,24 @@ import { z } from 'zod';
 export const PfcTierSchema = z.number().int().min(0).max(5);
 export type PfcTier = z.infer<typeof PfcTierSchema>;
 
-// --- Model Roles — from phase-1.1 spec ---
+// --- Model Roles — architectural-layer taxonomy (WR-142) ---
+// Collapsed from 7 capability-based roles to 4 architectural-layer roles.
+// See .architecture/.decisions/2026-04-09-model-role-taxonomy-collapse/
 export const ModelRoleSchema = z.enum([
-  'orchestrator',
-  'reasoner',
-  'tool-advisor',
-  'summarizer',
-  'embedder',
-  'reranker',
-  'vision',
+  'cortex-chat',
+  'cortex-system',
+  'orchestrators',
+  'workers',
 ]);
 export type ModelRole = z.infer<typeof ModelRoleSchema>;
+
+/** Display labels for each model role. */
+export const MODEL_ROLE_LABELS: Record<ModelRole, string> = {
+  'cortex-chat': 'Cortex Chat',
+  'cortex-system': 'Cortex System',
+  orchestrators: "Orchestrator's",
+  workers: "Worker's",
+};
 
 // --- Project Types — from project-model.mdx ---
 export const ProjectTypeSchema = z.enum(['protocol', 'intent', 'hybrid']);

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './ids.js';
 export * from './enums.js';
+export * from './model-role-migration.js';
 export * from './memory.js';
 export * from './retrieval.js';
 export * from './cross-project-retrieval.js';

--- a/self/shared/src/types/model-role-migration.ts
+++ b/self/shared/src/types/model-role-migration.ts
@@ -1,0 +1,38 @@
+/**
+ * U2 legacy model-role migration helper.
+ *
+ * Provides a single shared function for remapping legacy 7-role taxonomy
+ * literals to the canonical 4-role architectural-layer taxonomy (WR-142).
+ *
+ * Called from:
+ * - autonomic/config loader.ts (system config pre-safeParse)
+ * - shared/types/workflow.ts (WorkflowModelCallNodeConfigSchema preprocess)
+ * - shared/types/project.ts (NodeSchemaDefinition + ProjectConfigSchema preprocess)
+ */
+import type { ModelRole } from './enums.js';
+
+const LEGACY_REMAP: Record<string, ModelRole> = {
+  reasoner: 'cortex-chat',
+  orchestrator: 'orchestrators',
+};
+
+const LEGACY_DROPPED = new Set([
+  'tool-advisor',
+  'summarizer',
+  'embedder',
+  'reranker',
+  'vision',
+]);
+
+/**
+ * Migrate a legacy model-role string to the canonical 4-role taxonomy.
+ *
+ * @returns The canonical ModelRole string if remapped, `null` if the legacy
+ *          role should be silently dropped, or the original string unchanged
+ *          if it is already canonical or unrecognized.
+ */
+export function migrateLegacyModelRole(legacy: string): ModelRole | null | string {
+  if (legacy in LEGACY_REMAP) return LEGACY_REMAP[legacy]!;
+  if (LEGACY_DROPPED.has(legacy)) return null;
+  return legacy;
+}

--- a/self/shared/src/types/project.ts
+++ b/self/shared/src/types/project.ts
@@ -5,6 +5,7 @@
  * escalation contracts, project configuration, and project state.
  */
 import { z } from 'zod';
+import { migrateLegacyModelRole } from './model-role-migration.js';
 import {
   ProjectIdSchema,
   NodeIdSchema,
@@ -71,7 +72,14 @@ export const NodeSchemaDefinition = z.object({
   type: NodeTypeSchema,
   inputs: z.record(z.string(), z.unknown()),
   outputs: z.record(z.string(), z.unknown()),
-  modelRole: ModelRoleSchema.optional(),
+  modelRole: z.preprocess(
+    (val) => {
+      if (typeof val !== 'string') return val;
+      const result = migrateLegacyModelRole(val);
+      return result === null ? val : result;
+    },
+    ModelRoleSchema,
+  ).optional(),
   governance: GovernanceLevelSchema,
   escalation: z.object({
     enabled: z.boolean(),
@@ -193,7 +201,20 @@ export const ProjectConfigSchema = z.object({
   type: ProjectTypeSchema,
   pfcTier: PfcTierSchema,
   governanceDefaults: ProjectGovernanceDefaultsSchema.default({}),
-  modelAssignments: z.record(ModelRoleSchema, z.string()).optional(),
+  modelAssignments: z.preprocess(
+    (val) => {
+      if (val === null || val === undefined || typeof val !== 'object') return val;
+      const input = val as Record<string, unknown>;
+      const output: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(input)) {
+        const migrated = migrateLegacyModelRole(key);
+        if (migrated === null) continue; // silently drop
+        output[migrated as string] = value;
+      }
+      return output;
+    },
+    z.record(ModelRoleSchema, z.string()),
+  ).optional(),
   memoryAccessPolicy: MemoryAccessPolicySchema,
   escalationChannels: z.array(EscalationChannelSchema),
   escalationPreferences: ProjectEscalationPreferencesSchema.default({}),

--- a/self/shared/src/types/workflow.ts
+++ b/self/shared/src/types/workflow.ts
@@ -5,6 +5,7 @@
  * continuation, checkpoint, and run-state contracts.
  */
 import { z } from 'zod';
+import { migrateLegacyModelRole } from './model-role-migration.js';
 import {
   WorkflowDefinitionIdSchema,
   WorkflowNodeDefinitionIdSchema,
@@ -78,7 +79,14 @@ export type WorkflowAuthorityActor = z.infer<
 
 export const WorkflowModelCallNodeConfigSchema = z.object({
   type: z.literal('model-call'),
-  modelRole: ModelRoleSchema,
+  modelRole: z.preprocess(
+    (val) => {
+      if (typeof val !== 'string') return val;
+      const result = migrateLegacyModelRole(val);
+      return result === null ? val : result; // null → pass raw so ModelRoleSchema rejects
+    },
+    ModelRoleSchema,
+  ),
   promptRef: z.string().min(1),
   outputSchemaRef: WorkflowSchemaRefSchema.optional(),
 });

--- a/self/subcortex/coding-agents/src/__tests__/workflow-node-handler.test.ts
+++ b/self/subcortex/coding-agents/src/__tests__/workflow-node-handler.test.ts
@@ -124,7 +124,7 @@ function makeContext(overrides?: {
       executionModel: 'synchronous',
       config: {
         type: (overrides?.configType ?? 'model-call') as 'model-call',
-        modelRole: 'orchestrator' as const,
+        modelRole: 'orchestrators' as const,
         promptRef: overrides?.promptRef ?? 'default:nous.agent.claude',
         outputSchemaRef: 'schema://node-1/output',
       },

--- a/self/subcortex/mao/src/__tests__/mao-projection-budget.test.ts
+++ b/self/subcortex/mao/src/__tests__/mao-projection-budget.test.ts
@@ -136,7 +136,7 @@ function createWorkflowEngine(runState: WorkflowRunState): IWorkflowEngine {
           executionModel: 'synchronous',
           config: {
             type: 'model-call',
-            modelRole: 'reasoner',
+            modelRole: 'cortex-chat',
             promptRef: 'prompt://work',
           },
         },

--- a/self/subcortex/mao/src/__tests__/mao-projection-degraded-health.test.ts
+++ b/self/subcortex/mao/src/__tests__/mao-projection-degraded-health.test.ts
@@ -181,7 +181,7 @@ function createGraph(runState: WorkflowRunState) {
           type: 'model-call',
           governance: 'must',
           executionModel: 'synchronous',
-          config: { type: 'model-call', modelRole: 'reasoner', promptRef: 'prompt://draft' },
+          config: { type: 'model-call', modelRole: 'cortex-chat', promptRef: 'prompt://draft' },
         },
         inboundEdgeIds: [],
         outboundEdgeIds: ['edge-1'],

--- a/self/subcortex/mao/src/__tests__/mao-projection-service.test.ts
+++ b/self/subcortex/mao/src/__tests__/mao-projection-service.test.ts
@@ -189,7 +189,7 @@ function createWorkflowEngine(runState: WorkflowRunState): IWorkflowEngine {
           executionModel: 'synchronous',
           config: {
             type: 'model-call',
-            modelRole: 'reasoner',
+            modelRole: 'cortex-chat',
             promptRef: 'prompt://draft',
           },
         },
@@ -984,7 +984,7 @@ describe('MaoProjectionService', () => {
               executionModel: 'synchronous',
               config: {
                 type: 'model-call',
-                modelRole: 'reasoner',
+                modelRole: 'cortex-chat',
                 promptRef: 'prompt://draft',
               },
               metadata: {

--- a/self/subcortex/projects/src/__tests__/document-project-store.test.ts
+++ b/self/subcortex/projects/src/__tests__/document-project-store.test.ts
@@ -39,7 +39,7 @@ const createProjectConfig = () => ({
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call',
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
             },
           },
@@ -154,7 +154,7 @@ describe('DocumentProjectStore', () => {
                 executionModel: 'synchronous',
                 config: {
                   type: 'model-call',
-                  modelRole: 'reasoner',
+                  modelRole: 'cortex-chat',
                   promptRef: 'prompt://draft-v2',
                 },
               },
@@ -170,7 +170,7 @@ describe('DocumentProjectStore', () => {
     expect(got?.workflow?.definitions[0]?.version).toBe('1.0.1');
     expect(got?.workflow?.definitions[0]?.nodes[0]?.config).toEqual({
       type: 'model-call',
-      modelRole: 'reasoner',
+      modelRole: 'cortex-chat',
       promptRef: 'prompt://draft-v2',
     });
   });

--- a/self/subcortex/providers/src/__tests__/anthropic-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/anthropic-provider.test.ts
@@ -53,7 +53,7 @@ describe('AnthropicProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: {},
         traceId: TRACE_ID,
       }),
@@ -76,7 +76,7 @@ describe('AnthropicProvider', () => {
     );
 
     const result = await provider.invoke({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: {
         messages: [
           { role: 'system', content: 'Be concise.' },
@@ -132,7 +132,7 @@ describe('AnthropicProvider', () => {
     );
 
     await provider.invoke({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Write a haiku.' },
       traceId: TRACE_ID,
     });
@@ -163,7 +163,7 @@ describe('AnthropicProvider', () => {
     );
 
     await provider.invoke({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Default max tokens?' },
       traceId: TRACE_ID,
     });
@@ -186,7 +186,7 @@ describe('AnthropicProvider', () => {
     );
 
     const result = await provider.invoke({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'No content?' },
       traceId: TRACE_ID,
     });
@@ -204,7 +204,7 @@ describe('AnthropicProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: TRACE_ID,
       }),
@@ -224,7 +224,7 @@ describe('AnthropicProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: TRACE_ID,
       }),
@@ -244,7 +244,7 @@ describe('AnthropicProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: TRACE_ID,
       }),
@@ -288,7 +288,7 @@ describe('AnthropicProvider', () => {
 
     const chunks: Array<{ content: string; done: boolean; usage?: { inputTokens?: number; outputTokens?: number } }> = [];
     for await (const chunk of provider.stream({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Stream this.' },
       traceId: TRACE_ID,
     })) {
@@ -321,7 +321,7 @@ describe('AnthropicProvider', () => {
     } as Response);
 
     const iterator = provider.stream({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'hi' },
       traceId: TRACE_ID,
     });
@@ -351,7 +351,7 @@ describe('AnthropicProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: TRACE_ID,
         abortSignal: controller.signal,

--- a/self/subcortex/providers/src/__tests__/inference-lane.test.ts
+++ b/self/subcortex/providers/src/__tests__/inference-lane.test.ts
@@ -15,7 +15,7 @@ describe('InferenceLane', () => {
 
     const background = lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'background' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -29,7 +29,7 @@ describe('InferenceLane', () => {
 
     const orchestration = lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'orchestration' },
         traceId: TRACE_ID,
         agentClass: 'Orchestrator',
@@ -42,7 +42,7 @@ describe('InferenceLane', () => {
 
     const coordination = lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'coordination' },
         traceId: TRACE_ID,
         agentClass: 'Cortex::System',
@@ -66,7 +66,7 @@ describe('InferenceLane', () => {
 
     const background = lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'background' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -90,7 +90,7 @@ describe('InferenceLane', () => {
 
     const principal = lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'principal' },
         traceId: TRACE_ID,
         agentClass: 'Cortex::Principal',
@@ -113,7 +113,7 @@ describe('InferenceLane', () => {
     expect(() =>
       lane.enqueue(
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           input: { prompt: 'blocked' },
           traceId: TRACE_ID,
           agentClass: 'Worker',
@@ -130,7 +130,7 @@ describe('InferenceLane', () => {
     await expect(
       lane.reinsertPreempted(
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           input: { prompt: 'retry' },
           traceId: TRACE_ID,
           agentClass: 'Worker',
@@ -147,7 +147,7 @@ describe('InferenceLane', () => {
     for (let i = 0; i < 510; i++) {
       await lane.enqueue(
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           input: { prompt: `request-${i}` },
           traceId: TRACE_ID,
           agentClass: 'Worker',
@@ -165,7 +165,7 @@ describe('InferenceLane', () => {
     // enqueue one more and verify analytics still work (no memory explosion)
     await lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'final' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -184,7 +184,7 @@ describe('InferenceLane', () => {
 
     const firstPromise = lane.enqueue(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'first' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -199,7 +199,7 @@ describe('InferenceLane', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     const estimate = lane.getWaitEstimate({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'query' },
       traceId: TRACE_ID,
       agentClass: 'Worker',
@@ -227,7 +227,7 @@ describe('InferenceLane', () => {
     const chunks: ModelStreamChunk[] = [];
     for await (const chunk of lane.stream(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'stream' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -254,7 +254,7 @@ describe('InferenceLane', () => {
 
     for await (const _chunk of lane.stream(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'stream' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -279,7 +279,7 @@ describe('InferenceLane', () => {
 
     for await (const chunk of lane.stream(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'stream' },
         traceId: TRACE_ID,
         agentClass: 'Worker',
@@ -307,7 +307,7 @@ describe('InferenceLane', () => {
     try {
       for await (const chunk of lane.stream(
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           input: { prompt: 'stream' },
           traceId: TRACE_ID,
           agentClass: 'Worker',
@@ -334,7 +334,7 @@ describe('InferenceLane', () => {
 
     const generator = lane.stream(
       {
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'blocked' },
         traceId: TRACE_ID,
         agentClass: 'Worker',

--- a/self/subcortex/providers/src/__tests__/ollama-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/ollama-provider.test.ts
@@ -31,7 +31,7 @@ describe('OllamaProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { invalid: 'shape' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
       }),
@@ -51,7 +51,7 @@ describe('OllamaProvider', () => {
     } as Response);
 
     const result = await provider.invoke({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Say hello' },
       traceId: '00000000-0000-0000-0000-000000000002' as any,
     });
@@ -72,7 +72,7 @@ describe('OllamaProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
       }),
@@ -80,7 +80,7 @@ describe('OllamaProvider', () => {
 
     try {
       await provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
       });
@@ -105,7 +105,7 @@ describe('OllamaProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
         abortSignal: controller.signal,

--- a/self/subcortex/providers/src/__tests__/openai-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/openai-provider.test.ts
@@ -52,7 +52,7 @@ describe('OpenAiCompatibleProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: {},
         traceId: '00000000-0000-0000-0000-000000000002' as any,
       }),
@@ -72,7 +72,7 @@ describe('OpenAiCompatibleProvider', () => {
     } as Response);
 
     const result = await provider.invoke({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Say hello' },
       traceId: '00000000-0000-0000-0000-000000000002' as any,
     });
@@ -95,7 +95,7 @@ describe('OpenAiCompatibleProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
       }),
@@ -103,7 +103,7 @@ describe('OpenAiCompatibleProvider', () => {
 
     try {
       await provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
       });
@@ -130,7 +130,7 @@ describe('OpenAiCompatibleProvider', () => {
 
     await expect(
       provider.invoke({
-        role: 'reasoner',
+        role: 'cortex-chat',
         input: { prompt: 'hi' },
         traceId: '00000000-0000-0000-0000-000000000002' as any,
         abortSignal: controller.signal,

--- a/self/subcortex/router/src/__tests__/model-router.test.ts
+++ b/self/subcortex/router/src/__tests__/model-router.test.ts
@@ -5,7 +5,7 @@ import { ModelRouter } from '../model-router.js';
 const createMockConfig = (overrides: Record<string, unknown> = {}) => ({
   get: vi.fn().mockReturnValue({
     modelRoleAssignments: [
-      { role: 'reasoner', providerId: '00000000-0000-0000-0000-000000000001' },
+      { role: 'cortex-chat', providerId: '00000000-0000-0000-0000-000000000001' },
     ],
     providers: [
       {
@@ -27,7 +27,7 @@ describe('ModelRouter', () => {
     const config = createMockConfig();
     const router = new ModelRouter(config as any);
 
-    const providerId = await router.route('reasoner');
+    const providerId = await router.route('cortex-chat');
     expect(providerId).toBe('00000000-0000-0000-0000-000000000001');
   });
 
@@ -35,9 +35,9 @@ describe('ModelRouter', () => {
     const config = createMockConfig({ modelRoleAssignments: [] });
     const router = new ModelRouter(config as any);
 
-    await expect(router.route('reasoner')).rejects.toThrow(NousError);
+    await expect(router.route('cortex-chat')).rejects.toThrow(NousError);
     try {
-      await router.route('reasoner');
+      await router.route('cortex-chat');
     } catch (e) {
       expect((e as NousError).code).toBe('ROLE_NOT_ASSIGNED');
     }
@@ -46,14 +46,14 @@ describe('ModelRouter', () => {
   it('route() throws ROLE_NOT_ASSIGNED when role not in assignments', async () => {
     const config = createMockConfig({
       modelRoleAssignments: [
-        { role: 'summarizer', providerId: '00000000-0000-0000-0000-000000000001' },
+        { role: 'workers', providerId: '00000000-0000-0000-0000-000000000001' },
       ],
     });
     const router = new ModelRouter(config as any);
 
-    await expect(router.route('reasoner')).rejects.toThrow(NousError);
+    await expect(router.route('cortex-chat')).rejects.toThrow(NousError);
     try {
-      await router.route('reasoner');
+      await router.route('cortex-chat');
     } catch (e) {
       expect((e as NousError).code).toBe('ROLE_NOT_ASSIGNED');
     }
@@ -62,15 +62,15 @@ describe('ModelRouter', () => {
   it('route() throws PROVIDER_NOT_FOUND when provider not in config', async () => {
     const config = createMockConfig({
       modelRoleAssignments: [
-        { role: 'reasoner', providerId: '00000000-0000-0000-0000-000000000099' },
+        { role: 'cortex-chat', providerId: '00000000-0000-0000-0000-000000000099' },
       ],
       providers: [],
     });
     const router = new ModelRouter(config as any);
 
-    await expect(router.route('reasoner')).rejects.toThrow(NousError);
+    await expect(router.route('cortex-chat')).rejects.toThrow(NousError);
     try {
-      await router.route('reasoner');
+      await router.route('cortex-chat');
     } catch (e) {
       expect((e as NousError).code).toBe('PROVIDER_NOT_FOUND');
     }
@@ -99,7 +99,7 @@ describe('ModelRouter routeWithEvidence', () => {
     const config = createMockConfig();
     const router = new ModelRouter(config as any);
 
-    const result = await router.routeWithEvidence('reasoner', {
+    const result = await router.routeWithEvidence('cortex-chat', {
       traceId: TRACE_ID,
       modelRequirements: {
         profile: 'review-standard',
@@ -136,13 +136,13 @@ describe('ModelRouter routeWithEvidence', () => {
         },
       ],
       modelRoleAssignments: [
-        { role: 'reasoner', providerId: FALLBACK_ID },
+        { role: 'cortex-chat', providerId: FALLBACK_ID },
       ],
     });
     const router = new ModelRouter(config as any);
 
     await expect(
-      router.routeWithEvidence('reasoner', {
+      router.routeWithEvidence('cortex-chat', {
         traceId: TRACE_ID,
         modelRequirements: {
           profile: 'review-standard',
@@ -152,7 +152,7 @@ describe('ModelRouter routeWithEvidence', () => {
     ).rejects.toThrow(NousError);
 
     try {
-      await router.routeWithEvidence('reasoner', {
+      await router.routeWithEvidence('cortex-chat', {
         traceId: TRACE_ID,
         modelRequirements: {
           profile: 'review-standard',
@@ -196,7 +196,7 @@ describe('ModelRouter routeWithEvidence', () => {
       ],
       modelRoleAssignments: [
         {
-          role: 'reasoner',
+          role: 'cortex-chat',
           providerId: PROVIDER_ID,
           fallbackProviderId: FALLBACK_ID,
         },
@@ -204,7 +204,7 @@ describe('ModelRouter routeWithEvidence', () => {
     });
     const router = new ModelRouter(config as any);
 
-    const result = await router.routeWithEvidence('reasoner', {
+    const result = await router.routeWithEvidence('cortex-chat', {
       traceId: TRACE_ID,
       modelRequirements: {
         profile: 'review-standard',
@@ -229,12 +229,12 @@ describe('ModelRouter routeWithEvidence', () => {
           meetsProfiles: ['prompt-generation'],
         },
       ],
-      modelRoleAssignments: [{ role: 'reasoner', providerId: PROVIDER_ID }],
+      modelRoleAssignments: [{ role: 'cortex-chat', providerId: PROVIDER_ID }],
     });
     const router = new ModelRouter(config as any);
 
     await expect(
-      router.routeWithEvidence('reasoner', {
+      router.routeWithEvidence('cortex-chat', {
         traceId: TRACE_ID,
         modelRequirements: {
           profile: 'review-standard',
@@ -244,7 +244,7 @@ describe('ModelRouter routeWithEvidence', () => {
     ).rejects.toThrow(NousError);
 
     try {
-      await router.routeWithEvidence('reasoner', {
+      await router.routeWithEvidence('cortex-chat', {
         traceId: TRACE_ID,
         modelRequirements: {
           profile: 'review-standard',
@@ -271,11 +271,11 @@ describe('ModelRouter routeWithEvidence', () => {
           meetsProfiles: ['prompt-generation'],
         },
       ],
-      modelRoleAssignments: [{ role: 'reasoner', providerId: PROVIDER_ID }],
+      modelRoleAssignments: [{ role: 'cortex-chat', providerId: PROVIDER_ID }],
     });
     const router = new ModelRouter(config as any);
 
-    const result = await router.routeWithEvidence('reasoner', {
+    const result = await router.routeWithEvidence('cortex-chat', {
       traceId: TRACE_ID,
       modelRequirements: {
         profile: 'review-standard',

--- a/self/subcortex/router/src/__tests__/router-provider-integration.test.ts
+++ b/self/subcortex/router/src/__tests__/router-provider-integration.test.ts
@@ -12,7 +12,7 @@ const PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as const;
 const createMockConfig = () => ({
   get: vi.fn().mockReturnValue({
     modelRoleAssignments: [
-      { role: 'reasoner', providerId: PROVIDER_ID },
+      { role: 'cortex-chat', providerId: PROVIDER_ID },
     ],
     providers: [
       {
@@ -57,7 +57,7 @@ describe('Router + Provider integration', () => {
     const router = new ModelRouter(config as any);
     const registry = new ProviderRegistry(config as any);
 
-    const providerId = await router.route('reasoner');
+    const providerId = await router.route('cortex-chat');
     expect(providerId).toBe(PROVIDER_ID);
 
     const provider = registry.getProvider(providerId);
@@ -65,7 +65,7 @@ describe('Router + Provider integration', () => {
 
     const chunks: string[] = [];
     for await (const chunk of provider!.stream({
-      role: 'reasoner',
+      role: 'cortex-chat',
       input: { prompt: 'Say hello' },
       traceId: '00000000-0000-0000-0000-000000000002' as any,
     })) {

--- a/self/subcortex/scheduler/src/__tests__/scheduler-gateway-integration.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-gateway-integration.test.ts
@@ -73,7 +73,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
             },
           },

--- a/self/subcortex/scheduler/src/__tests__/scheduler-recovery.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-recovery.test.ts
@@ -73,7 +73,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
             },
           },

--- a/self/subcortex/scheduler/src/__tests__/scheduler-service.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-service.test.ts
@@ -80,7 +80,7 @@ const projectConfig = ProjectConfigSchema.parse({
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
             },
           },
@@ -324,7 +324,7 @@ describe('SchedulerService', () => {
               executionModel: 'synchronous' as const,
               config: {
                 type: 'model-call' as const,
-                modelRole: 'reasoner' as const,
+                modelRole: 'cortex-chat' as const,
                 promptRef: 'prompt://draft',
               },
             },

--- a/self/subcortex/stubs/src/__tests__/stubs.test.ts
+++ b/self/subcortex/stubs/src/__tests__/stubs.test.ts
@@ -356,7 +356,7 @@ describe('StubProjectApi', () => {
 
   it('model.invoke() throws NousError with code NOT_IMPLEMENTED', async () => {
     await assertNotImplemented(
-      () => stub.model.invoke('reasoner', {}),
+      () => stub.model.invoke('cortex-chat', {}),
       'IProjectApi.model',
     );
   });

--- a/self/subcortex/witnessd/src/__tests__/witness-service.test.ts
+++ b/self/subcortex/witnessd/src/__tests__/witness-service.test.ts
@@ -28,7 +28,7 @@ describe('WitnessService', () => {
       actionRef: 'reasoner',
       actor: 'core',
       status: 'approved',
-      detail: { role: 'reasoner' },
+      detail: { role: 'cortex-chat' },
     });
 
     const completion = await service.appendCompletion({

--- a/self/subcortex/workflows/src/__tests__/graph-validator.test.ts
+++ b/self/subcortex/workflows/src/__tests__/graph-validator.test.ts
@@ -28,7 +28,7 @@ const baseDefinition = () => ({
       executionModel: 'synchronous' as const,
       config: {
         type: 'model-call' as const,
-        modelRole: 'reasoner' as const,
+        modelRole: 'cortex-chat' as const,
         promptRef: 'prompt://draft',
         outputSchemaRef: 'schema://node-output/draft',
       },

--- a/self/subcortex/workflows/src/__tests__/loop-error-integration.test.ts
+++ b/self/subcortex/workflows/src/__tests__/loop-error-integration.test.ts
@@ -500,7 +500,7 @@ describe('full regression: all handlers in a single workflow graph', () => {
       name: 'Full Regression',
       entryNodeIds: [MODEL_CALL],
       nodes: [
-        { id: MODEL_CALL, name: 'Model Call', type: 'model-call', governance: 'must', executionModel: 'synchronous', config: { type: 'model-call', modelRole: 'reasoner', promptRef: 'prompt://test', outputSchemaRef: 'schema://output' } },
+        { id: MODEL_CALL, name: 'Model Call', type: 'model-call', governance: 'must', executionModel: 'synchronous', config: { type: 'model-call', modelRole: 'cortex-chat', promptRef: 'prompt://test', outputSchemaRef: 'schema://output' } },
         { id: TRANSFORM, name: 'Transform', type: 'transform', governance: 'must', executionModel: 'synchronous', config: { type: 'transform', transformRef: 'transform://t', inputMappingRef: 'mapping://t' } },
         { id: CONDITION, name: 'Condition', type: 'condition', governance: 'must', executionModel: 'synchronous', config: { type: 'condition', predicateRef: 'pred://x', trueBranchKey: 'true', falseBranchKey: 'false' } },
         { id: TRUE_NODE, name: 'True Path', type: 'transform', governance: 'must', executionModel: 'synchronous', config: { type: 'transform', transformRef: 'transform://true', inputMappingRef: 'mapping://true' } },

--- a/self/subcortex/workflows/src/__tests__/phase-9.1-workflow-runtime-integration.test.ts
+++ b/self/subcortex/workflows/src/__tests__/phase-9.1-workflow-runtime-integration.test.ts
@@ -58,7 +58,7 @@ describe('Phase 9.1 workflow runtime integration', () => {
                 executionModel: 'synchronous',
                 config: {
                   type: 'model-call',
-                  modelRole: 'reasoner',
+                  modelRole: 'cortex-chat',
                   promptRef: 'prompt://draft',
                   outputSchemaRef: 'schema://node-output/draft',
                 },

--- a/self/subcortex/workflows/src/__tests__/phase-9.2-governed-node-runtime-integration.test.ts
+++ b/self/subcortex/workflows/src/__tests__/phase-9.2-governed-node-runtime-integration.test.ts
@@ -43,7 +43,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
               outputSchemaRef: 'schema://node-output/draft',
             },

--- a/self/subcortex/workflows/src/__tests__/phase-9.3-trigger-provenance-integration.test.ts
+++ b/self/subcortex/workflows/src/__tests__/phase-9.3-trigger-provenance-integration.test.ts
@@ -37,7 +37,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
               outputSchemaRef: 'schema://node-output/draft',
             },

--- a/self/subcortex/workflows/src/__tests__/phase-9.5-projects-ui-runtime-integration.test.ts
+++ b/self/subcortex/workflows/src/__tests__/phase-9.5-projects-ui-runtime-integration.test.ts
@@ -37,7 +37,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
               outputSchemaRef: 'schema://node-output/draft',
             },

--- a/self/subcortex/workflows/src/__tests__/run-state.test.ts
+++ b/self/subcortex/workflows/src/__tests__/run-state.test.ts
@@ -69,7 +69,7 @@ const linearGraph = buildDerivedWorkflowGraph({
       executionModel: 'synchronous',
       config: {
         type: 'model-call',
-        modelRole: 'reasoner',
+        modelRole: 'cortex-chat',
         promptRef: 'prompt://draft',
         outputSchemaRef: 'schema://node-output/draft',
       },

--- a/self/subcortex/workflows/src/__tests__/traversal.test.ts
+++ b/self/subcortex/workflows/src/__tests__/traversal.test.ts
@@ -35,7 +35,7 @@ describe('workflow traversal', () => {
           executionModel: 'synchronous',
           config: {
             type: 'model-call',
-            modelRole: 'reasoner',
+            modelRole: 'cortex-chat',
             promptRef: 'prompt://draft',
             outputSchemaRef: 'schema://node-output/draft',
           },

--- a/self/subcortex/workflows/src/__tests__/workflow-dispatch-harness-integration.test.ts
+++ b/self/subcortex/workflows/src/__tests__/workflow-dispatch-harness-integration.test.ts
@@ -65,7 +65,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://model-call',
               outputSchemaRef: 'schema://node-output/model-call',
             },
@@ -273,7 +273,7 @@ describe('WorkflowDispatchHarness Integration', () => {
                 executionModel: 'synchronous' as const,
                 config: {
                   type: 'model-call' as const,
-                  modelRole: 'reasoner' as const,
+                  modelRole: 'cortex-chat' as const,
                   promptRef: 'prompt://model-call',
                   outputSchemaRef: 'schema://output',
                 },

--- a/self/subcortex/workflows/src/__tests__/workflow-engine-events.test.ts
+++ b/self/subcortex/workflows/src/__tests__/workflow-engine-events.test.ts
@@ -39,7 +39,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://a',
               outputSchemaRef: 'schema://node-output/a',
             },

--- a/self/subcortex/workflows/src/__tests__/workflow-engine.test.ts
+++ b/self/subcortex/workflows/src/__tests__/workflow-engine.test.ts
@@ -47,7 +47,7 @@ const projectConfig = {
             executionModel: 'synchronous' as const,
             config: {
               type: 'model-call' as const,
-              modelRole: 'reasoner' as const,
+              modelRole: 'cortex-chat' as const,
               promptRef: 'prompt://draft',
               outputSchemaRef: 'schema://node-output/draft',
             },

--- a/self/subcortex/workflows/src/spec/runtime-adapter.ts
+++ b/self/subcortex/workflows/src/spec/runtime-adapter.ts
@@ -79,7 +79,7 @@ function mapNodeTypeToConfig(node: WorkflowNode): WorkflowNodeConfig {
       // Agent nodes map to model-call configs
       return {
         type: 'model-call' as const,
-        modelRole: 'orchestrator' as const,
+        modelRole: 'orchestrators' as const,
         promptRef: node.parameters.systemPrompt
           ? `inline:${node.id}`
           : `default:${node.type}`,

--- a/self/transport/src/hooks/__tests__/usePreferencesApi.test.ts
+++ b/self/transport/src/hooks/__tests__/usePreferencesApi.test.ts
@@ -7,7 +7,6 @@ import { usePreferencesApi } from '../usePreferencesApi'
 const mockFetch = {
   getApiKeys: vi.fn(),
   getAvailableModels: vi.fn(),
-  getModelSelection: vi.fn(),
   getRoleAssignments: vi.fn(),
   getSystemStatus: vi.fn(),
   listOllamaModels: vi.fn(),
@@ -17,7 +16,6 @@ const mockMutateAsync = {
   setApiKey: vi.fn(),
   deleteApiKey: vi.fn(),
   testApiKey: vi.fn(),
-  setModelSelection: vi.fn(),
   setRoleAssignment: vi.fn(),
   resetWizard: vi.fn(),
   pullOllamaModel: vi.fn(),
@@ -31,7 +29,6 @@ vi.mock('../../client', () => ({
       preferences: {
         getApiKeys: { fetch: mockFetch.getApiKeys },
         getAvailableModels: { fetch: mockFetch.getAvailableModels },
-        getModelSelection: { fetch: mockFetch.getModelSelection },
         getRoleAssignments: { fetch: mockFetch.getRoleAssignments },
         getSystemStatus: { fetch: mockFetch.getSystemStatus },
       },
@@ -44,7 +41,6 @@ vi.mock('../../client', () => ({
       setApiKey: { useMutation: () => ({ mutateAsync: mockMutateAsync.setApiKey }) },
       deleteApiKey: { useMutation: () => ({ mutateAsync: mockMutateAsync.deleteApiKey }) },
       testApiKey: { useMutation: () => ({ mutateAsync: mockMutateAsync.testApiKey }) },
-      setModelSelection: { useMutation: () => ({ mutateAsync: mockMutateAsync.setModelSelection }) },
       setRoleAssignment: { useMutation: () => ({ mutateAsync: mockMutateAsync.setRoleAssignment }) },
     },
     firstRun: {
@@ -84,8 +80,6 @@ describe('usePreferencesApi', () => {
       const api = result.current
 
       expect(typeof api.getAvailableModels).toBe('function')
-      expect(typeof api.getModelSelection).toBe('function')
-      expect(typeof api.setModelSelection).toBe('function')
       expect(typeof api.getRoleAssignments).toBe('function')
       expect(typeof api.setRoleAssignment).toBe('function')
       expect(typeof api.resetWizard).toBe('function')
@@ -138,16 +132,6 @@ describe('usePreferencesApi', () => {
       expect(data).toEqual(mockData)
     })
 
-    it('getModelSelection calls utils.preferences.getModelSelection.fetch', async () => {
-      const mockData = { principal: 'openai:gpt-4', system: null }
-      mockFetch.getModelSelection.mockResolvedValueOnce(mockData)
-
-      const { result } = renderHook(() => usePreferencesApi())
-      const data = await result.current.getModelSelection()
-
-      expect(mockFetch.getModelSelection).toHaveBeenCalledOnce()
-      expect(data).toEqual(mockData)
-    })
   })
 
   describe('mutation delegation', () => {
@@ -184,19 +168,8 @@ describe('usePreferencesApi', () => {
       expect(data).toEqual({ valid: true, error: null })
     })
 
-    it('setModelSelection calls mutation.mutateAsync with input', async () => {
-      const input = { principal: 'openai:gpt-4' }
-      mockMutateAsync.setModelSelection.mockResolvedValueOnce({ success: true })
-
-      const { result } = renderHook(() => usePreferencesApi())
-      const data = await result.current.setModelSelection(input)
-
-      expect(mockMutateAsync.setModelSelection).toHaveBeenCalledWith(input)
-      expect(data).toEqual({ success: true })
-    })
-
     it('setRoleAssignment calls mutation.mutateAsync with input', async () => {
-      const input = { role: 'orchestrator', modelSpec: 'openai:gpt-4' }
+      const input = { role: 'orchestrators', modelSpec: 'openai:gpt-4' }
       mockMutateAsync.setRoleAssignment.mockResolvedValueOnce({ success: true })
 
       const { result } = renderHook(() => usePreferencesApi())
@@ -212,29 +185,29 @@ describe('usePreferencesApi', () => {
   describe('getRoleAssignments adapter', () => {
     it('transforms Record to array', async () => {
       mockFetch.getRoleAssignments.mockResolvedValueOnce({
-        orchestrator: { providerId: 'openai:gpt-4' },
-        reasoner: null,
+        orchestrators: { providerId: 'openai:gpt-4' },
+        'cortex-chat': null,
       })
 
       const { result } = renderHook(() => usePreferencesApi())
       const data = await result.current.getRoleAssignments()
 
       expect(data).toEqual([
-        { role: 'orchestrator', providerId: 'openai:gpt-4' },
-        { role: 'reasoner', providerId: null },
+        { role: 'orchestrators', providerId: 'openai:gpt-4' },
+        { role: 'cortex-chat', providerId: null },
       ])
     })
 
     it('drops fallbackProviderId', async () => {
       mockFetch.getRoleAssignments.mockResolvedValueOnce({
-        orchestrator: { providerId: 'openai:gpt-4', fallbackProviderId: 'anthropic:claude' },
+        orchestrators: { providerId: 'openai:gpt-4', fallbackProviderId: 'anthropic:claude' },
       })
 
       const { result } = renderHook(() => usePreferencesApi())
       const data = await result.current.getRoleAssignments()
 
       expect(data).toEqual([
-        { role: 'orchestrator', providerId: 'openai:gpt-4' },
+        { role: 'orchestrators', providerId: 'openai:gpt-4' },
       ])
       // Verify no fallbackProviderId key
       expect(data[0]).not.toHaveProperty('fallbackProviderId')

--- a/self/transport/src/hooks/usePreferencesApi.ts
+++ b/self/transport/src/hooks/usePreferencesApi.ts
@@ -15,7 +15,6 @@ export function usePreferencesApi() {
   const setApiKey = trpc.preferences.setApiKey.useMutation()
   const deleteApiKey = trpc.preferences.deleteApiKey.useMutation()
   const testApiKey = trpc.preferences.testApiKey.useMutation()
-  const setModelSelection = trpc.preferences.setModelSelection.useMutation()
   const setRoleAssignment = trpc.preferences.setRoleAssignment.useMutation()
   const resetWizardMutation = trpc.firstRun.resetWizard.useMutation()
   const pullOllamaModel = trpc.ollama.pullModel.useMutation()
@@ -30,8 +29,6 @@ export function usePreferencesApi() {
   deleteApiKeyRef.current = deleteApiKey.mutateAsync
   const testApiKeyRef = useRef(testApiKey.mutateAsync)
   testApiKeyRef.current = testApiKey.mutateAsync
-  const setModelSelectionRef = useRef(setModelSelection.mutateAsync)
-  setModelSelectionRef.current = setModelSelection.mutateAsync
   const setRoleAssignmentRef = useRef(setRoleAssignment.mutateAsync)
   setRoleAssignmentRef.current = setRoleAssignment.mutateAsync
   const resetWizardRef = useRef(resetWizardMutation.mutateAsync)
@@ -64,12 +61,6 @@ export function usePreferencesApi() {
       // Optional methods (all provided — wired to existing tRPC endpoints)
       getAvailableModels: async () => {
         return utilsRef.current.preferences.getAvailableModels.fetch()
-      },
-      getModelSelection: async () => {
-        return utilsRef.current.preferences.getModelSelection.fetch()
-      },
-      setModelSelection: async (input: { principal?: string; system?: string }) => {
-        return setModelSelectionRef.current(input)
       },
       getRoleAssignments: async () => {
         const record = await utilsRef.current.preferences.getRoleAssignments.fetch()

--- a/self/ui/src/panels/PreferencesPanel.tsx
+++ b/self/ui/src/panels/PreferencesPanel.tsx
@@ -10,7 +10,6 @@ import type { AppPanelEntry } from './settings/types'
 export type {
   PreferencesApi,
   AvailableModel,
-  ModelSelection,
   RoleAssignmentDisplayEntry,
 } from './settings/types'
 

--- a/self/ui/src/panels/__tests__/PreferencesPanel.test.tsx
+++ b/self/ui/src/panels/__tests__/PreferencesPanel.test.tsx
@@ -6,25 +6,10 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesPanel, type PreferencesApi } from '../PreferencesPanel.js'
 
-const ROLE_LABELS = [
-  'Orchestrator',
-  'Reasoner',
-  'Tool Advisor',
-  'Summarizer',
-  'Embedder',
-  'Reranker',
-  'Vision',
-] as const
+import { ModelRoleSchema, MODEL_ROLE_LABELS } from '@nous/shared'
 
-const ROLE_KEYS = [
-  'orchestrator',
-  'reasoner',
-  'tool-advisor',
-  'summarizer',
-  'embedder',
-  'reranker',
-  'vision',
-] as const
+const ROLE_LABELS = ModelRoleSchema.options.map((r) => MODEL_ROLE_LABELS[r])
+const ROLE_KEYS = ModelRoleSchema.options
 
 let container: HTMLDivElement
 let root: Root
@@ -49,11 +34,6 @@ function createBaseApi(overrides: Partial<PreferencesApi> = {}): PreferencesApi 
         { id: 'openai:gpt-4o', name: 'GPT-4o', provider: 'openai', available: true },
       ],
     }),
-    getModelSelection: async () => ({
-      principal: 'openai:gpt-4o',
-      system: 'ollama:qwen2.5:7b',
-    }),
-    setModelSelection: async () => ({ success: true }),
     ...overrides,
   }
 }
@@ -62,13 +42,10 @@ function createRoleAssignments(
   overrides: Partial<Record<(typeof ROLE_KEYS)[number], string | null>> = {},
 ) {
   const defaults: Record<(typeof ROLE_KEYS)[number], string | null> = {
-    orchestrator: 'ollama:qwen2.5:7b',
-    reasoner: 'openai:gpt-4o',
-    'tool-advisor': 'anthropic:claude-sonnet-4-20250514',
-    summarizer: 'ollama:qwen2.5:7b',
-    embedder: 'ollama:qwen2.5:7b',
-    reranker: 'ollama:qwen2.5:7b',
-    vision: 'openai:gpt-4o',
+    'cortex-chat': 'openai:gpt-4o',
+    'cortex-system': 'ollama:qwen2.5:7b',
+    orchestrators: 'anthropic:claude-sonnet-4-20250514',
+    workers: 'ollama:qwen2.5:7b',
   }
 
   return ROLE_KEYS.map((role) => {
@@ -235,7 +212,7 @@ describe('PreferencesPanel role assignment settings', () => {
     }
   })
 
-  it('displays all 7 roles with their current assignments', async () => {
+  it('displays all 4 roles with their current assignments', async () => {
     const api = createBaseApi({
       getRoleAssignments: async () => createRoleAssignments() as any,
       setRoleAssignment: async () => ({ success: true }),
@@ -259,14 +236,14 @@ describe('PreferencesPanel role assignment settings', () => {
     await renderPanel(api)
     await navigateToPage('role-assignments')
     await changeSelect(
-      getSelectByAriaLabel('Orchestrator assignment'),
-      'anthropic:claude-sonnet-4-20250514',
+      getSelectByAriaLabel("Orchestrator's assignment"),
+      'openai:gpt-4o',
     )
     await click(getButton('Save Role Assignments'))
 
     expect(setRoleAssignment).toHaveBeenCalledWith({
-      role: 'orchestrator',
-      modelSpec: 'anthropic:claude-sonnet-4-20250514',
+      role: 'orchestrators',
+      modelSpec: 'openai:gpt-4o',
     })
   })
 
@@ -295,8 +272,8 @@ describe('PreferencesPanel role assignment settings', () => {
 
   it('shows an error message when a role assignment save fails', async () => {
     const setRoleAssignment = vi.fn(async (input: { role: string }) => {
-      if (input.role === 'reasoner') {
-        return { success: false, error: 'Reasoner update failed.' }
+      if (input.role === 'cortex-chat') {
+        return { success: false, error: 'Cortex Chat update failed.' }
       }
 
       return { success: true }
@@ -308,17 +285,17 @@ describe('PreferencesPanel role assignment settings', () => {
 
     await renderPanel(api)
     await navigateToPage('role-assignments')
-    await changeSelect(getSelectByAriaLabel('Reasoner assignment'), 'anthropic:claude-sonnet-4-20250514')
+    await changeSelect(getSelectByAriaLabel('Cortex Chat assignment'), 'anthropic:claude-sonnet-4-20250514')
     await click(getButton('Save Role Assignments'))
 
-    expect(textContent()).toContain('Error: Reasoner update failed.')
+    expect(textContent()).toContain('Error: Cortex Chat update failed.')
   })
 
   it('shows Not assigned for null assignments', async () => {
     const api = createBaseApi({
       getRoleAssignments: async () => createRoleAssignments({
-        orchestrator: null,
-        reasoner: null,
+        orchestrators: null,
+        'cortex-chat': null,
       }) as any,
       setRoleAssignment: async () => ({ success: true }),
     })
@@ -344,16 +321,13 @@ describe('PreferencesPanel role assignment settings', () => {
     expect(container.querySelector('[data-testid="page-role-assignments"]')).toBeTruthy()
   })
 
-  it('renders a fully empty state when all 7 roles are unassigned', async () => {
+  it('renders a fully empty state when all 4 roles are unassigned', async () => {
     const api = createBaseApi({
       getRoleAssignments: async () => createRoleAssignments({
-        orchestrator: null,
-        reasoner: null,
-        'tool-advisor': null,
-        summarizer: null,
-        embedder: null,
-        reranker: null,
-        vision: null,
+        'cortex-chat': null,
+        'cortex-system': null,
+        orchestrators: null,
+        workers: null,
       }) as any,
       setRoleAssignment: async () => ({ success: true }),
     })
@@ -361,16 +335,16 @@ describe('PreferencesPanel role assignment settings', () => {
     await renderPanel(api)
     await navigateToPage('role-assignments')
 
-    expect((textContent().match(/Not assigned/g) ?? []).length).toBeGreaterThanOrEqual(7)
+    expect((textContent().match(/Not assigned/g) ?? []).length).toBeGreaterThanOrEqual(4)
   })
 
   it('renders mixed assigned and unassigned role states', async () => {
     const api = createBaseApi({
       getRoleAssignments: async () => createRoleAssignments({
-        orchestrator: 'openai:gpt-4o',
-        reasoner: null,
-        'tool-advisor': 'anthropic:claude-sonnet-4-20250514',
-        summarizer: null,
+        orchestrators: 'openai:gpt-4o',
+        'cortex-chat': null,
+        workers: 'anthropic:claude-sonnet-4-20250514',
+        'cortex-system': null,
       }) as any,
       setRoleAssignment: async () => ({ success: true }),
     })

--- a/self/ui/src/panels/__tests__/preferences-panel.test.ts
+++ b/self/ui/src/panels/__tests__/preferences-panel.test.ts
@@ -7,7 +7,6 @@ import {
 import type {
   PreferencesApi,
   AvailableModel,
-  ModelSelection,
   RoleAssignmentDisplayEntry,
 } from '../PreferencesPanel.js';
 
@@ -231,14 +230,9 @@ describe('Model selector API contract', () => {
           { id: 'openai:gpt-4o', name: 'GPT-4o', provider: 'openai', available: true },
         ],
       }),
-      getModelSelection: async () => ({
-        principal: 'anthropic:claude-opus-4-20250514',
-        system: 'anthropic:claude-sonnet-4-20250514',
-      }),
-      setModelSelection: async () => ({ success: true }),
       getRoleAssignments: async () => ([
         {
-          role: 'orchestrator',
+          role: 'orchestrators',
           providerId: '10000000-0000-0000-0000-000000000003',
         },
       ]),
@@ -249,8 +243,6 @@ describe('Model selector API contract', () => {
   it('PreferencesApi shape supports optional model selector methods', () => {
     const api = createFullApi();
     expect(typeof api.getAvailableModels).toBe('function');
-    expect(typeof api.getModelSelection).toBe('function');
-    expect(typeof api.setModelSelection).toBe('function');
     expect(typeof api.getRoleAssignments).toBe('function');
     expect(typeof api.setRoleAssignment).toBe('function');
   });
@@ -266,38 +258,6 @@ describe('Model selector API contract', () => {
     expect(providers.has('openai')).toBe(true);
   });
 
-  it('getModelSelection returns principal and system roles', async () => {
-    const api = createFullApi();
-    const selection = await api.getModelSelection!();
-    expect(selection.principal).toBe('anthropic:claude-opus-4-20250514');
-    expect(selection.system).toBe('anthropic:claude-sonnet-4-20250514');
-  });
-
-  it('getModelSelection returns null when nothing saved', async () => {
-    const api: PreferencesApi = {
-      ...createFullApi(),
-      getModelSelection: async () => ({ principal: null, system: null }),
-    };
-
-    const selection = await api.getModelSelection!();
-    expect(selection.principal).toBeNull();
-    expect(selection.system).toBeNull();
-  });
-
-  it('setModelSelection accepts partial input', async () => {
-    let captured: { principal?: string; system?: string } | null = null;
-    const api: PreferencesApi = {
-      ...createFullApi(),
-      setModelSelection: async (input) => {
-        captured = input;
-        return { success: true };
-      },
-    };
-
-    await api.setModelSelection!({ principal: 'openai:o3' });
-    expect(captured).toEqual({ principal: 'openai:o3' });
-  });
-
   it('model IDs follow provider:model-name format', async () => {
     const api = createFullApi();
     const result = await api.getAvailableModels!();
@@ -308,7 +268,7 @@ describe('Model selector API contract', () => {
     }
   });
 
-  it('AvailableModel and ModelSelection types are structurally sound', () => {
+  it('AvailableModel and RoleAssignmentDisplayEntry types are structurally sound', () => {
     const model: AvailableModel = {
       id: 'ollama:llama3.2:3b',
       name: 'llama3.2:3b',
@@ -318,18 +278,11 @@ describe('Model selector API contract', () => {
     expect(model.id).toBeTruthy();
     expect(typeof model.available).toBe('boolean');
 
-    const selection: ModelSelection = {
-      principal: 'anthropic:claude-opus-4-20250514',
-      system: null,
-    };
-    expect(selection.principal).toBeTruthy();
-    expect(selection.system).toBeNull();
-
     const roleAssignment: RoleAssignmentDisplayEntry = {
-      role: 'orchestrator',
+      role: 'orchestrators',
       providerId: '10000000-0000-0000-0000-000000000003',
     };
-    expect(roleAssignment.role).toBe('orchestrator');
+    expect(roleAssignment.role).toBe('orchestrators');
     expect(roleAssignment.providerId).toBeTruthy();
   });
 
@@ -339,7 +292,7 @@ describe('Model selector API contract', () => {
 
     expect(assignments).toEqual([
       {
-        role: 'orchestrator',
+        role: 'orchestrators',
         providerId: '10000000-0000-0000-0000-000000000003',
       },
     ]);
@@ -356,12 +309,12 @@ describe('Model selector API contract', () => {
     };
 
     await api.setRoleAssignment!({
-      role: 'vision',
+      role: 'cortex-chat',
       modelSpec: 'openai:gpt-4o',
     });
 
     expect(captured).toEqual({
-      role: 'vision',
+      role: 'cortex-chat',
       modelSpec: 'openai:gpt-4o',
     });
   });

--- a/self/ui/src/panels/index.ts
+++ b/self/ui/src/panels/index.ts
@@ -13,7 +13,7 @@ export { DashboardPanel, DashboardWidgetMenu, useDashboardApi } from './dashboar
 export { PreferencesPanel } from './PreferencesPanel'
 export { WorkflowBuilderPanel } from './workflow-builder'
 export type { WorkflowBuilderPanelCoreProps } from './workflow-builder'
-export type { PreferencesApi, AvailableModel, ModelSelection, RoleAssignmentDisplayEntry } from './PreferencesPanel'
+export type { PreferencesApi, AvailableModel, RoleAssignmentDisplayEntry } from './PreferencesPanel'
 export { testStoredProviderKey, formatFeedbackError } from './PreferencesPanel'
 export { SettingsShell } from './settings'
 export { TaskDetailView, TaskCreateForm } from './tasks'

--- a/self/ui/src/panels/settings/__tests__/helpers.test.ts
+++ b/self/ui/src/panels/settings/__tests__/helpers.test.ts
@@ -74,7 +74,7 @@ describe('formatFeedbackError', () => {
 })
 
 describe('isModelRole', () => {
-  it('returns true for all 7 valid roles', () => {
+  it('returns true for all 4 valid roles', () => {
     for (const role of MODEL_ROLES) {
       expect(isModelRole(role)).toBe(true)
     }
@@ -83,12 +83,12 @@ describe('isModelRole', () => {
   it('returns false for invalid strings', () => {
     expect(isModelRole('invalid-role')).toBe(false)
     expect(isModelRole('')).toBe(false)
-    expect(isModelRole('orchestrators')).toBe(false)
+    expect(isModelRole('reasoner')).toBe(false)
   })
 })
 
 describe('buildEmptyRoleAssignments', () => {
-  it('returns object with all 7 MODEL_ROLES keys', () => {
+  it('returns object with all 4 MODEL_ROLES keys', () => {
     const result = buildEmptyRoleAssignments()
     for (const role of MODEL_ROLES) {
       expect(result[role]).toBeDefined()
@@ -103,35 +103,35 @@ describe('buildEmptyRoleAssignments', () => {
 describe('buildPendingRoleAssignments', () => {
   it('extracts modelSpec for each role', () => {
     const state = buildEmptyRoleAssignments()
-    state.orchestrator.modelSpec = 'claude-opus'
-    state.reasoner.modelSpec = 'gpt-4'
+    state['orchestrators'].modelSpec = 'claude-opus'
+    state['cortex-chat'].modelSpec = 'gpt-4'
 
     const result = buildPendingRoleAssignments(state)
-    expect(result.orchestrator).toBe('claude-opus')
-    expect(result.reasoner).toBe('gpt-4')
-    expect(result.summarizer).toBe('')
+    expect(result['orchestrators']).toBe('claude-opus')
+    expect(result['cortex-chat']).toBe('gpt-4')
+    expect(result['workers']).toBe('')
   })
 })
 
 describe('normalizeRoleAssignmentEntries', () => {
   it('maps display entries to RoleAssignmentState', () => {
     const entries = [
-      { role: 'orchestrator', providerId: 'anthropic', displayName: 'Claude', modelSpec: 'claude-3' },
-      { role: 'reasoner', providerId: 'openai', displayName: 'GPT', modelSpec: 'gpt-4' },
+      { role: 'orchestrators', providerId: 'anthropic', displayName: 'Claude', modelSpec: 'claude-3' },
+      { role: 'cortex-chat', providerId: 'openai', displayName: 'GPT', modelSpec: 'gpt-4' },
     ]
     const result = normalizeRoleAssignmentEntries(entries)
-    expect(result.orchestrator.modelSpec).toBe('claude-3')
-    expect(result.reasoner.providerId).toBe('openai')
-    expect(result.summarizer.providerId).toBeNull()
+    expect(result['orchestrators'].modelSpec).toBe('claude-3')
+    expect(result['cortex-chat'].providerId).toBe('openai')
+    expect(result['workers'].providerId).toBeNull()
   })
 
   it('skips entries with unknown roles', () => {
     const entries = [
       { role: 'unknown-role', providerId: 'test' },
-      { role: 'orchestrator', providerId: 'anthropic' },
+      { role: 'orchestrators', providerId: 'anthropic' },
     ]
     const result = normalizeRoleAssignmentEntries(entries)
-    expect(result.orchestrator.providerId).toBe('anthropic')
+    expect(result['orchestrators'].providerId).toBe('anthropic')
     expect((result as Record<string, unknown>)['unknown-role']).toBeUndefined()
   })
 
@@ -177,42 +177,42 @@ describe('getRoleAssignmentDisplay', () => {
 
   it('returns matching model name when modelSpec matches', () => {
     const entry: HydratedRoleAssignmentDisplayEntry = {
-      role: 'orchestrator', providerId: 'anthropic', modelSpec: 'claude-3',
+      role: 'orchestrators', providerId: 'anthropic', modelSpec: 'claude-3',
     }
     expect(getRoleAssignmentDisplay(entry, models)).toBe('Claude 3 Opus')
   })
 
   it('falls back to displayName when modelSpec has no matching model', () => {
     const entry: HydratedRoleAssignmentDisplayEntry = {
-      role: 'orchestrator', providerId: 'anthropic', modelSpec: 'unknown-id', displayName: 'Custom Model',
+      role: 'orchestrators', providerId: 'anthropic', modelSpec: 'unknown-id', displayName: 'Custom Model',
     }
     expect(getRoleAssignmentDisplay(entry, models)).toBe('Custom Model')
   })
 
   it('falls back to modelSpec string when no model match and no displayName', () => {
     const entry: HydratedRoleAssignmentDisplayEntry = {
-      role: 'orchestrator', providerId: 'anthropic', modelSpec: 'unknown-id',
+      role: 'orchestrators', providerId: 'anthropic', modelSpec: 'unknown-id',
     }
     expect(getRoleAssignmentDisplay(entry, models)).toBe('unknown-id')
   })
 
   it('returns displayName when no modelSpec', () => {
     const entry: HydratedRoleAssignmentDisplayEntry = {
-      role: 'orchestrator', providerId: null, displayName: 'A display name',
+      role: 'orchestrators', providerId: null, displayName: 'A display name',
     }
     expect(getRoleAssignmentDisplay(entry, models)).toBe('A display name')
   })
 
   it('returns providerId when no modelSpec and no displayName', () => {
     const entry: HydratedRoleAssignmentDisplayEntry = {
-      role: 'orchestrator', providerId: 'anthropic',
+      role: 'orchestrators', providerId: 'anthropic',
     }
     expect(getRoleAssignmentDisplay(entry, models)).toBe('anthropic')
   })
 
   it('returns "Not assigned" when nothing available', () => {
     const entry: HydratedRoleAssignmentDisplayEntry = {
-      role: 'orchestrator', providerId: null,
+      role: 'orchestrators', providerId: null,
     }
     expect(getRoleAssignmentDisplay(entry, models)).toBe('Not assigned')
   })
@@ -221,19 +221,16 @@ describe('getRoleAssignmentDisplay', () => {
 describe('buildChangedRoleAssignments', () => {
   it('returns only changed entries', () => {
     const state = buildEmptyRoleAssignments()
-    state.orchestrator.modelSpec = 'claude-3'
+    state['orchestrators'].modelSpec = 'claude-3'
     const pending: PendingRoleAssignments = {
-      orchestrator: 'gpt-4',
-      reasoner: '',
-      'tool-advisor': '',
-      summarizer: '',
-      embedder: '',
-      reranker: '',
-      vision: '',
+      'cortex-chat': '',
+      'cortex-system': '',
+      orchestrators: 'gpt-4',
+      workers: '',
     }
     const result = buildChangedRoleAssignments(state, pending)
     expect(result).toHaveLength(1)
-    expect(result[0]!.role).toBe('orchestrator')
+    expect(result[0]!.role).toBe('orchestrators')
     expect(result[0]!.modelSpec).toBe('gpt-4')
   })
 
@@ -246,9 +243,9 @@ describe('buildChangedRoleAssignments', () => {
 
   it('ignores pending values that are empty strings', () => {
     const state = buildEmptyRoleAssignments()
-    state.orchestrator.modelSpec = 'claude-3'
+    state['orchestrators'].modelSpec = 'claude-3'
     const pending = buildPendingRoleAssignments(state)
-    pending.orchestrator = ''
+    pending['orchestrators'] = ''
     const result = buildChangedRoleAssignments(state, pending)
     expect(result).toHaveLength(0)
   })

--- a/self/ui/src/panels/settings/__tests__/pages.test.tsx
+++ b/self/ui/src/panels/settings/__tests__/pages.test.tsx
@@ -264,8 +264,8 @@ describe('ModelConfigPage', () => {
         { id: 'gpt-4', name: 'GPT-4', provider: 'openai', available: true },
       ],
     }),
-    getModelSelection: vi.fn().mockResolvedValue({ principal: null, system: null }),
-    setModelSelection: vi.fn().mockResolvedValue({ success: true }),
+    getRoleAssignments: vi.fn().mockResolvedValue([]),
+    setRoleAssignment: vi.fn().mockResolvedValue({ success: true }),
   })
 
   it('renders model dropdowns after data loads', async () => {
@@ -281,7 +281,7 @@ describe('ModelConfigPage', () => {
     expect(container.textContent).toContain('Cortex::System')
   })
 
-  it('save button calls api.setModelSelection', async () => {
+  it('save button calls api.setRoleAssignment', async () => {
     const api = makeApi()
     await act(async () => {
       root.render(<ModelConfigPage api={api} />)
@@ -305,14 +305,14 @@ describe('ModelConfigPage', () => {
       await flush()
     })
 
-    expect(api.setModelSelection).toHaveBeenCalled()
+    expect(api.setRoleAssignment).toHaveBeenCalled()
   })
 
   it('returns null when getAvailableModels is undefined', async () => {
     const api = {
       getAvailableModels: undefined,
-      getModelSelection: vi.fn(),
-      setModelSelection: vi.fn(),
+      getRoleAssignments: vi.fn().mockResolvedValue([]),
+      setRoleAssignment: vi.fn(),
     }
     await act(async () => {
       root.render(<ModelConfigPage api={api as never} />)
@@ -329,8 +329,8 @@ describe('ModelConfigPage', () => {
 describe('RoleAssignmentsPage', () => {
   const makeApi = () => ({
     getRoleAssignments: vi.fn().mockResolvedValue([
-      { role: 'orchestrator', providerId: 'anthropic', modelSpec: 'claude-3' },
-      { role: 'reasoner', providerId: 'openai', modelSpec: 'gpt-4' },
+      { role: 'orchestrators', providerId: 'anthropic', modelSpec: 'claude-3' },
+      { role: 'cortex-chat', providerId: 'openai', modelSpec: 'gpt-4' },
     ]),
     getAvailableModels: vi.fn().mockResolvedValue({
       models: [
@@ -346,7 +346,7 @@ describe('RoleAssignmentsPage', () => {
     setRoleAssignment: vi.fn().mockResolvedValue({ success: true }),
   })
 
-  it('renders 7-role grid after data loads', async () => {
+  it('renders 4-role grid after data loads', async () => {
     const api = makeApi()
     await act(async () => {
       root.render(<RoleAssignmentsPage api={api} />)
@@ -355,9 +355,9 @@ describe('RoleAssignmentsPage', () => {
 
     const el = container.querySelector('[data-testid="settings-page-role-assignments"]')
     expect(el).not.toBeNull()
-    expect(container.textContent).toContain('Orchestrator')
-    expect(container.textContent).toContain('Reasoner')
-    expect(container.textContent).toContain('Vision')
+    expect(container.textContent).toContain('Cortex Chat')
+    expect(container.textContent).toContain('Cortex System')
+    expect(container.textContent).toContain("Orchestrator's")
   })
 
   it('save calls api.setRoleAssignment for changed roles', async () => {
@@ -368,7 +368,7 @@ describe('RoleAssignmentsPage', () => {
     })
 
     // Change a role assignment via select
-    const select = container.querySelector<HTMLSelectElement>('#role-assignment-orchestrator')!
+    const select = container.querySelector<HTMLSelectElement>('#role-assignment-orchestrators')!
     await act(async () => {
       select.value = 'gpt-4'
       select.dispatchEvent(new Event('change', { bubbles: true }))

--- a/self/ui/src/panels/settings/__tests__/types.test.ts
+++ b/self/ui/src/panels/settings/__tests__/types.test.ts
@@ -15,7 +15,6 @@ import type {
   AppPanelEntry,
   PreferencesApi,
   AvailableModel,
-  ModelSelection,
   RoleAssignmentDisplayEntry,
   ShellMode,
   Provider,
@@ -23,19 +22,16 @@ import type {
 } from '../types'
 
 describe('settings types contract', () => {
-  it('MODEL_ROLES has 7 entries', () => {
-    expect(MODEL_ROLES).toHaveLength(7)
+  it('MODEL_ROLES has 4 entries', () => {
+    expect(MODEL_ROLES).toHaveLength(4)
   })
 
   it('MODEL_ROLES contains all expected role strings', () => {
     expect([...MODEL_ROLES]).toEqual([
-      'orchestrator',
-      'reasoner',
-      'tool-advisor',
-      'summarizer',
-      'embedder',
-      'reranker',
-      'vision',
+      'cortex-chat',
+      'cortex-system',
+      'orchestrators',
+      'workers',
     ])
   })
 
@@ -76,8 +72,8 @@ describe('settings types contract', () => {
     const provider: Provider = 'anthropic'
     expect(provider).toBe('anthropic')
 
-    const role: ModelRole = 'orchestrator'
-    expect(role).toBe('orchestrator')
+    const role: ModelRole = 'cortex-chat'
+    expect(role).toBe('cortex-chat')
   })
 
   it('SettingsCategory has expected structural shape', () => {

--- a/self/ui/src/panels/settings/pages/ModelConfigPage.tsx
+++ b/self/ui/src/panels/settings/pages/ModelConfigPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import type { PreferencesApi, AvailableModel, ModelSelection, FeedbackState } from '../types'
+import type { PreferencesApi, AvailableModel, FeedbackState } from '../types'
 import {
   sectionStyle,
   sectionTitleStyle,
@@ -14,12 +14,13 @@ import {
 import { buildModelsByProvider, formatFeedbackError } from './helpers'
 
 export interface ModelConfigPageProps {
-  api: Pick<PreferencesApi, 'getAvailableModels' | 'getModelSelection' | 'setModelSelection'>
+  api: Pick<PreferencesApi, 'getAvailableModels' | 'getRoleAssignments' | 'setRoleAssignment'>
 }
 
 export function ModelConfigPage({ api }: ModelConfigPageProps) {
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
-  const [modelSelection, setModelSelection] = useState<ModelSelection>({ principal: null, system: null })
+  const [currentPrincipal, setCurrentPrincipal] = useState<string | null>(null)
+  const [currentSystem, setCurrentSystem] = useState<string | null>(null)
   const [pendingPrincipal, setPendingPrincipal] = useState<string>('')
   const [pendingSystem, setPendingSystem] = useState<string>('')
   const [savingModels, setSavingModels] = useState(false)
@@ -27,19 +28,24 @@ export function ModelConfigPage({ api }: ModelConfigPageProps) {
 
   const loadData = useCallback(async () => {
     try {
-      const [modelsResult, selectionResult] = await Promise.all([
+      const [modelsResult, assignmentsResult] = await Promise.all([
         api.getAvailableModels ? api.getAvailableModels() : Promise.resolve(null),
-        api.getModelSelection ? api.getModelSelection() : Promise.resolve(null),
+        api.getRoleAssignments ? api.getRoleAssignments() : Promise.resolve(null),
       ])
 
       if (modelsResult) {
         setAvailableModels(modelsResult.models)
       }
 
-      if (selectionResult) {
-        setModelSelection(selectionResult)
-        setPendingPrincipal(selectionResult.principal ?? '')
-        setPendingSystem(selectionResult.system ?? '')
+      if (assignmentsResult && Array.isArray(assignmentsResult)) {
+        const principalEntry = assignmentsResult.find((a: any) => a.role === 'cortex-chat')
+        const systemEntry = assignmentsResult.find((a: any) => a.role === 'cortex-system')
+        setCurrentPrincipal(principalEntry?.providerId ?? null)
+        setCurrentSystem(systemEntry?.providerId ?? null)
+        // Minimal rewire: pending values start empty; user reselects from dropdown.
+        // The getRoleAssignments returns providerIds, not modelSpecs, so we cannot
+        // pre-populate the dropdown (which expects modelSpec strings) without a
+        // reverse lookup. This is acceptable for 1.1's minimal rewire mandate.
       }
     } catch (err) {
       setModelFeedback(formatFeedbackError(err))
@@ -57,22 +63,22 @@ export function ModelConfigPage({ api }: ModelConfigPageProps) {
   const modelsByProvider = buildModelsByProvider(availableModels)
 
   const modelSelectionChanged =
-    pendingPrincipal !== (modelSelection.principal ?? '') ||
-    pendingSystem !== (modelSelection.system ?? '')
+    pendingPrincipal !== (currentPrincipal ?? '') ||
+    pendingSystem !== (currentSystem ?? '')
 
   const handleSaveModels = async () => {
-    if (!api.setModelSelection) return
+    if (!api.setRoleAssignment) return
     setSavingModels(true)
     setModelFeedback(null)
     try {
-      await api.setModelSelection({
-        principal: pendingPrincipal || undefined,
-        system: pendingSystem || undefined,
-      })
-      setModelSelection({
-        principal: pendingPrincipal || null,
-        system: pendingSystem || null,
-      })
+      if (pendingPrincipal) {
+        await api.setRoleAssignment({ role: 'cortex-chat', modelSpec: pendingPrincipal })
+      }
+      if (pendingSystem) {
+        await api.setRoleAssignment({ role: 'cortex-system', modelSpec: pendingSystem })
+      }
+      setCurrentPrincipal(pendingPrincipal || null)
+      setCurrentSystem(pendingSystem || null)
       setModelFeedback({ message: 'Model selection saved.', success: true })
     } catch (err) {
       setModelFeedback(formatFeedbackError(err))

--- a/self/ui/src/panels/settings/types.ts
+++ b/self/ui/src/panels/settings/types.ts
@@ -49,11 +49,6 @@ export interface AvailableModel {
   available: boolean
 }
 
-export interface ModelSelection {
-  principal: string | null
-  system: string | null
-}
-
 export interface RoleAssignmentDisplayEntry {
   role: string
   providerId: string | null
@@ -99,8 +94,6 @@ export interface PreferencesApi {
   getSystemStatus: () => Promise<SystemStatus>
   resetWizard?: () => Promise<unknown>
   getAvailableModels?: () => Promise<{ models: AvailableModel[] }>
-  getModelSelection?: () => Promise<ModelSelection>
-  setModelSelection?: (input: { principal?: string; system?: string }) => Promise<{ success: boolean }>
   getRoleAssignments?: () => Promise<RoleAssignmentDisplayEntry[]>
   getHardwareRecommendations?: () => Promise<HardwareRecommendations>
   setRoleAssignment?: (
@@ -116,35 +109,26 @@ export interface PreferencesApi {
 // ─── Constants ─────────────────────────────────────────────────────────────────
 
 export const MODEL_ROLES = [
-  'orchestrator',
-  'reasoner',
-  'tool-advisor',
-  'summarizer',
-  'embedder',
-  'reranker',
-  'vision',
+  'cortex-chat',
+  'cortex-system',
+  'orchestrators',
+  'workers',
 ] as const
 
 export type ModelRole = typeof MODEL_ROLES[number]
 
 export const MODEL_ROLE_LABELS: Record<ModelRole, string> = {
-  orchestrator: 'Orchestrator',
-  reasoner: 'Reasoner',
-  'tool-advisor': 'Tool Advisor',
-  summarizer: 'Summarizer',
-  embedder: 'Embedder',
-  reranker: 'Reranker',
-  vision: 'Vision',
+  'cortex-chat': 'Cortex Chat',
+  'cortex-system': 'Cortex System',
+  orchestrators: "Orchestrator's",
+  workers: "Worker's",
 }
 
 export const MODEL_ROLE_HINTS: Record<ModelRole, string> = {
-  orchestrator: 'Prefer the fastest model available for low-latency coordination.',
-  reasoner: 'Prefer the strongest model your current setup can comfortably sustain.',
-  'tool-advisor': 'Use a balanced model that stays responsive while calling tools.',
-  summarizer: 'A fast mid-tier model is usually enough for condensation passes.',
-  embedder: 'A lightweight local model keeps indexing and retrieval work snappy.',
-  reranker: 'Favor the quickest model that still preserves useful ranking quality.',
-  vision: 'Choose a multimodal-capable model when one is available.',
+  'cortex-chat': 'Prefer the strongest model your current setup can comfortably sustain.',
+  'cortex-system': 'Prefer the fastest model available for low-latency coordination.',
+  orchestrators: 'Use a balanced model that stays responsive while coordinating workflows.',
+  workers: 'A fast mid-tier model is usually enough for task execution.',
 }
 
 // ─── Page ID Constants ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Collapse `ModelRoleSchema` from 7 capability-based roles to 4 architectural-layer roles: `cortex-chat`, `cortex-system`, `orchestrators`, `workers`
- Excise entire `nous:model_selection` document-store bridge (6 procedures/helpers, 2 constants, transport hooks)
- Add `deriveDefaultModelRole(agentClass)` to AgentGateway with 6-case test coverage
- Create shared `migrateLegacyModelRole()` helper for U2 silent remap at 4 preprocess sites
- Rewire `ModelConfigPage` to `getRoleAssignments`/`setRoleAssignment` (2-slot layout preserved)
- Sweep ~56 test files for lockstep fixture rename

## Stats

- 85 files changed | 497 insertions | 952 deletions
- Tests: 544/544 files pass (4865 tests)
- Build: clean | Lint: 0 errors

## Commits

1. **Schema + migration + config tightening** — `enums.ts` shrink, `migrateLegacyModelRole`, `config.ts` role boundary `z.string()` → `ModelRoleSchema` (CO-COMMIT 1)
2. **Bridge excision + page rewire** — delete model-selection bridge, rewire ModelConfigPage
3. **Runtime derive + renames** — AgentGateway `deriveDefaultModelRole`, hardware-detection E2-C, wizard E1 convergence
4. **Fixture sweep** — 56 test files renamed to 4-role taxonomy

## Ratified decisions executed

Q1, R7/E5-B, E1 (3 of 4), E2-C, E4, E6, E7, U2

## Test plan

- [x] `pnpm test` — 4865/4865 pass
- [x] `pnpm build` — clean
- [x] `pnpm lint` — 0 errors
- [x] Bridge excision greps — all zero hits
- [x] Gateway construction sites — untouched
- [x] Scope fence — no 1.2 items pulled forward
- [ ] BT: boot app, verify Model Config 2-slot persistence
- [ ] BT: verify Role Assignments 4-row grid
- [ ] BT: verify legacy config loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)