### PR TITLE
fix(bootstrap): recompose harness after provider registration

### DIFF
--- a/self/apps/desktop/server/main.ts
+++ b/self/apps/desktop/server/main.ts
@@ -19,6 +19,7 @@ import {
   loadStoredApiKeys,
   pullOllamaModel,
   registerStoredProviders,
+  WELL_KNOWN_PROVIDER_IDS,
 } from '@nous/shared-server';
 import type { OllamaModelPullProgress, OllamaStatus } from '@nous/shared-server';
 import { createHTTPHandler } from '@trpc/server/adapters/standalone';
@@ -213,6 +214,21 @@ async function main() {
   });
   await loadStoredApiKeys(context);
   await registerStoredProviders(context);
+
+  // Recompose harness after providers are registered. createNousServices runs
+  // attachProviders before providers exist (they're registered by
+  // registerStoredProviders above), so the harness is composed with the 'text'
+  // fallback adapter. Now that providers are registered, recompose with the
+  // correct vendor so the response parser matches the actual provider.
+  for (const agentClass of ['Cortex::Principal', 'Cortex::System'] as const) {
+    const provider = context.providerRegistry.getProvider(
+      WELL_KNOWN_PROVIDER_IDS.anthropic,
+    );
+    const vendor = provider?.getConfig().vendor;
+    if (vendor) {
+      context.gatewayRuntime.recomposeHarnessForClass(agentClass, vendor);
+    }
+  }
 
   const trpcHandler = createHTTPHandler({
     router: appRouter,

--- a/self/apps/web/server/bootstrap.ts
+++ b/self/apps/web/server/bootstrap.ts
@@ -8,6 +8,7 @@ import {
   createNousServices,
   loadStoredApiKeys,
   registerStoredProviders,
+  WELL_KNOWN_PROVIDER_IDS,
 } from '@nous/shared-server';
 import type { NousContext } from '@nous/shared-server';
 
@@ -42,6 +43,19 @@ export async function initializeNousContext(): Promise<NousContext> {
   initPromise = (async () => {
     await loadStoredApiKeys(ctx);
     await registerStoredProviders(ctx);
+
+    // Recompose harness after providers are registered. createNousServices runs
+    // attachProviders before providers exist, so the harness defaults to 'text'.
+    for (const agentClass of ['Cortex::Principal', 'Cortex::System'] as const) {
+      const provider = ctx.providerRegistry.getProvider(
+        WELL_KNOWN_PROVIDER_IDS.anthropic,
+      );
+      const vendor = provider?.getConfig().vendor;
+      if (vendor) {
+        ctx.gatewayRuntime.recomposeHarnessForClass(agentClass, vendor);
+      }
+    }
+
     return ctx;
   })();
 

--- a/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
@@ -331,8 +331,13 @@ export function createAnthropicAdapter(): ProviderAdapter {
     parseResponse(output: unknown, _traceId: TraceId): ParsedModelOutput {
       try {
         return parseAnthropicResponse(output);
-      } catch {
+      } catch (error) {
         // Fallback: never throw from parseResponse
+        console.error('[nous:anthropic-adapter] parseResponse error — falling back to String(output)', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          outputType: typeof output,
+          outputKeys: output && typeof output === 'object' ? Object.keys(output) : [],
+        });
         return {
           response: String(output ?? ''),
           toolCalls: [],


### PR DESCRIPTION
## Summary

- **Bootstrap ordering fix:** `createNousServices()` calls `attachProviders()` before providers are registered, so the harness defaults to the `'text'` adapter. After `registerStoredProviders()` completes, recompose the harness for both Principal and System agent classes with the actual provider vendor. Fixes `[object Object]` rendering on first tool_use response after fresh boot.
- **Error logging:** Anthropic adapter's `parseResponse` catch block now logs the actual error instead of silently swallowing it.
- Applied to both `desktop/server/main.ts` and `web/server/bootstrap.ts`.

## Test plan

- [x] Boot logs show `Recomposed harness for Cortex::Principal with vendor anthropic` without manual provider switch
- [x] Tool_use response parses correctly on first attempt (parsedToolCalls: 1, no `[object Object]`)
- [x] Tool_result pairing works (tool_use id matches tool_result id)
- [x] `pnpm typecheck` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)