### PR TITLE
fix(providers): guard against missing API key during boot provider construction (WR-155)

### DIFF
--- a/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
+++ b/self/apps/shared-server/__tests__/provider-lifecycle.test.ts
@@ -1,10 +1,10 @@
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ModelRole, ProviderId, TraceId } from '@nous/shared';
-import { ConfigManager, DEFAULT_PROFILES } from '@nous/autonomic-config';
+import { ConfigManager, DEFAULT_PROFILES, DEFAULT_SYSTEM_CONFIG } from '@nous/autonomic-config';
 import {
   OLLAMA_WELL_KNOWN_PROVIDER_ID,
   WELL_KNOWN_PROVIDER_IDS,
@@ -439,6 +439,67 @@ describe('provider lifecycle wiring', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it('createNousServices does not throw with saved cloud provider config and no API keys', async () => {
+    const dataDir = join(tmpdir(), `nous-shared-server-${randomUUID()}`);
+    mkdirSync(dataDir, { recursive: true });
+
+    // Write a fully valid config file with a saved Anthropic provider entry
+    // (simulates a config persisted by a prior session via SP 1.6).
+    // Start from DEFAULT_SYSTEM_CONFIG to satisfy the full SystemConfigSchema,
+    // then overlay the Anthropic provider entry and hybrid profile.
+    const configPath = join(dataDir, 'config.json');
+    const savedConfig = {
+      ...DEFAULT_SYSTEM_CONFIG,
+      profile: {
+        ...DEFAULT_SYSTEM_CONFIG.profile,
+        name: 'hybrid',
+        defaultProviderType: 'remote',
+        allowRemoteProviders: true,
+        allowSilentLocalToRemoteFailover: true,
+      },
+      providers: [
+        {
+          id: WELL_KNOWN_PROVIDER_IDS.anthropic,
+          name: 'anthropic',
+          type: 'text',
+          endpoint: 'https://api.anthropic.com',
+          modelId: 'claude-sonnet-4-20250514',
+          isLocal: false,
+          capabilities: ['chat', 'streaming'],
+          providerClass: 'remote_text',
+          vendor: 'anthropic',
+        },
+      ],
+      modelRoleAssignments: [
+        {
+          role: 'cortex-chat',
+          providerId: WELL_KNOWN_PROVIDER_IDS.anthropic,
+        },
+      ],
+    };
+    writeFileSync(configPath, JSON.stringify(savedConfig));
+
+    // No ANTHROPIC_API_KEY in process.env — must not throw
+    let ctx: ReturnType<typeof createNousServices> | undefined;
+    expect(() => {
+      ctx = createNousServices({
+        dataDir,
+        configPath,
+        runtimeLabel: 'test',
+        publicBaseUrl: 'http://localhost:3000',
+      });
+    }).not.toThrow();
+
+    // The Anthropic provider should NOT be in the registry yet
+    // (skipped by the guard clause because no API key in env)
+    const anthropicProvider = ctx!.providerRegistry.getProvider(
+      WELL_KNOWN_PROVIDER_IDS.anthropic,
+    );
+    expect(anthropicProvider).toBeNull();
+    // Temp dir cleanup omitted: createNousServices opens a SQLite database that
+    // holds a file lock on Windows, preventing synchronous rmSync.
   });
 
   it('keeps mock fallback active when no keys are configured', async () => {

--- a/self/subcortex/providers/src/__tests__/provider-registry.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-registry.test.ts
@@ -268,6 +268,120 @@ describe('ProviderRegistry', () => {
     expect(provider.inner).toBeInstanceOf(OpenAiCompatibleProvider);
   });
 
+  it('constructor skips non-local entries when API key is unavailable', () => {
+    // No ANTHROPIC_API_KEY set in env — constructor must not throw
+    const registry = new ProviderRegistry({
+      get: () => ({
+        providers: [
+          {
+            id: '10000000-0000-0000-0000-000000000001',
+            name: 'anthropic',
+            type: 'text',
+            endpoint: 'https://api.anthropic.com',
+            modelId: 'claude-sonnet-4-20250514',
+            isLocal: false,
+            capabilities: ['chat', 'streaming'],
+            providerClass: 'remote_text',
+          },
+        ],
+      }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    expect(
+      registry.getProvider('10000000-0000-0000-0000-000000000001' as any),
+    ).toBeNull();
+    expect(registry.listProviders()).toHaveLength(0);
+  });
+
+  it('constructor still registers local entries when cloud entries are skipped', () => {
+    // No ANTHROPIC_API_KEY set — Anthropic entry should be skipped,
+    // but the local Ollama entry should still be registered.
+    const registry = new ProviderRegistry({
+      get: () => ({
+        providers: [
+          {
+            id: '10000000-0000-0000-0000-000000000002',
+            name: 'anthropic',
+            type: 'text',
+            endpoint: 'https://api.anthropic.com',
+            modelId: 'claude-sonnet-4-20250514',
+            isLocal: false,
+            capabilities: ['chat', 'streaming'],
+            providerClass: 'remote_text',
+          },
+          {
+            id: '10000000-0000-0000-0000-000000000003',
+            name: 'local-ollama',
+            type: 'text',
+            modelId: 'llama3.2',
+            isLocal: true,
+            capabilities: ['text'],
+          },
+        ],
+      }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    expect(
+      registry.getProvider('10000000-0000-0000-0000-000000000002' as any),
+    ).toBeNull();
+    expect(
+      registry.getProvider('10000000-0000-0000-0000-000000000003' as any),
+    ).toBeInstanceOf(LaneAwareProvider);
+    expect(registry.listProviders()).toHaveLength(1);
+  });
+
+  it('skipped cloud entry can be registered after construction via registerProvider', () => {
+    // No ANTHROPIC_API_KEY set — Anthropic entry skipped during construction
+    const registry = new ProviderRegistry({
+      get: () => ({
+        providers: [
+          {
+            id: '10000000-0000-0000-0000-000000000004',
+            name: 'anthropic',
+            type: 'text',
+            endpoint: 'https://api.anthropic.com',
+            modelId: 'claude-sonnet-4-20250514',
+            isLocal: false,
+            capabilities: ['chat', 'streaming'],
+            providerClass: 'remote_text',
+          },
+        ],
+      }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    // Verify skipped
+    expect(
+      registry.getProvider('10000000-0000-0000-0000-000000000004' as any),
+    ).toBeNull();
+
+    // Simulate loadStoredApiKeys → registerStoredProviders
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    registry.registerProvider({
+      id: '10000000-0000-0000-0000-000000000004' as any,
+      name: 'anthropic',
+      type: 'text',
+      endpoint: 'https://api.anthropic.com',
+      modelId: 'claude-sonnet-4-20250514',
+      isLocal: false,
+      capabilities: ['chat', 'streaming'],
+      providerClass: 'remote_text',
+    });
+
+    expect(
+      registry.getProvider('10000000-0000-0000-0000-000000000004' as any),
+    ).toBeInstanceOf(LaneAwareProvider);
+    expect(registry.listProviders()).toHaveLength(1);
+  });
+
   it('routes local providers to OllamaProvider inside LaneAwareProvider', () => {
     const registry = new ProviderRegistry({
       get: () => ({ providers: [] }),

--- a/self/subcortex/providers/src/provider-registry.ts
+++ b/self/subcortex/providers/src/provider-registry.ts
@@ -70,6 +70,20 @@ export class ProviderRegistry {
         vendor: baseConfig.vendor ?? this.resolveVendor(baseConfig),
       };
 
+      // Skip non-local entries whose API key is not yet available.
+      // The post-boot flow (loadStoredApiKeys → registerStoredProviders) will
+      // register these providers after credentials are loaded from the vault.
+      if (!providerConfig.isLocal) {
+        const apiKey = this.resolveRemoteApiKey(providerConfig);
+        if (!apiKey) {
+          console.info(
+            `[nous:providers] Skipping provider '${entry.name}' during construction — ` +
+            `API key not yet available (will be registered after credential vault loads)`,
+          );
+          continue;
+        }
+      }
+
       const validated = this.validateProviderConfig(providerConfig);
       const provider = this.createProvider(validated);
       this.providers.set(validated.id, provider);


### PR DESCRIPTION
## Summary

- Adds defensive guard against missing API key during boot provider construction, preventing crash when no key is configured for the boot provider.

## Context

Phase 1.8 of provider-execution-infrastructure sprint. Fixes boot ordering regression where provider construction could fail if API key was not yet available.

## Merge target

`feat/provider-execution-infrastructure` (phase integration branch)