### PR TITLE
docs(github): add issue forms for bug, feature, adapter, integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter-request.yml
+++ b/.github/ISSUE_TEMPLATE/adapter-request.yml
@@ -1,0 +1,83 @@
+name: Adapter request
+description: Request an adapter for a coding-agent harness or model provider
+title: "Adapter: "
+labels: ["needs-triage", "adapter"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for things Nous wraps and drives through its contracts
+        (`AgentAdapter` for agent harnesses, `IModelProvider` for model providers).
+        For orchestration frameworks or hosted autonomous services, use the
+        Integration template instead.
+
+  - type: dropdown
+    id: contract
+    attributes:
+      label: Which contract?
+      options:
+        - AgentAdapter (coding-agent harness)
+        - IModelProvider (model provider)
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      placeholder: e.g. Gemini, Aider, Grok
+    validations:
+      required: true
+
+  - type: input
+    id: vendor
+    attributes:
+      label: Vendor or project
+      placeholder: e.g. Google, Aider-AI, xAI
+    validations:
+      required: true
+
+  - type: input
+    id: reference
+    attributes:
+      label: Reference URL
+      placeholder: Repo, docs, or product page
+    validations:
+      required: true
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface type
+      options:
+        - CLI
+        - HTTP API
+        - SDK / library
+        - IDE extension
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: license
+    attributes:
+      label: License
+      placeholder: e.g. MIT, Apache-2.0, proprietary
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why this one?
+      description: Use case, user base, or unique capability
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true
+        - label: This fits the adapter shape (we wrap and drive it), not the integration shape
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Something that worked, or should work, is broken
+title: "Bug: "
+labels: ["needs-triage", "bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what did you get?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Nous version / commit
+      placeholder: e.g. v0.0.0, or commit sha
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS and runtime
+      placeholder: e.g. macOS 14.5, Node 22.3, pnpm 10.6
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps. Logs, error output, or a short snippet are great.
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/orthogonalhq/nous-core/discussions
+    about: Questions, ideas, and open-ended discussions belong in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Propose a new capability within Nous
+title: "Feature: "
+labels: ["needs-triage", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For external adapter or integration requests, use the dedicated
+        Adapter or Integration templates instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What can't you do today, or what's painful?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: How should it work from a user's perspective?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface area
+      options:
+        - Chat
+        - Workflow
+        - Memory
+        - Cortex
+        - MCP Tool
+        - Docs
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/integration-request.yml
+++ b/.github/ISSUE_TEMPLATE/integration-request.yml
@@ -1,0 +1,70 @@
+name: Integration request
+description: Request an integration with an orchestration framework or hosted service
+title: "Integration: "
+labels: ["needs-triage", "integration"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for things Nous connects *to* on their terms — orchestration
+        frameworks (MetaGPT, AutoGen, LangGraph, CrewAI) and hosted autonomous
+        services (Devin, Factory). Direction of control differs from an adapter.
+        For things Nous wraps and drives, use the Adapter template.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Orchestration framework (they orchestrate, Nous participates)
+        - Hosted autonomous service (managed product, REST API)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      placeholder: e.g. MetaGPT, Devin
+    validations:
+      required: true
+
+  - type: input
+    id: vendor
+    attributes:
+      label: Vendor or project
+    validations:
+      required: true
+
+  - type: input
+    id: reference
+    attributes:
+      label: Reference URL
+      placeholder: Repo, docs, or product page
+    validations:
+      required: true
+
+  - type: textarea
+    id: connection-shape
+    attributes:
+      label: How would the connection work?
+      description: Who orchestrates — them or Nous? What does the handshake look like?
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why this one?
+      description: Use case or unique value
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true


### PR DESCRIPTION
## Summary
Seed structured issue submission: 5-entry chooser (bug, feature, adapter, integration, question→Discussions). All new issues land with \`needs-triage\`; curators promote.

Docs-only, path-ignored in CI.