### PR TITLE
fix: thread thinkingContent through chat pipeline + useEffect dep fix — WR-135

### DIFF
--- a/self/apps/shared-server/src/trpc/routers/chat.ts
+++ b/self/apps/shared-server/src/trpc/routers/chat.ts
@@ -24,7 +24,7 @@ export const chatRouter = router({
         traceId,
       });
 
-      return { response: result.response, traceId: result.traceId, contentType: result.contentType };
+      return { response: result.response, traceId: result.traceId, contentType: result.contentType, thinkingContent: result.thinkingContent };
     }),
 
   getHistory: publicProcedure

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -521,6 +521,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       response: responseText,
       traceId,
       contentType: resolved.contentType,
+      thinkingContent: resolved.thinkingContent,
     };
   }
 
@@ -753,9 +754,14 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     return result;
   }
 
-  private resolveChatResponse(result: AgentResult): { response: string; contentType: 'text' | 'openui' } {
+  private resolveChatResponse(result: AgentResult): { response: string; contentType: 'text' | 'openui'; thinkingContent?: string } {
     if (result.status === 'completed') {
-      const output = result.output as { response?: unknown; output?: unknown; contentType?: unknown } | string;
+      const output = result.output as { response?: unknown; output?: unknown; contentType?: unknown; thinkingContent?: unknown } | string;
+
+      // Extract thinkingContent from structured output (undefined for direct-string outputs)
+      const thinkingContent = (typeof output === 'object' && output !== null && typeof output.thinkingContent === 'string')
+        ? output.thinkingContent
+        : undefined;
 
       // 1. Direct string — use as-is
       if (typeof output === 'string') return { response: output, contentType: 'text' };
@@ -763,7 +769,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       // 2. { response: string } — extract .response
       if (typeof output?.response === 'string') {
         const ct = output.contentType === 'openui' ? 'openui' as const : 'text' as const;
-        return { response: output.response, contentType: ct };
+        return { response: output.response, contentType: ct, thinkingContent };
       }
 
       // 3. Recursive one-level unwrap: { output: { response: string } }
@@ -777,6 +783,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         return {
           response: ((output as { output: { response: string } }).output).response,
           contentType: 'text',
+          thinkingContent,
         };
       }
 
@@ -786,7 +793,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         if (keys.length === 1) {
           const value = (output as Record<string, unknown>)[keys[0]];
           if (typeof value === 'string') {
-            return { response: value, contentType: 'text' };
+            return { response: value, contentType: 'text', thinkingContent };
           }
         }
       }
@@ -795,6 +802,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       return {
         response: '```json\n' + JSON.stringify(output, null, 2) + '\n```',
         contentType: 'text',
+        thinkingContent,
       };
     }
     if (result.status === 'escalated') return { response: `[escalated: ${result.reason}]`, contentType: 'text' };

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -193,6 +193,7 @@ export const ChatTurnResultSchema = z.object({
   response: z.string(),
   traceId: z.string(),
   contentType: z.enum(['text', 'openui']).optional(),
+  thinkingContent: z.string().optional(),
 }).strict();
 export type ChatTurnResult = z.infer<typeof ChatTurnResultSchema>;
 

--- a/self/transport/src/hooks/useChatApi.ts
+++ b/self/transport/src/hooks/useChatApi.ts
@@ -8,7 +8,7 @@ export interface UseChatApiOptions {
 
 /** Matches the ChatAPI interface from @nous/ui/panels (structural compatibility). */
 interface ChatApiShape {
-  send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui' }>
+  send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui'; thinkingContent?: string }>
   getHistory: () => Promise<{
     role: 'user' | 'assistant'
     content: string
@@ -56,7 +56,7 @@ export function useChatApi(options?: UseChatApiOptions): ChatApiShape {
         if (projectId) {
           await utilsRef.current.chat.getHistory.invalidate({ projectId })
         }
-        return { response: result.response, traceId: result.traceId, contentType: result.contentType }
+        return { response: result.response, traceId: result.traceId, contentType: result.contentType, thinkingContent: result.thinkingContent }
       },
       getHistory: async () => {
         const data = await utilsRef.current.chat.getHistory.fetch(

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -156,7 +156,7 @@ export function ChatPanel(props: ChatPanelProps) {
             }
         }
         prevMessageCountRef.current = messages.length
-    }, [messages, stage])
+    }, [messages, stage, onUnreadMessage])
 
     // Clear unread when the user opens full view
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Thread `thinkingContent` field through all 6 pipeline breaks (schema → resolver → handler → tRPC → transport type → hook return) so model thinking from Anthropic/Ollama reaches the UI
- Fix stale-closure bug in ChatPanel useEffect by adding `onUnreadMessage` to dependency array

## Changes (5 files)
- `self/cortex/core/src/gateway-runtime/types.ts` — add `thinkingContent` to `ChatTurnResultSchema`
- `self/cortex/core/src/gateway-runtime/cortex-runtime.ts` — extract + pass `thinkingContent` in `resolveChatResponse` and `handleChatTurn`
- `self/apps/shared-server/src/trpc/routers/chat.ts` — pass `thinkingContent` through tRPC sendMessage
- `self/transport/src/hooks/useChatApi.ts` — update `ChatApiShape` type + `send` return
- `self/ui/src/panels/ChatPanel.tsx` — add `onUnreadMessage` to useEffect deps

## Test plan
- [x] TypeScript build clean across all 4 affected packages
- [x] chat-router tests pass (13/13)
- [x] cortex-runtime harness tests pass (25/25)
- [x] ChatPanel tests pass (15/15)
- [x] anthropic-adapter tests pass (25/25)
- [ ] BT: send message with Anthropic extended thinking, verify `<details>` renders
- [ ] BT: verify non-thinking responses unaffected
- [ ] BT: verify chat stage transitions work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)