### PR TITLE
fix(cortex-core): runtime adapter recomposition + tool schema normalization [1.1]

### DIFF
--- a/self/apps/shared-server/src/trpc/routers/preferences.ts
+++ b/self/apps/shared-server/src/trpc/routers/preferences.ts
@@ -558,6 +558,19 @@ export const preferencesRouter = router({
         await upsertProviderConfig(ctx, providerConfig);
         await updateRoleAssignment(ctx, input.role, providerId);
 
+        // WR-148 phase 1.1: trigger runtime harness recomposition for
+        // affected agent classes when model role assignments change.
+        const ROLE_TO_AGENT_CLASS: Record<string, 'Cortex::Principal' | 'Cortex::System' | null> = {
+          'cortex-chat': 'Cortex::Principal',
+          'cortex-system': 'Cortex::System',
+          orchestrators: null,  // dispatch-time, not recomposed
+          workers: null,        // dispatch-time, not recomposed
+        };
+        const agentClass = ROLE_TO_AGENT_CLASS[input.role];
+        if (agentClass && providerConfig.vendor) {
+          ctx.gatewayRuntime.recomposeHarnessForClass(agentClass, providerConfig.vendor);
+        }
+
         console.info(
           `[nous:preferences] Updated ${input.role} assignment to ${input.modelSpec}`,
         );

--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter-format-tools.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter-format-tools.test.ts
@@ -1,0 +1,109 @@
+/**
+ * formatTools defensive injection — WR-148 phase 1.1 / T5b
+ *
+ * Tier 2 behavior test: validates that the Anthropic adapter's formatTools
+ * function defensively injects `type: "object"` for tools with missing type
+ * fields, logs when injection occurs, and does not mutate original schemas.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { createAnthropicAdapter } from '../../../agent-gateway/adapters/anthropic-adapter.js';
+import type { ToolDefinition, GatewayContextFrame } from '@nous/shared';
+
+function makeToolDefinition(
+  name: string,
+  inputSchema: Record<string, unknown>,
+): ToolDefinition {
+  return {
+    name,
+    version: '1.0.0',
+    description: `Test tool: ${name}`,
+    inputSchema,
+    outputSchema: {},
+    capabilities: ['read'],
+    permissionScope: 'project',
+  };
+}
+
+/**
+ * Exercise formatTools indirectly through the adapter's formatRequest.
+ * Returns the `tools` array from the formatted request.
+ */
+function formatToolsViaAdapter(
+  toolDefinitions: readonly ToolDefinition[],
+): Array<{ name: string; description: string; input_schema: Record<string, unknown> }> {
+  const adapter = createAnthropicAdapter();
+  const context: GatewayContextFrame[] = [
+    { role: 'user', source: 'runtime', content: 'test', createdAt: new Date().toISOString() },
+  ];
+  const result = adapter.formatRequest({
+    systemPrompt: 'test',
+    context,
+    toolDefinitions,
+  });
+  return (result.input as Record<string, unknown>).tools as Array<{
+    name: string;
+    description: string;
+    input_schema: Record<string, unknown>;
+  }>;
+}
+
+describe('formatTools defensive injection (WR-148 phase 1.1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes through a valid schema unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: { mode: { type: 'string' } },
+      required: ['mode'],
+    };
+    const tools = formatToolsViaAdapter([makeToolDefinition('valid_tool', schema)]);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].input_schema).toEqual(schema);
+  });
+
+  it('injects type: "object" when inputSchema is empty ({})', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const tools = formatToolsViaAdapter([makeToolDefinition('empty_schema', {})]);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].input_schema.type).toBe('object');
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('Injecting type:"object" for tool "empty_schema"'),
+    );
+  });
+
+  it('injects type: "object" when inputSchema has properties but no type', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const schema = {
+      properties: { mode: { type: 'string' } },
+      required: ['mode'],
+    };
+    const tools = formatToolsViaAdapter([makeToolDefinition('no_type_tool', schema)]);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].input_schema.type).toBe('object');
+    expect(tools[0].input_schema.properties).toEqual({ mode: { type: 'string' } });
+    expect(tools[0].input_schema.required).toEqual(['mode']);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does not log when schema already has a type field', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const schema = { type: 'object', properties: {} };
+    formatToolsViaAdapter([makeToolDefinition('typed_tool', schema)]);
+    expect(spy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Injecting type:"object"'),
+    );
+  });
+
+  it('does not mutate the original schema object (uses spread)', () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    const originalSchema: Record<string, unknown> = {
+      properties: { mode: { type: 'string' } },
+    };
+    const originalRef = originalSchema;
+    formatToolsViaAdapter([makeToolDefinition('no_mutate', originalSchema)]);
+    // The original schema should NOT have type added
+    expect(originalRef.type).toBeUndefined();
+  });
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/cortex-runtime-recompose.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/cortex-runtime-recompose.test.ts
@@ -1,0 +1,218 @@
+/**
+ * CortexRuntime.recomposeHarnessForClass — WR-148 phase 1.1 / T5c
+ *
+ * Tier 2 behavior test: validates runtime harness recomposition, including
+ * turn-in-progress guard, deferred recompose application, and last-write-wins
+ * semantics for rapid vendor changes during an active turn.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentGatewayConfig, IModelRouter } from '@nous/shared';
+import { createPrincipalSystemGatewayRuntime } from '../../gateway-runtime/index.js';
+import { resolveAdapter } from '../../agent-gateway/adapters/index.js';
+import {
+  createDocumentStore,
+  createPfcEngine,
+  createProjectApi,
+} from '../agent-gateway/helpers.js';
+
+function createStubModelRouter(): IModelRouter {
+  return {
+    route: vi.fn(),
+    routeWithEvidence: vi.fn(),
+    listProviders: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function idFactory(): () => string {
+  let counter = 0;
+  return () => {
+    const suffix = String(counter).padStart(12, '0');
+    counter += 1;
+    return `00000000-0000-4000-8000-${suffix}`;
+  };
+}
+
+function createRuntime() {
+  return createPrincipalSystemGatewayRuntime({
+    documentStore: createDocumentStore(),
+    modelRouter: createStubModelRouter(),
+    getProvider: () => null,
+    getProjectApi: () => createProjectApi(),
+    pfc: createPfcEngine(),
+    outputSchemaValidator: {
+      validate: vi.fn().mockResolvedValue({ success: true }),
+    },
+    idFactory: idFactory(),
+  });
+}
+
+function readPrincipalConfig(
+  runtime: ReturnType<typeof createPrincipalSystemGatewayRuntime>,
+): AgentGatewayConfig {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (runtime as any).principalGatewayConfig as AgentGatewayConfig;
+}
+
+function readSystemConfig(
+  runtime: ReturnType<typeof createPrincipalSystemGatewayRuntime>,
+): AgentGatewayConfig {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (runtime as any).systemGatewayConfig as AgentGatewayConfig;
+}
+
+function getTurnInProgressByClass(
+  runtime: ReturnType<typeof createPrincipalSystemGatewayRuntime>,
+): Map<string, boolean> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (runtime as any).turnInProgressByClass as Map<string, boolean>;
+}
+
+function getPendingRecompose(
+  runtime: ReturnType<typeof createPrincipalSystemGatewayRuntime>,
+): Map<string, string> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (runtime as any).pendingRecompose as Map<string, string>;
+}
+
+describe('CortexRuntime.recomposeHarnessForClass (WR-148 phase 1.1)', () => {
+  it('swaps Principal harness to the Ollama adapter', () => {
+    const runtime = createRuntime();
+    const harnessBefore = readPrincipalConfig(runtime).harness;
+    const gatewayRef = runtime.getPrincipalGateway();
+
+    runtime.recomposeHarnessForClass('Cortex::Principal', 'ollama');
+
+    const harnessAfter = readPrincipalConfig(runtime).harness;
+    // Harness is replaced
+    expect(harnessAfter).not.toBe(harnessBefore);
+    expect(harnessAfter).toBeDefined();
+    // Gateway identity preserved
+    expect(runtime.getPrincipalGateway()).toBe(gatewayRef);
+  });
+
+  it('swaps System harness to the Ollama adapter', () => {
+    const runtime = createRuntime();
+    const harnessBefore = readSystemConfig(runtime).harness;
+
+    runtime.recomposeHarnessForClass('Cortex::System', 'ollama');
+
+    const harnessAfter = readSystemConfig(runtime).harness;
+    expect(harnessAfter).not.toBe(harnessBefore);
+    expect(harnessAfter).toBeDefined();
+  });
+
+  it('recomposition with anthropic vendor produces adapter with cacheControl capability', () => {
+    const runtime = createRuntime();
+    runtime.recomposeHarnessForClass('Cortex::Principal', 'anthropic');
+
+    // Verify the adapter matches by checking the anthropic-only capability
+    const anthropicAdapter = resolveAdapter('anthropic');
+    expect(anthropicAdapter.capabilities.cacheControl).toBe(true);
+  });
+
+  it('recomposition with unknown vendor falls back to text adapter', () => {
+    const runtime = createRuntime();
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    // 'unknown_vendor' should fallback to text adapter via resolveAdapter
+    runtime.recomposeHarnessForClass('Cortex::Principal', 'unknown_vendor' as never);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('Recomposed harness for Cortex::Principal with vendor unknown_vendor'),
+    );
+    spy.mockRestore();
+  });
+
+  describe('turn-in-progress guard', () => {
+    it('defers recompose when turn is in progress', () => {
+      const runtime = createRuntime();
+      const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      // Simulate turn in progress
+      getTurnInProgressByClass(runtime).set('Cortex::Principal', true);
+
+      const harnessBefore = readPrincipalConfig(runtime).harness;
+      runtime.recomposeHarnessForClass('Cortex::Principal', 'ollama');
+
+      // Harness should NOT be changed yet
+      expect(readPrincipalConfig(runtime).harness).toBe(harnessBefore);
+
+      // Should be stored in pendingRecompose
+      expect(getPendingRecompose(runtime).get('Cortex::Principal')).toBe('ollama');
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('Deferred harness recompose for Cortex::Principal'),
+      );
+      spy.mockRestore();
+    });
+
+    it('applies deferred recompose when turn completes (via checkPendingRecompose)', () => {
+      const runtime = createRuntime();
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      // Simulate turn in progress, then a deferred recompose
+      getTurnInProgressByClass(runtime).set('Cortex::Principal', true);
+      runtime.recomposeHarnessForClass('Cortex::Principal', 'ollama');
+
+      const harnessDuringTurn = readPrincipalConfig(runtime).harness;
+
+      // Simulate turn completion
+      getTurnInProgressByClass(runtime).set('Cortex::Principal', false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runtime as any).checkPendingRecompose('Cortex::Principal');
+
+      // Now the harness should be swapped
+      expect(readPrincipalConfig(runtime).harness).not.toBe(harnessDuringTurn);
+      // And the pending map should be cleared
+      expect(getPendingRecompose(runtime).get('Cortex::Principal')).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it('last-write-wins for multiple rapid recompose calls during active turn', () => {
+      const runtime = createRuntime();
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      // Simulate turn in progress
+      getTurnInProgressByClass(runtime).set('Cortex::Principal', true);
+
+      // Rapid successive calls
+      runtime.recomposeHarnessForClass('Cortex::Principal', 'ollama');
+      runtime.recomposeHarnessForClass('Cortex::Principal', 'anthropic');
+      runtime.recomposeHarnessForClass('Cortex::Principal', 'openai');
+
+      // Only the last vendor should be stored
+      expect(getPendingRecompose(runtime).get('Cortex::Principal')).toBe('openai');
+
+      // Simulate turn completion
+      getTurnInProgressByClass(runtime).set('Cortex::Principal', false);
+      const harnessBefore = readPrincipalConfig(runtime).harness;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runtime as any).checkPendingRecompose('Cortex::Principal');
+
+      // Harness should be swapped (only once — for 'openai')
+      expect(readPrincipalConfig(runtime).harness).not.toBe(harnessBefore);
+      expect(getPendingRecompose(runtime).get('Cortex::Principal')).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it('no-op checkPendingRecompose when no pending recompose exists', () => {
+      const runtime = createRuntime();
+      const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      const harnessBefore = readPrincipalConfig(runtime).harness;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (runtime as any).checkPendingRecompose('Cortex::Principal');
+
+      // Harness unchanged
+      expect(readPrincipalConfig(runtime).harness).toBe(harnessBefore);
+
+      // No deferred recompose log
+      expect(spy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Applied deferred harness recompose'),
+      );
+      spy.mockRestore();
+    });
+  });
+});

--- a/self/cortex/core/src/__tests__/internal-mcp/catalog-schema-validity.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/catalog-schema-validity.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Catalog schema validity — WR-148 phase 1.1 / T5a
+ *
+ * Tier 1 contract test: validates that every tool definition in the
+ * internal MCP catalog uses a valid JSON Schema `inputSchema` object.
+ * Prevents regression if a new tool is added with informal schemas.
+ */
+import { describe, expect, it } from 'vitest';
+import { INTERNAL_MCP_CATALOG } from '../../internal-mcp/catalog.js';
+
+describe('INTERNAL_MCP_CATALOG inputSchema validity', () => {
+  for (const entry of INTERNAL_MCP_CATALOG) {
+    describe(`${entry.name}`, () => {
+      const schema = entry.definition.inputSchema as Record<string, unknown>;
+
+      it('has type: "object"', () => {
+        expect(schema.type).toBe('object');
+      });
+
+      it('has properties that is an object', () => {
+        expect(schema.properties).toBeDefined();
+        expect(typeof schema.properties).toBe('object');
+        expect(schema.properties).not.toBeNull();
+      });
+
+      it('required entries (if present) exist in properties', () => {
+        if (!schema.required) return; // optional — no required array is valid
+        const required = schema.required as string[];
+        const properties = schema.properties as Record<string, unknown>;
+        for (const key of required) {
+          expect(properties).toHaveProperty(
+            key,
+            expect.anything(),
+          );
+        }
+      });
+    });
+  }
+});

--- a/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
@@ -79,11 +79,24 @@ function formatTools(
 ): Array<{ name: string; description: string; input_schema: Record<string, unknown> }> | undefined {
   if (!toolDefinitions || toolDefinitions.length === 0) return undefined;
 
-  return toolDefinitions.map((tool) => ({
-    name: tool.name,
-    description: tool.description ?? '',
-    input_schema: (tool.inputSchema as Record<string, unknown>) ?? {},
-  }));
+  return toolDefinitions.map((tool) => {
+    const schema = (tool.inputSchema as Record<string, unknown>) ?? {};
+    if (!schema.type) {
+      console.info(
+        `[nous:anthropic-adapter] Injecting type:"object" for tool "${tool.name}" — inputSchema missing type field`,
+      );
+      return {
+        name: tool.name,
+        description: tool.description ?? '',
+        input_schema: { ...schema, type: 'object' },
+      };
+    }
+    return {
+      name: tool.name,
+      description: tool.description ?? '',
+      input_schema: schema,
+    };
+  });
 }
 
 function formatMessages(

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -221,6 +221,11 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     | Partial<Record<AgentClass, ProviderVendor>>
     | null = null;
   private attachWarningEmitted = false;
+  // WR-148 phase 1.1: turn-in-progress guard for runtime harness recomposition.
+  // Simple boolean flag per agent class — the gateway run loop is sequential per
+  // instance, so no concurrency primitive is needed.
+  private turnInProgressByClass: Map<string, boolean> = new Map();
+  private pendingRecompose: Map<string, ProviderVendor> = new Map();
   private readonly principalTools: ToolDefinition[];
   private readonly systemTools: ToolDefinition[];
   private readonly systemBacklogQueue: SystemBacklogQueue;
@@ -497,24 +502,31 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       },
     ];
 
-    // Run Principal gateway
-    const result = await this.principalGateway.run({
-      taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${WORKFLOW_PROMPT_FRAGMENT}\n\n${CARD_PROMPT_FRAGMENT}`,
-      context: chatContext,
-      budget: DEFAULT_CHAT_TURN_BUDGET,
-      spawnBudgetCeiling: 0,
-      correlation: {
-        runId: this.nextRunId() as never,
-        parentId: this.principalGateway.agentId,
-        sequence: 0,
-      },
-      execution: {
-        projectId: projectId as never,
-        traceId: traceId as never,
-        workmodeId: 'system:implementation',
-      },
-      modelRequirements: this.deps.defaultModelRequirements,
-    });
+    // Run Principal gateway (with turn-in-progress guard for recompose safety)
+    this.turnInProgressByClass.set('Cortex::Principal', true);
+    let result;
+    try {
+      result = await this.principalGateway.run({
+        taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${WORKFLOW_PROMPT_FRAGMENT}\n\n${CARD_PROMPT_FRAGMENT}`,
+        context: chatContext,
+        budget: DEFAULT_CHAT_TURN_BUDGET,
+        spawnBudgetCeiling: 0,
+        correlation: {
+          runId: this.nextRunId() as never,
+          parentId: this.principalGateway.agentId,
+          sequence: 0,
+        },
+        execution: {
+          projectId: projectId as never,
+          traceId: traceId as never,
+          workmodeId: 'system:implementation',
+        },
+        modelRequirements: this.deps.defaultModelRequirements,
+      });
+    } finally {
+      this.turnInProgressByClass.set('Cortex::Principal', false);
+      this.checkPendingRecompose('Cortex::Principal');
+    }
 
     // Resolve response
     const resolved = this.resolveChatResponse(result);
@@ -741,24 +753,31 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     }
 
     const { inboxFrame: _ignored, ...payload } = entry.payload;
-    const result = await this.systemGateway.run({
-      taskInstructions: entry.instructions,
-      payload,
-      context: [],
-      budget: DEFAULT_TOP_LEVEL_BUDGET,
-      spawnBudgetCeiling: 12,
-      correlation: {
-        runId: entry.runId as never,
-        parentId: this.systemGateway.agentId,
-        sequence: 0,
-      },
-      execution: {
-        projectId: entry.projectId as never,
-        traceId: traceId as never,
-        workmodeId: 'system:implementation',
-      },
-      modelRequirements: this.deps.defaultModelRequirements,
-    });
+    this.turnInProgressByClass.set('Cortex::System', true);
+    let result;
+    try {
+      result = await this.systemGateway.run({
+        taskInstructions: entry.instructions,
+        payload,
+        context: [],
+        budget: DEFAULT_TOP_LEVEL_BUDGET,
+        spawnBudgetCeiling: 12,
+        correlation: {
+          runId: entry.runId as never,
+          parentId: this.systemGateway.agentId,
+          sequence: 0,
+        },
+        execution: {
+          projectId: entry.projectId as never,
+          traceId: traceId as never,
+          workmodeId: 'system:implementation',
+        },
+        modelRequirements: this.deps.defaultModelRequirements,
+      });
+    } finally {
+      this.turnInProgressByClass.set('Cortex::System', false);
+      this.checkPendingRecompose('Cortex::System');
+    }
 
     if (result.status === 'escalated') {
       await this.principalGateway.getInboxHandle().injectContext(
@@ -1220,6 +1239,47 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     // Orchestrator and Worker are intentionally NOT recomposed here — their
     // gateways do not exist at boot time and the Option α chain handles them
     // at dispatch time via `createChildGateway -> createGatewayConfig`.
+  }
+
+  // ── Runtime harness recomposition (WR-148 phase 1.1 / RC-1) ─────────
+
+  recomposeHarnessForClass(
+    agentClass: 'Cortex::Principal' | 'Cortex::System',
+    vendorString: ProviderVendor,
+  ): void {
+    if (this.turnInProgressByClass.get(agentClass)) {
+      console.info(
+        `[nous:cortex-runtime] Deferred harness recompose for ${agentClass} — turn in progress`,
+      );
+      this.pendingRecompose.set(agentClass, vendorString);
+      return;
+    }
+    this.applyRecompose(agentClass, vendorString);
+  }
+
+  private applyRecompose(
+    agentClass: 'Cortex::Principal' | 'Cortex::System',
+    vendorString: ProviderVendor,
+  ): void {
+    const config = agentClass === 'Cortex::Principal'
+      ? this.principalGatewayConfig
+      : this.systemGatewayConfig;
+    config.harness = this.composeHarnessStrategies(agentClass, vendorString);
+    console.info(
+      `[nous:cortex-runtime] Recomposed harness for ${agentClass} with vendor ${vendorString}`,
+    );
+  }
+
+  /** Check and apply any deferred recomposition after a turn completes. */
+  private checkPendingRecompose(agentClass: 'Cortex::Principal' | 'Cortex::System'): void {
+    const pending = this.pendingRecompose.get(agentClass);
+    if (pending !== undefined) {
+      this.pendingRecompose.delete(agentClass);
+      console.info(
+        `[nous:cortex-runtime] Applied deferred harness recompose for ${agentClass} with vendor ${pending}`,
+      );
+      this.applyRecompose(agentClass, pending);
+    }
   }
 
   /**

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -1100,6 +1100,19 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
   }): void {
     // no-op: legacy class, not wired into production
   }
+
+  /**
+   * WR-148 stub: runtime harness recomposition. No-op in this legacy runtime
+   * class — exists solely to satisfy the IPrincipalSystemGatewayRuntime
+   * interface contract.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  recomposeHarnessForClass(
+    _agentClass: 'Cortex::Principal' | 'Cortex::System',
+    _vendorString: import('@nous/shared').ProviderVendor,
+  ): void {
+    // no-op: legacy class, not wired into production
+  }
 }
 
 export function createPrincipalSystemGatewayRuntime(

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -319,6 +319,16 @@ export interface IPrincipalSystemGatewayRuntime {
   attachProviders(args: {
     providerVendorByClass: Partial<Record<AgentClass, ProviderVendor>>;
   }): void;
+  /**
+   * Runtime harness recomposition — swaps the response parser and prompt
+   * formatter for the given agent class to match a new provider vendor.
+   * If a gateway turn is in progress for the targeted class, the
+   * recomposition is deferred until the turn completes.
+   */
+  recomposeHarnessForClass(
+    agentClass: 'Cortex::Principal' | 'Cortex::System',
+    vendorString: ProviderVendor,
+  ): void;
   whenIdle(): Promise<void>;
 }
 

--- a/self/cortex/core/src/internal-mcp/__tests__/workflow-authoring-reference.test.ts
+++ b/self/cortex/core/src/internal-mcp/__tests__/workflow-authoring-reference.test.ts
@@ -25,7 +25,7 @@ describe('workflow_authoring_reference MCP tool', () => {
 
     it('catalog entry has no input parameters', () => {
       const entry = INTERNAL_MCP_CATALOG.find((e) => e.name === 'workflow_authoring_reference');
-      expect(entry?.definition.inputSchema).toEqual({});
+      expect(entry?.definition.inputSchema).toEqual({ type: 'object', properties: {} });
     });
   });
 

--- a/self/cortex/core/src/internal-mcp/catalog.ts
+++ b/self/cortex/core/src/internal-mcp/catalog.ts
@@ -40,7 +40,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'memory_search',
       'Search or retrieve scoped project memory.',
-      { mode: 'read | retrieve' },
+      {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', description: 'read | retrieve' },
+        },
+        required: ['mode'],
+      },
       { entries: 'memory results' },
       ['read'],
       'project',
@@ -53,7 +59,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'memory_write',
       'Submit a governed memory write candidate.',
-      { candidate: 'MemoryWriteCandidate' },
+      {
+        type: 'object',
+        properties: {
+          candidate: { type: 'object', description: 'MemoryWriteCandidate' },
+        },
+        required: ['candidate'],
+      },
       { memoryEntryId: 'string | null' },
       ['write'],
       'project',
@@ -66,7 +78,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'external_memory_put',
       'Execute a public external-memory append or supersede write.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { entry: 'ExternalSourceMutationResult' },
       ['write'],
       'runtime',
@@ -79,7 +97,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'external_memory_get',
       'Read one public external-memory entry.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { entry: 'ExternalSourceMemoryEntry | null' },
       ['read'],
       'runtime',
@@ -92,7 +116,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'external_memory_search',
       'Search public external-memory entries.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { entries: 'ExternalSourceSearchResult' },
       ['read'],
       'runtime',
@@ -105,7 +135,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'external_memory_delete',
       'Soft-delete one public external-memory entry.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { entry: 'ExternalSourceMutationResult' },
       ['write'],
       'runtime',
@@ -118,7 +154,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'external_memory_compact',
       'Compact source-local public external memory.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { result: 'ExternalSourceCompactionResult' },
       ['write'],
       'runtime',
@@ -131,7 +173,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'public_agent_list',
       'List externally visible public agents.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { agents: 'PublicMcpAgentCatalogEntry[]' },
       ['read'],
       'runtime',
@@ -144,7 +192,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'public_agent_invoke',
       'Invoke a public agent through the canonical AgentGateway seam.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { result: 'PublicMcpAgentInvokeResult' },
       ['execute'],
       'runtime',
@@ -157,7 +211,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'public_system_info',
       'Project public-safe system and task-support metadata.',
-      { request: 'PublicMcpExecutionRequest' },
+      {
+        type: 'object',
+        properties: {
+          request: { type: 'object', description: 'PublicMcpExecutionRequest' },
+        },
+        required: ['request'],
+      },
       { info: 'PublicMcpSystemInfo' },
       ['read'],
       'runtime',
@@ -170,7 +230,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'promoted_memory_promote',
       'Promote one external source record into the internal promoted tier.',
-      { command: 'PromoteExternalRecordCommand' },
+      {
+        type: 'object',
+        properties: {
+          command: { type: 'object', description: 'PromoteExternalRecordCommand' },
+        },
+        required: ['command'],
+      },
       { record: 'PromotedMemoryRecord' },
       ['write'],
       'runtime',
@@ -183,7 +249,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'promoted_memory_demote',
       'Soft-delete one promoted-tier record while preserving audit lineage.',
-      { command: 'DemotePromotedRecordCommand' },
+      {
+        type: 'object',
+        properties: {
+          command: { type: 'object', description: 'DemotePromotedRecordCommand' },
+        },
+        required: ['command'],
+      },
       { record: 'PromotedMemoryRecord' },
       ['write'],
       'runtime',
@@ -196,7 +268,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'promoted_memory_get',
       'Read one promoted-tier record by promoted ID.',
-      { query: 'PromotedMemoryGetQuery' },
+      {
+        type: 'object',
+        properties: {
+          query: { type: 'object', description: 'PromotedMemoryGetQuery' },
+        },
+        required: ['query'],
+      },
       { record: 'PromotedMemoryRecord | null' },
       ['read'],
       'runtime',
@@ -209,7 +287,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'promoted_memory_search',
       'Search promoted-tier records without querying external source tables.',
-      { query: 'PromotedMemorySearchQuery' },
+      {
+        type: 'object',
+        properties: {
+          query: { type: 'object', description: 'PromotedMemorySearchQuery' },
+        },
+        required: ['query'],
+      },
       { entries: 'PromotedMemorySearchResult' },
       ['read'],
       'runtime',
@@ -222,7 +306,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'project_discover',
       'Read current project configuration and state.',
-      { includeConfig: 'boolean', includeState: 'boolean' },
+      {
+        type: 'object',
+        properties: {
+          includeConfig: { type: 'boolean' },
+          includeState: { type: 'boolean' },
+        },
+        required: ['includeConfig', 'includeState'],
+      },
       { config: 'ProjectConfig?', state: 'ProjectState?' },
       ['read'],
       'project',
@@ -235,7 +326,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'artifact_store',
       'Persist a versioned project artifact.',
-      { artifact: 'ArtifactWriteRequest without projectId' },
+      {
+        type: 'object',
+        properties: {
+          artifact: { type: 'object', description: 'ArtifactWriteRequest without projectId' },
+        },
+        required: ['artifact'],
+      },
       { artifactRef: 'string', version: 'number' },
       ['write'],
       'project',
@@ -248,7 +345,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'artifact_retrieve',
       'Retrieve a versioned project artifact.',
-      { artifact: 'ArtifactReadRequest without projectId' },
+      {
+        type: 'object',
+        properties: {
+          artifact: { type: 'object', description: 'ArtifactReadRequest without projectId' },
+        },
+        required: ['artifact'],
+      },
       { artifact: 'ArtifactReadResult | null' },
       ['read'],
       'project',
@@ -261,7 +364,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'tool_execute',
       'Execute an external project tool.',
-      { name: 'string', params: 'unknown' },
+      {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          params: { type: 'object', description: 'unknown' },
+        },
+        required: ['name', 'params'],
+      },
       { toolResult: 'ToolResult' },
       ['execute'],
       'project',
@@ -274,7 +384,12 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'tool_list',
       'List external project tools.',
-      { capabilities: 'string[]?' },
+      {
+        type: 'object',
+        properties: {
+          capabilities: { type: 'array', description: 'string[]', items: { type: 'string' } },
+        },
+      },
       { tools: 'ToolDefinition[]' },
       ['read'],
       'project',
@@ -287,7 +402,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'witness_checkpoint',
       'Create a witness ledger checkpoint.',
-      { reason: 'interval | manual | rotation' },
+      {
+        type: 'object',
+        properties: {
+          reason: { type: 'string', description: 'interval | manual | rotation' },
+        },
+        required: ['reason'],
+      },
       { checkpointId: 'string' },
       ['write'],
       'runtime',
@@ -300,7 +421,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'escalation_notify',
       'Create a canonical in-app escalation.',
-      { escalation: 'EscalationContract without projectId' },
+      {
+        type: 'object',
+        properties: {
+          escalation: { type: 'object', description: 'EscalationContract without projectId' },
+        },
+        required: ['escalation'],
+      },
       { escalationId: 'string' },
       ['write'],
       'project',
@@ -313,7 +440,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'scheduler_register',
       'Register a project schedule.',
-      { schedule: 'ScheduleDefinition without projectId' },
+      {
+        type: 'object',
+        properties: {
+          schedule: { type: 'object', description: 'ScheduleDefinition without projectId' },
+        },
+        required: ['schedule'],
+      },
       { scheduleId: 'string' },
       ['write'],
       'project',
@@ -327,11 +460,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       'workflow_list',
       'List installed workflow definitions and known workflow runs.',
       {
-        projectId: 'ProjectId?',
-        status: 'WorkflowRunStatus[]?',
-        definition: 'string?',
-        includeInstalledDefinitions: 'boolean?',
-        includeActiveInstances: 'boolean?',
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          status: { type: 'array', description: 'WorkflowRunStatus[]', items: { type: 'string' } },
+          definition: { type: 'string' },
+          includeInstalledDefinitions: { type: 'boolean' },
+          includeActiveInstances: { type: 'boolean' },
+        },
       },
       { definitions: 'WorkflowLifecycleDefinitionSummary[]', instances: 'WorkflowLifecycleInstanceSummary[]' },
       ['read'],
@@ -345,7 +481,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_inspect',
       'Inspect one installed workflow package manifest, flow, steps, and dependencies.',
-      { packageId: 'string' },
+      {
+        type: 'object',
+        properties: {
+          packageId: { type: 'string' },
+        },
+        required: ['packageId'],
+      },
       { workflow: 'WorkflowLifecycleInspectResult' },
       ['read'],
       'runtime',
@@ -359,11 +501,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       'workflow_start',
       'Resolve, preflight, and start one workflow run in a project context.',
       {
-        definition: 'string',
-        projectId: 'ProjectId',
-        entrypoint: 'string?',
-        config: 'Record<string, unknown>?',
-        triggerContext: 'WorkflowRunTriggerContext?',
+        type: 'object',
+        properties: {
+          definition: { type: 'string' },
+          projectId: { type: 'string', description: 'ProjectId' },
+          entrypoint: { type: 'string' },
+          config: { type: 'object', description: 'Record<string, unknown>' },
+          triggerContext: { type: 'object', description: 'WorkflowRunTriggerContext' },
+        },
+        required: ['definition', 'projectId'],
       },
       { result: 'WorkflowLifecycleMutationResult' },
       ['control'],
@@ -377,7 +523,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_status',
       'Inspect the canonical status projection for one workflow run.',
-      { runId: 'WorkflowExecutionId' },
+      {
+        type: 'object',
+        properties: {
+          runId: { type: 'string', description: 'WorkflowExecutionId' },
+        },
+        required: ['runId'],
+      },
       { status: 'WorkflowLifecycleStatusResult' },
       ['read'],
       'runtime',
@@ -390,7 +542,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_pause',
       'Pause a workflow run while preserving canonical run-state truth.',
-      { runId: 'WorkflowExecutionId', reasonCode: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          runId: { type: 'string', description: 'WorkflowExecutionId' },
+          reasonCode: { type: 'string' },
+        },
+        required: ['runId'],
+      },
       { result: 'WorkflowLifecycleMutationResult' },
       ['control'],
       'runtime',
@@ -403,7 +562,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_resume',
       'Resume a paused workflow run after canonical dependency preflight.',
-      { runId: 'WorkflowExecutionId', reasonCode: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          runId: { type: 'string', description: 'WorkflowExecutionId' },
+          reasonCode: { type: 'string' },
+        },
+        required: ['runId'],
+      },
       { result: 'WorkflowLifecycleMutationResult' },
       ['control'],
       'runtime',
@@ -416,7 +582,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_cancel',
       'Cancel an in-flight workflow run without rewriting history.',
-      { runId: 'WorkflowExecutionId', reasonCode: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          runId: { type: 'string', description: 'WorkflowExecutionId' },
+          reasonCode: { type: 'string' },
+        },
+        required: ['runId'],
+      },
       { result: 'WorkflowLifecycleMutationResult' },
       ['control'],
       'runtime',
@@ -429,7 +602,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_validate',
       'Validate a YAML workflow spec without executing it.',
-      { yamlSpec: 'string' },
+      {
+        type: 'object',
+        properties: {
+          yamlSpec: { type: 'string' },
+        },
+        required: ['yamlSpec'],
+      },
       { valid: 'boolean', errors: 'WorkflowSpecValidationError[]?' },
       ['read'],
       'runtime',
@@ -443,9 +622,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       'workflow_execute_node',
       'Execute an engine-internal ready node (condition, transform, quality-gate) in a running workflow.',
       {
-        runId: 'WorkflowExecutionId',
-        nodeDefinitionId: 'WorkflowNodeDefinitionId',
-        payload: 'unknown?',
+        type: 'object',
+        properties: {
+          runId: { type: 'string', description: 'WorkflowExecutionId' },
+          nodeDefinitionId: { type: 'string', description: 'WorkflowNodeDefinitionId' },
+          payload: { type: 'object', description: 'unknown' },
+        },
+        required: ['runId', 'nodeDefinitionId'],
       },
       { result: 'WorkflowLifecycleMutationResult' },
       ['control'],
@@ -460,12 +643,16 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       'workflow_complete_node',
       'Record external node completion (from Worker/Orchestrator dispatch) and advance workflow state.',
       {
-        runId: 'WorkflowExecutionId',
-        nodeDefinitionId: 'WorkflowNodeDefinitionId',
-        output: 'unknown?',
-        status: "'completed' | 'failed' (default 'completed')",
-        reasonCode: 'string?',
-        evidenceRefs: 'string[]?',
+        type: 'object',
+        properties: {
+          runId: { type: 'string', description: 'WorkflowExecutionId' },
+          nodeDefinitionId: { type: 'string', description: 'WorkflowNodeDefinitionId' },
+          output: { type: 'object', description: 'unknown' },
+          status: { type: 'string', description: "'completed' | 'failed' (default 'completed')" },
+          reasonCode: { type: 'string' },
+          evidenceRefs: { type: 'array', description: 'string[]', items: { type: 'string' } },
+        },
+        required: ['runId', 'nodeDefinitionId'],
       },
       { result: 'WorkflowLifecycleMutationResult' },
       ['control'],
@@ -479,7 +666,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_from_spec',
       'Create a persisted workflow definition from a YAML spec without starting it.',
-      { yamlSpec: 'string', projectId: 'ProjectId' },
+      {
+        type: 'object',
+        properties: {
+          yamlSpec: { type: 'string' },
+          projectId: { type: 'string', description: 'ProjectId' },
+        },
+        required: ['yamlSpec', 'projectId'],
+      },
       { workflowDefinitionId: 'string', definitionName: 'string' },
       ['control'],
       'runtime',
@@ -492,7 +686,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_create',
       'Create a new persisted workflow definition from a YAML spec. Returns the generated definition ID.',
-      { specYaml: 'string', projectId: 'ProjectId', name: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          specYaml: { type: 'string' },
+          projectId: { type: 'string', description: 'ProjectId' },
+          name: { type: 'string' },
+        },
+        required: ['specYaml', 'projectId'],
+      },
       { definitionId: 'string', definitionName: 'string' },
       ['control'],
       'runtime',
@@ -505,7 +707,16 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_update',
       'Update an existing persisted workflow definition from a YAML spec. Requires the definitionId to upsert.',
-      { specYaml: 'string', projectId: 'ProjectId', definitionId: 'string', name: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          specYaml: { type: 'string' },
+          projectId: { type: 'string', description: 'ProjectId' },
+          definitionId: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['specYaml', 'projectId', 'definitionId'],
+      },
       { definitionId: 'string', definitionName: 'string' },
       ['control'],
       'runtime',
@@ -518,7 +729,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_delete',
       'Delete a persisted workflow definition by ID. Clears default if the deleted definition was the default.',
-      { projectId: 'ProjectId', definitionId: 'string' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          definitionId: { type: 'string' },
+        },
+        required: ['projectId', 'definitionId'],
+      },
       { deleted: 'boolean' },
       ['control'],
       'runtime',
@@ -531,7 +749,7 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_authoring_reference',
       'Return the complete workflow authoring reference including node catalog, YAML structure, connection syntax, validation rules, example workflow, and dispatch classification. Call before authoring WorkflowSpec YAML.',
-      {},
+      { type: 'object', properties: {} },
       { reference: 'string' },
       ['read'],
       'runtime',
@@ -544,7 +762,16 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'health_report',
       'Publish a canonical app-runtime health snapshot.',
-      { session_id: 'string', status: 'healthy | degraded | unhealthy | stale', reported_at: 'ISO datetime', details: 'object?' },
+      {
+        type: 'object',
+        properties: {
+          session_id: { type: 'string' },
+          status: { type: 'string', description: 'healthy | degraded | unhealthy | stale' },
+          reported_at: { type: 'string', description: 'ISO datetime' },
+          details: { type: 'object' },
+        },
+        required: ['session_id', 'status', 'reported_at'],
+      },
       { accepted: 'boolean', health: 'AppHealthSnapshot' },
       ['write'],
       'runtime',
@@ -557,7 +784,16 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'health_heartbeat',
       'Publish an app-runtime heartbeat signal.',
-      { session_id: 'string', reported_at: 'ISO datetime', sequence: 'number', status_hint: 'healthy | degraded | unhealthy | stale?' },
+      {
+        type: 'object',
+        properties: {
+          session_id: { type: 'string' },
+          reported_at: { type: 'string', description: 'ISO datetime' },
+          sequence: { type: 'number' },
+          status_hint: { type: 'string', description: 'healthy | degraded | unhealthy | stale' },
+        },
+        required: ['session_id', 'reported_at', 'sequence'],
+      },
       { accepted: 'boolean', heartbeat: 'AppHeartbeatSignal' },
       ['write'],
       'runtime',
@@ -571,13 +807,17 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       'credentials_store',
       'Store one app-scoped credential without exposing it back to the app.',
       {
-        key: 'string',
-        value: 'string',
-        credential_type: 'api_key | bearer_token | basic_auth | oauth2 | custom',
-        target_host: 'string',
-        injection_location: 'header | query | body',
-        injection_key: 'string',
-        expires_at: 'ISO datetime?',
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          value: { type: 'string' },
+          credential_type: { type: 'string', description: 'api_key | bearer_token | basic_auth | oauth2 | custom' },
+          target_host: { type: 'string' },
+          injection_location: { type: 'string', description: 'header | query | body' },
+          injection_key: { type: 'string' },
+          expires_at: { type: 'string', description: 'ISO datetime' },
+        },
+        required: ['key', 'value', 'credential_type', 'target_host', 'injection_location', 'injection_key'],
       },
       { credential_ref: 'string', metadata: 'CredentialMetadata' },
       ['write'],
@@ -592,8 +832,12 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       'credentials_inject',
       'Execute one outbound request with a credential injected by infrastructure.',
       {
-        key: 'string',
-        request_descriptor: 'AppCredentialRequestDescriptor',
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          request_descriptor: { type: 'object', description: 'AppCredentialRequestDescriptor' },
+        },
+        required: ['key', 'request_descriptor'],
       },
       { status: 'number', headers: 'Record<string, string>', body: 'unknown' },
       ['execute'],
@@ -607,7 +851,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'credentials_revoke',
       'Revoke one app-scoped credential and remove it from the vault.',
-      { key: 'string', reason: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          reason: { type: 'string' },
+        },
+        required: ['key'],
+      },
       { revoked: 'boolean', credential_ref: 'string?' },
       ['write'],
       'runtime',
@@ -620,7 +871,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_list',
       'List task definitions for a project.',
-      { projectId: 'ProjectId' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+        },
+        required: ['projectId'],
+      },
       { tasks: 'TaskDefinition[]' },
       ['read'],
       'project',
@@ -633,7 +890,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_get',
       'Get a task definition by ID.',
-      { projectId: 'ProjectId', taskId: 'string (UUID)' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          taskId: { type: 'string', description: 'UUID' },
+        },
+        required: ['projectId', 'taskId'],
+      },
       { task: 'TaskDefinition' },
       ['read'],
       'project',
@@ -646,7 +910,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_create',
       'Create a new task definition.',
-      { projectId: 'ProjectId', task: 'TaskCreateInput' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          task: { type: 'object', description: 'TaskCreateInput' },
+        },
+        required: ['projectId', 'task'],
+      },
       { task: 'TaskDefinition' },
       ['write'],
       'project',
@@ -659,7 +930,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_update',
       'Update an existing task definition.',
-      { projectId: 'ProjectId', taskId: 'string (UUID)', updates: 'TaskUpdateInput' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          taskId: { type: 'string', description: 'UUID' },
+          updates: { type: 'object', description: 'TaskUpdateInput' },
+        },
+        required: ['projectId', 'taskId', 'updates'],
+      },
       { task: 'TaskDefinition' },
       ['write'],
       'project',
@@ -672,7 +951,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_delete',
       'Delete a task definition by ID.',
-      { projectId: 'ProjectId', taskId: 'string (UUID)' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          taskId: { type: 'string', description: 'UUID' },
+        },
+        required: ['projectId', 'taskId'],
+      },
       { deleted: 'boolean' },
       ['write'],
       'project',
@@ -685,7 +971,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_toggle',
       'Toggle the enabled state of a task definition.',
-      { projectId: 'ProjectId', taskId: 'string (UUID)' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          taskId: { type: 'string', description: 'UUID' },
+        },
+        required: ['projectId', 'taskId'],
+      },
       { task: 'TaskDefinition' },
       ['write'],
       'project',
@@ -698,7 +991,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_trigger',
       'Manually trigger execution of an enabled task definition.',
-      { projectId: 'ProjectId', taskId: 'string (UUID)' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          taskId: { type: 'string', description: 'UUID' },
+        },
+        required: ['projectId', 'taskId'],
+      },
       { executionId: 'string', runId: 'string' },
       ['execute'],
       'project',
@@ -711,7 +1011,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'task_history',
       'List execution history for a task definition.',
-      { projectId: 'ProjectId', taskId: 'string (UUID)', limit: 'number?' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          taskId: { type: 'string', description: 'UUID' },
+          limit: { type: 'number' },
+        },
+        required: ['projectId', 'taskId'],
+      },
       { executions: 'TaskExecutionRecord[]' },
       ['read'],
       'project',
@@ -724,7 +1032,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       'workflow_history',
       'List workflow execution history for a project. (V1 stub — returns empty array)',
-      { projectId: 'ProjectId', limit: 'number?' },
+      {
+        type: 'object',
+        properties: {
+          projectId: { type: 'string', description: 'ProjectId' },
+          limit: { type: 'number' },
+        },
+        required: ['projectId'],
+      },
       { executions: '[]' },
       ['read'],
       'project',
@@ -738,9 +1053,13 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       DISPATCH_ORCHESTRATOR_TOOL_NAME,
       'Dispatch an Orchestrator-class agent with a structured intent.',
       {
-        dispatch_intent: '{ type: "workflow" | "task" | "skill" | "autonomous", ... }',
-        task_instructions: 'string',
-        budget: 'GatewayBudgetOverride?',
+        type: 'object',
+        properties: {
+          dispatch_intent: { type: 'object', description: '{ type: "workflow" | "task" | "skill" | "autonomous", ... }' },
+          task_instructions: { type: 'string' },
+          budget: { type: 'object', description: 'GatewayBudgetOverride' },
+        },
+        required: ['dispatch_intent', 'task_instructions'],
       },
       { child_result: 'AgentResult' },
       ['control'],
@@ -755,10 +1074,14 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       DISPATCH_WORKER_TOOL_NAME,
       'Dispatch a Worker-class agent for task execution.',
       {
-        task_instructions: 'string',
-        node_id: 'string?',
-        payload: 'unknown?',
-        budget: 'GatewayBudgetOverride?',
+        type: 'object',
+        properties: {
+          task_instructions: { type: 'string' },
+          node_id: { type: 'string' },
+          payload: { type: 'object', description: 'unknown' },
+          budget: { type: 'object', description: 'GatewayBudgetOverride' },
+        },
+        required: ['task_instructions'],
       },
       { child_result: 'AgentResult' },
       ['control'],
@@ -772,7 +1095,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       TASK_COMPLETE_TOOL_NAME,
       'Complete the current task with a gateway-stamped packet.',
-      { output: 'unknown', artifact_refs: 'string[]?', summary: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          output: { type: 'object', description: 'unknown' },
+          artifact_refs: { type: 'array', description: 'string[]', items: { type: 'string' } },
+          summary: { type: 'string' },
+        },
+        required: ['output'],
+      },
       { result: 'AgentCompletedResult' },
       ['control'],
       'runtime',
@@ -785,7 +1116,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       REQUEST_ESCALATION_TOOL_NAME,
       'Block and request escalation.',
-      { reason: 'string', severity: 'priority', context_snapshot: 'string?' },
+      {
+        type: 'object',
+        properties: {
+          reason: { type: 'string' },
+          severity: { type: 'string', description: 'priority' },
+          context_snapshot: { type: 'string' },
+        },
+        required: ['reason', 'severity'],
+      },
       { result: 'AgentEscalatedResult' },
       ['control'],
       'runtime',
@@ -798,7 +1137,15 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
     definition: defineTool(
       FLAG_OBSERVATION_TOOL_NAME,
       'Emit a non-blocking observation.',
-      { observation_type: 'string', content: 'string', detail: 'object?' },
+      {
+        type: 'object',
+        properties: {
+          observation_type: { type: 'string' },
+          content: { type: 'string' },
+          detail: { type: 'object' },
+        },
+        required: ['observation_type', 'content'],
+      },
       { observation: 'accepted' },
       ['control'],
       'runtime',


### PR DESCRIPTION
## Summary

- Normalize all 56 catalog `inputSchema` entries to valid JSON Schema (`type: "object"`, `properties`, `required`)
- Add defensive `type: "object"` injection in `formatTools` (Anthropic adapter) with info-level logging
- Implement `recomposeHarnessForClass` on `CortexRuntime` with turn-safety guard (`turnInProgressByClass` + `pendingRecompose` deferral)
- Wire preference-change handler to trigger harness recomposition on role assignment update

## Test plan

- [x] 168 catalog schema validity assertions (all 56 tools)
- [x] 5 formatTools defensive injection tests
- [x] 8 recomposeHarnessForClass tests (swap, guard, defer, last-write-wins)
- [x] 9 workflow-authoring-reference tests (updated for new schema format)
- [x] Full cortex-core suite: 831 tests passing

## Review

Completion Report reviewed and approved (Cycle 2). See `.worklog/sprints/fix/wr-148-behavioral-testing/phase-1/1.1/reviews/completion-report.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)