### PR TITLE
docs(github): refresh PR template for public contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,25 @@
-## Links
-- Roadmap phase/sub-phase:
-- Goals doc:
-- Implementation spec:
-- System Design Spec:
-- Architecture Decision Record(s):
-
 ## Summary
-<!-- Brief description of what this PR delivers and why -->
+<!-- What does this PR deliver and why? Keep it tight. -->
+
+## Linked Issue
+<!-- Fixes #123 / Closes #123 — or N/A -->
+
+## Changes
+<!-- Bullet list of notable changes -->
+-
 
 ## Verification
-- [ ] Tests pass (unit/integration as applicable)
-- [ ] Lint/typecheck pass
-- [ ] Acceptance criteria met (from implementation spec or PR description)
-- [ ] Docs updated or N/A + reason
+- [ ] Tests pass (`pnpm test`)
+- [ ] Lint passes (`pnpm lint`)
+- [ ] Typecheck passes (`pnpm typecheck`)
+- [ ] Build passes (`pnpm build`)
+- [ ] Manually ran the change end-to-end and confirmed it behaves as described (describe below)
 
-## Ratification
-- [ ] Reference docs updated to match reality (architecture, roadmap, etc.)
-- [ ] ADR updated with PR link (if ADR exists)
-- [ ] SDS updated if implementation diverged from design
+### Manual behavior check
+<!-- What did you run? What did you observe? Screenshots/logs welcome. -->
+
+
+## Checklist
+- [ ] Branch follows flow: `feat/*` or `fix/*` → `dev` (never direct to `main`)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] Docs updated if behavior changed (or N/A)


### PR DESCRIPTION
## Summary
- Remove legacy MVP-era fields (roadmap phase, SDS/ADR links) that pointed at private artifacts
- Add manual behavior check section — contributors run their own Principal verification
- Add branch flow + conventional commits reminders

Docs-only, path-ignored in CI. Promoting through to main.