### PR TITLE
feat(testing): add contract tests and coverage infrastructure — WR-147 phase 1.2

### DIFF
--- a/.coverage-thresholds.json
+++ b/.coverage-thresholds.json
@@ -1,0 +1,7 @@
+{
+  "packages": {
+    "self/cortex/core": { "lines": 0 },
+    "self/apps/desktop": { "lines": 0 },
+    "self/shared": { "lines": 0 }
+  }
+}

--- a/.github/workflows/ci-release-candidate.yml
+++ b/.github/workflows/ci-release-candidate.yml
@@ -58,6 +58,40 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+      - name: Per-package coverage reporting
+        continue-on-error: true
+        run: |
+          PACKAGES=("self/cortex/core" "self/apps/desktop" "self/shared")
+          for PKG in "${PACKAGES[@]}"; do
+            echo "::group::Coverage for $PKG"
+            pnpm --filter "./$PKG" exec vitest run --coverage --coverage.reporter=lcov --coverage.reportsDirectory=./coverage 2>/dev/null || echo "[coverage] $PKG: test run failed (non-blocking)"
+            if [ -f "$PKG/coverage/lcov.info" ]; then
+              LINES=$(grep -c "^DA:" "$PKG/coverage/lcov.info" 2>/dev/null || echo "0")
+              HITS=$(grep "^DA:" "$PKG/coverage/lcov.info" 2>/dev/null | grep -cv ",0$" || echo "0")
+              if [ "$LINES" -gt 0 ]; then
+                PCT=$(( HITS * 100 / LINES ))
+                echo "[coverage] $PKG: ${PCT}% lines"
+              else
+                echo "[coverage] $PKG: no coverage data"
+              fi
+            else
+              echo "[coverage] $PKG: no lcov.info produced"
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Upload per-package coverage artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: per-package-coverage
+          path: |
+            self/cortex/core/coverage/lcov.info
+            self/apps/desktop/coverage/lcov.info
+            self/shared/coverage/lcov.info
+          if-no-files-found: ignore
+
       - name: Benchmark Tier 0
         run: pnpm run benchmark:tier0
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -55,6 +55,53 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+      - name: Per-package coverage collection
+        run: |
+          PACKAGES=("self/cortex/core" "self/apps/desktop" "self/shared")
+          for PKG in "${PACKAGES[@]}"; do
+            echo "::group::Coverage for $PKG"
+            pnpm --filter "./$PKG" exec vitest run --coverage --coverage.reporter=lcov --coverage.reportsDirectory=./coverage 2>/dev/null || echo "[coverage] $PKG: test run failed"
+            echo "::endgroup::"
+          done
+
+      - name: Coverage floor check
+        run: |
+          node -e "
+            const fs = require('fs');
+            const thresholds = JSON.parse(fs.readFileSync('.coverage-thresholds.json', 'utf-8'));
+            let failed = false;
+            for (const [pkg, config] of Object.entries(thresholds.packages)) {
+              const lcovPath = pkg + '/coverage/lcov.info';
+              let pct = 0;
+              if (fs.existsSync(lcovPath)) {
+                const content = fs.readFileSync(lcovPath, 'utf-8');
+                const lines = content.split('\n').filter(l => l.startsWith('DA:'));
+                const hits = lines.filter(l => !l.endsWith(',0')).length;
+                pct = lines.length > 0 ? Math.floor(hits * 100 / lines.length) : 0;
+              }
+              const floor = config.lines;
+              const status = pct >= floor ? 'PASS' : 'FAIL';
+              console.log('[coverage] ' + pkg + ': ' + pct + '% lines (floor: ' + floor + '%) — ' + status);
+              if (pct < floor) failed = true;
+            }
+            if (failed) {
+              console.error('Coverage floor check failed — one or more packages below threshold');
+              process.exit(1);
+            }
+            console.log('Coverage floor check passed');
+          "
+
+      - name: Upload per-package coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: per-package-coverage
+          path: |
+            self/cortex/core/coverage/lcov.info
+            self/apps/desktop/coverage/lcov.info
+            self/shared/coverage/lcov.info
+          if-no-files-found: ignore
+
       - name: Benchmark Tier 0
         run: pnpm run benchmark:tier0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,19 +37,19 @@ importers:
         version: 2.0.13
       fumadocs-core:
         specifier: ^16.6.0
-        version: 16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+        version: 16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       fumadocs-mdx:
         specifier: ^14.2.7
-        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       fumadocs-ui:
         specifier: ^16.6.0
-        version: 16.6.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)
+        version: 16.6.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)
       mermaid:
         specifier: ^11.12.2
         version: 11.12.2
       next:
         specifier: 16.1.6
-        version: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -414,7 +414,7 @@ importers:
         version: 11.10.0(typescript@5.9.3)
       next:
         specifier: ^15.0.0
-        version: 15.5.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.12(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -557,6 +557,15 @@ importers:
       '@nous/subcortex-tools':
         specifier: workspace:*
         version: link:../../subcortex/tools
+
+  self/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.59.1
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   self/memory/access:
     dependencies:
@@ -2070,6 +2079,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -4591,6 +4605,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6008,6 +6027,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -8216,6 +8245,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -11097,10 +11130,13 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76):
+  fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -11132,21 +11168,21 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
       lucide-react: 0.563.0(react@19.2.3)
-      next: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
+  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+      fumadocs-core: 16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       js-yaml: 4.1.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -11164,13 +11200,13 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       mdast-util-mdx-jsx: 3.2.0
-      next: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       vite: 7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.6.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18):
+  fumadocs-ui@16.6.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18):
     dependencies:
       '@fumadocs/tailwind': 0.0.2(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -11184,7 +11220,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.3)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+      fumadocs-core: 16.6.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.3))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       lucide-react: 0.563.0(react@19.2.3)
       motion: 12.34.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -11198,7 +11234,7 @@ snapshots:
       unist-util-visit: 5.1.0
     optionalDependencies:
       '@types/react': 19.2.14
-      next: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
@@ -12577,7 +12613,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@15.5.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.12(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -12595,12 +12631,13 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.12
       '@next/swc-win32-arm64-msvc': 15.5.12
       '@next/swc-win32-x64-msvc': 15.5.12
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -12619,6 +12656,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -12877,6 +12915,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - self/memory/*
   - self/subcortex/*
   - self/apps/*
+  - self/e2e
   - scripts/install
   - scripts/benchmark
   - docs

--- a/self/apps/desktop/src/__tests__/ipc-channels.ts
+++ b/self/apps/desktop/src/__tests__/ipc-channels.ts
@@ -1,0 +1,35 @@
+/**
+ * IPC channel extraction helper for contract tests.
+ *
+ * Reads main/index.ts and preload/index.ts as text files and extracts
+ * channel names via regex. No Electron runtime imports required.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const MAIN_PATH = resolve(__dirname, '../main/index.ts');
+const PRELOAD_PATH = resolve(__dirname, '../preload/index.ts');
+
+const MAIN_CHANNEL_REGEX = /ipcMain\.handle\('([^']+)'/g;
+const PRELOAD_CHANNEL_REGEX = /ipcRenderer\.invoke\('([^']+)'/g;
+
+function extractChannels(filePath: string, regex: RegExp): string[] {
+  const source = readFileSync(filePath, 'utf-8');
+  const channels: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(source)) !== null) {
+    channels.push(match[1]);
+  }
+  return channels;
+}
+
+export function getMainChannels(): string[] {
+  return extractChannels(MAIN_PATH, MAIN_CHANNEL_REGEX);
+}
+
+export function getPreloadChannels(): string[] {
+  return extractChannels(PRELOAD_PATH, PRELOAD_CHANNEL_REGEX);
+}

--- a/self/apps/desktop/src/__tests__/ipc-contract.test.ts
+++ b/self/apps/desktop/src/__tests__/ipc-contract.test.ts
@@ -1,0 +1,50 @@
+/**
+ * IPC channel contract test.
+ *
+ * Validates that every channel registered via ipcMain.handle() in the main
+ * process has a corresponding ipcRenderer.invoke() call in the preload script,
+ * and vice versa. Catches channel name drift between the two sides.
+ */
+import { describe, expect, it } from 'vitest';
+import { getMainChannels, getPreloadChannels } from './ipc-channels.js';
+
+describe('IPC channel contract', () => {
+  const mainChannels = getMainChannels();
+  const preloadChannels = getPreloadChannels();
+
+  it('extracts a non-empty list of main channels', () => {
+    expect(mainChannels.length).toBeGreaterThan(0);
+  });
+
+  it('extracts a non-empty list of preload channels', () => {
+    expect(preloadChannels.length).toBeGreaterThan(0);
+  });
+
+  it('every main channel exists in preload channels', () => {
+    const preloadSet = new Set(preloadChannels);
+    const missing = mainChannels.filter((ch) => !preloadSet.has(ch));
+    expect(missing, `Main channels missing from preload: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every preload channel exists in main channels', () => {
+    const mainSet = new Set(mainChannels);
+    const missing = preloadChannels.filter((ch) => !mainSet.has(ch));
+    expect(missing, `Preload channels missing from main: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('channel sets are identical', () => {
+    expect(new Set(mainChannels)).toEqual(new Set(preloadChannels));
+  });
+
+  it('contains known channels as a smoke check', () => {
+    const allChannels = new Set([...mainChannels, ...preloadChannels]);
+    expect(allChannels.has('layout:get')).toBe(true);
+    expect(allChannels.has('layout:set')).toBe(true);
+    expect(allChannels.has('fs:readDir')).toBe(true);
+    expect(allChannels.has('fs:readFile')).toBe(true);
+  });
+
+  it('channel counts match between main and preload', () => {
+    expect(mainChannels.length).toBe(preloadChannels.length);
+  });
+});

--- a/self/apps/desktop/vitest.config.mts
+++ b/self/apps/desktop/vitest.config.mts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+    exclude: ['**/dist/**', '**/node_modules/**'],
+  },
+});

--- a/self/apps/web/server/__tests__/discovery-contract.test.ts
+++ b/self/apps/web/server/__tests__/discovery-contract.test.ts
@@ -1,0 +1,288 @@
+/**
+ * tRPC discovery router contract test.
+ *
+ * Validates Zod schema shapes for the discovery router procedures using
+ * .safeParse() only -- no createCaller, no network, no runtime dependencies.
+ * Tests input validation, boundary values, and output schema parsing.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  ProjectDiscoveryRequestSchema,
+  ProjectDiscoveryResultSchema,
+  ProjectKnowledgeSnapshotSchema,
+  ProjectKnowledgeRefreshRecordSchema,
+} from '@nous/shared';
+import { ProjectIdSchema } from '@nous/shared';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const VALID_UUID_2 = '550e8400-e29b-41d4-a716-446655440001';
+
+describe('ProjectDiscoveryRequestSchema', () => {
+  it('accepts valid input with all required fields', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test query',
+      topK: 5,
+      includeMetaVector: true,
+      includeTaxonomy: true,
+      includeRelationships: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts input with defaults applied (topK, includes)', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test query',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.topK).toBe(10);
+      expect(result.data.includeMetaVector).toBe(true);
+      expect(result.data.includeTaxonomy).toBe(true);
+      expect(result.data.includeRelationships).toBe(true);
+    }
+  });
+
+  it('accepts topK at minimum boundary (1)', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test',
+      topK: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts topK at maximum boundary (25)', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test',
+      topK: 25,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts input with optional traceId omitted', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test query',
+      topK: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing requestingProjectId', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      query: 'test query',
+      topK: 5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty query string', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: '',
+      topK: 5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only query string', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: '   ',
+      topK: 5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects topK below minimum (0)', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test',
+      topK: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects topK above maximum (26)', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: VALID_UUID,
+      query: 'test',
+      topK: 26,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-UUID requestingProjectId', () => {
+    const result = ProjectDiscoveryRequestSchema.safeParse({
+      requestingProjectId: 'not-a-uuid',
+      query: 'test',
+      topK: 5,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ProjectDiscoveryResultSchema', () => {
+  it('accepts a representative output object', () => {
+    const result = ProjectDiscoveryResultSchema.safeParse({
+      discovery: {
+        version: '1.0',
+        exportedAt: new Date().toISOString(),
+        requestingProjectId: VALID_UUID,
+        projectIds: [VALID_UUID],
+        results: [{ projectId: VALID_UUID, rank: 1, combinedScore: 0.9 }],
+        audit: {
+          projectIdsDiscovered: [VALID_UUID],
+          metaVectorCount: 1,
+          taxonomyCount: 0,
+          relationshipCount: 0,
+          mergeStrategy: 'meta-vector-primary',
+        },
+      },
+      policy: {
+        deniedProjectCount: 0,
+        reasonCodes: [],
+      },
+      snapshot: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects output missing discovery field', () => {
+    const result = ProjectDiscoveryResultSchema.safeParse({
+      policy: { deniedProjectCount: 0, reasonCodes: [] },
+      snapshot: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects output missing policy field', () => {
+    const result = ProjectDiscoveryResultSchema.safeParse({
+      discovery: {
+        version: '1.0',
+        exportedAt: new Date().toISOString(),
+        requestingProjectId: VALID_UUID,
+        projectIds: [],
+        results: [],
+        audit: {
+          projectIdsDiscovered: [],
+          metaVectorCount: 0,
+          taxonomyCount: 0,
+          relationshipCount: 0,
+          mergeStrategy: 'meta-vector-primary',
+        },
+      },
+      snapshot: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ProjectKnowledgeSnapshotSchema', () => {
+  it('accepts a representative snapshot object', () => {
+    const result = ProjectKnowledgeSnapshotSchema.safeParse({
+      projectId: VALID_UUID,
+      metaVector: null,
+      taxonomy: [],
+      relationships: {
+        projectId: VALID_UUID,
+        outgoing: [],
+        incoming: [],
+      },
+      latestRefresh: null,
+      diagnostics: {
+        runtimePosture: 'single_process_local',
+        refreshInFlight: false,
+        confidenceReasonCodes: [],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects snapshot with invalid runtimePosture value', () => {
+    const result = ProjectKnowledgeSnapshotSchema.safeParse({
+      projectId: VALID_UUID,
+      metaVector: null,
+      taxonomy: [],
+      relationships: {
+        projectId: VALID_UUID,
+        outgoing: [],
+        incoming: [],
+      },
+      latestRefresh: null,
+      diagnostics: {
+        runtimePosture: 'distributed',
+        refreshInFlight: false,
+        confidenceReasonCodes: [],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ProjectKnowledgeRefreshRecordSchema', () => {
+  const SHA256_HASH = 'a'.repeat(64);
+
+  it('accepts a representative record', () => {
+    const result = ProjectKnowledgeRefreshRecordSchema.safeParse({
+      id: VALID_UUID,
+      projectId: VALID_UUID_2,
+      trigger: 'manual',
+      reasonCode: 'test-refresh',
+      inputDigest: SHA256_HASH,
+      outcome: 'updated',
+      metaVectorState: 'updated',
+      taxonomyTagCount: 3,
+      relationship: {
+        projectId: VALID_UUID_2,
+        edgesCreated: 0,
+        edgesUpdated: 0,
+        edgesInvalidated: 0,
+        evidenceRefs: [],
+      },
+      evidenceRefs: [],
+      sourcePatternIds: [],
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects record with invalid outcome enum', () => {
+    const result = ProjectKnowledgeRefreshRecordSchema.safeParse({
+      id: VALID_UUID,
+      projectId: VALID_UUID_2,
+      trigger: 'manual',
+      reasonCode: 'test-refresh',
+      inputDigest: SHA256_HASH,
+      outcome: 'invalid_outcome',
+      metaVectorState: 'updated',
+      taxonomyTagCount: 3,
+      relationship: {
+        projectId: VALID_UUID_2,
+        edgesCreated: 0,
+        edgesUpdated: 0,
+        edgesInvalidated: 0,
+        evidenceRefs: [],
+      },
+      evidenceRefs: [],
+      sourcePatternIds: [],
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ProjectIdSchema', () => {
+  it('accepts a valid UUID', () => {
+    expect(ProjectIdSchema.safeParse(VALID_UUID).success).toBe(true);
+  });
+
+  it('rejects a non-UUID string', () => {
+    expect(ProjectIdSchema.safeParse('not-a-uuid').success).toBe(false);
+  });
+});

--- a/self/e2e/.gitignore
+++ b/self/e2e/.gitignore
@@ -1,0 +1,3 @@
+playwright-report/
+test-results/
+node_modules/

--- a/self/e2e/fixtures/desktop.ts
+++ b/self/e2e/fixtures/desktop.ts
@@ -1,0 +1,76 @@
+import { test as base, type ElectronApplication, type Page } from '@playwright/test';
+import { _electron } from '@playwright/test';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Monorepo root: e2e/fixtures -> e2e -> self -> nous-core */
+const monorepoRoot = resolve(__dirname, '..', '..', '..');
+
+/** Path to the built desktop app main process entry */
+const appEntry = resolve(monorepoRoot, 'self', 'apps', 'desktop', 'out', 'main', 'index.js');
+
+/**
+ * Resolve the Electron binary path.
+ *
+ * `electron` package exports a string path to the binary when required.
+ * We use createRequire to resolve it from the desktop package's context,
+ * since that's where Electron is installed as a devDependency.
+ */
+function resolveElectronPath(): string {
+  const desktopRoot = resolve(monorepoRoot, 'self', 'apps', 'desktop');
+  const require = createRequire(resolve(desktopRoot, 'package.json'));
+  return require('electron') as unknown as string;
+}
+
+type DesktopFixtures = {
+  electronApp: ElectronApplication;
+  page: Page;
+};
+
+/**
+ * Extended Playwright test fixture that launches the Nous desktop Electron app.
+ *
+ * Prerequisites:
+ *   - `pnpm --filter @nous/desktop build` must have been run (produces out/main/index.js)
+ *   - Electron must be installed (via pnpm install)
+ *
+ * The fixture clears ELECTRON_RUN_AS_NODE before launch, mirroring the pattern
+ * in self/apps/desktop/scripts/start-dev.mjs. Without this, Electron runs as
+ * plain Node.js and BrowserWindow/app APIs are unavailable.
+ */
+export const test = base.extend<DesktopFixtures>({
+  electronApp: async ({}, use) => {
+    // Clear ELECTRON_RUN_AS_NODE — required when running inside VSCode/Claude Code
+    // (both are Electron apps that set this env var)
+    delete process.env.ELECTRON_RUN_AS_NODE;
+
+    if (!existsSync(appEntry)) {
+      throw new Error(
+        `Desktop app not built: ${appEntry} does not exist.\n` +
+        'Run "pnpm --filter @nous/desktop build" before running desktop E2E specs.'
+      );
+    }
+
+    const executablePath = resolveElectronPath();
+
+    const electronApp = await _electron.launch({
+      executablePath,
+      args: [appEntry],
+    });
+
+    await use(electronApp);
+
+    await electronApp.close();
+  },
+
+  page: async ({ electronApp }, use) => {
+    const page = await electronApp.firstWindow();
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/self/e2e/package.json
+++ b/self/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@nous/e2e",
+  "version": "0.0.1",
+  "private": true,
+  "description": "End-to-end Playwright tests for Nous desktop and web applications",
+  "scripts": {
+    "test": "playwright test",
+    "test:desktop": "playwright test --project=desktop",
+    "test:web": "playwright test --project=web",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "typescript": "^5"
+  }
+}

--- a/self/e2e/playwright.config.ts
+++ b/self/e2e/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'desktop',
+      testDir: './specs/desktop',
+    },
+    {
+      name: 'web',
+      testDir: './specs/web',
+      use: {
+        baseURL: 'http://localhost:3199',
+      },
+    },
+  ],
+  webServer: {
+    command: 'pnpm --filter @nous/web exec next start -p 3199',
+    port: 3199,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  reporter: 'html',
+});

--- a/self/e2e/specs/desktop/chat-flow.spec.ts
+++ b/self/e2e/specs/desktop/chat-flow.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../../fixtures/desktop';
+
+test.describe('chat flow (requires backend)', () => {
+  test('can send a message and receive a response', async ({ page }) => {
+    // Generous timeout — backend response time varies
+    test.setTimeout(60_000);
+
+    // Locate the chat input — the ChatInput component renders a textarea or input
+    const chatInput = page.locator('[data-testid="chat-input"], textarea, input[type="text"]').first();
+    await chatInput.waitFor({ state: 'visible', timeout: 15_000 });
+
+    // Type a test message
+    await chatInput.fill('Hello, this is an E2E test message');
+
+    // Send the message — press Enter or click a send button
+    await chatInput.press('Enter');
+
+    // Wait for a response element to appear in the conversation
+    // The assistant response renders as a new element in the chat history
+    const responseElement = page.locator(
+      '[data-testid="chat-response"], [data-testid="assistant-message"], [role="assistant"], .assistant-message'
+    ).first();
+
+    await responseElement.waitFor({ state: 'visible', timeout: 30_000 });
+
+    // Assert the response contains text content
+    const responseText = await responseElement.textContent();
+    expect(responseText).toBeTruthy();
+    expect(responseText!.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/self/e2e/specs/desktop/window-state.spec.ts
+++ b/self/e2e/specs/desktop/window-state.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '../../fixtures/desktop';
+
+test.describe('desktop window state', () => {
+  test('window is visible', async ({ electronApp }) => {
+    const window = await electronApp.firstWindow();
+    const isVisible = await electronApp.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      return win ? win.isVisible() : false;
+    });
+    expect(isVisible).toBe(true);
+  });
+
+  test('window dimensions are at least 800x600', async ({ page }) => {
+    const size = page.viewportSize();
+    expect(size).not.toBeNull();
+    // Desktop app has minWidth: 800, minHeight: 600
+    expect(size!.width).toBeGreaterThanOrEqual(800);
+    expect(size!.height).toBeGreaterThanOrEqual(600);
+  });
+
+  test('page has loaded with DOM content', async ({ page }) => {
+    // Wait for the page to have content in the body
+    await page.waitForSelector('body', { state: 'attached' });
+    const bodyChildren = await page.locator('body').locator('> *').count();
+    expect(bodyChildren).toBeGreaterThan(0);
+  });
+});

--- a/self/e2e/specs/web/navigation.spec.ts
+++ b/self/e2e/specs/web/navigation.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('web navigation', () => {
+  test('root page loads successfully', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response).not.toBeNull();
+    expect(response!.ok() || response!.status() === 304).toBe(true);
+  });
+
+  test('page has visible content', async ({ page }) => {
+    await page.goto('/');
+    // Assert the page is not blank — body has visible content
+    const body = page.locator('body');
+    await expect(body).not.toBeEmpty();
+  });
+});

--- a/self/e2e/specs/web/rendered-content.spec.ts
+++ b/self/e2e/specs/web/rendered-content.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('web rendered content', () => {
+  test('page loads with correct title', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle('Nous');
+  });
+
+  test('body has child elements', async ({ page }) => {
+    await page.goto('/');
+    const bodyChildren = await page.locator('body').locator('> *').count();
+    expect(bodyChildren).toBeGreaterThan(0);
+  });
+
+  test('no error indicators on page', async ({ page }) => {
+    await page.goto('/');
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText).not.toContain('Internal Server Error');
+    // Ensure the page is not a raw 500 error page
+    expect(bodyText).not.toMatch(/^500$/);
+  });
+});

--- a/self/e2e/specs/web/smoke.spec.ts
+++ b/self/e2e/specs/web/smoke.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Web smoke test — Playwright replacement for the curl HTTP-only check
+ * in ci-release-candidate.yml lines 119-135.
+ *
+ * The original curl check only validates HTTP status codes (non-500, non-000).
+ * A server returning an empty 200 page would pass. This Playwright spec
+ * validates that the page actually renders DOM content.
+ *
+ * CI integration (replacing the curl check in the workflow) is handled
+ * in sub-phase 1.3.
+ */
+test.describe('web smoke (replaces curl check)', () => {
+  test('server responds with non-error status', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response).not.toBeNull();
+    // Must not be a server error (5xx)
+    expect(response!.status()).toBeLessThan(500);
+  });
+
+  test('page renders DOM content', async ({ page }) => {
+    await page.goto('/');
+    // Body must have child elements — not an empty page
+    const bodyChildren = await page.locator('body').locator('> *').count();
+    expect(bodyChildren).toBeGreaterThan(0);
+  });
+
+  test('page has a title', async ({ page }) => {
+    await page.goto('/');
+    const title = await page.title();
+    expect(title).toBeTruthy();
+    expect(title.length).toBeGreaterThan(0);
+  });
+});

--- a/self/e2e/tsconfig.json
+++ b/self/e2e/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": [
+    "fixtures/**/*.ts",
+    "specs/**/*.ts",
+    "playwright.config.ts"
+  ]
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     projects: [
       'self/**/vitest.config.ts',
+      'self/**/vitest.config.mts',
       'scripts/**/vitest.config.ts',
     ],
     coverage: {


### PR DESCRIPTION
## Summary
- IPC contract tests: channel name alignment between Electron main/preload (21 channels, 7 assertions)
- tRPC contract tests: Zod schema round-trip for discovery router (5 schemas, 20 assertions)
- Per-package coverage: T3 non-blocking reporting, T4 blocking floor enforcement
- `.coverage-thresholds.json` with per-package floor thresholds (placeholder 0, needs baseline)

## Test plan
- [x] `pnpm test` — 337 files, 1920 tests pass (27 new)
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — 0 errors
- [x] CI Gate — pending
- [ ] T3/T4 coverage steps validated in CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)