### PR TITLE
feat(WR-157): structured logging facade with togglable egress

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@nous/autonomic-health':
         specifier: workspace:*
         version: link:../../autonomic/health
+      '@nous/autonomic-logger':
+        specifier: workspace:*
+        version: link:../../autonomic/logger
       '@nous/autonomic-runtime':
         specifier: workspace:*
         version: link:../../autonomic/runtime
@@ -612,6 +615,12 @@ importers:
         version: link:../../shared
 
   self/autonomic/health:
+    dependencies:
+      '@nous/shared':
+        specifier: workspace:*
+        version: link:../../shared
+
+  self/autonomic/logger:
     dependencies:
       '@nous/shared':
         specifier: workspace:*
@@ -10973,8 +10982,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -10996,7 +11005,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11007,22 +11016,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11033,7 +11042,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/scripts/install/src/config-generator.ts
+++ b/scripts/install/src/config-generator.ts
@@ -57,6 +57,10 @@ export function generateDefaultConfig(
     security: {
       traceSensitiveData: false,
     },
+    logging: {
+      level: 0,
+      channels: {},
+    },
   };
 
   return SystemConfigSchema.parse(config);

--- a/self/apps/shared-server/package.json
+++ b/self/apps/shared-server/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@nous/autonomic-health": "workspace:*",
+    "@nous/autonomic-logger": "workspace:*",
     "@nous/autonomic-credentials": "workspace:*",
     "@nous/autonomic-config": "workspace:*",
     "@nous/autonomic-embeddings": "workspace:*",

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -671,6 +671,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
   const embedder = new InMemoryEmbedder();
   const stmStore = new DocumentStmStore(documentStore, {
     compactionPolicy: resolveStmCompactionPolicy(resolvedConfig),
+    log: logger.channel('nous:stm'),
   });
   const projectStore = new DocumentProjectStore(documentStore);
   const taskStore = new DocumentTaskStore(documentStore);
@@ -708,7 +709,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     new DiscoverProjectsTool(knowledgeIndex),
     new RefreshProjectKnowledgeTool(knowledgeIndex),
   ]);
-  const Cortex = new PfcEngine(appConfig, toolExecutor);
+  const Cortex = new PfcEngine(appConfig, toolExecutor, undefined, undefined, logger.channel('nous:pfc'));
   const mwcPipeline = new MwcPipeline(
     documentStore,
     stmStore,
@@ -1136,7 +1137,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     documentStore,
     vectorStore,
     build: ({ binding, documentStore: tenantDocumentStore, vectorStore: tenantVectorStore }) => {
-      const tenantPfc = new PfcEngine(appConfig, toolExecutor);
+      const tenantPfc = new PfcEngine(appConfig, toolExecutor, undefined, undefined, logger.channel('nous:pfc'));
       const tenantWorkflowEngine = new DeterministicWorkflowEngine({
         pfcEngine: tenantPfc,
         modelRouter: router,
@@ -1283,6 +1284,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     checkpointManager: checkpointManager as any,
     recoveryLedgerStore,
     recoveryOrchestrator,
+    logger,
   });
 
   // WR-138 row #8 / CPAL § 6: attach providers exactly once after

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -137,6 +137,7 @@ import {
 } from '@nous/subcortex-public-mcp';
 import { MemoryAccessPolicyEngine } from '@nous/memory-access';
 import { HealthAggregator, HealthMonitor } from '@nous/autonomic-health';
+import { NousLogger, ConsoleEgress, AxiomEgress } from '@nous/autonomic-logger';
 import { EventBus } from './event-bus/event-bus.js';
 import { ThoughtEmitterImpl } from './event-bus/thought-emitter.js';
 import { GatewayHealthSourceAdapter } from './adapters/gateway-health-source-adapter.js';
@@ -647,9 +648,21 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
   const resolved = resolveBootstrapConfig(config);
   const { dataDir, instanceRoot, publicBaseUrl, runtimeLabel } = resolved;
 
+  // --- Logger (phase 1: hardcoded defaults, console egress) ---
+  const logger = new NousLogger();
+  logger.addEgress(new ConsoleEgress());
+  if (process.env.AXIOM_TOKEN) {
+    logger.addEgress(
+      new AxiomEgress(process.env.AXIOM_TOKEN, process.env.AXIOM_DATASET),
+    );
+  }
+
   const baseConfig = new ConfigManager({ configPath: resolved.configPath });
   const appConfig = configWithFallback(baseConfig) as typeof baseConfig;
   const resolvedConfig = appConfig.get();
+
+  // --- Logger (phase 2: bind config-driven settings) ---
+  logger.bindConfig(appConfig);
   const dbPath = join(dataDir, 'nous.sqlite');
 
   const documentStore = new SqliteDocumentStore(dbPath);

--- a/self/autonomic/config/src/defaults.ts
+++ b/self/autonomic/config/src/defaults.ts
@@ -168,4 +168,8 @@ export const DEFAULT_SYSTEM_CONFIG: SystemConfig = {
   security: {
     traceSensitiveData: false,
   },
+  logging: {
+    level: 0, // LogLevel.Debug
+    channels: {},
+  },
 };

--- a/self/autonomic/config/src/index.ts
+++ b/self/autonomic/config/src/index.ts
@@ -10,6 +10,7 @@ export {
   SecurityConfigSchema,
   DefaultsConfigSchema,
   ProviderConfigEntrySchema,
+  LoggingConfigSchema,
 } from './schema.js';
 export type {
   SystemConfig,
@@ -20,6 +21,7 @@ export type {
   SecurityConfig,
   DefaultsConfig,
   ProviderConfigEntry,
+  LoggingConfig,
 } from './schema.js';
 
 export {

--- a/self/autonomic/config/src/schema.ts
+++ b/self/autonomic/config/src/schema.ts
@@ -18,6 +18,7 @@ import {
   ProviderVendorSchema,
   StmCompactionPolicySchema,
   DEFAULT_STM_COMPACTION_POLICY,
+  LogLevel,
 } from '@nous/shared';
 
 // --- Cortex Tier Preset ---
@@ -138,6 +139,13 @@ export const DefaultsConfigSchema = z.object({
 });
 export type DefaultsConfig = z.infer<typeof DefaultsConfigSchema>;
 
+// --- Logging Configuration ---
+export const LoggingConfigSchema = z.object({
+  level: z.nativeEnum(LogLevel).optional().default(LogLevel.Debug),
+  channels: z.record(z.string(), z.boolean()).optional().default({}),
+}).optional().default({});
+export type LoggingConfig = z.infer<typeof LoggingConfigSchema>;
+
 // --- Full System Configuration ---
 export const SystemConfigSchema = z.object({
   profile: ProfileSchema,
@@ -150,5 +158,6 @@ export const SystemConfigSchema = z.object({
   security: SecurityConfigSchema.optional().default({
     traceSensitiveData: false,
   }),
+  logging: LoggingConfigSchema,
 });
 export type SystemConfig = z.infer<typeof SystemConfigSchema>;

--- a/self/autonomic/logger/package.json
+++ b/self/autonomic/logger/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nous/autonomic-logger",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Structured logging facade for Nous-OSS",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@nous/shared": "workspace:*"
+  }
+}

--- a/self/autonomic/logger/src/__bench__/logger.bench.ts
+++ b/self/autonomic/logger/src/__bench__/logger.bench.ts
@@ -1,0 +1,43 @@
+/**
+ * Manual benchmark for the logger hot path.
+ *
+ * Run with: npx vitest bench src/__bench__/logger.bench.ts
+ */
+import { bench, describe } from 'vitest';
+import { LogLevel } from '@nous/shared';
+import { NousLogger } from '../logger.js';
+import { NullEgress } from '../egress/null-egress.js';
+
+describe('Logger performance', () => {
+  const logger = new NousLogger();
+  logger.addEgress(new NullEgress());
+
+  const enabledChannel = logger.channel('nous:bench-enabled');
+  const disabledLogger = new NousLogger();
+  disabledLogger.addEgress(new NullEgress());
+  disabledLogger.bindConfig({
+    get: () => ({
+      logging: { level: LogLevel.Debug, channels: { 'nous:bench-disabled': false } },
+    }),
+    getSection: () => undefined as any,
+    update: async () => {},
+    reload: async () => {},
+  });
+  const disabledChannel = disabledLogger.channel('nous:bench-disabled');
+
+  bench('enabled channel — info with data', () => {
+    enabledChannel.info('benchmark message', { iteration: 1 });
+  });
+
+  bench('enabled channel — info without data', () => {
+    enabledChannel.info('benchmark message');
+  });
+
+  bench('disabled channel — info (short-circuit)', () => {
+    disabledChannel.info('should not emit', { iteration: 1 });
+  });
+
+  bench('channel() lookup (cached)', () => {
+    logger.channel('nous:bench-enabled');
+  });
+});

--- a/self/autonomic/logger/src/__tests__/logger.test.ts
+++ b/self/autonomic/logger/src/__tests__/logger.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LogLevel } from '@nous/shared';
+import type { LogEntry, ILogEgress, IConfig } from '@nous/shared';
+import { NousLogger } from '../logger.js';
+import { ConsoleEgress } from '../egress/console-egress.js';
+import { NullEgress } from '../egress/null-egress.js';
+
+// --- Helpers ---
+
+function createSpyEgress(name = 'spy'): ILogEgress & { entries: LogEntry[] } {
+  const entries: LogEntry[] = [];
+  return {
+    name,
+    entries,
+    write(entry: LogEntry) {
+      entries.push(entry);
+    },
+  };
+}
+
+function createFailingEgress(name = 'failing'): ILogEgress & { callCount: number } {
+  let callCount = 0;
+  return {
+    name,
+    get callCount() {
+      return callCount;
+    },
+    write() {
+      callCount++;
+      throw new Error('egress failure');
+    },
+  };
+}
+
+function createMockConfig(overrides?: {
+  level?: LogLevel;
+  channels?: Record<string, boolean>;
+}): IConfig {
+  return {
+    get: () => ({
+      logging: {
+        level: overrides?.level ?? LogLevel.Debug,
+        channels: overrides?.channels ?? {},
+      },
+    }),
+    getSection: () => undefined as any,
+    update: async () => {},
+    reload: async () => {},
+  };
+}
+
+// --- Tests ---
+
+describe('NousLogger', () => {
+  let logger: NousLogger;
+  let spy: ReturnType<typeof createSpyEgress>;
+
+  beforeEach(() => {
+    logger = new NousLogger();
+    spy = createSpyEgress();
+    logger.addEgress(spy);
+  });
+
+  describe('channel()', () => {
+    it('returns cached channel for same namespace', () => {
+      const ch1 = logger.channel('nous:test');
+      const ch2 = logger.channel('nous:test');
+      expect(ch1).toBe(ch2);
+    });
+
+    it('throws on invalid namespace format', () => {
+      expect(() => logger.channel('invalid')).toThrow('Invalid logger namespace');
+      expect(() => logger.channel('NOUS:TEST')).toThrow('Invalid logger namespace');
+      expect(() => logger.channel('nous:')).toThrow('Invalid logger namespace');
+      expect(() => logger.channel('')).toThrow('Invalid logger namespace');
+    });
+
+    it('accepts valid namespace formats', () => {
+      expect(() => logger.channel('nous:config')).not.toThrow();
+      expect(() => logger.channel('nous:gateway:auth')).not.toThrow();
+      expect(() => logger.channel('nous:cortex-pfc')).not.toThrow();
+      expect(() => logger.channel('nous:a1b2')).not.toThrow();
+    });
+  });
+
+  describe('log entry emission', () => {
+    it('emits debug entries', () => {
+      logger.channel('nous:test').debug('hello');
+      expect(spy.entries).toHaveLength(1);
+      expect(spy.entries[0].level).toBe(LogLevel.Debug);
+      expect(spy.entries[0].namespace).toBe('nous:test');
+      expect(spy.entries[0].message).toBe('hello');
+      expect(spy.entries[0].timestamp).toBeGreaterThan(0);
+    });
+
+    it('emits info entries', () => {
+      logger.channel('nous:test').info('info msg');
+      expect(spy.entries[0].level).toBe(LogLevel.Info);
+    });
+
+    it('emits warn entries', () => {
+      logger.channel('nous:test').warn('warn msg');
+      expect(spy.entries[0].level).toBe(LogLevel.Warn);
+    });
+
+    it('emits error entries', () => {
+      logger.channel('nous:test').error('error msg');
+      expect(spy.entries[0].level).toBe(LogLevel.Error);
+    });
+
+    it('includes data when provided', () => {
+      logger.channel('nous:test').info('with data', { key: 'value' });
+      expect(spy.entries[0].data).toEqual({ key: 'value' });
+    });
+
+    it('omits data field when not provided', () => {
+      logger.channel('nous:test').info('no data');
+      expect(spy.entries[0].data).toBeUndefined();
+    });
+  });
+
+  describe('level filtering', () => {
+    it('filters entries below the configured level', () => {
+      logger.setLevel(LogLevel.Warn);
+      const ch = logger.channel('nous:test');
+      ch.debug('skip');
+      ch.info('skip');
+      ch.warn('keep');
+      ch.error('keep');
+      expect(spy.entries).toHaveLength(2);
+      expect(spy.entries[0].level).toBe(LogLevel.Warn);
+      expect(spy.entries[1].level).toBe(LogLevel.Error);
+    });
+
+    it('defaults to Debug level (passes everything)', () => {
+      const ch = logger.channel('nous:test');
+      ch.debug('keep');
+      ch.info('keep');
+      ch.warn('keep');
+      ch.error('keep');
+      expect(spy.entries).toHaveLength(4);
+    });
+  });
+
+  describe('channel enable/disable', () => {
+    it('disabled channel short-circuits (no entry emitted)', () => {
+      logger.bindConfig(
+        createMockConfig({ channels: { 'nous:disabled': false } }),
+      );
+      logger.channel('nous:disabled').info('should not appear');
+      expect(spy.entries).toHaveLength(0);
+    });
+
+    it('explicitly enabled channel emits entries', () => {
+      logger.bindConfig(
+        createMockConfig({ channels: { 'nous:enabled': true } }),
+      );
+      logger.channel('nous:enabled').info('visible');
+      expect(spy.entries).toHaveLength(1);
+    });
+
+    it('channels default to enabled when not in config', () => {
+      logger.bindConfig(createMockConfig({ channels: {} }));
+      logger.channel('nous:unmentioned').info('visible');
+      expect(spy.entries).toHaveLength(1);
+    });
+  });
+
+  describe('longest-prefix-match for channels', () => {
+    it('disabling a prefix disables child channels', () => {
+      logger.bindConfig(
+        createMockConfig({ channels: { 'nous:gateway': false } }),
+      );
+      logger.channel('nous:gateway').info('skip');
+      logger.channel('nous:gateway:auth').info('skip');
+      expect(spy.entries).toHaveLength(0);
+    });
+
+    it('more specific config overrides less specific', () => {
+      logger.bindConfig(
+        createMockConfig({
+          channels: {
+            'nous:gateway': false,
+            'nous:gateway:auth': true,
+          },
+        }),
+      );
+      logger.channel('nous:gateway').info('skip');
+      logger.channel('nous:gateway:auth').info('visible');
+      expect(spy.entries).toHaveLength(1);
+      expect(spy.entries[0].namespace).toBe('nous:gateway:auth');
+    });
+
+    it('recomputes states for already-created channels on bindConfig', () => {
+      const ch = logger.channel('nous:recompute');
+      ch.info('visible before');
+      expect(spy.entries).toHaveLength(1);
+
+      logger.bindConfig(
+        createMockConfig({ channels: { 'nous:recompute': false } }),
+      );
+      ch.info('invisible after');
+      expect(spy.entries).toHaveLength(1); // still 1
+    });
+  });
+
+  describe('bindConfig()', () => {
+    it('applies level from config', () => {
+      logger.bindConfig(createMockConfig({ level: LogLevel.Error }));
+      logger.channel('nous:test').warn('filtered');
+      logger.channel('nous:test').error('kept');
+      expect(spy.entries).toHaveLength(1);
+      expect(spy.entries[0].level).toBe(LogLevel.Error);
+    });
+
+    it('handles missing logging section gracefully', () => {
+      const config: IConfig = {
+        get: () => ({}),
+        getSection: () => undefined as any,
+        update: async () => {},
+        reload: async () => {},
+      };
+      expect(() => logger.bindConfig(config)).not.toThrow();
+    });
+  });
+
+  describe('egress management', () => {
+    it('addEgress delivers entries to the new egress', () => {
+      const spy2 = createSpyEgress('spy2');
+      logger.addEgress(spy2);
+      logger.channel('nous:test').info('to both');
+      expect(spy.entries).toHaveLength(1);
+      expect(spy2.entries).toHaveLength(1);
+    });
+
+    it('removeEgress stops delivery to the removed egress', () => {
+      logger.removeEgress('spy');
+      logger.channel('nous:test').info('to nobody');
+      expect(spy.entries).toHaveLength(0);
+    });
+
+    it('addEgress with duplicate name replaces the existing egress', () => {
+      const spy2 = createSpyEgress('spy');
+      logger.addEgress(spy2);
+      logger.channel('nous:test').info('to replacement');
+      expect(spy.entries).toHaveLength(0);
+      expect(spy2.entries).toHaveLength(1);
+    });
+
+    it('removeEgress with unknown name is a no-op', () => {
+      expect(() => logger.removeEgress('nonexistent')).not.toThrow();
+    });
+  });
+
+  describe('egress failure handling', () => {
+    it('auto-disables egress after 5 consecutive failures', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const failing = createFailingEgress();
+      logger.addEgress(failing);
+
+      const ch = logger.channel('nous:test');
+      // 5 failures to trigger auto-disable
+      for (let i = 0; i < 5; i++) {
+        ch.info(`attempt ${i}`);
+      }
+      // The spy egress still receives entries (it doesn't fail)
+      expect(spy.entries).toHaveLength(5);
+      // The failing egress was called 5 times
+      expect(failing.callCount).toBe(5);
+
+      // 6th call should not reach the failing egress
+      ch.info('after disable');
+      expect(failing.callCount).toBe(5); // no increase
+      expect(spy.entries).toHaveLength(6);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('auto-disabled'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('resets failure count on successful write', () => {
+      let shouldFail = true;
+      let callCount = 0;
+      const flaky: ILogEgress = {
+        name: 'flaky',
+        write() {
+          callCount++;
+          if (shouldFail) throw new Error('fail');
+        },
+      };
+      logger.addEgress(flaky);
+
+      const ch = logger.channel('nous:test');
+      // 4 failures (not enough to disable)
+      for (let i = 0; i < 4; i++) {
+        ch.info(`fail ${i}`);
+      }
+      expect(callCount).toBe(4);
+
+      // Succeed once to reset counter
+      shouldFail = false;
+      ch.info('success');
+      expect(callCount).toBe(5);
+
+      // 4 more failures should not disable (counter was reset)
+      shouldFail = true;
+      for (let i = 0; i < 4; i++) {
+        ch.info(`fail again ${i}`);
+      }
+      expect(callCount).toBe(9); // still receiving calls
+    });
+  });
+
+  describe('flush and dispose', () => {
+    it('flush calls flush on all active egresses', async () => {
+      const flushFn = vi.fn().mockResolvedValue(undefined);
+      const egressWithFlush: ILogEgress = {
+        name: 'flushable',
+        write() {},
+        flush: flushFn,
+      };
+      logger.addEgress(egressWithFlush);
+      await logger.flush();
+      expect(flushFn).toHaveBeenCalledOnce();
+    });
+
+    it('dispose calls dispose on all egresses', async () => {
+      const disposeFn = vi.fn().mockResolvedValue(undefined);
+      const egressWithDispose: ILogEgress = {
+        name: 'disposable',
+        write() {},
+        dispose: disposeFn,
+      };
+      logger.addEgress(egressWithDispose);
+      await logger.dispose();
+      expect(disposeFn).toHaveBeenCalledOnce();
+    });
+  });
+});
+
+describe('ConsoleEgress', () => {
+  it('maps LogLevel to correct console method', () => {
+    const egress = new ConsoleEgress();
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    egress.write({
+      level: LogLevel.Debug,
+      namespace: 'nous:test',
+      message: 'debug msg',
+      timestamp: Date.now(),
+    });
+    expect(debugSpy).toHaveBeenCalledWith('[nous:test] debug msg');
+
+    egress.write({
+      level: LogLevel.Info,
+      namespace: 'nous:test',
+      message: 'info msg',
+      timestamp: Date.now(),
+    });
+    expect(infoSpy).toHaveBeenCalledWith('[nous:test] info msg');
+
+    egress.write({
+      level: LogLevel.Warn,
+      namespace: 'nous:test',
+      message: 'warn msg',
+      timestamp: Date.now(),
+    });
+    expect(warnSpy).toHaveBeenCalledWith('[nous:test] warn msg');
+
+    egress.write({
+      level: LogLevel.Error,
+      namespace: 'nous:test',
+      message: 'error msg',
+      timestamp: Date.now(),
+    });
+    expect(errorSpy).toHaveBeenCalledWith('[nous:test] error msg');
+
+    debugSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('includes JSON-serialized data in output', () => {
+    const egress = new ConsoleEgress();
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    egress.write({
+      level: LogLevel.Info,
+      namespace: 'nous:test',
+      message: 'with data',
+      data: { key: 'value' },
+      timestamp: Date.now(),
+    });
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[nous:test] with data {"key":"value"}',
+    );
+
+    infoSpy.mockRestore();
+  });
+});
+
+describe('NullEgress', () => {
+  it('silently discards entries', () => {
+    const egress = new NullEgress();
+    expect(() =>
+      egress.write({
+        level: LogLevel.Info,
+        namespace: 'nous:test',
+        message: 'discarded',
+        timestamp: Date.now(),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/self/autonomic/logger/src/egress/axiom-egress.ts
+++ b/self/autonomic/logger/src/egress/axiom-egress.ts
@@ -1,0 +1,73 @@
+/**
+ * AxiomEgress — buffers log entries and batch-sends via HTTP to Axiom.
+ *
+ * Env-var-toggled: only active when AXIOM_TOKEN is set.
+ * AXIOM_DATASET defaults to 'nous-dev'.
+ * Flushes every 5 seconds or when buffer reaches 100 entries.
+ */
+import type { LogEntry, ILogEgress } from '@nous/shared';
+
+const FLUSH_INTERVAL_MS = 5_000;
+const FLUSH_THRESHOLD = 100;
+
+export class AxiomEgress implements ILogEgress {
+  readonly name = 'axiom';
+
+  private readonly _token: string;
+  private readonly _dataset: string;
+  private _buffer: LogEntry[] = [];
+  private _flushTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(token: string, dataset?: string) {
+    this._token = token;
+    this._dataset = dataset ?? 'nous-dev';
+    this._flushTimer = setInterval(() => {
+      void this.flush();
+    }, FLUSH_INTERVAL_MS);
+  }
+
+  write(entry: LogEntry): void {
+    this._buffer.push(entry);
+    if (this._buffer.length >= FLUSH_THRESHOLD) {
+      void this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this._buffer.length === 0) return;
+
+    const batch = this._buffer;
+    this._buffer = [];
+
+    try {
+      const response = await fetch(
+        `https://api.axiom.co/v1/datasets/${this._dataset}/ingest`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this._token}`,
+          },
+          body: JSON.stringify(batch),
+        },
+      );
+      if (!response.ok) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[nous:logger:axiom] Flush failed: ${response.status} ${response.statusText}`,
+        );
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[nous:logger:axiom] Flush error:', err);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this._flushTimer) {
+      clearInterval(this._flushTimer);
+      this._flushTimer = null;
+    }
+    await this.flush();
+  }
+}

--- a/self/autonomic/logger/src/egress/console-egress.ts
+++ b/self/autonomic/logger/src/egress/console-egress.ts
@@ -1,0 +1,37 @@
+/**
+ * ConsoleEgress — maps LogLevel to console methods.
+ *
+ * Format: `[nous:<ns>] message { data }`
+ */
+import { LogLevel } from '@nous/shared';
+import type { LogEntry, ILogEgress } from '@nous/shared';
+
+export class ConsoleEgress implements ILogEgress {
+  readonly name = 'console';
+
+  write(entry: LogEntry): void {
+    const prefix = `[${entry.namespace}]`;
+    const suffix =
+      entry.data !== undefined ? ` ${JSON.stringify(entry.data)}` : '';
+    const message = `${prefix} ${entry.message}${suffix}`;
+
+    switch (entry.level) {
+      case LogLevel.Debug:
+        // eslint-disable-next-line no-console
+        console.debug(message);
+        break;
+      case LogLevel.Info:
+        // eslint-disable-next-line no-console
+        console.info(message);
+        break;
+      case LogLevel.Warn:
+        // eslint-disable-next-line no-console
+        console.warn(message);
+        break;
+      case LogLevel.Error:
+        // eslint-disable-next-line no-console
+        console.error(message);
+        break;
+    }
+  }
+}

--- a/self/autonomic/logger/src/egress/null-egress.ts
+++ b/self/autonomic/logger/src/egress/null-egress.ts
@@ -1,0 +1,14 @@
+/**
+ * NullEgress — discards all log entries.
+ *
+ * Useful for testing or environments where logging should be suppressed.
+ */
+import type { LogEntry, ILogEgress } from '@nous/shared';
+
+export class NullEgress implements ILogEgress {
+  readonly name = 'null';
+
+  write(_entry: LogEntry): void {
+    // Intentionally discards the entry.
+  }
+}

--- a/self/autonomic/logger/src/index.ts
+++ b/self/autonomic/logger/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @nous/autonomic-logger — Structured logging facade for Nous-OSS.
+ */
+export { NousLogger } from './logger.js';
+export { LogChannel } from './log-channel.js';
+export { ConsoleEgress } from './egress/console-egress.js';
+export { NullEgress } from './egress/null-egress.js';
+export { AxiomEgress } from './egress/axiom-egress.js';

--- a/self/autonomic/logger/src/log-channel.ts
+++ b/self/autonomic/logger/src/log-channel.ts
@@ -1,0 +1,96 @@
+/**
+ * LogChannel — ILogChannel implementation for a single namespace.
+ *
+ * Channels short-circuit before LogEntry construction when disabled,
+ * keeping the hot path effectively free.
+ */
+import type { LogEntry, LogLevel } from '@nous/shared';
+import type { ILogChannel, ILogEgress } from '@nous/shared';
+
+export class LogChannel implements ILogChannel {
+  private _enabled = true;
+  private readonly _namespace: string;
+  private readonly _getLevel: () => LogLevel;
+  private readonly _getEgresses: () => readonly EgressSlot[];
+
+  constructor(
+    namespace: string,
+    getLevel: () => LogLevel,
+    getEgresses: () => readonly EgressSlot[],
+  ) {
+    this._namespace = namespace;
+    this._getLevel = getLevel;
+    this._getEgresses = getEgresses;
+  }
+
+  debug(message: string, data?: Record<string, unknown>): void {
+    this._emit(0 /* LogLevel.Debug */, message, data);
+  }
+
+  info(message: string, data?: Record<string, unknown>): void {
+    this._emit(1 /* LogLevel.Info */, message, data);
+  }
+
+  warn(message: string, data?: Record<string, unknown>): void {
+    this._emit(2 /* LogLevel.Warn */, message, data);
+  }
+
+  error(message: string, data?: Record<string, unknown>): void {
+    this._emit(3 /* LogLevel.Error */, message, data);
+  }
+
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  /** @internal — called by NousLogger when config changes */
+  _setEnabled(enabled: boolean): void {
+    this._enabled = enabled;
+  }
+
+  private _emit(
+    level: LogLevel,
+    message: string,
+    data?: Record<string, unknown>,
+  ): void {
+    if (!this._enabled) return;
+    if (level < this._getLevel()) return;
+
+    const entry: LogEntry = {
+      level,
+      namespace: this._namespace,
+      message,
+      data,
+      timestamp: Date.now(),
+    };
+
+    const egresses = this._getEgresses();
+    for (let i = 0; i < egresses.length; i++) {
+      const slot = egresses[i];
+      if (!slot.active) continue;
+      try {
+        slot.egress.write(entry);
+        slot.consecutiveFailures = 0;
+      } catch {
+        slot.consecutiveFailures++;
+        if (slot.consecutiveFailures >= 5) {
+          slot.active = false;
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[nous:logger] Egress "${slot.egress.name}" auto-disabled after 5 consecutive failures`,
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Internal egress tracking structure.
+ * Exported for use by NousLogger — not part of the public API.
+ */
+export interface EgressSlot {
+  egress: ILogEgress;
+  active: boolean;
+  consecutiveFailures: number;
+}

--- a/self/autonomic/logger/src/logger.ts
+++ b/self/autonomic/logger/src/logger.ts
@@ -1,0 +1,161 @@
+/**
+ * NousLogger — ILogger implementation with two-phase bootstrap.
+ *
+ * Phase 1 (construction): All channels enabled, console egress, LogLevel.Debug.
+ * Phase 2 (bindConfig): Config-driven level, channel enable/disable via
+ *   longest-prefix-match on the `logging.channels` config section.
+ */
+import { LogLevel } from '@nous/shared';
+import type { IConfig, ILogger, ILogChannel, ILogEgress } from '@nous/shared';
+import { LogChannel, type EgressSlot } from './log-channel.js';
+
+const NAMESPACE_REGEX = /^nous:[a-z0-9]+(?:[:-][a-z0-9]+)*$/;
+
+export class NousLogger implements ILogger {
+  private _level: LogLevel = LogLevel.Debug;
+  private readonly _channels = new Map<string, LogChannel>();
+  private readonly _egresses: EgressSlot[] = [];
+  private _channelConfig: Record<string, boolean> = {};
+
+  channel(namespace: string): ILogChannel {
+    const existing = this._channels.get(namespace);
+    if (existing) return existing;
+
+    if (!NAMESPACE_REGEX.test(namespace)) {
+      throw new Error(
+        `Invalid logger namespace "${namespace}". ` +
+          'Expected format: nous:<subsystem> or nous:<subsystem>:<detail>, ' +
+          'chars [a-z0-9:-]',
+      );
+    }
+
+    const ch = new LogChannel(
+      namespace,
+      () => this._level,
+      () => this._egresses,
+    );
+    ch._setEnabled(this._resolveChannelEnabled(namespace));
+    this._channels.set(namespace, ch);
+    return ch;
+  }
+
+  bindConfig(config: IConfig): void {
+    const fullConfig = config.get() as {
+      logging?: { level?: LogLevel; channels?: Record<string, boolean> };
+    };
+    const logging = fullConfig.logging;
+    if (!logging) return;
+
+    if (logging.level !== undefined) {
+      this._level = logging.level;
+    }
+
+    if (logging.channels) {
+      this._channelConfig = logging.channels;
+      this._recomputeChannelStates();
+    }
+  }
+
+  setLevel(level: LogLevel): void {
+    this._level = level;
+  }
+
+  /**
+   * Register an egress plugin.
+   * Not on the ILogger interface — only available on the concrete class.
+   */
+  addEgress(egress: ILogEgress): void {
+    // Prevent duplicate registration
+    const existing = this._egresses.findIndex(
+      (slot) => slot.egress.name === egress.name,
+    );
+    if (existing !== -1) {
+      this._egresses[existing] = {
+        egress,
+        active: true,
+        consecutiveFailures: 0,
+      };
+      return;
+    }
+
+    this._egresses.push({
+      egress,
+      active: true,
+      consecutiveFailures: 0,
+    });
+  }
+
+  /**
+   * Remove an egress plugin by name.
+   * Not on the ILogger interface — only available on the concrete class.
+   */
+  removeEgress(name: string): void {
+    const idx = this._egresses.findIndex((slot) => slot.egress.name === name);
+    if (idx !== -1) {
+      this._egresses.splice(idx, 1);
+    }
+  }
+
+  /**
+   * Flush all egress plugins that support it.
+   */
+  async flush(): Promise<void> {
+    const promises: Promise<void>[] = [];
+    for (const slot of this._egresses) {
+      if (slot.active && slot.egress.flush) {
+        promises.push(slot.egress.flush());
+      }
+    }
+    await Promise.all(promises);
+  }
+
+  /**
+   * Dispose all egress plugins that support it.
+   */
+  async dispose(): Promise<void> {
+    const promises: Promise<void>[] = [];
+    for (const slot of this._egresses) {
+      if (slot.egress.dispose) {
+        promises.push(slot.egress.dispose());
+      }
+    }
+    await Promise.all(promises);
+  }
+
+  /**
+   * Resolve whether a channel namespace is enabled using
+   * longest-prefix-match against config entries.
+   *
+   * `"nous:gateway": false` disables `nous:gateway`, `nous:gateway:auth`, etc.
+   * Default: enabled.
+   */
+  private _resolveChannelEnabled(namespace: string): boolean {
+    let bestPrefix = '';
+    let bestValue = true; // default: all channels enabled
+
+    for (const [pattern, enabled] of Object.entries(this._channelConfig)) {
+      // Check if pattern is a prefix of namespace (or exact match)
+      if (
+        namespace === pattern ||
+        namespace.startsWith(pattern + ':') ||
+        namespace.startsWith(pattern + '-')
+      ) {
+        if (pattern.length > bestPrefix.length) {
+          bestPrefix = pattern;
+          bestValue = enabled;
+        }
+      }
+    }
+
+    return bestValue;
+  }
+
+  /**
+   * Recompute enabled state for all cached channels after config change.
+   */
+  private _recomputeChannelStates(): void {
+    for (const [namespace, ch] of this._channels) {
+      ch._setEnabled(this._resolveChannelEnabled(namespace));
+    }
+  }
+}

--- a/self/autonomic/logger/tsconfig.json
+++ b/self/autonomic/logger/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "paths": {
+      "@nous/shared": ["../../shared/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../shared" }
+  ]
+}

--- a/self/autonomic/logger/vitest.config.ts
+++ b/self/autonomic/logger/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  resolve: {
+    alias: {
+      '@nous/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+    exclude: ['**/dist/**', '**/node_modules/**'],
+  },
+});

--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter-format-tools.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter-format-tools.test.ts
@@ -7,7 +7,17 @@
  */
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { createAnthropicAdapter } from '../../../agent-gateway/adapters/anthropic-adapter.js';
-import type { ToolDefinition, GatewayContextFrame } from '@nous/shared';
+import type { ToolDefinition, GatewayContextFrame, ILogChannel } from '@nous/shared';
+
+function createMockLog(): ILogChannel & { info: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    isEnabled: () => true,
+  };
+}
 
 function makeToolDefinition(
   name: string,
@@ -30,8 +40,9 @@ function makeToolDefinition(
  */
 function formatToolsViaAdapter(
   toolDefinitions: readonly ToolDefinition[],
+  log?: ILogChannel,
 ): Array<{ name: string; description: string; input_schema: Record<string, unknown> }> {
-  const adapter = createAnthropicAdapter();
+  const adapter = createAnthropicAdapter(log);
   const context: GatewayContextFrame[] = [
     { role: 'user', source: 'runtime', content: 'test', createdAt: new Date().toISOString() },
   ];
@@ -64,45 +75,45 @@ describe('formatTools defensive injection (WR-148 phase 1.1)', () => {
   });
 
   it('injects type: "object" when inputSchema is empty ({})', () => {
-    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    const tools = formatToolsViaAdapter([makeToolDefinition('empty_schema', {})]);
+    const log = createMockLog();
+    const tools = formatToolsViaAdapter([makeToolDefinition('empty_schema', {})], log);
     expect(tools).toHaveLength(1);
     expect(tools[0].input_schema.type).toBe('object');
-    expect(spy).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining('Injecting type:"object" for tool "empty_schema"'),
     );
   });
 
   it('injects type: "object" when inputSchema has properties but no type', () => {
-    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const log = createMockLog();
     const schema = {
       properties: { mode: { type: 'string' } },
       required: ['mode'],
     };
-    const tools = formatToolsViaAdapter([makeToolDefinition('no_type_tool', schema)]);
+    const tools = formatToolsViaAdapter([makeToolDefinition('no_type_tool', schema)], log);
     expect(tools).toHaveLength(1);
     expect(tools[0].input_schema.type).toBe('object');
     expect(tools[0].input_schema.properties).toEqual({ mode: { type: 'string' } });
     expect(tools[0].input_schema.required).toEqual(['mode']);
-    expect(spy).toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalled();
   });
 
   it('does not log when schema already has a type field', () => {
-    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const log = createMockLog();
     const schema = { type: 'object', properties: {} };
-    formatToolsViaAdapter([makeToolDefinition('typed_tool', schema)]);
-    expect(spy).not.toHaveBeenCalledWith(
+    formatToolsViaAdapter([makeToolDefinition('typed_tool', schema)], log);
+    expect(log.info).not.toHaveBeenCalledWith(
       expect.stringContaining('Injecting type:"object"'),
     );
   });
 
   it('does not mutate the original schema object (uses spread)', () => {
-    vi.spyOn(console, 'info').mockImplementation(() => {});
+    const log = createMockLog();
     const originalSchema: Record<string, unknown> = {
       properties: { mode: { type: 'string' } },
     };
     const originalRef = originalSchema;
-    formatToolsViaAdapter([makeToolDefinition('no_mutate', originalSchema)]);
+    formatToolsViaAdapter([makeToolDefinition('no_mutate', originalSchema)], log);
     // The original schema should NOT have type added
     expect(originalRef.type).toBeUndefined();
   });

--- a/self/cortex/core/src/__tests__/gateway-runtime/backlog-queue.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/backlog-queue.test.ts
@@ -413,8 +413,7 @@ describe('SystemBacklogQueue', () => {
   });
 
   it('logs recovery count and emits health event for stranded active entries', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const mockLog = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isEnabled: () => true };
     const documentStore = createDocumentStore();
     const backlogStore = new DocumentBacklogStore(documentStore);
     const healthSink = new GatewayRuntimeHealthSink();
@@ -453,23 +452,20 @@ describe('SystemBacklogQueue', () => {
       healthSink,
       now: () => '2026-03-13T17:00:00.000Z',
       executeEntry: async () => completedResult(),
+      log: mockLog,
     });
 
     await vi.waitFor(() => {
-      expect(warnSpy).toHaveBeenCalledWith(
-        'Backlog recovery: 2 entries reset from active to queued.',
+      expect(mockLog.warn).toHaveBeenCalledWith(
+        'Backlog recovery: 2 entries reset from active to queued',
       );
     });
 
     expect(healthSink.getBootSnapshot().issueCodes).toContain('backlog_recovery_reset');
-
-    warnSpy.mockRestore();
-    infoSpy.mockRestore();
   });
 
   it('logs info with zero count on clean startup', async () => {
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mockLog = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isEnabled: () => true };
     const documentStore = createDocumentStore();
     const healthSink = new GatewayRuntimeHealthSink();
 
@@ -478,18 +474,16 @@ describe('SystemBacklogQueue', () => {
       healthSink,
       now: () => '2026-03-13T17:00:00.000Z',
       executeEntry: async () => completedResult(),
+      log: mockLog,
     });
 
     await vi.waitFor(() => {
-      expect(infoSpy).toHaveBeenCalledWith(
-        'Backlog recovery: 0 entries reset from active to queued.',
+      expect(mockLog.info).toHaveBeenCalledWith(
+        'Backlog recovery: 0 entries reset from active to queued',
       );
     });
 
     expect(healthSink.getBootSnapshot().issueCodes).not.toContain('backlog_recovery_reset');
-
-    infoSpy.mockRestore();
-    warnSpy.mockRestore();
   });
 
   it('promotes multiple entries concurrently with activeCapacity > 1', async () => {

--- a/self/cortex/core/src/__tests__/gateway-runtime/cortex-runtime-attach.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/cortex-runtime-attach.test.ts
@@ -13,6 +13,7 @@
  * `submitTask` / `submitIngressEnvelope`).
  */
 import { describe, expect, it, vi } from 'vitest';
+import type { ILogger, ILogChannel } from '@nous/shared';
 import type { AgentGatewayConfig, IModelRouter } from '@nous/shared';
 import { createPrincipalSystemGatewayRuntime } from '../../gateway-runtime/index.js';
 import { resolveAdapter } from '../../agent-gateway/adapters/index.js';
@@ -39,7 +40,7 @@ function idFactory(): () => string {
   };
 }
 
-function createAttachRuntime() {
+function createAttachRuntime(logger?: ILogger) {
   return createPrincipalSystemGatewayRuntime({
     documentStore: createDocumentStore(),
     // Stub modelRouter + getProvider so the AgentGatewayFactory precondition
@@ -55,6 +56,7 @@ function createAttachRuntime() {
       validate: vi.fn().mockResolvedValue({ success: true }),
     },
     idFactory: idFactory(),
+    logger,
   });
 }
 
@@ -183,53 +185,54 @@ describe('CortexRuntime.attachProviders (WR-138 row #11)', () => {
   });
 
   it('(f) startup warning fires exactly once on first use when attachProviders has not been called', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mockLog = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isEnabled: () => true };
+    const mockLogger: ILogger = {
+      channel: () => mockLog,
+      bindConfig: vi.fn(),
+      setLevel: vi.fn(),
+    };
+    const runtime = createAttachRuntime(mockLogger);
+    // Invoke submitTaskToSystem via the public `submitTask` entry point
+    // (which gates on `checkAttachOrWarn`) — the internal handoff may
+    // settle with an internal error due to minimal fixture, but the
+    // warn spy should have been called exactly once before any error.
     try {
-      const runtime = createAttachRuntime();
-      // Invoke submitTaskToSystem via the public `submitTask` entry point
-      // (which gates on `checkAttachOrWarn`) — the internal handoff may
-      // settle with an internal error due to minimal fixture, but the
-      // warn spy should have been called exactly once before any error.
-      try {
-        await runtime.submitTask({
-          task: 'noop',
-          projectId: '00000000-0000-4000-8000-000000000001' as never,
-          detail: { source: 'row-11-warn-test' },
-        });
-      } catch {
-        // The test does not care about internal submission settlement —
-        // only that `checkAttachOrWarn` ran at method entry.
-      }
-
-      const warningCalls = warnSpy.mock.calls.filter((call) =>
-        typeof call[0] === 'string' &&
-        (call[0] as string).includes(
-          'CortexRuntime exposed without attached vendor map',
-        ),
-      );
-      expect(warningCalls.length).toBe(1);
-
-      // Second call on the same runtime must NOT re-emit the warning
-      // (one-shot guard per Finding IP-6).
-      try {
-        await runtime.submitTask({
-          task: 'noop-2',
-          projectId: '00000000-0000-4000-8000-000000000002' as never,
-          detail: { source: 'row-11-warn-test-2' },
-        });
-      } catch {
-        // ignore settlement
-      }
-      const warningCallsAfterSecond = warnSpy.mock.calls.filter((call) =>
-        typeof call[0] === 'string' &&
-        (call[0] as string).includes(
-          'CortexRuntime exposed without attached vendor map',
-        ),
-      );
-      expect(warningCallsAfterSecond.length).toBe(1);
-    } finally {
-      warnSpy.mockRestore();
+      await runtime.submitTask({
+        task: 'noop',
+        projectId: '00000000-0000-4000-8000-000000000001' as never,
+        detail: { source: 'row-11-warn-test' },
+      });
+    } catch {
+      // The test does not care about internal submission settlement —
+      // only that `checkAttachOrWarn` ran at method entry.
     }
+
+    const warningCalls = mockLog.warn.mock.calls.filter((call: unknown[]) =>
+      typeof call[0] === 'string' &&
+      (call[0] as string).includes(
+        'CortexRuntime exposed without attached vendor map',
+      ),
+    );
+    expect(warningCalls.length).toBe(1);
+
+    // Second call on the same runtime must NOT re-emit the warning
+    // (one-shot guard per Finding IP-6).
+    try {
+      await runtime.submitTask({
+        task: 'noop-2',
+        projectId: '00000000-0000-4000-8000-000000000002' as never,
+        detail: { source: 'row-11-warn-test-2' },
+      });
+    } catch {
+      // ignore settlement
+    }
+    const warningCallsAfterSecond = mockLog.warn.mock.calls.filter((call: unknown[]) =>
+      typeof call[0] === 'string' &&
+      (call[0] as string).includes(
+        'CortexRuntime exposed without attached vendor map',
+      ),
+    );
+    expect(warningCallsAfterSecond.length).toBe(1);
   });
 
   it('(f.2) startup warning does NOT fire when attachProviders has been called first', async () => {

--- a/self/cortex/core/src/__tests__/gateway-runtime/cortex-runtime-recompose.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/cortex-runtime-recompose.test.ts
@@ -6,7 +6,7 @@
  * semantics for rapid vendor changes during an active turn.
  */
 import { describe, expect, it, vi } from 'vitest';
-import type { AgentGatewayConfig, IModelRouter } from '@nous/shared';
+import type { AgentGatewayConfig, ILogger, ILogChannel, IModelRouter } from '@nous/shared';
 import { createPrincipalSystemGatewayRuntime } from '../../gateway-runtime/index.js';
 import { resolveAdapter } from '../../agent-gateway/adapters/index.js';
 import {
@@ -14,6 +14,21 @@ import {
   createPfcEngine,
   createProjectApi,
 } from '../agent-gateway/helpers.js';
+
+function createMockLogger(): ILogger & { channels: Map<string, ILogChannel & { info: ReturnType<typeof vi.fn> }> } {
+  const channels = new Map<string, ILogChannel & { info: ReturnType<typeof vi.fn> }>();
+  return {
+    channels,
+    channel(namespace: string) {
+      if (!channels.has(namespace)) {
+        channels.set(namespace, { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isEnabled: () => true });
+      }
+      return channels.get(namespace)!;
+    },
+    bindConfig: vi.fn(),
+    setLevel: vi.fn(),
+  };
+}
 
 function createStubModelRouter(): IModelRouter {
   return {
@@ -32,7 +47,7 @@ function idFactory(): () => string {
   };
 }
 
-function createRuntime() {
+function createRuntime(logger?: ILogger) {
   return createPrincipalSystemGatewayRuntime({
     documentStore: createDocumentStore(),
     modelRouter: createStubModelRouter(),
@@ -43,6 +58,7 @@ function createRuntime() {
       validate: vi.fn().mockResolvedValue({ success: true }),
     },
     idFactory: idFactory(),
+    logger,
   });
 }
 
@@ -111,22 +127,22 @@ describe('CortexRuntime.recomposeHarnessForClass (WR-148 phase 1.1)', () => {
   });
 
   it('recomposition with unknown vendor falls back to text adapter', () => {
-    const runtime = createRuntime();
-    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = createMockLogger();
+    const runtime = createRuntime(logger);
 
     // 'unknown_vendor' should fallback to text adapter via resolveAdapter
     runtime.recomposeHarnessForClass('Cortex::Principal', 'unknown_vendor' as never);
 
-    expect(spy).toHaveBeenCalledWith(
+    const log = logger.channels.get('nous:cortex-runtime');
+    expect(log?.info).toHaveBeenCalledWith(
       expect.stringContaining('Recomposed harness for Cortex::Principal with vendor unknown_vendor'),
     );
-    spy.mockRestore();
   });
 
   describe('turn-in-progress guard', () => {
     it('defers recompose when turn is in progress', () => {
-      const runtime = createRuntime();
-      const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const logger = createMockLogger();
+      const runtime = createRuntime(logger);
 
       // Simulate turn in progress
       getTurnInProgressByClass(runtime).set('Cortex::Principal', true);
@@ -140,10 +156,10 @@ describe('CortexRuntime.recomposeHarnessForClass (WR-148 phase 1.1)', () => {
       // Should be stored in pendingRecompose
       expect(getPendingRecompose(runtime).get('Cortex::Principal')).toBe('ollama');
 
-      expect(spy).toHaveBeenCalledWith(
+      const log = logger.channels.get('nous:cortex-runtime');
+      expect(log?.info).toHaveBeenCalledWith(
         expect.stringContaining('Deferred harness recompose for Cortex::Principal'),
       );
-      spy.mockRestore();
     });
 
     it('applies deferred recompose when turn completes (via checkPendingRecompose)', () => {

--- a/self/cortex/core/src/__tests__/gateway-runtime/principal-system-runtime.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/principal-system-runtime.test.ts
@@ -249,8 +249,12 @@ describe('PrincipalSystemGatewayRuntime', () => {
   });
 
   it('logs a warning when no documentStore is injected (in-memory fallback)', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const mockLog = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isEnabled: () => true };
+    const mockLogger = {
+      channel: () => mockLog,
+      bindConfig: vi.fn(),
+      setLevel: vi.fn(),
+    };
 
     // Create runtime WITHOUT documentStore — triggers in-memory fallback
     createPrincipalSystemGatewayRuntime({
@@ -281,14 +285,12 @@ describe('PrincipalSystemGatewayRuntime', () => {
           return `00000000-0000-4000-8000-${suffix}`;
         };
       })(),
+      logger: mockLogger,
     });
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Using in-memory document store for backlog queue -- queued work will not survive restart.',
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      'Using in-memory document store for backlog queue -- queued work will not survive restart',
     );
-
-    warnSpy.mockRestore();
-    infoSpy.mockRestore();
   });
 
   describe('HealthTrackingOutboxSink event bus publication', () => {

--- a/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
@@ -3,7 +3,7 @@
  *
  * WR-127 Phase 1.3 — first production ProviderAdapter for the Anthropic Messages API.
  */
-import type { TraceId } from '@nous/shared';
+import type { ILogChannel, TraceId } from '@nous/shared';
 import type { ParsedModelOutput } from '../../output-parser.js';
 import type {
   AdapterCapabilities,
@@ -76,14 +76,15 @@ function formatSystemPrompt(
 
 function formatTools(
   toolDefinitions?: readonly import('@nous/shared').ToolDefinition[],
+  log?: ILogChannel,
 ): Array<{ name: string; description: string; input_schema: Record<string, unknown> }> | undefined {
   if (!toolDefinitions || toolDefinitions.length === 0) return undefined;
 
   return toolDefinitions.map((tool) => {
     const schema = (tool.inputSchema as Record<string, unknown>) ?? {};
     if (!schema.type) {
-      console.info(
-        `[nous:anthropic-adapter] Injecting type:"object" for tool "${tool.name}" — inputSchema missing type field`,
+      log?.info(
+        `Injecting type:"object" for tool "${tool.name}" — inputSchema missing type field`,
       );
       return {
         name: tool.name,
@@ -103,6 +104,7 @@ type AnthropicMessage = { role: 'user' | 'assistant'; content: string | Array<Re
 
 function formatMessages(
   context: readonly import('@nous/shared').GatewayContextFrame[],
+  log?: ILogChannel,
 ): AnthropicMessage[] {
   const raw: AnthropicMessage[] = context.map((frame) => {
     // Tool result with tool_call_id metadata → Anthropic tool_result content block
@@ -168,8 +170,8 @@ function formatMessages(
     }
   }
 
-  // Debug: log message structure for tool use debugging (JSON.stringify to expand nested arrays)
-  console.debug('[nous:anthropic-adapter] formatMessages output', JSON.stringify({
+  // Debug: log message structure for tool use debugging
+  log?.debug('formatMessages output', {
     messageCount: merged.length,
     messages: merged.map((m, i) => {
       const blocks = Array.isArray(m.content) ? m.content : [];
@@ -190,7 +192,7 @@ function formatMessages(
       if (toolResultIds.length > 0) detail.toolResultIds = toolResultIds;
       return detail;
     }),
-  }, null, 2));
+  });
 
   return merged;
 }
@@ -302,14 +304,14 @@ function parseAnthropicResponse(
 
 // ── Adapter factory ─────────────────────────────────────────────────
 
-export function createAnthropicAdapter(): ProviderAdapter {
+export function createAnthropicAdapter(log?: ILogChannel): ProviderAdapter {
   return {
     capabilities: ANTHROPIC_CAPABILITIES,
 
     formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
       const system = formatSystemPrompt(input.systemPrompt);
-      const messages = formatMessages(input.context);
-      const tools = formatTools(input.toolDefinitions);
+      const messages = formatMessages(input.context, log);
+      const tools = formatTools(input.toolDefinitions, log);
 
       const result: Record<string, unknown> = {
         system,
@@ -333,7 +335,7 @@ export function createAnthropicAdapter(): ProviderAdapter {
         return parseAnthropicResponse(output);
       } catch (error) {
         // Fallback: never throw from parseResponse
-        console.error('[nous:anthropic-adapter] parseResponse error — falling back to String(output)', {
+        log?.error('parseResponse error — falling back to String(output)', {
           error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           outputType: typeof output,
           outputKeys: output && typeof output === 'object' ? Object.keys(output) : [],

--- a/self/cortex/core/src/agent-gateway/adapters/index.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/index.ts
@@ -16,26 +16,25 @@ export { createOpenAiAdapter } from './openai-adapter.js';
 export { createAnthropicAdapter } from './anthropic-adapter.js';
 export { createOllamaAdapter, isToolCapableModel } from './ollama-adapter.js';
 
+import type { ILogChannel } from '@nous/shared';
 import type { ProviderAdapter } from './types.js';
 import { createTextAdapter } from './text-adapter.js';
 import { createOpenAiAdapter } from './openai-adapter.js';
 import { createAnthropicAdapter } from './anthropic-adapter.js';
 import { createOllamaAdapter } from './ollama-adapter.js';
 
-const ADAPTER_REGISTRY: Record<string, () => ProviderAdapter> = {
-  anthropic: () => createAnthropicAdapter(),
-  openai: () => createOpenAiAdapter(),
-  ollama: () => createOllamaAdapter(),
-};
-
 /**
  * Resolves a ProviderAdapter for the given provider type.
  * Unknown provider types fall back to text adapter (preserving current behavior).
+ * When a log channel is provided, it is forwarded to the adapter factory.
  */
-export function resolveAdapter(providerType: string): ProviderAdapter {
-  const factory = ADAPTER_REGISTRY[providerType];
-  if (factory) return factory();
-  return createTextAdapter();
+export function resolveAdapter(providerType: string, log?: ILogChannel): ProviderAdapter {
+  switch (providerType) {
+    case 'anthropic': return createAnthropicAdapter(log);
+    case 'openai': return createOpenAiAdapter();
+    case 'ollama': return createOllamaAdapter(undefined, log);
+    default: return createTextAdapter(log);
+  }
 }
 
 /**

--- a/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
@@ -12,7 +12,7 @@
  *
  * WR-127 Phase 1.4
  */
-import type { TraceId } from '@nous/shared';
+import type { ILogChannel, TraceId } from '@nous/shared';
 import type { ParsedModelOutput } from '../../output-parser.js';
 import type {
   AdapterCapabilities,
@@ -166,8 +166,8 @@ function parseOllamaToolCalls(
  * 2. Message object with content + optional thinking (chat response)
  * 3. Plain string (generate endpoint or passthrough)
  */
-function parseOllamaResponse(output: unknown): ParsedModelOutput {
-  console.debug('[nous:ollama-adapter] parseOllamaResponse input:', {
+function parseOllamaResponse(output: unknown, log?: ILogChannel): ParsedModelOutput {
+  log?.debug('parseOllamaResponse input', {
     type: typeof output,
     isNull: output === null,
     keys: output && typeof output === 'object' ? Object.keys(output) : 'n/a',
@@ -223,7 +223,7 @@ function parseOllamaResponse(output: unknown): ParsedModelOutput {
  *   When provided, the adapter checks if the model supports native tool calling.
  *   When omitted, defaults to tool-capable (adapter still checks toolDefinitions presence).
  */
-export function createOllamaAdapter(modelId?: string): ProviderAdapter {
+export function createOllamaAdapter(modelId?: string, log?: ILogChannel): ProviderAdapter {
   const toolCapable = modelId ? isToolCapableModel(modelId) : true;
 
   const capabilities: AdapterCapabilities = {
@@ -310,9 +310,12 @@ export function createOllamaAdapter(modelId?: string): ProviderAdapter {
 
     parseResponse(output: unknown, _traceId: TraceId): ParsedModelOutput {
       try {
-        return parseOllamaResponse(output);
+        return parseOllamaResponse(output, log);
       } catch (err) {
-        console.error('[nous:ollama-adapter] parseResponse error:', err, 'output type:', typeof output);
+        log?.error('parseResponse error', {
+          error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+          outputType: typeof output,
+        });
         // Never throw — return text fallback
         return {
           response: String(output ?? ''),

--- a/self/cortex/core/src/agent-gateway/adapters/text-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/text-adapter.ts
@@ -1,4 +1,4 @@
-import type { TraceId } from '@nous/shared';
+import type { ILogChannel, TraceId } from '@nous/shared';
 import { parseModelOutput, type ParsedModelOutput } from '../../output-parser.js';
 import type { AdapterCapabilities, AdapterFormatInput, AdapterFormattedRequest, ProviderAdapter } from './types.js';
 
@@ -9,7 +9,7 @@ const TEXT_ADAPTER_CAPABILITIES: AdapterCapabilities = {
   streaming: false,
 };
 
-export function createTextAdapter(): ProviderAdapter {
+export function createTextAdapter(log?: ILogChannel): ProviderAdapter {
   return {
     capabilities: TEXT_ADAPTER_CAPABILITIES,
     formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
@@ -31,7 +31,9 @@ export function createTextAdapter(): ProviderAdapter {
       try {
         return parseModelOutput(output, traceId);
       } catch (err) {
-        console.warn('[nous:text-adapter] parseResponse caught unexpected error, falling back to text-mode', err);
+        log?.warn('parseResponse caught unexpected error, falling back to text-mode', {
+          error: err instanceof Error ? { message: err.message, stack: err.stack } : String(err),
+        });
         return {
           response: String(output ?? ''),
           toolCalls: [],

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -147,7 +147,7 @@ export class AgentGateway implements IAgentGateway {
   private resolveAdapterFromProvider(provider: IModelProvider): ProviderAdapter {
     if (this.cachedAdapter) return this.cachedAdapter;
     const providerType = resolveProviderTypeFromConfig(provider);
-    this.cachedAdapter = resolveAdapter(providerType);
+    this.cachedAdapter = resolveAdapter(providerType, this.log);
     this.log.debug('adapter resolved', { agentClass: this.agentClass, providerType });
     return this.cachedAdapter;
   }

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -55,7 +55,17 @@ import {
 import { GatewayOutbox } from './outbox.js';
 import { composeSystemPrompt } from './system-prompt-composer.js';
 import { resolveAdapter, resolveProviderTypeFromConfig } from './adapters/index.js';
+import type { ILogChannel } from '@nous/shared';
 import type { ProviderAdapter } from './adapters/types.js';
+
+/** No-op log channel used when no ILogChannel is provided. */
+const NOOP_LOG: ILogChannel = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  isEnabled() { return false; },
+};
 
 const DEFAULT_MODEL_ROLE_BY_CLASS: Record<AgentClass, ModelRole> = {
   'Cortex::Principal': 'cortex-chat',
@@ -108,6 +118,7 @@ export class AgentGateway implements IAgentGateway {
   private readonly now: () => string;
   private readonly nowMs: () => number;
   private readonly idFactory: () => string;
+  private readonly log: ILogChannel;
   private cachedAdapter: ProviderAdapter | null = null;
 
   constructor(private readonly config: AgentGatewayConfig) {
@@ -116,6 +127,7 @@ export class AgentGateway implements IAgentGateway {
     this.now = config.now ?? defaultNow;
     this.nowMs = config.nowMs ?? defaultNowMs;
     this.idFactory = config.idFactory ?? randomUUID;
+    this.log = config.log ?? NOOP_LOG;
     this.inbox = new GatewayInbox(this.now, this.idFactory);
     this.outbox = new GatewayOutbox(config.outbox);
 
@@ -136,7 +148,7 @@ export class AgentGateway implements IAgentGateway {
     if (this.cachedAdapter) return this.cachedAdapter;
     const providerType = resolveProviderTypeFromConfig(provider);
     this.cachedAdapter = resolveAdapter(providerType);
-    console.debug('[nous:gateway] adapter resolved', { agentClass: this.agentClass, providerType });
+    this.log.debug('adapter resolved', { agentClass: this.agentClass, providerType });
     return this.cachedAdapter;
   }
 
@@ -220,7 +232,7 @@ export class AgentGateway implements IAgentGateway {
         // Extract the last user message from context for logging
         const lastUserFrame = [...context].reverse().find(f => f.role === 'user');
 
-        console.debug('[nous:gateway] invoke provider', {
+        this.log.debug('invoke provider', {
           agentClass: this.agentClass,
           hasHarness: !!this.config.harness,
           inputKeys: Object.keys(formatted.input),
@@ -239,7 +251,7 @@ export class AgentGateway implements IAgentGateway {
 
         budgetTracker.recordModelUsage(modelResponse.usage);
 
-        console.debug('[nous:gateway] model response received', {
+        this.log.debug('model response received', {
           agentClass: this.agentClass,
           outputType: typeof modelResponse.output,
           outputLength: typeof modelResponse.output === 'string' ? modelResponse.output.length : 'non-string',
@@ -253,7 +265,7 @@ export class AgentGateway implements IAgentGateway {
           ? (this.config.harness!.responseParser!(modelResponse.output, traceId) as ParsedModelOutput)
           : parseModelOutput(modelResponse.output, traceId);
 
-        console.debug('[nous:gateway] parser selection', {
+        this.log.debug('parser selection', {
           usingHarnessParser,
           outputType: typeof modelResponse.output,
           parsedResponse: parsedOutput.response.slice(0, 100),
@@ -261,7 +273,7 @@ export class AgentGateway implements IAgentGateway {
           parsedThinking: !!parsedOutput.thinkingContent,
         });
 
-        console.debug('[nous:gateway] parsed output', {
+        this.log.debug('parsed output', {
           agentClass: this.agentClass,
           responseLength: parsedOutput.response.length,
           toolCallCount: parsedOutput.toolCalls.length,
@@ -295,7 +307,7 @@ export class AgentGateway implements IAgentGateway {
         // Single-turn exit: return immediately after one model invocation.
         // No tool handling, no task_complete required.
         if (this.config.harness?.loopConfig?.singleTurn) {
-          console.debug('[nous:gateway] single-turn exit', { agentClass: this.agentClass });
+          this.log.debug('single-turn exit', { agentClass: this.agentClass });
           budgetTracker.recordTurn();
           return this.finalizeTerminalResult(
             this.buildSingleTurnResult(
@@ -312,7 +324,7 @@ export class AgentGateway implements IAgentGateway {
         // calls, the turn is complete. Only continue looping when there are
         // pending tool calls to execute.
         if (parsedOutput.toolCalls.length === 0 && parsedOutput.response.trim()) {
-          console.debug('[nous:gateway] conversational exit (no tool calls)', { agentClass: this.agentClass });
+          this.log.debug('conversational exit (no tool calls)', { agentClass: this.agentClass });
           budgetTracker.recordTurn();
           return this.finalizeTerminalResult(
             this.buildSingleTurnResult(
@@ -381,7 +393,7 @@ export class AgentGateway implements IAgentGateway {
         }
       }
     } catch (error) {
-      console.error('[nous:gateway] run() error', {
+      this.log.error('run() error', {
         agentClass: this.agentClass,
         errorName: (error as Error).name,
         errorMessage: (error as Error).message,
@@ -489,7 +501,7 @@ export class AgentGateway implements IAgentGateway {
         ? await this.handleDispatchBatch(args, dispatchIndexes)
         : new Map<number, ToolHandlingResult>();
 
-    console.debug('[nous:gateway] handleToolCalls', {
+    this.log.debug('handleToolCalls', {
       toolCallCount: args.toolCalls.length,
       toolCalls: args.toolCalls.map((tc, i) => ({
         index: i,
@@ -511,7 +523,7 @@ export class AgentGateway implements IAgentGateway {
 
       if (handled.contextFrame) {
         frameByIndex.set(index, handled.contextFrame);
-        console.debug('[nous:gateway] tool result frame', {
+        this.log.debug('tool result frame', {
           index,
           toolName: toolCall.name,
           toolCallId: toolCall.id ?? '(no id)',

--- a/self/cortex/core/src/gateway-runtime/backlog-queue.ts
+++ b/self/cortex/core/src/gateway-runtime/backlog-queue.ts
@@ -1,5 +1,5 @@
 import { AgentResultSchema } from '@nous/shared';
-import type { AgentResult, IDocumentStore } from '@nous/shared';
+import type { AgentResult, IDocumentStore, ILogChannel } from '@nous/shared';
 import { DocumentBacklogStore } from './backlog-store.js';
 import type {
   BacklogAnalytics,
@@ -35,6 +35,7 @@ export interface SystemBacklogQueueDeps {
   executeEntry: (entry: BacklogEntry) => Promise<AgentResult>;
   now: () => string;
   config?: Partial<BacklogQueueConfig>;
+  log?: ILogChannel;
 }
 
 export class SystemBacklogQueue {
@@ -43,10 +44,12 @@ export class SystemBacklogQueue {
   private readonly ready: Promise<void>;
   private promotionInFlight = false;
   private readonly idleWaiters = new Set<() => void>();
+  private readonly log: ILogChannel;
 
   constructor(private readonly deps: SystemBacklogQueueDeps) {
     this.store = new DocumentBacklogStore(deps.documentStore);
     this.config = BacklogQueueConfigSchema.parse(deps.config ?? {});
+    this.log = deps.log ?? { debug() {}, info() {}, warn() {}, error() {}, isEnabled() { return false; } };
     this.ready = this.initialize();
   }
 
@@ -113,10 +116,10 @@ export class SystemBacklogQueue {
   private async initialize(): Promise<void> {
     const resetCount = await this.store.resetActiveToQueued();
     if (resetCount > 0) {
-      console.warn(`Backlog recovery: ${resetCount} entries reset from active to queued.`);
+      this.log.warn(`Backlog recovery: ${resetCount} entries reset from active to queued`);
       this.deps.healthSink.addIssue('backlog_recovery_reset', 'Cortex::System');
     } else {
-      console.info('Backlog recovery: 0 entries reset from active to queued.');
+      this.log.info('Backlog recovery: 0 entries reset from active to queued');
     }
     await this.refreshAnalytics();
     void this.promote();

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -337,6 +337,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       now: this.now,
       config: this.deps.backlogConfig,
       executeEntry: async (entry) => this.executeSystemEntry(entry),
+      log: this.deps.logger?.channel('nous:backlog-queue'),
     });
   }
 
@@ -975,6 +976,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       now: this.now,
       nowMs: this.nowMs,
       idFactory: this.idFactory,
+      log: this.deps.logger?.channel('nous:gateway'),
     };
   }
 
@@ -988,7 +990,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     agentClass: AgentClass,
     providerType: string,
   ): HarnessStrategies {
-    const adapter = resolveAdapter(providerType);
+    const adapter = resolveAdapter(providerType, this.deps.logger?.channel('nous:gateway'));
     const profile = resolveAgentProfile(agentClass);
 
     return {

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -35,6 +35,7 @@ import type {
   TraceEvidenceReference,
   TraceId,
   HarnessStrategies,
+  ILogChannel,
   PromptFormatterInput,
   ProviderVendor,
 } from '@nous/shared';
@@ -236,6 +237,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
   private readonly recoveryOrchestrator?: IRecoveryOrchestrator;
   private readonly retryPolicyEvaluator: IRetryPolicyEvaluator;
   private readonly rollbackPolicyEvaluator: IRollbackPolicyEvaluator;
+  private readonly log: ILogChannel;
 
   constructor(private readonly deps: PrincipalSystemGatewayRuntimeDeps = {}) {
     this.healthSink = new GatewayRuntimeHealthSink({ eventBus: deps.eventBus });
@@ -253,6 +255,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     this.recoveryOrchestrator = deps.recoveryOrchestrator;
     this.retryPolicyEvaluator = new RetryPolicyEvaluator();
     this.rollbackPolicyEvaluator = new RollbackPolicyEvaluator();
+    this.log = deps.logger?.channel('nous:cortex-runtime') ?? { debug() {}, info() {}, warn() {}, error() {}, isEnabled() { return false; } };
 
     this.healthSink.completeBootStep('subcortex_initialized', this.now());
     this.healthSink.completeBootStep('internal_mcp_registered', this.now());
@@ -326,7 +329,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     );
     this.healthSink.markInboxReady(this.now());
     if (!this.deps.documentStore) {
-      console.warn('Using in-memory document store for backlog queue -- queued work will not survive restart.');
+      this.log.warn('Using in-memory document store for backlog queue -- queued work will not survive restart');
     }
     this.systemBacklogQueue = new SystemBacklogQueue({
       documentStore: this.deps.documentStore ?? createInMemoryDocumentStore(),
@@ -472,7 +475,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Fail-open: opctl service error should not block chat
-        console.warn('[nous:gateway-runtime] handleChatTurn: opctl gate check failed, allowing execution');
+        this.log.warn('handleChatTurn: opctl gate check failed, allowing execution');
       }
     }
 
@@ -483,10 +486,10 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         const stmContext = await this.deps.stmStore.getContext(projectId as ProjectId);
         contextFrames = this.buildChatContextFrames(stmContext);
       } catch {
-        console.warn('[nous:gateway-runtime] handleChatTurn: STM context load failed, proceeding without history');
+        this.log.warn('handleChatTurn: STM context load failed, proceeding without history');
       }
     } else if (projectId && !this.deps.stmStore) {
-      console.warn('[nous:gateway-runtime] handleChatTurn: stmStore not available, proceeding without conversation history');
+      this.log.warn('handleChatTurn: stmStore not available, proceeding without conversation history');
     }
 
     // Add the user message as a plain-text user frame, not as a JSON payload.
@@ -534,7 +537,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     // Normalize — strip chain-of-thought narration if detected
     const normalized = detectAndStripNarration(resolved.response);
     if (normalized.wasNarrated) {
-      console.debug('[nous:gateway-runtime] handleChatTurn: narration detected and stripped');
+      this.log.debug('handleChatTurn: narration detected and stripped');
     }
     const responseText = normalized.cleaned;
 
@@ -637,7 +640,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Fail-open: opctl service error should not block execution
-        console.warn('[nous:gateway-runtime] opctl gate check failed, allowing execution');
+        this.log.warn('opctl gate check failed, allowing execution');
       }
     }
     // scheduler, system_event, hook sources bypass the gate entirely
@@ -670,7 +673,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Checkpoint capture is advisory for V1 — proceed without checkpoint
-        console.warn('[nous:gateway-runtime] checkpoint prepare failed, proceeding without checkpoint');
+        this.log.warn('checkpoint prepare failed, proceeding without checkpoint');
       }
     }
 
@@ -690,7 +693,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Commit failure: checkpoint remains prepared-only
-        console.warn('[nous:gateway-runtime] checkpoint commit failed');
+        this.log.warn('checkpoint commit failed');
       }
     }
 
@@ -736,7 +739,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Recovery failure must not mask the original error
-        console.warn('[nous:gateway-runtime] recovery orchestrator failed, propagating original error');
+        this.log.warn('recovery orchestrator failed, propagating original error');
         return result;
       }
     }
@@ -913,7 +916,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       }
     } catch {
       // Preserve chat-path availability even if STM finalization fails.
-      console.warn('[nous:gateway-runtime] handleChatTurn: STM finalization failed, chat response preserved');
+      this.log.warn('handleChatTurn: STM finalization failed, chat response preserved');
     }
   }
 
@@ -1248,8 +1251,8 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     vendorString: ProviderVendor,
   ): void {
     if (this.turnInProgressByClass.get(agentClass)) {
-      console.info(
-        `[nous:cortex-runtime] Deferred harness recompose for ${agentClass} — turn in progress`,
+      this.log.info(
+        `Deferred harness recompose for ${agentClass} — turn in progress`,
       );
       this.pendingRecompose.set(agentClass, vendorString);
       return;
@@ -1265,8 +1268,8 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       ? this.principalGatewayConfig
       : this.systemGatewayConfig;
     config.harness = this.composeHarnessStrategies(agentClass, vendorString);
-    console.info(
-      `[nous:cortex-runtime] Recomposed harness for ${agentClass} with vendor ${vendorString}`,
+    this.log.info(
+      `Recomposed harness for ${agentClass} with vendor ${vendorString}`,
     );
   }
 
@@ -1275,8 +1278,8 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     const pending = this.pendingRecompose.get(agentClass);
     if (pending !== undefined) {
       this.pendingRecompose.delete(agentClass);
-      console.info(
-        `[nous:cortex-runtime] Applied deferred harness recompose for ${agentClass} with vendor ${pending}`,
+      this.log.info(
+        `Applied deferred harness recompose for ${agentClass} with vendor ${pending}`,
       );
       this.applyRecompose(agentClass, pending);
     }
@@ -1307,8 +1310,8 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
    */
   private checkAttachOrWarn(): void {
     if (this.attachedVendorByClass === null && !this.attachWarningEmitted) {
-      console.warn(
-        '[nous:cortex-runtime] CortexRuntime exposed without attached vendor map. ' +
+      this.log.warn(
+        'CortexRuntime exposed without attached vendor map. ' +
           'Principal and System gateways will run with the text adapter. ' +
           'This is likely a bootstrap bug — see cortex-provider-attach-lifecycle-v1.md.',
       );

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -299,6 +299,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       now: this.now,
       config: this.deps.backlogConfig,
       executeEntry: async (entry) => this.executeSystemEntry(entry),
+      log: this.deps.logger?.channel('nous:backlog-queue'),
     });
   }
 
@@ -882,6 +883,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       now: this.now,
       nowMs: this.nowMs,
       idFactory: this.idFactory,
+      log: this.deps.logger?.channel('nous:gateway'),
     };
   }
 

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -21,6 +21,7 @@ import type {
   RecoveryOrchestratorContext,
   StmContext,
   ToolDefinition,
+  ILogChannel,
   TraceEvidenceReference,
   TraceId,
 } from '@nous/shared';
@@ -200,6 +201,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
   private readonly recoveryOrchestrator?: IRecoveryOrchestrator;
   private readonly retryPolicyEvaluator: IRetryPolicyEvaluator;
   private readonly rollbackPolicyEvaluator: IRollbackPolicyEvaluator;
+  private readonly log: ILogChannel;
 
   constructor(private readonly deps: PrincipalSystemGatewayRuntimeDeps = {}) {
     this.healthSink = new GatewayRuntimeHealthSink({ eventBus: deps.eventBus });
@@ -217,6 +219,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     this.recoveryOrchestrator = deps.recoveryOrchestrator;
     this.retryPolicyEvaluator = new RetryPolicyEvaluator();
     this.rollbackPolicyEvaluator = new RollbackPolicyEvaluator();
+    this.log = deps.logger?.channel('nous:gateway-runtime') ?? { debug() {}, info() {}, warn() {}, error() {}, isEnabled() { return false; } };
 
     this.healthSink.completeBootStep('subcortex_initialized', this.now());
     this.healthSink.completeBootStep('internal_mcp_registered', this.now());
@@ -288,7 +291,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     );
     this.healthSink.markInboxReady(this.now());
     if (!this.deps.documentStore) {
-      console.warn('Using in-memory document store for backlog queue -- queued work will not survive restart.');
+      this.log.warn('Using in-memory document store for backlog queue -- queued work will not survive restart');
     }
     this.systemBacklogQueue = new SystemBacklogQueue({
       documentStore: this.deps.documentStore ?? createInMemoryDocumentStore(),
@@ -431,7 +434,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Fail-open: opctl service error should not block chat
-        console.warn('[nous:gateway-runtime] handleChatTurn: opctl gate check failed, allowing execution');
+        this.log.warn('handleChatTurn: opctl gate check failed, allowing execution');
       }
     }
 
@@ -442,10 +445,10 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         const stmContext = await this.deps.stmStore.getContext(projectId as ProjectId);
         contextFrames = this.buildChatContextFrames(stmContext);
       } catch {
-        console.warn('[nous:gateway-runtime] handleChatTurn: STM context load failed, proceeding without history');
+        this.log.warn('handleChatTurn: STM context load failed, proceeding without history');
       }
     } else if (projectId && !this.deps.stmStore) {
-      console.warn('[nous:gateway-runtime] handleChatTurn: stmStore not available, proceeding without conversation history');
+      this.log.warn('handleChatTurn: stmStore not available, proceeding without conversation history');
     }
 
     // Run Principal gateway
@@ -474,7 +477,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     // Normalize — strip chain-of-thought narration if detected
     const normalized = detectAndStripNarration(resolved.response);
     if (normalized.wasNarrated) {
-      console.debug('[nous:gateway-runtime] handleChatTurn: narration detected and stripped');
+      this.log.debug('handleChatTurn: narration detected and stripped');
     }
     const responseText = normalized.cleaned;
 
@@ -576,7 +579,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Fail-open: opctl service error should not block execution
-        console.warn('[nous:gateway-runtime] opctl gate check failed, allowing execution');
+        this.log.warn('opctl gate check failed, allowing execution');
       }
     }
     // scheduler, system_event, hook sources bypass the gate entirely
@@ -609,7 +612,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Checkpoint capture is advisory for V1 — proceed without checkpoint
-        console.warn('[nous:gateway-runtime] checkpoint prepare failed, proceeding without checkpoint');
+        this.log.warn('checkpoint prepare failed, proceeding without checkpoint');
       }
     }
 
@@ -629,7 +632,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Commit failure: checkpoint remains prepared-only
-        console.warn('[nous:gateway-runtime] checkpoint commit failed');
+        this.log.warn('checkpoint commit failed');
       }
     }
 
@@ -675,7 +678,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         }
       } catch {
         // Recovery failure must not mask the original error
-        console.warn('[nous:gateway-runtime] recovery orchestrator failed, propagating original error');
+        this.log.warn('recovery orchestrator failed, propagating original error');
         return result;
       }
     }
@@ -838,7 +841,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       }
     } catch {
       // Preserve chat-path availability even if STM finalization fails.
-      console.warn('[nous:gateway-runtime] handleChatTurn: STM finalization failed, chat response preserved');
+      this.log.warn('handleChatTurn: STM finalization failed, chat response preserved');
     }
   }
 

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -29,6 +29,7 @@ import type {
   IAppCredentialInstallService,
   ICredentialVaultService,
   ICredentialInjector,
+  ILogger,
   IOpctlService,
   IngressDispatchOutcome,
   IngressTriggerEnvelope,
@@ -285,6 +286,9 @@ export interface PrincipalSystemGatewayRuntimeDeps {
   now?: () => string;
   nowMs?: () => number;
   idFactory?: () => string;
+  /** Structured logger (WR-157). When provided, the runtime creates
+   *  channels for itself, the gateways, and the backlog queue. */
+  logger?: ILogger;
 }
 
 export interface LaneLeaseReleasedEvent {

--- a/self/cortex/pfc/src/pfc-engine.ts
+++ b/self/cortex/pfc/src/pfc-engine.ts
@@ -6,6 +6,7 @@
 import type {
   IPfcEngine,
   IConfig,
+  ILogChannel,
   IToolExecutor,
   IThoughtEmitter,
   ConfidenceGovernanceEvaluationInput,
@@ -29,14 +30,17 @@ import {
 export class PfcEngine implements IPfcEngine {
   private thoughtEmitter?: IThoughtEmitter;
   private currentTraceId: string = '';
+  private readonly log: ILogChannel;
 
   constructor(
     private readonly config: IConfig,
     private readonly toolExecutor: IToolExecutor,
     private readonly confidenceGovernanceObserver?: ConfidenceGovernanceObserver,
     thoughtEmitter?: IThoughtEmitter,
+    log?: ILogChannel,
   ) {
     this.thoughtEmitter = thoughtEmitter;
+    this.log = log ?? { debug() {}, info() {}, warn() {}, error() {}, isEnabled() { return false; } };
   }
 
   setThoughtEmitter(emitter: IThoughtEmitter): void {
@@ -55,8 +59,8 @@ export class PfcEngine implements IPfcEngine {
       decision,
       this.confidenceGovernanceObserver,
     );
-    console.info(
-      `[nous:pfc] confidence_governance patternId=${decision.patternId} outcome=${decision.outcome} reasonCode=${decision.reasonCode} governance=${decision.governance} tier=${decision.confidenceTier} actionCategory=${decision.actionCategory}`,
+    this.log.info(
+      `confidence_governance patternId=${decision.patternId} outcome=${decision.outcome} reasonCode=${decision.reasonCode} governance=${decision.governance} tier=${decision.confidenceTier} actionCategory=${decision.actionCategory}`,
     );
     this.thoughtEmitter?.emitPfcDecision({
       traceId: this.currentTraceId,
@@ -81,8 +85,8 @@ export class PfcEngine implements IPfcEngine {
         reason: 'MEM-CONFIDENCE-BELOW-THRESHOLD',
         confidence: candidate.confidence,
       };
-      console.info(
-        `[nous:pfc] memory_write approved=false reason=${decision.reason}`,
+      this.log.info(
+        `memory_write approved=false reason=${decision.reason}`,
       );
       this.thoughtEmitter?.emitPfcDecision({
         traceId: this.currentTraceId,
@@ -101,8 +105,8 @@ export class PfcEngine implements IPfcEngine {
       reason: 'MEM-WRITE-APPROVED',
       confidence: candidate.confidence,
     };
-    console.info(
-      `[nous:pfc] memory_write approved=true reason=${decision.reason}`,
+    this.log.info(
+      `memory_write approved=true reason=${decision.reason}`,
     );
     this.thoughtEmitter?.emitPfcDecision({
       traceId: this.currentTraceId,
@@ -228,8 +232,8 @@ export class PfcEngine implements IPfcEngine {
         reason: 'tool not registered',
         confidence: 0,
       };
-      console.info(
-        `[nous:pfc] tool_auth toolName=${toolName} approved=false reason=${decision.reason}`,
+      this.log.info(
+        `tool_auth toolName=${toolName} approved=false reason=${decision.reason}`,
       );
       this.thoughtEmitter?.emitPfcDecision({
         traceId: this.currentTraceId,
@@ -248,8 +252,8 @@ export class PfcEngine implements IPfcEngine {
       reason: 'passed Phase 1 checks',
       confidence: 1,
     };
-    console.info(
-      `[nous:pfc] tool_auth toolName=${toolName} approved=true reason=${decision.reason}`,
+    this.log.info(
+      `tool_auth toolName=${toolName} approved=true reason=${decision.reason}`,
     );
     this.thoughtEmitter?.emitPfcDecision({
       traceId: this.currentTraceId,
@@ -268,7 +272,7 @@ export class PfcEngine implements IPfcEngine {
     _output: unknown,
     _context: ReflectionContext,
   ): Promise<ReflectionResult> {
-    console.debug('[nous:pfc] reflect confidence=0.8 qualityScore=0.8');
+    this.log.debug('reflect confidence=0.8 qualityScore=0.8');
     this.thoughtEmitter?.emitPfcDecision({
       traceId: this.currentTraceId,
       thoughtType: 'reflection',
@@ -291,8 +295,8 @@ export class PfcEngine implements IPfcEngine {
     situation: EscalationSituation,
   ): Promise<EscalationDecision> {
     if (situation.confidence < 0.3) {
-      console.info(
-        `[nous:pfc] escalation trigger=${situation.trigger} context=${situation.context}`,
+      this.log.info(
+        `escalation trigger=${situation.trigger} context=${situation.context}`,
       );
       this.thoughtEmitter?.emitPfcDecision({
         traceId: this.currentTraceId,

--- a/self/memory/stm/src/document-stm-store.ts
+++ b/self/memory/stm/src/document-stm-store.ts
@@ -5,7 +5,7 @@
  * Document ID: ProjectId.
  */
 import { createHash, randomUUID } from 'node:crypto';
-import type { IDocumentStore, IStmStore } from '@nous/shared';
+import type { IDocumentStore, ILogChannel, IStmStore } from '@nous/shared';
 import {
   DEFAULT_STM_COMPACTION_POLICY,
   StmContextSchema,
@@ -29,10 +29,12 @@ function estimateTokenCount(content: string): number {
 
 export interface DocumentStmStoreOptions {
   compactionPolicy?: Partial<StmCompactionPolicy>;
+  log?: ILogChannel;
 }
 
 export class DocumentStmStore implements IStmStore {
   private readonly compactionPolicy: StmCompactionPolicy;
+  private readonly log: ILogChannel;
 
   constructor(
     private readonly documentStore: IDocumentStore,
@@ -42,6 +44,7 @@ export class DocumentStmStore implements IStmStore {
       ...DEFAULT_STM_COMPACTION_POLICY,
       ...options.compactionPolicy,
     });
+    this.log = options.log ?? { debug() {}, info() {}, warn() {}, error() {}, isEnabled() { return false; } };
   }
 
   async getContext(projectId: ProjectId): Promise<StmContext> {
@@ -65,8 +68,8 @@ export class DocumentStmStore implements IStmStore {
     }
 
     const context = buildContext(result.data, this.compactionPolicy);
-    console.debug(
-      `[nous:stm] get_context projectId=${projectId} entries=${context.entries.length} tokens=${context.tokenCount}`,
+    this.log.debug(
+      `get_context projectId=${projectId} entries=${context.entries.length} tokens=${context.tokenCount}`,
     );
     return context;
   }
@@ -92,8 +95,8 @@ export class DocumentStmStore implements IStmStore {
     );
 
     await this.documentStore.put(COLLECTION, projectId, updated);
-    console.debug(
-      `[nous:stm] append projectId=${projectId} role=${validated.role} length=${validated.content.length} tokens=${updated.tokenCount}`,
+    this.log.debug(
+      `append projectId=${projectId} role=${validated.role} length=${validated.content.length} tokens=${updated.tokenCount}`,
     );
   }
 
@@ -169,14 +172,14 @@ export class DocumentStmStore implements IStmStore {
     );
 
     await this.documentStore.put(COLLECTION, projectId, updated);
-    console.info(
-      `[nous:stm] compact projectId=${projectId} trigger=${trigger} compacted=${compactedEntries.length} retained=${retainedEntries.length} preTokens=${context.tokenCount} postTokens=${updated.tokenCount}`,
+    this.log.info(
+      `compact projectId=${projectId} trigger=${trigger} compacted=${compactedEntries.length} retained=${retainedEntries.length} preTokens=${context.tokenCount} postTokens=${updated.tokenCount}`,
     );
   }
 
   async clear(projectId: ProjectId): Promise<void> {
     await this.documentStore.delete(COLLECTION, projectId);
-    console.info(`[nous:stm] clear projectId=${projectId}`);
+    this.log.info(`clear projectId=${projectId}`);
   }
 }
 

--- a/self/shared/src/interfaces/agent-gateway.ts
+++ b/self/shared/src/interfaces/agent-gateway.ts
@@ -175,6 +175,10 @@ export interface AgentGatewayConfig {
   /** Composable harness strategies (WR-127). When present, the gateway
    *  delegates to these instead of built-in behavior. */
   harness?: HarnessStrategies;
+
+  /** Optional structured log channel (WR-157). When present, the gateway
+   *  routes all diagnostic output through this channel instead of console. */
+  log?: import('./logging.js').ILogChannel;
 }
 
 export interface IAgentGateway {

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -149,3 +149,8 @@ export type {
   ICredentialInjector,
   SystemConfig,
 } from './autonomic.js';
+export type {
+  ILogChannel,
+  ILogEgress,
+  ILogger,
+} from './logging.js';

--- a/self/shared/src/interfaces/logging.ts
+++ b/self/shared/src/interfaces/logging.ts
@@ -1,0 +1,42 @@
+/**
+ * Logging interface contracts for the structured logging facade.
+ */
+import type { LogEntry, LogLevel } from '../types/logging.js';
+import type { IConfig } from './autonomic.js';
+
+/**
+ * A namespaced log channel. Each channel corresponds to a subsystem
+ * (e.g. `nous:config`, `nous:gateway:auth`).
+ *
+ * Disabled channels short-circuit before LogEntry construction.
+ */
+export interface ILogChannel {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+  isEnabled(): boolean;
+}
+
+/**
+ * Egress plugin interface. Each egress receives every log entry
+ * and decides how to persist or forward it.
+ *
+ * `write()` is synchronous, fire-and-forget. The logger wraps each
+ * call in try/catch and auto-disables after 5 consecutive failures.
+ */
+export interface ILogEgress {
+  readonly name: string;
+  write(entry: LogEntry): void;
+  flush?(): Promise<void>;
+  dispose?(): Promise<void>;
+}
+
+/**
+ * Top-level logger interface exposed to service graph consumers.
+ */
+export interface ILogger {
+  channel(namespace: string): ILogChannel;
+  bindConfig(config: IConfig): void;
+  setLevel(level: LogLevel): void;
+}

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -88,3 +88,4 @@ export * from './workflow-spec.js';
 export * from './workflow-node-types.js';
 export * from './workflow-package.js';
 export * from './cost.js';
+export * from './logging.js';

--- a/self/shared/src/types/logging.ts
+++ b/self/shared/src/types/logging.ts
@@ -1,0 +1,28 @@
+/**
+ * Logging types for the structured logging facade.
+ *
+ * These types define the contract between the logger package
+ * (@nous/autonomic-logger) and the rest of the system.
+ */
+
+/**
+ * Severity levels for log entries, ordered by increasing severity.
+ * Numeric values enable comparison: `level >= LogLevel.Warn`.
+ */
+export enum LogLevel {
+  Debug = 0,
+  Info = 1,
+  Warn = 2,
+  Error = 3,
+}
+
+/**
+ * A single structured log entry emitted by a channel.
+ */
+export interface LogEntry {
+  level: LogLevel;
+  namespace: string;
+  message: string;
+  data?: Record<string, unknown>;
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary

- Adds `@nous/autonomic-logger` package with `NousLogger` class implementing `ILogger`/`ILogChannel` interfaces
- Three egress plugins: ConsoleEgress (default), NullEgress, AxiomEgress (env-var-toggled via `AXIOM_TOKEN`)
- Namespaced channel system (`nous:<subsystem>`) with config-driven enable/disable (longest-prefix-match)
- Two-phase bootstrap: logger available before ConfigManager, config-driven after `bindConfig()`
- `LoggingConfigSchema` added to `SystemConfigSchema` with zero-config defaults
- Migrates 52 `console.*` calls across 9 core files (cortex-core, cortex-pfc, memory-stm) to logger facade
- Full repo console call inventory documenting ~211 remaining calls for future migration waves

## Commits (9)

1. `feat(shared)` — ILogger, ILogChannel, ILogEgress interfaces + LogLevel, LogEntry types
2. `feat(autonomic)` — LoggingConfigSchema + @nous/autonomic-logger package (NousLogger, egress plugins, 30 unit tests)
3. `feat(bootstrap)` — Two-phase logger wiring in shared-server bootstrap
4. `refactor(cortex-core)` — Migrate adapter console calls (5 calls across 3 files)
5. `refactor(cortex-core)` — Migrate agent-gateway console calls (10 calls)
6. `refactor(cortex-core)` — Migrate gateway runtime console calls (26 calls across 3 files)
7. `refactor(cortex-pfc)` — Migrate PfcEngine console calls (7 calls)
8. `refactor(memory-stm)` — Migrate DocumentStmStore console calls (4 calls)
9. `test(cortex-core)` — Update 5 test files to use mock ILogChannel

## Test plan

- [x] `pnpm build` — full monorepo builds cleanly
- [x] `pnpm test` — 557 test files, 5148 tests pass, zero regressions
- [x] Logger-specific: 30/30 unit tests pass
- [x] Zero raw `console.*` calls in migrated files (verified via grep)
- [x] Console output format unchanged (`[nous:<ns>] message { data }`)
- [ ] BT deferred — Principal will test on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)