### PR TITLE
fix(desktop,cortex-core): model persistence & workflow list fixes (Phase 1.6)

### DIFF
--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -573,6 +573,7 @@ function spawnBackendServer(port: number): Promise<number> {
     // Set data dir to app's userData directory for production isolation
     const dataDir = app.getPath('userData')
     args.push(`--data-dir=${join(dataDir, 'data')}`)
+    args.push(`--config-path=${join(dataDir, 'data', 'config.json')}`)
 
     console.log(`[nous:desktop] spawning backend server: ${serverPath} ${args.join(' ')}`)
 

--- a/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
+++ b/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
@@ -1,10 +1,10 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ModelRole, ProviderId, TraceId } from '@nous/shared';
-import { DEFAULT_PROFILES } from '@nous/autonomic-config';
+import { ConfigManager, DEFAULT_PROFILES } from '@nous/autonomic-config';
 import {
   OLLAMA_WELL_KNOWN_PROVIDER_ID,
   WELL_KNOWN_PROVIDER_IDS,
@@ -410,6 +410,35 @@ describe('provider lifecycle wiring', () => {
     await registerStoredProviders(ctx);
     // User's model selection should survive the restart
     expect(state.providers[0]!.modelId).toBe('gpt-4-turbo');
+  });
+
+  it('ConfigManager persists config changes to disk across instances', async () => {
+    const tempDir = join(tmpdir(), `nous-config-persist-${randomUUID()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const configPath = join(tempDir, 'config.json');
+
+    try {
+      // Instance 1: write a provider config change
+      const cm1 = new ConfigManager({ configPath });
+      const testProvider = {
+        id: randomUUID() as ProviderId,
+        name: 'TestPersistence',
+        type: 'text' as const,
+        modelId: 'test-model',
+        isLocal: true,
+        capabilities: [],
+      };
+      await cm1.update('providers', [testProvider] as any);
+
+      // Instance 2: fresh ConfigManager from the same file — simulates process restart
+      const cm2 = new ConfigManager({ configPath });
+      const providers = cm2.getSection('providers') as any[];
+      expect(providers).toHaveLength(1);
+      expect(providers[0]!.name).toBe('TestPersistence');
+      expect(providers[0]!.modelId).toBe('test-model');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('keeps mock fallback active when no keys are configured', async () => {

--- a/self/autonomic/config/src/__tests__/config-manager.test.ts
+++ b/self/autonomic/config/src/__tests__/config-manager.test.ts
@@ -197,10 +197,9 @@ describe('ConfigManager', () => {
   });
 
   describe('constructor', () => {
-    it('throws ConfigError with invalid configPath', () => {
-      expect(
-        () => new ConfigManager({ configPath: join(TEST_DIR, 'nope.json') }),
-      ).toThrow(ConfigError);
+    it('falls back to defaults when configPath points to non-existent file (ENOENT)', () => {
+      const manager = new ConfigManager({ configPath: join(TEST_DIR, 'nope.json') });
+      expect(manager.get()).toEqual(DEFAULT_SYSTEM_CONFIG);
     });
   });
 });

--- a/self/autonomic/config/src/__tests__/loader.test.ts
+++ b/self/autonomic/config/src/__tests__/loader.test.ts
@@ -54,8 +54,9 @@ describe('loadConfig', () => {
     expect(config.defaults.governance).toBe('should');
   });
 
-  it('throws ConfigError for non-existent file', () => {
-    expect(() => loadConfig(join(TEST_DIR, 'nope.json5'))).toThrow(ConfigError);
+  it('returns default config when path points to non-existent file (ENOENT)', () => {
+    const config = loadConfig(join(TEST_DIR, 'does-not-exist.json'));
+    expect(config).toEqual(DEFAULT_SYSTEM_CONFIG);
   });
 
   it('throws ConfigError for malformed JSON5', () => {

--- a/self/autonomic/config/src/loader.ts
+++ b/self/autonomic/config/src/loader.ts
@@ -28,6 +28,12 @@ export function loadConfig(path?: string): SystemConfig {
   try {
     raw = readFileSync(path, 'utf-8');
   } catch (err) {
+    // First-boot: config file does not exist yet — fall back to defaults.
+    // The file will be created on the first ConfigManager.update() call.
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.log(`[nous:config] Config file not found at ${path}, using defaults (will be created on first update)`);
+      return DEFAULT_SYSTEM_CONFIG;
+    }
     throw new ConfigError(`Failed to read config file: ${path}`, {
       path,
       cause: err instanceof Error ? err.message : String(err),

--- a/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
@@ -872,6 +872,10 @@ describe('Internal MCP capability handlers', () => {
         projectStore: projectStore as any,
         runtime: {
           instanceRoot: '/tmp/test',
+          resolvePath: (...segments: string[]) => segments.join('/'),
+          exists: vi.fn().mockResolvedValue(false),
+          ensureDir: vi.fn().mockResolvedValue(undefined),
+          listDirectory: vi.fn().mockResolvedValue([]),
         } as any,
       },
     });
@@ -889,6 +893,73 @@ describe('Internal MCP capability handlers', () => {
     expect(defs.some((d: any) => d.name === 'UserCreatedWorkflow')).toBe(true);
   });
 
+  it('workflow_list returns project store definitions when projectId is in execution context but not in params', async () => {
+    const projectStore = {
+      get: vi.fn().mockResolvedValue({
+        id: PROJECT_ID,
+        workflow: {
+          definitions: [
+            {
+              id: '550e8400-e29b-41d4-a716-446655440700',
+              projectId: PROJECT_ID,
+              mode: 'protocol',
+              version: '1.0.0',
+              name: 'ExecutionContextWorkflow',
+              entryNodeIds: ['550e8400-e29b-41d4-a716-446655440701'],
+              nodes: [
+                {
+                  id: '550e8400-e29b-41d4-a716-446655440701',
+                  name: 'Start',
+                  type: 'model-call',
+                  governance: 'must',
+                  executionModel: 'synchronous',
+                  config: {
+                    type: 'model-call',
+                    modelRole: 'cortex-chat',
+                    promptRef: 'prompt://start',
+                  },
+                },
+              ],
+              edges: [],
+            },
+          ],
+        },
+      }),
+      list: vi.fn().mockResolvedValue([]),
+      create: vi.fn(),
+      update: vi.fn(),
+      archive: vi.fn(),
+    };
+    const handlers = createCapabilityHandlers({
+      agentClass: 'Cortex::System',
+      agentId: AGENT_ID as any,
+      deps: {
+        projectStore: projectStore as any,
+        runtime: {
+          instanceRoot: '/tmp/test',
+          resolvePath: (...segments: string[]) => segments.join('/'),
+          exists: vi.fn().mockResolvedValue(false),
+          ensureDir: vi.fn().mockResolvedValue(undefined),
+          listDirectory: vi.fn().mockResolvedValue([]),
+        } as any,
+      },
+    });
+
+    // Call WITHOUT projectId in params, WITH projectId in execution context
+    const result = await handlers.workflow_list(
+      {
+        includeInstalledDefinitions: true,
+        includeActiveInstances: false,
+      },
+      { projectId: PROJECT_ID } as any,
+    );
+
+    expect(result.success).toBe(true);
+    const defs = (result.output as any).definitions;
+    expect(defs.some((d: any) => d.name === 'ExecutionContextWorkflow')).toBe(true);
+    expect(projectStore.get).toHaveBeenCalledWith(PROJECT_ID);
+  });
+
   it('workflow_list returns only installed definitions when projectStore is unavailable', async () => {
     const handlers = createCapabilityHandlers({
       agentClass: 'Cortex::System',
@@ -896,6 +967,10 @@ describe('Internal MCP capability handlers', () => {
       deps: {
         runtime: {
           instanceRoot: '/tmp/test',
+          resolvePath: (...segments: string[]) => segments.join('/'),
+          exists: vi.fn().mockResolvedValue(false),
+          ensureDir: vi.fn().mockResolvedValue(undefined),
+          listDirectory: vi.fn().mockResolvedValue([]),
         } as any,
       },
     });

--- a/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/anthropic-adapter.ts
@@ -127,7 +127,7 @@ function formatMessages(
       if (frame.content.trim()) {
         contentBlocks.push({ type: 'text', text: frame.content });
       }
-      for (const tc of frame.metadata.tool_calls as Array<{ id?: string; name: string; input: unknown }>) {
+      for (const tc of frame.metadata!.tool_calls as Array<{ id?: string; name: string; input: unknown }>) {
         if (tc.id) {
           contentBlocks.push({
             type: 'tool_use',

--- a/self/cortex/core/src/internal-mcp/capability-handlers.ts
+++ b/self/cortex/core/src/internal-mcp/capability-handlers.ts
@@ -1258,7 +1258,7 @@ export function createCapabilityHandlers(
         0,
       );
     },
-    workflow_list: async (params) => {
+    workflow_list: async (params, execution) => {
       const request = parseWorkflowListRequest(params);
       const installedDefinitions = request.includeInstalledDefinitions
         ? await listInstalledWorkflowPackages({
@@ -1266,11 +1266,14 @@ export function createCapabilityHandlers(
           })
         : [];
 
+      // Use execution context projectId as fallback when LLM doesn't pass projectId in params
+      const effectiveProjectId = request.projectId ?? execution?.projectId;
+
       // Query project store for user-created workflow definitions
       let projectStoreDefinitions: WorkflowLifecycleDefinitionSummary[] = [];
-      if (request.projectId && context.deps.projectStore) {
+      if (effectiveProjectId && context.deps.projectStore) {
         try {
-          const projectConfig = await context.deps.projectStore.get(request.projectId);
+          const projectConfig = await context.deps.projectStore.get(effectiveProjectId);
           const rawDefs: WorkflowDefinition[] = projectConfig?.workflow?.definitions ?? [];
           const installedNames = new Set(
             installedDefinitions.map((d: WorkflowLifecycleDefinitionSummary) => d.name.toLowerCase()),
@@ -1304,7 +1307,7 @@ export function createCapabilityHandlers(
 
       const definitions = [...installedDefinitions, ...projectStoreDefinitions];
       const instances = request.includeActiveInstances
-        ? await listWorkflowInstances(context, request.projectId)
+        ? await listWorkflowInstances(context, effectiveProjectId)
         : [];
 
       const definitionFilter = request.definition?.toLowerCase();

--- a/self/cortex/core/src/internal-mcp/public-tool-mappings.ts
+++ b/self/cortex/core/src/internal-mcp/public-tool-mappings.ts
@@ -160,7 +160,7 @@ export function resolvePublicMcpRequiredScopes(
         };
       }).memory;
       const readScopes: PublicMcpScope[] = Array.isArray(memory?.readTiers)
-        ? memory.readTiers.flatMap((tier) =>
+        ? memory!.readTiers.flatMap((tier) =>
             tier === 'ltm'
               ? ['ortho.memory.ltm.read']
               : tier === 'stm'
@@ -169,7 +169,7 @@ export function resolvePublicMcpRequiredScopes(
           )
         : [];
       const writeScopes: PublicMcpScope[] = Array.isArray(memory?.writeTiers)
-        ? memory.writeTiers.flatMap((tier) =>
+        ? memory!.writeTiers.flatMap((tier) =>
             tier === 'ltm'
               ? ['ortho.memory.ltm.write']
               : tier === 'stm'


### PR DESCRIPTION
## Summary

- Pass `--config-path` from Electron main process to backend server so `cortex-core` resolves the correct user config directory at runtime
- Fix `workflow_list` tool to resolve `projectId` from session context instead of requiring it as a parameter, preventing empty results

**Work Register:** WR-155, WR-158

## Commits

- `70aa72f` — fix(desktop,cortex-core): pass config path to backend server and fix workflow_list projectId resolution (WR-155, WR-158)

## Test plan

- [x] Code compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [ ] Behavioral testing on phase integration branch (post-merge)