### PR TITLE
fix(shared-server,ui): sync model config UI state with runtime role assignments (Phase 1.7)

### DIFF
--- a/self/apps/shared-server/__tests__/preferences-router.test.ts
+++ b/self/apps/shared-server/__tests__/preferences-router.test.ts
@@ -16,6 +16,7 @@ const bootstrapConstants = vi.hoisted(() => ({
 const bootstrapMock = vi.hoisted(() => ({
   buildOllamaProviderConfig: vi.fn(),
   buildProviderConfig: vi.fn(),
+  currentProviderEntries: vi.fn().mockReturnValue([]),
   currentRoleAssignment: vi.fn(),
   parseSelectedModelSpec: vi.fn(),
   registerConfiguredProvider: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock('../src/bootstrap', () => ({
   WELL_KNOWN_PROVIDER_IDS: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS,
   buildOllamaProviderConfig: bootstrapMock.buildOllamaProviderConfig,
   buildProviderConfig: bootstrapMock.buildProviderConfig,
+  currentProviderEntries: bootstrapMock.currentProviderEntries,
   currentRoleAssignment: bootstrapMock.currentRoleAssignment,
   parseSelectedModelSpec: bootstrapMock.parseSelectedModelSpec,
   registerConfiguredProvider: bootstrapMock.registerConfiguredProvider,
@@ -383,14 +385,102 @@ describe('preferences router', () => {
       expect(result).toEqual({
         orchestrators: {
           providerId: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+          modelSpec: null,
         },
         'cortex-chat': {
           providerId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.openai,
           fallbackProviderId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.anthropic,
+          modelSpec: null,
         },
         'cortex-system': null,
         workers: null,
       });
+    });
+
+    it('returns modelSpec when provider config entries exist', async () => {
+      const { ctx } = createMockContext();
+      const preferencesRouter = await loadPreferencesRouter();
+      const caller = preferencesRouter.createCaller(ctx);
+
+      bootstrapMock.currentRoleAssignment.mockImplementation(
+        (_ctx: unknown, role: string) => {
+          if (role === 'orchestrators') {
+            return {
+              role,
+              providerId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.anthropic,
+            };
+          }
+          if (role === 'cortex-chat') {
+            return {
+              role,
+              providerId: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+            };
+          }
+          return undefined;
+        },
+      );
+
+      bootstrapMock.currentProviderEntries.mockReturnValue([
+        {
+          id: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.anthropic,
+          name: 'anthropic',
+          modelId: 'claude-sonnet-4-20250514',
+        },
+        {
+          id: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+          name: 'ollama',
+          modelId: 'llama3',
+        },
+      ]);
+
+      const result = await caller.getRoleAssignments();
+
+      expect(result).toEqual({
+        orchestrators: {
+          providerId: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.anthropic,
+          modelSpec: 'anthropic:claude-sonnet-4-20250514',
+        },
+        'cortex-chat': {
+          providerId: bootstrapConstants.OLLAMA_WELL_KNOWN_PROVIDER_ID,
+          modelSpec: 'ollama:llama3',
+        },
+        'cortex-system': null,
+        workers: null,
+      });
+    });
+
+    it('returns modelSpec null when provider config entry not found (orphaned)', async () => {
+      const { ctx } = createMockContext();
+      const preferencesRouter = await loadPreferencesRouter();
+      const caller = preferencesRouter.createCaller(ctx);
+
+      bootstrapMock.currentRoleAssignment.mockImplementation(
+        (_ctx: unknown, role: string) => {
+          if (role === 'orchestrators') {
+            return {
+              role,
+              providerId: '99999999-0000-0000-0000-000000000099',
+            };
+          }
+          return undefined;
+        },
+      );
+
+      bootstrapMock.currentProviderEntries.mockReturnValue([
+        {
+          id: bootstrapConstants.WELL_KNOWN_PROVIDER_IDS.anthropic,
+          name: 'anthropic',
+          modelId: 'claude-sonnet-4-20250514',
+        },
+      ]);
+
+      const result = await caller.getRoleAssignments();
+
+      expect(result.orchestrators).toEqual({
+        providerId: '99999999-0000-0000-0000-000000000099',
+        modelSpec: null,
+      });
+      expect(result['cortex-chat']).toBeNull();
     });
   });
 

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -184,7 +184,7 @@ function hasConfiguredProviderKey(provider: CloudProviderName): boolean {
   return !!process.env[CLOUD_PROVIDER_ENV_VARS[provider]];
 }
 
-function currentProviderEntries(ctx: NousContext): ProviderConfigEntry[] {
+export function currentProviderEntries(ctx: NousContext): ProviderConfigEntry[] {
   const config = ctx.config.get() as { providers?: ProviderConfigEntry[] };
   return Array.isArray(config.providers) ? config.providers : [];
 }

--- a/self/apps/shared-server/src/trpc/routers/preferences.ts
+++ b/self/apps/shared-server/src/trpc/routers/preferences.ts
@@ -11,6 +11,7 @@ import {
   WELL_KNOWN_PROVIDER_IDS,
   buildOllamaProviderConfig,
   buildProviderConfig,
+  currentProviderEntries,
   currentRoleAssignment,
   parseSelectedModelSpec,
   registerConfiguredProvider,
@@ -49,6 +50,7 @@ const modelCache = new Map<Provider, CachedModelList>();
 type RoleAssignmentSummary = {
   providerId: ProviderId;
   fallbackProviderId?: ProviderId;
+  modelSpec: string | null;
 };
 
 const AnthropicModelSchema = z.object({
@@ -520,17 +522,23 @@ export const preferencesRouter = router({
   }),
 
   getRoleAssignments: publicProcedure.query(async ({ ctx }) => {
+    const providers = currentProviderEntries(ctx);
     return Object.fromEntries(
       MODEL_ROLES.map((role) => {
         const assignment = currentRoleAssignment(ctx, role);
-        const value: RoleAssignmentSummary | null = assignment
-          ? {
-              providerId: assignment.providerId,
-              ...(assignment.fallbackProviderId
-                ? { fallbackProviderId: assignment.fallbackProviderId }
-                : {}),
-            }
-          : null;
+        if (!assignment) {
+          return [role, null];
+        }
+
+        const entry = providers.find((p) => p.id === assignment.providerId);
+        const modelSpec = entry ? `${entry.name}:${entry.modelId}` : null;
+        const value: RoleAssignmentSummary = {
+          providerId: assignment.providerId,
+          modelSpec,
+          ...(assignment.fallbackProviderId
+            ? { fallbackProviderId: assignment.fallbackProviderId }
+            : {}),
+        };
 
         return [role, value];
       }),

--- a/self/transport/src/hooks/__tests__/usePreferencesApi.test.ts
+++ b/self/transport/src/hooks/__tests__/usePreferencesApi.test.ts
@@ -183,9 +183,9 @@ describe('usePreferencesApi', () => {
   // ── Tier 3: Adapter Tests ───────────────────────────────────────────────
 
   describe('getRoleAssignments adapter', () => {
-    it('transforms Record to array', async () => {
+    it('transforms Record to array mapping modelSpec to providerId', async () => {
       mockFetch.getRoleAssignments.mockResolvedValueOnce({
-        orchestrators: { providerId: 'openai:gpt-4' },
+        orchestrators: { providerId: '10000000-0000-0000-0000-000000000002', modelSpec: 'openai:gpt-4' },
         'cortex-chat': null,
       })
 
@@ -198,9 +198,9 @@ describe('usePreferencesApi', () => {
       ])
     })
 
-    it('drops fallbackProviderId', async () => {
+    it('drops fallbackProviderId and maps modelSpec', async () => {
       mockFetch.getRoleAssignments.mockResolvedValueOnce({
-        orchestrators: { providerId: 'openai:gpt-4', fallbackProviderId: 'anthropic:claude' },
+        orchestrators: { providerId: '10000000-0000-0000-0000-000000000002', modelSpec: 'openai:gpt-4', fallbackProviderId: '10000000-0000-0000-0000-000000000001' },
       })
 
       const { result } = renderHook(() => usePreferencesApi())
@@ -211,6 +211,19 @@ describe('usePreferencesApi', () => {
       ])
       // Verify no fallbackProviderId key
       expect(data[0]).not.toHaveProperty('fallbackProviderId')
+    })
+
+    it('maps null modelSpec to null providerId', async () => {
+      mockFetch.getRoleAssignments.mockResolvedValueOnce({
+        orchestrators: { providerId: '99999999-0000-0000-0000-000000000099', modelSpec: null },
+      })
+
+      const { result } = renderHook(() => usePreferencesApi())
+      const data = await result.current.getRoleAssignments()
+
+      expect(data).toEqual([
+        { role: 'orchestrators', providerId: null },
+      ])
     })
 
     it('handles empty record', async () => {

--- a/self/transport/src/hooks/usePreferencesApi.ts
+++ b/self/transport/src/hooks/usePreferencesApi.ts
@@ -66,7 +66,7 @@ export function usePreferencesApi() {
         const record = await utilsRef.current.preferences.getRoleAssignments.fetch()
         return Object.entries(record).map(([role, assignment]) => ({
           role,
-          providerId: (assignment as any)?.providerId ?? null,
+          providerId: (assignment as any)?.modelSpec ?? null,
         }))
       },
       setRoleAssignment: async (input: { role: string; modelSpec: string }) => {

--- a/self/ui/src/panels/settings/__tests__/pages.test.tsx
+++ b/self/ui/src/panels/settings/__tests__/pages.test.tsx
@@ -394,6 +394,44 @@ describe('ModelConfigPage', () => {
     expect(el).toBeNull()
   })
 
+  it('displays persisted role assignments on load (round-trip)', async () => {
+    const api = makeApi()
+    api.getAvailableModels.mockResolvedValue({
+      models: [
+        { id: 'anthropic:claude-sonnet-4-20250514', name: 'Claude Sonnet', provider: 'anthropic', available: true },
+        { id: 'openai:gpt-4o', name: 'GPT-4o', provider: 'openai', available: true },
+        { id: 'ollama:llama3', name: 'llama3', provider: 'ollama', available: true },
+      ],
+    })
+    api.getRoleAssignments.mockResolvedValue([
+      { role: 'cortex-chat', providerId: 'anthropic:claude-sonnet-4-20250514' },
+      { role: 'orchestrators', providerId: 'openai:gpt-4o' },
+      { role: 'cortex-system', providerId: null },
+      { role: 'workers', providerId: null },
+    ])
+
+    await act(async () => {
+      root.render(<ModelConfigPage api={api} />)
+      await flush()
+    })
+
+    const cortexChatSelect = container.querySelector<HTMLSelectElement>('#role-select-cortex-chat')!
+    const orchestratorsSelect = container.querySelector<HTMLSelectElement>('#role-select-orchestrators')!
+    const cortexSystemSelect = container.querySelector<HTMLSelectElement>('#role-select-cortex-system')!
+    const workersSelect = container.querySelector<HTMLSelectElement>('#role-select-workers')!
+
+    expect(cortexChatSelect.value).toBe('anthropic:claude-sonnet-4-20250514')
+    expect(orchestratorsSelect.value).toBe('openai:gpt-4o')
+    expect(cortexSystemSelect.value).toBe('')
+    expect(workersSelect.value).toBe('')
+
+    // Save button should be disabled (no pending changes)
+    const saveButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Save',
+    )!
+    expect(saveButton.disabled).toBe(true)
+  })
+
   it('no-models fallback renders with 4-slot layout', async () => {
     const api = makeApi()
     api.getAvailableModels.mockResolvedValue({ models: [] })

--- a/self/ui/src/panels/settings/pages/ModelConfigPage.tsx
+++ b/self/ui/src/panels/settings/pages/ModelConfigPage.tsx
@@ -61,6 +61,13 @@ export function ModelConfigPage({ api }: ModelConfigPageProps) {
           nextValues[role] = entry?.providerId ?? null
         }
         setCurrentValues(nextValues)
+        setPendingValues(() => {
+          const next = emptyPendingValues()
+          for (const role of ModelRoleSchema.options) {
+            next[role] = nextValues[role] ?? ''
+          }
+          return next
+        })
       }
     } catch (err) {
       setModelFeedback(formatFeedbackError(err))


### PR DESCRIPTION
## Summary

- Fixes model configuration UI state to correctly reflect runtime role assignments, ensuring the UI stays in sync with the actual provider/model configuration used by the inference engine.

## Context

- **Sub-phase:** Phase 1.7 — Model Config UI State Fix
- **WR:** WR-155
- **Commit:** `02f566c`

## Merge target

`feat/provider-execution-infrastructure` (phase integration branch)