### PR TITLE
feat(cortex-core): workflow-from-chat Principal prompt wiring — WR-146

### DIFF
--- a/self/cortex/core/src/__tests__/gateway-runtime/workflow-chat-turn-wiring.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/workflow-chat-turn-wiring.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const cortexRuntimeSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../gateway-runtime/cortex-runtime.ts'),
+  'utf-8',
+);
+
+const principalSystemRuntimeSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../gateway-runtime/principal-system-runtime.ts'),
+  'utf-8',
+);
+
+describe('handleChatTurn task instruction wiring — WORKFLOW_PROMPT_FRAGMENT', () => {
+  // ── Tier 2: Behavior Tests ─────────────────────────────────────────────
+
+  it('cortex-runtime.ts imports WORKFLOW_PROMPT_FRAGMENT', () => {
+    expect(cortexRuntimeSrc).toContain("import { WORKFLOW_PROMPT_FRAGMENT } from './workflow-prompt-fragment.js'");
+  });
+
+  it('cortex-runtime.ts handleChatTurn taskInstructions includes WORKFLOW_PROMPT_FRAGMENT in template literal', () => {
+    expect(cortexRuntimeSrc).toContain('${WORKFLOW_PROMPT_FRAGMENT}');
+  });
+
+  it('principal-system-runtime.ts imports WORKFLOW_PROMPT_FRAGMENT', () => {
+    expect(principalSystemRuntimeSrc).toContain("import { WORKFLOW_PROMPT_FRAGMENT } from './workflow-prompt-fragment.js'");
+  });
+
+  it('principal-system-runtime.ts handleChatTurn taskInstructions includes WORKFLOW_PROMPT_FRAGMENT in template literal', () => {
+    expect(principalSystemRuntimeSrc).toContain('${WORKFLOW_PROMPT_FRAGMENT}');
+  });
+
+  it('both files use the same fragment constant (consistency check)', () => {
+    const cortexImportMatch = cortexRuntimeSrc.match(
+      /import\s*\{\s*WORKFLOW_PROMPT_FRAGMENT\s*\}\s*from\s*'([^']+)'/,
+    );
+    const principalImportMatch = principalSystemRuntimeSrc.match(
+      /import\s*\{\s*WORKFLOW_PROMPT_FRAGMENT\s*\}\s*from\s*'([^']+)'/,
+    );
+
+    expect(cortexImportMatch).not.toBeNull();
+    expect(principalImportMatch).not.toBeNull();
+    expect(cortexImportMatch![1]).toBe(principalImportMatch![1]);
+  });
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/workflow-delegation-integration.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/workflow-delegation-integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createPrincipalCommunicationToolSurface,
+  SUBMIT_TASK_TO_SYSTEM_TOOL_NAME,
+} from '../../gateway-runtime/index.js';
+
+describe('workflow delegation integration — submit_task_to_system with workflow payload', () => {
+  // ── Tier 3: Integration Tests ──────────────────────────────────────────
+
+  it('accepts a workflow-flavored task payload and returns a submission receipt', async () => {
+    const submitTask = vi.fn().mockResolvedValue({
+      runId: '00000000-0000-4000-8000-000000000099',
+      dispatchRef: 'dispatch:wf-1',
+      acceptedAt: '2026-04-10T12:00:00.000Z',
+      source: 'principal_tool',
+    });
+
+    const surface = createPrincipalCommunicationToolSurface({
+      baseToolSurface: {
+        listTools: vi.fn().mockResolvedValue([]),
+        executeTool: vi.fn(),
+      },
+      submissionService: {
+        submitTask,
+        injectDirective: vi.fn(),
+      },
+      replicaReader: {
+        getReplica: () => ({
+          bootStatus: 'ready',
+          inboxReady: true,
+          pendingSystemRuns: 0,
+          backlogAnalytics: {
+            queuedCount: 0,
+            activeCount: 0,
+            suspendedCount: 0,
+            activeCapacity: 1,
+            windowStart: '2026-04-10T11:00:00.000Z',
+            windowEnd: '2026-04-10T11:00:00.000Z',
+            completedInWindow: 0,
+            failedInWindow: 0,
+            avgWaitMs: 0,
+            avgExecutionMs: 0,
+            p95WaitMs: 0,
+            peakQueueDepth: 0,
+            pressureTrend: 'stable',
+          },
+          issueCodes: [],
+          visibleTools: [],
+        }),
+      },
+    });
+
+    const workflowTaskPayload = {
+      task: "Start workflow run. Call workflow_start with definition_id 'deploy-def-123' for project 'proj-456'.",
+      projectId: '00000000-0000-4000-8000-000000000456',
+      detail: { tool: 'workflow_start', definition_id: 'deploy-def-123' },
+    };
+
+    const result = await surface.executeTool(SUBMIT_TASK_TO_SYSTEM_TOOL_NAME, workflowTaskPayload);
+
+    // Assert result contains receipt fields (spread directly into output)
+    expect(result.success).toBe(true);
+    const output = result.output as {
+      runId: string;
+      dispatchRef: string;
+      acceptedAt: string;
+      source: string;
+      systemReplica: { bootStatus: string };
+    };
+    expect(output.runId).toBe('00000000-0000-4000-8000-000000000099');
+    expect(output.dispatchRef).toBe('dispatch:wf-1');
+    expect(output.acceptedAt).toBe('2026-04-10T12:00:00.000Z');
+    expect(output.source).toBe('principal_tool');
+
+    // Assert submissionService.submitTask was called with the workflow task
+    expect(submitTask).toHaveBeenCalledTimes(1);
+    expect(submitTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: workflowTaskPayload.task,
+        detail: workflowTaskPayload.detail,
+      }),
+    );
+  });
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/workflow-prompt-fragment.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/workflow-prompt-fragment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { WORKFLOW_PROMPT_FRAGMENT } from '../../gateway-runtime/workflow-prompt-fragment.js';
+
+describe('WORKFLOW_PROMPT_FRAGMENT — content contract', () => {
+  // ── Tier 1: Contract Tests ─────────────────────────────────────────────
+
+  it('contains read-only tool names', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('workflow_list');
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('workflow_inspect');
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('workflow_status');
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('workflow_validate');
+  });
+
+  it('contains delegation tool reference (submit_task_to_system)', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('submit_task_to_system');
+  });
+
+  it('contains "when to delegate" guidance', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('When to delegate');
+  });
+
+  it('contains "when NOT to delegate" guidance', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('When NOT to delegate');
+  });
+
+  it('contains delegation task format examples (workflow_start, workflow_create)', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('workflow_start');
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('workflow_create');
+  });
+
+  it('contains project-scoped thread note', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('project-scoped thread');
+  });
+
+  it('is a non-empty string', () => {
+    expect(typeof WORKFLOW_PROMPT_FRAGMENT).toBe('string');
+    expect(WORKFLOW_PROMPT_FRAGMENT.length).toBeGreaterThan(100);
+  });
+});

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -47,6 +47,7 @@ import {
 } from '../internal-mcp/index.js';
 import { detectAndStripNarration } from '../output-parser.js';
 import { CARD_PROMPT_FRAGMENT } from './card-prompt-fragment.js';
+import { WORKFLOW_PROMPT_FRAGMENT } from './workflow-prompt-fragment.js';
 import { getOrchestratorPrompt } from '../prompts/index.js';
 import { resolvePromptConfig, composeSystemPromptFromConfig, resolveAgentProfile } from './prompt-strategy.js';
 import { resolveAdapter } from '../agent-gateway/adapters/index.js';
@@ -480,7 +481,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
 
     // Run Principal gateway
     const result = await this.principalGateway.run({
-      taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${CARD_PROMPT_FRAGMENT}`,
+      taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${WORKFLOW_PROMPT_FRAGMENT}\n\n${CARD_PROMPT_FRAGMENT}`,
       context: chatContext,
       budget: DEFAULT_CHAT_TURN_BUDGET,
       spawnBudgetCeiling: 0,

--- a/self/cortex/core/src/gateway-runtime/index.ts
+++ b/self/cortex/core/src/gateway-runtime/index.ts
@@ -84,3 +84,7 @@ export type {
   ContextBudgetSettingsSource,
 } from './context-budget-resolver.js';
 export { composeFromProfile } from './prompt-composer.js';
+
+// Prompt fragments — domain-specific guidance injected into Principal task instructions
+export { CARD_PROMPT_FRAGMENT } from './card-prompt-fragment.js';
+export { WORKFLOW_PROMPT_FRAGMENT } from './workflow-prompt-fragment.js';

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -34,6 +34,7 @@ import {
 } from '../internal-mcp/index.js';
 import { detectAndStripNarration, parseModelOutput } from '../output-parser.js';
 import { CARD_PROMPT_FRAGMENT } from './card-prompt-fragment.js';
+import { WORKFLOW_PROMPT_FRAGMENT } from './workflow-prompt-fragment.js';
 import { getOrchestratorPrompt } from '../prompts/index.js';
 import { resolvePromptConfig, composeSystemPromptFromConfig } from './prompt-strategy.js';
 import { RetryPolicyEvaluator } from '../recovery/retry-policy-evaluator.js';
@@ -449,7 +450,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
 
     // Run Principal gateway
     const result = await this.principalGateway.run({
-      taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${CARD_PROMPT_FRAGMENT}`,
+      taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${WORKFLOW_PROMPT_FRAGMENT}\n\n${CARD_PROMPT_FRAGMENT}`,
       payload: { message },
       context: contextFrames,
       budget: DEFAULT_CHAT_TURN_BUDGET,

--- a/self/cortex/core/src/gateway-runtime/workflow-prompt-fragment.ts
+++ b/self/cortex/core/src/gateway-runtime/workflow-prompt-fragment.ts
@@ -1,0 +1,52 @@
+/**
+ * Workflow prompt fragment — teaches Principal agents how to use workflow tools
+ * and when to delegate mutation operations via submit_task_to_system.
+ *
+ * This is extracted to its own file so that:
+ * 1. Tests can import it without resolving the full gateway-turn-executor dependency tree.
+ * 2. The constant is co-located with the gateway runtime but independently testable.
+ */
+export const WORKFLOW_PROMPT_FRAGMENT = `## Workflow Operations
+
+You have access to workflow tools. Here is how to use them.
+
+### Read-Only Tools (call these directly)
+- **workflow_list**: List installed workflow definitions and active runs for the current project. Use when the user asks "what workflows do I have?", "show my workflows", or similar.
+- **workflow_inspect**: Get detailed information about a specific workflow definition. Use when the user asks about a particular workflow's structure or configuration.
+- **workflow_status**: Check the status of a running workflow. Use when the user asks "how is my workflow going?", "is it done?", or similar.
+- **workflow_validate**: Validate a workflow YAML spec without persisting it. Use when the user provides a spec and asks you to check it.
+
+### Mutation Operations (delegate via submit_task_to_system)
+You CANNOT directly start, create, or modify workflows. For these operations, delegate to the System agent using the \`submit_task_to_system\` tool.
+
+**When to delegate:**
+- User asks to run/start/execute/dispatch a workflow -> delegate workflow_start
+- User asks to create/define/build a new workflow -> delegate workflow_create
+- User asks to update or modify an existing workflow definition -> delegate workflow_update
+
+**How to delegate:**
+Call \`submit_task_to_system\` with:
+- \`task\`: A clear instruction for the System agent. Include the specific workflow tool to call and all required arguments.
+- \`projectId\`: The current project ID (when available from context).
+- \`detail\`: An object with structured parameters the System agent needs.
+
+**Delegation task format examples:**
+
+To start a workflow:
+  task: "Start workflow run. Call workflow_start with definition_id '<id>' for project '<project_id>'."
+  detail: { "tool": "workflow_start", "definition_id": "<id>" }
+
+To create a workflow from a user description:
+  task: "Create a new workflow definition. First call workflow_authoring_reference to get the YAML syntax, then compose a workflow spec based on the user's description: '<description>'. Validate with workflow_validate, then persist with workflow_create."
+  detail: { "tool": "workflow_create", "user_description": "<description>" }
+
+**When NOT to delegate:**
+- User is just asking questions about workflows (use read-only tools directly)
+- User is asking a general question that mentions workflows but does not request an action
+- You are unsure whether the user wants to execute -- ask for confirmation first
+
+### Presenting Results
+- For workflow listings: summarize the results conversationally. Mention workflow names, statuses, and counts naturally.
+- For delegation acknowledgments: tell the user you have submitted the request and they will see the result shortly.
+- For workflow status checks: present the status clearly with any relevant progress information.
+- Workflow operations require a project-scoped thread. If no project context is available, let the user know.`;


### PR DESCRIPTION
## Summary
- Add `WORKFLOW_PROMPT_FRAGMENT` constant teaching the Principal LLM to use read-only workflow tools (`workflow_list`, `workflow_inspect`, `workflow_status`, `workflow_validate`) directly and delegate mutation operations (`workflow_start`, `workflow_create`) via `submit_task_to_system`
- Inject fragment into both `handleChatTurn` implementations (`cortex-runtime.ts` and `principal-system-runtime.ts`) alongside existing `CARD_PROMPT_FRAGMENT`
- 13 new tests across 3 tiers: content contract, wiring verification, and delegation integration

## Design decisions
- **D1 — Pure delegation:** Principal stays read-only; dispatch/create delegated to System agent via existing `submit_task_to_system` bypass tool
- **D2 — LLM judgment:** No intent classifier changes; prompt guidance teaches the LLM when to use tools
- **D3 — Wiring only:** No frontend/UI work; plain text chat responses

## Test plan
- [ ] `workflow-prompt-fragment.test.ts` — 7 Tier 1 contract tests verify fragment content
- [ ] `workflow-chat-turn-wiring.test.ts` — 5 Tier 2 behavior tests verify both runtimes include the fragment
- [ ] `workflow-delegation-integration.test.ts` — 1 Tier 3 integration test exercises delegation path
- [ ] Existing tests pass (612/613; 1 pre-existing timeout unrelated)
- [ ] Build passes (`tsc --build`)
- [ ] BTs deferred until sprint completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)