### PR TITLE
feat(WR-160): SP 1.2 — Adapter Tool Round-Trip Formatting

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/anthropic-adapter.test.ts
@@ -96,6 +96,79 @@ describe('createAnthropicAdapter', () => {
       expect(messages[2]).toEqual({ role: 'user', content: 'Tool result' }); // tool -> user
     });
 
+    it('formats multi-turn tool calling round-trip (assistant tool_use + tool_result)', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'user',
+            content: 'What is the weather in NYC?',
+            source: 'initial_context',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+          {
+            role: 'assistant',
+            content: 'Let me check the weather.',
+            source: 'model_response',
+            createdAt: '2026-01-01T00:00:01Z',
+            metadata: {
+              tool_calls: [
+                { id: 'toolu_weather', name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+          {
+            role: 'tool',
+            content: '72°F and sunny',
+            source: 'tool_result',
+            createdAt: '2026-01-01T00:00:02Z',
+            metadata: { tool_call_id: 'toolu_weather' },
+          },
+          {
+            role: 'assistant',
+            content: 'The weather in NYC is 72°F and sunny.',
+            source: 'model_response',
+            createdAt: '2026-01-01T00:00:03Z',
+          },
+        ],
+      };
+      const result = adapter.formatRequest(input);
+      const messages = result.input.messages as Array<{ role: string; content: unknown }>;
+
+      expect(messages).toHaveLength(4);
+
+      // User message
+      expect(messages[0]).toEqual({ role: 'user', content: 'What is the weather in NYC?' });
+
+      // Assistant message with tool_use content blocks
+      expect(messages[1].role).toBe('assistant');
+      const assistantContent = messages[1].content as Array<Record<string, unknown>>;
+      expect(assistantContent).toHaveLength(2);
+      expect(assistantContent[0]).toEqual({ type: 'text', text: 'Let me check the weather.' });
+      expect(assistantContent[1]).toEqual({
+        type: 'tool_use',
+        id: 'toolu_weather',
+        name: 'get_weather',
+        input: { city: 'NYC' },
+      });
+
+      // Tool result as user message with tool_result content block
+      expect(messages[2].role).toBe('user');
+      expect(messages[2].content).toEqual([
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_weather',
+          content: '72°F and sunny',
+        },
+      ]);
+
+      // Final assistant message
+      expect(messages[3]).toEqual({
+        role: 'assistant',
+        content: 'The weather in NYC is 72°F and sunny.',
+      });
+    });
+
     it('passes model requirements as model_profile', () => {
       const input: AdapterFormatInput = {
         systemPrompt: 'test',

--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
@@ -242,7 +242,125 @@ describe('createOllamaAdapter', () => {
       expect(messages[1]).toEqual({ role: 'user', content: 'tool output' });
     });
 
-    it('parseResponse returns undefined id for tool calls (Ollama does not provide IDs)', () => {
+    it('emits tool_calls array on assistant message with metadata.tool_calls', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'prompt',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: 'I will check the weather.',
+            source: 'model_output' as const,
+            createdAt: new Date().toISOString(),
+            metadata: {
+              tool_calls: [
+                { id: 'call_abc', name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: 'I will check the weather.',
+        tool_calls: [
+          {
+            id: 'call_abc',
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              arguments: '{"city":"NYC"}',
+            },
+          },
+        ],
+      });
+    });
+
+    it('strips thinking from assistant content even when tool_calls present', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'prompt',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: '<think>Let me reason...</think>I will check.',
+            source: 'model_output' as const,
+            createdAt: new Date().toISOString(),
+            metadata: {
+              tool_calls: [
+                { id: 'call_1', name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1].content).toBe('I will check.');
+      expect(messages[1].tool_calls).toBeDefined();
+    });
+
+    it('formats multi-turn tool calling sequence', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'prompt',
+        context: [
+          makeFrame('user', 'What is the weather?'),
+          {
+            role: 'assistant' as const,
+            content: 'Let me check.',
+            source: 'model_output' as const,
+            createdAt: new Date().toISOString(),
+            metadata: {
+              tool_calls: [
+                { id: 'call_w', name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+          {
+            role: 'tool' as const,
+            content: '72°F and sunny',
+            source: 'tool_result' as const,
+            createdAt: new Date().toISOString(),
+            metadata: { tool_call_id: 'call_w' },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      // system + user + assistant(tool_calls) + tool(tool_call_id)
+      expect(messages).toHaveLength(4);
+      expect(messages[2]).toEqual({
+        role: 'assistant',
+        content: 'Let me check.',
+        tool_calls: [{
+          id: 'call_w',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+        }],
+      });
+      expect(messages[3]).toEqual({
+        role: 'tool',
+        content: '72°F and sunny',
+        tool_call_id: 'call_w',
+      });
+    });
+
+    it('does not emit tool_calls for assistant frame without metadata.tool_calls', () => {
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'prompt',
+        context: [makeFrame('assistant', 'Just a regular message.')],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1]).toEqual({ role: 'assistant', content: 'Just a regular message.' });
+      expect(messages[1].tool_calls).toBeUndefined();
+    });
+
+    it('parseResponse returns undefined id for tool calls without id field on raw object', () => {
       const adapter = createOllamaAdapter('gemma4:12b');
       const output = {
         content: '',
@@ -279,7 +397,26 @@ describe('createOllamaAdapter', () => {
       };
       const result = adapter.parseResponse(output, TRACE_ID);
       expect(result.toolCalls).toEqual([
-        { name: 'get_weather', params: { city: 'NYC' } },
+        { name: 'get_weather', params: { city: 'NYC' }, id: undefined },
+      ]);
+    });
+
+    it('extracts id from tool call when present', () => {
+      const output = {
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_abc123',
+            function: {
+              name: 'get_weather',
+              arguments: { city: 'NYC' },
+            },
+          },
+        ],
+      };
+      const result = adapter.parseResponse(output, TRACE_ID);
+      expect(result.toolCalls).toEqual([
+        { name: 'get_weather', params: { city: 'NYC' }, id: 'call_abc123' },
       ]);
     });
 

--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/openai-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/openai-adapter.test.ts
@@ -117,6 +117,182 @@ describe('createOpenAiAdapter', () => {
       const messages = input.messages as Array<Record<string, unknown>>;
       expect(messages[1]).toEqual({ role: 'user', content: 'tool output' });
     });
+
+    it('emits tool_calls array on assistant message with metadata.tool_calls', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: 'I will get the weather.',
+            source: 'model_output' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+            metadata: {
+              tool_calls: [
+                { id: 'call_abc', name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: 'I will get the weather.',
+        tool_calls: [
+          {
+            id: 'call_abc',
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              arguments: '{"city":"NYC"}',
+            },
+          },
+        ],
+      });
+    });
+
+    it('generates synthetic id when metadata.tool_calls[].id is undefined', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: '',
+            source: 'model_output' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+            metadata: {
+              tool_calls: [
+                { name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      const toolCalls = (messages[1] as Record<string, unknown>).tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls[0].id).toBe('call_0');
+    });
+
+    it('JSON.stringifies tool_calls arguments', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: '',
+            source: 'model_output' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+            metadata: {
+              tool_calls: [
+                { id: 'call_1', name: 'test', input: { nested: { deep: true } } },
+              ],
+            },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      const toolCalls = (messages[1] as Record<string, unknown>).tool_calls as Array<Record<string, unknown>>;
+      const fn = toolCalls[0].function as Record<string, unknown>;
+      expect(fn.arguments).toBe('{"nested":{"deep":true}}');
+      expect(typeof fn.arguments).toBe('string');
+    });
+
+    it('handles null/undefined input in tool_calls arguments with fallback', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: '',
+            source: 'model_output' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+            metadata: {
+              tool_calls: [
+                { id: 'call_1', name: 'test', input: undefined },
+              ],
+            },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      const toolCalls = (messages[1] as Record<string, unknown>).tool_calls as Array<Record<string, unknown>>;
+      const fn = toolCalls[0].function as Record<string, unknown>;
+      expect(fn.arguments).toBe('{}');
+    });
+
+    it('formats multi-turn tool calling sequence (assistant + tool result)', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'user' as const,
+            content: 'What is the weather?',
+            source: 'initial_context' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+          {
+            role: 'assistant' as const,
+            content: 'Let me check.',
+            source: 'model_output' as const,
+            createdAt: '2026-01-01T00:00:01Z',
+            metadata: {
+              tool_calls: [
+                { id: 'call_weather', name: 'get_weather', input: { city: 'NYC' } },
+              ],
+            },
+          },
+          {
+            role: 'tool' as const,
+            content: '72°F and sunny',
+            source: 'tool_result' as const,
+            createdAt: '2026-01-01T00:00:02Z',
+            metadata: { tool_call_id: 'call_weather' },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      // system + user + assistant(tool_calls) + tool(tool_call_id)
+      expect(messages).toHaveLength(4);
+      expect(messages[1]).toEqual({ role: 'user', content: 'What is the weather?' });
+      expect(messages[2]).toEqual({
+        role: 'assistant',
+        content: 'Let me check.',
+        tool_calls: [{
+          id: 'call_weather',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+        }],
+      });
+      expect(messages[3]).toEqual({
+        role: 'tool',
+        content: '72°F and sunny',
+        tool_call_id: 'call_weather',
+      });
+    });
+
+    it('does not emit tool_calls for assistant frame without metadata.tool_calls', () => {
+      const result = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: 'Just a regular message.',
+            source: 'model_output' as const,
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      expect(messages[1]).toEqual({ role: 'assistant', content: 'Just a regular message.' });
+      expect(messages[1].tool_calls).toBeUndefined();
+    });
   });
 
   describe('parseResponse', () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-tool-roundtrip.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-tool-roundtrip.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Integration test: adapter tool round-trip formatting.
+ *
+ * Verifies the full cycle:
+ *   1. Provider returns tool_calls in response
+ *   2. Adapter parses response → ParsedModelOutput with toolCalls
+ *   3. Gateway stores toolCalls metadata on assistant context frame
+ *   4. Gateway stores tool_call_id metadata on tool result context frame
+ *   5. Adapter re-formats context frames → provider-specific request with tool_calls + tool_call_id
+ *
+ * This proves the round-trip: parseResponse → context frame metadata → formatRequest
+ */
+import { describe, expect, it } from 'vitest';
+import type { GatewayContextFrame, TraceId } from '@nous/shared';
+import { createOpenAiAdapter } from '../../agent-gateway/adapters/openai-adapter.js';
+import { createOllamaAdapter } from '../../agent-gateway/adapters/ollama-adapter.js';
+import { createAnthropicAdapter } from '../../agent-gateway/adapters/anthropic-adapter.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440300' as TraceId;
+
+/**
+ * Simulates the gateway's context frame accumulation after a model response
+ * with tool calls and a subsequent tool result.
+ *
+ * This mirrors the logic in AgentGateway.run() (lines 286-294 for tool_calls
+ * metadata, lines 648-654 for tool_call_id metadata).
+ */
+function simulateGatewayContextAccumulation(
+  parsedOutput: { response: string; toolCalls: Array<{ name: string; params: unknown; id?: string }> },
+  toolResultContent: string,
+): GatewayContextFrame[] {
+  const frames: GatewayContextFrame[] = [];
+
+  // User message that triggered the tool call
+  frames.push({
+    role: 'user',
+    source: 'initial_context',
+    content: 'What is the weather in NYC?',
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+
+  // Assistant frame with tool_calls metadata (mirrors agent-gateway.ts:286-294)
+  const assistantFrame: GatewayContextFrame = {
+    role: 'assistant',
+    source: 'model_output',
+    content: parsedOutput.response,
+    createdAt: '2026-01-01T00:00:01Z',
+  };
+  if (parsedOutput.toolCalls.length > 0) {
+    assistantFrame.metadata = {
+      tool_calls: parsedOutput.toolCalls.map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        input: tc.params,
+      })),
+    };
+  }
+  frames.push(assistantFrame);
+
+  // Tool result frame with tool_call_id metadata (mirrors agent-gateway.ts:648-654)
+  const toolCallId = parsedOutput.toolCalls[0]?.id;
+  const toolFrame: GatewayContextFrame = {
+    role: 'tool',
+    source: 'tool_result',
+    content: toolResultContent,
+    createdAt: '2026-01-01T00:00:02Z',
+  };
+  if (toolCallId) {
+    toolFrame.metadata = { tool_call_id: toolCallId };
+  }
+  frames.push(toolFrame);
+
+  return frames;
+}
+
+describe('Adapter tool round-trip formatting', () => {
+  describe('OpenAI adapter round-trip', () => {
+    const adapter = createOpenAiAdapter();
+
+    it('parses tool_calls from response, then re-formats context frames correctly', () => {
+      // Step 1: Parse a provider response with tool_calls
+      const providerResponse = {
+        choices: [{
+          message: {
+            content: 'Let me check the weather.',
+            tool_calls: [{
+              id: 'call_weather_1',
+              type: 'function',
+              function: {
+                name: 'get_weather',
+                arguments: '{"city":"NYC"}',
+              },
+            }],
+          },
+        }],
+      };
+      const parsed = adapter.parseResponse(providerResponse, TRACE_ID);
+      expect(parsed.toolCalls).toHaveLength(1);
+      expect(parsed.toolCalls[0]).toEqual({
+        name: 'get_weather',
+        params: { city: 'NYC' },
+        id: 'call_weather_1',
+      });
+
+      // Step 2: Simulate gateway context accumulation
+      const frames = simulateGatewayContextAccumulation(parsed, '72°F and sunny');
+
+      // Step 3: Re-format with adapter
+      const formatted = adapter.formatRequest({
+        systemPrompt: 'You are a weather assistant.',
+        context: frames,
+      });
+      const messages = (formatted.input as Record<string, unknown>).messages as Array<Record<string, unknown>>;
+
+      // system + user + assistant(tool_calls) + tool(tool_call_id)
+      expect(messages).toHaveLength(4);
+
+      // Verify assistant message has tool_calls array
+      expect(messages[2]).toEqual({
+        role: 'assistant',
+        content: 'Let me check the weather.',
+        tool_calls: [{
+          id: 'call_weather_1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"city":"NYC"}',
+          },
+        }],
+      });
+
+      // Verify tool result message has tool_call_id
+      expect(messages[3]).toEqual({
+        role: 'tool',
+        content: '72°F and sunny',
+        tool_call_id: 'call_weather_1',
+      });
+    });
+  });
+
+  describe('Ollama adapter round-trip', () => {
+    const adapter = createOllamaAdapter('gemma4:12b');
+
+    it('parses tool_calls from response (with id), then re-formats context frames correctly', () => {
+      // Step 1: Parse response with tool_calls including id
+      const providerResponse = {
+        content: 'Checking weather.',
+        tool_calls: [{
+          id: 'call_ollama_1',
+          function: {
+            name: 'get_weather',
+            arguments: { city: 'NYC' },
+          },
+        }],
+      };
+      const parsed = adapter.parseResponse(providerResponse, TRACE_ID);
+      expect(parsed.toolCalls).toHaveLength(1);
+      expect(parsed.toolCalls[0].id).toBe('call_ollama_1');
+
+      // Step 2: Simulate gateway context accumulation
+      const frames = simulateGatewayContextAccumulation(parsed, '72°F and sunny');
+
+      // Step 3: Re-format with adapter
+      const formatted = adapter.formatRequest({
+        systemPrompt: 'You are a weather assistant.',
+        context: frames,
+      });
+      const messages = (formatted.input as Record<string, unknown>).messages as Array<Record<string, unknown>>;
+
+      // system + user + assistant(tool_calls) + tool(tool_call_id)
+      expect(messages).toHaveLength(4);
+
+      // Verify assistant message has tool_calls
+      expect(messages[2]).toEqual({
+        role: 'assistant',
+        content: 'Checking weather.',
+        tool_calls: [{
+          id: 'call_ollama_1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"city":"NYC"}',
+          },
+        }],
+      });
+
+      // Verify tool result has tool_call_id
+      expect(messages[3]).toEqual({
+        role: 'tool',
+        content: '72°F and sunny',
+        tool_call_id: 'call_ollama_1',
+      });
+    });
+
+    it('handles round-trip when provider response lacks id on tool_calls', () => {
+      // Ollama may not return id on tool_calls
+      const providerResponse = {
+        content: '',
+        tool_calls: [{
+          function: {
+            name: 'get_weather',
+            arguments: { city: 'NYC' },
+          },
+        }],
+      };
+      const parsed = adapter.parseResponse(providerResponse, TRACE_ID);
+      expect(parsed.toolCalls[0].id).toBeUndefined();
+
+      // Gateway stores undefined id
+      const frames = simulateGatewayContextAccumulation(parsed, '72°F');
+
+      // Adapter generates synthetic id during formatting
+      const formatted = adapter.formatRequest({
+        systemPrompt: 'test',
+        context: frames,
+      });
+      const messages = (formatted.input as Record<string, unknown>).messages as Array<Record<string, unknown>>;
+      const assistantMsg = messages[2] as Record<string, unknown>;
+      const toolCalls = assistantMsg.tool_calls as Array<Record<string, unknown>>;
+      // Synthetic id should be generated
+      expect(toolCalls[0].id).toBe('call_0');
+    });
+  });
+
+  describe('Anthropic adapter round-trip', () => {
+    const adapter = createAnthropicAdapter();
+
+    it('parses tool_use from response, then re-formats context frames correctly', () => {
+      // Step 1: Parse Anthropic response with tool_use blocks
+      const providerResponse = {
+        content: [
+          { type: 'text', text: 'Let me check the weather.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_weather_1',
+            name: 'get_weather',
+            input: { city: 'NYC' },
+          },
+        ],
+        stop_reason: 'tool_use',
+      };
+      const parsed = adapter.parseResponse(providerResponse, TRACE_ID);
+      expect(parsed.toolCalls).toHaveLength(1);
+      expect(parsed.toolCalls[0]).toEqual({
+        name: 'get_weather',
+        params: { city: 'NYC' },
+        id: 'toolu_weather_1',
+      });
+
+      // Step 2: Simulate gateway context accumulation
+      const frames = simulateGatewayContextAccumulation(parsed, '72°F and sunny');
+
+      // Step 3: Re-format with adapter
+      const formatted = adapter.formatRequest({
+        systemPrompt: 'You are a weather assistant.',
+        context: frames,
+      });
+      const messages = (formatted.input as Record<string, unknown>).messages as Array<Record<string, unknown>>;
+
+      // user + assistant(tool_use blocks) + user(tool_result block)
+      expect(messages).toHaveLength(3);
+
+      // Verify assistant has tool_use content blocks
+      expect(messages[1].role).toBe('assistant');
+      const assistantContent = messages[1].content as Array<Record<string, unknown>>;
+      expect(assistantContent).toHaveLength(2);
+      expect(assistantContent[0]).toEqual({ type: 'text', text: 'Let me check the weather.' });
+      expect(assistantContent[1]).toEqual({
+        type: 'tool_use',
+        id: 'toolu_weather_1',
+        name: 'get_weather',
+        input: { city: 'NYC' },
+      });
+
+      // Verify tool result content block
+      expect(messages[2].role).toBe('user');
+      const toolContent = messages[2].content as Array<Record<string, unknown>>;
+      expect(toolContent[0]).toEqual({
+        type: 'tool_result',
+        tool_use_id: 'toolu_weather_1',
+        content: '72°F and sunny',
+      });
+    });
+  });
+});

--- a/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
@@ -127,13 +127,14 @@ function detectContentType(response: string): 'text' | 'openui' {
  */
 function parseOllamaToolCalls(
   toolCalls: unknown,
-): Array<{ name: string; params: unknown }> {
+): Array<{ name: string; params: unknown; id?: string }> {
   if (!Array.isArray(toolCalls)) return [];
-  const result: Array<{ name: string; params: unknown }> = [];
+  const result: Array<{ name: string; params: unknown; id?: string }> = [];
 
   for (const tc of toolCalls) {
     if (tc && typeof tc === 'object' && 'function' in tc) {
-      const fn = (tc as Record<string, unknown>).function;
+      const tcObj = tc as Record<string, unknown>;
+      const fn = tcObj.function;
       if (fn && typeof fn === 'object') {
         const fnObj = fn as Record<string, unknown>;
         const name = typeof fnObj.name === 'string' ? fnObj.name : '';
@@ -150,7 +151,8 @@ function parseOllamaToolCalls(
           params = fnObj.arguments;
         }
 
-        if (name) result.push({ name, params });
+        const id = typeof tcObj.id === 'string' ? tcObj.id : undefined;
+        if (name) result.push({ name, params, id });
       }
     }
   }
@@ -243,7 +245,7 @@ export function createOllamaAdapter(modelId?: string, log?: ILogChannel): Provid
         : input.systemPrompt;
 
       // Build messages array
-      const messages: Array<{ role: string; content: string; tool_call_id?: string }> = [
+      const messages: Array<{ role: string; content: string; tool_call_id?: string; tool_calls?: unknown[] }> = [
         { role: 'system', content: systemPrompt },
       ];
 
@@ -254,6 +256,25 @@ export function createOllamaAdapter(modelId?: string, log?: ILogChannel): Provid
         // to avoid confusing the model with prior reasoning traces
         if (frame.role === 'assistant') {
           content = stripThinkingFromContext(content);
+        }
+
+        // Assistant frame with tool_calls metadata → OpenAI-compatible tool_calls on assistant message
+        if (frame.role === 'assistant' && Array.isArray(frame.metadata?.tool_calls)) {
+          const toolCalls = (frame.metadata!.tool_calls as Array<{ id?: string; name: string; input: unknown }>)
+            .map((tc, index) => ({
+              id: tc.id ?? `call_${index}`,
+              type: 'function' as const,
+              function: {
+                name: tc.name,
+                arguments: (() => { try { return JSON.stringify(tc.input ?? {}); } catch { return '{}'; } })(),
+              },
+            }));
+          messages.push({
+            role: 'assistant',
+            content,
+            tool_calls: toolCalls,
+          });
+          continue;
         }
 
         // Tool result with tool_call_id metadata → OpenAI-compatible tool result message

--- a/self/cortex/core/src/agent-gateway/adapters/openai-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/openai-adapter.ts
@@ -20,6 +20,23 @@ export function createOpenAiAdapter(): ProviderAdapter {
       const messages = [
         { role: 'system' as const, content: systemPrompt } as Record<string, unknown>,
         ...input.context.map((frame) => {
+          // Assistant frame with tool_calls metadata → OpenAI tool_calls on assistant message
+          if (frame.role === 'assistant' && Array.isArray(frame.metadata?.tool_calls)) {
+            const toolCalls = (frame.metadata!.tool_calls as Array<{ id?: string; name: string; input: unknown }>)
+              .map((tc, index) => ({
+                id: tc.id ?? `call_${index}`,
+                type: 'function' as const,
+                function: {
+                  name: tc.name,
+                  arguments: (() => { try { return JSON.stringify(tc.input ?? {}); } catch { return '{}'; } })(),
+                },
+              }));
+            return {
+              role: 'assistant' as const,
+              content: frame.content,
+              tool_calls: toolCalls,
+            };
+          }
           // Tool result with tool_call_id metadata → OpenAI tool result message
           if (frame.role === 'tool' && frame.metadata?.tool_call_id) {
             return {

--- a/self/subcortex/providers/src/ollama-provider.ts
+++ b/self/subcortex/providers/src/ollama-provider.ts
@@ -139,7 +139,7 @@ export class OllamaProvider implements IModelProvider {
 
   private validateInput(input: unknown): {
     prompt?: string;
-    messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }>;
+    messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }>;
     tools?: Array<Record<string, unknown>>;
   } {
     const result = TextModelInputSchema.safeParse(input);
@@ -156,7 +156,7 @@ export class OllamaProvider implements IModelProvider {
   private buildRequestBody(
     input: {
       prompt?: string;
-      messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }>;
+      messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }>;
       tools?: Array<Record<string, unknown>>;
     },
   ): Record<string, unknown> {

--- a/self/subcortex/providers/src/openai-provider.ts
+++ b/self/subcortex/providers/src/openai-provider.ts
@@ -202,7 +202,7 @@ export class OpenAiCompatibleProvider implements IModelProvider {
     }
   }
 
-  private validateInput(input: unknown): { prompt?: string; messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }> } {
+  private validateInput(input: unknown): { prompt?: string; messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }> } {
     const result = TextModelInputSchema.safeParse(input);
     if (!result.success) {
       const errors = result.error.errors.map((e) => ({
@@ -215,13 +215,14 @@ export class OpenAiCompatibleProvider implements IModelProvider {
   }
 
   private toOpenAiMessages(
-    input: { prompt?: string; messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string }> },
-  ): Array<{ role: string; content: string; tool_call_id?: string }> {
+    input: { prompt?: string; messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }> },
+  ): Array<{ role: string; content: string; tool_call_id?: string; tool_calls?: unknown[] }> {
     if (input.messages && input.messages.length > 0) {
       return input.messages.map((m) => ({
         role: m.role as 'user' | 'assistant' | 'system' | 'tool',
         content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
         ...(m.tool_call_id ? { tool_call_id: m.tool_call_id } : {}),
+        ...(m.tool_calls ? { tool_calls: m.tool_calls } : {}),
       }));
     }
     return [{ role: 'user' as const, content: input.prompt ?? '' }];

--- a/self/subcortex/providers/src/schemas.ts
+++ b/self/subcortex/providers/src/schemas.ts
@@ -36,6 +36,14 @@ const MessageSchema = z.object({
   role: z.enum(['user', 'assistant', 'system', 'tool']),
   content: z.union([z.string(), z.array(ContentBlockSchema)]),
   tool_call_id: z.string().optional(),
+  tool_calls: z.array(z.object({
+    id: z.string(),
+    type: z.literal('function'),
+    function: z.object({
+      name: z.string(),
+      arguments: z.string(),
+    }),
+  })).optional(),
 });
 
 export const TextModelInputSchema = z.union([


### PR DESCRIPTION
## Summary

- Add `tool_calls` field to `MessageSchema` and preserve tool call data through provider message mapping
- Implement assistant `tool_calls` formatting in OpenAI and Ollama adapters for round-trip fidelity
- Add comprehensive round-trip tests for all three adapters (Anthropic, OpenAI, Ollama)

## Context

Sub-phase 1.2 of the Provider Execution Infrastructure sprint (WR-160). Ensures tool call metadata survives the adapter round-trip so downstream consumers can reconstruct the full conversation including tool use.

## Merge target

`feat/provider-execution-infrastructure` (phase integration branch)