### PR TITLE
fix(WR-159): SP 1.11 — BT Round 3 fixes (RC-1 gateway parser, RC-2 StatusCard diagnostic, RC-3 thinking-state unlock + queue)

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-harness-delegation.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-harness-delegation.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AgentResultSchema } from '@nous/shared';
-import type { AgentGatewayConfig, HarnessStrategies, PromptFormatterOutput } from '@nous/shared';
+import type { AgentGatewayConfig, HarnessStrategies, IModelProvider, PromptFormatterOutput } from '@nous/shared';
 import {
   AGENT_ID,
   NOW,
+  PROVIDER_ID,
   RUN_ID,
   createBaseInput,
   createGatewayHarness,
@@ -76,8 +77,11 @@ describe('AgentGateway harness delegation', () => {
     });
   });
 
-  describe('responseParser delegation', () => {
-    it('calls responseParser when present and uses its result', async () => {
+  describe('responseParser deprecation (field retained, not read by gateway)', () => {
+    it('does not call harness.responseParser; live adapter parses model output', async () => {
+      // Post-RC-1: AgentGateway.run no longer reads harness.responseParser; the
+      // live adapter's parseResponse is invoked instead. The field remains on the
+      // harness type for external-consumer back-compat (O-1 deferred).
       const responseParser = vi.fn().mockReturnValue({
         response: 'parsed by custom parser',
         toolCalls: [{ name: 'task_complete', params: { output: { done: true }, summary: 'Done' } }],
@@ -100,8 +104,64 @@ describe('AgentGateway harness delegation', () => {
       });
 
       const result = await gateway.run(createBaseInput());
-      expect(responseParser).toHaveBeenCalled();
+      // Inverted assertion: harness spy MUST NOT be called post-RC-1.
+      expect(responseParser).not.toHaveBeenCalled();
       expect(result.status).toBe('completed');
+      // The text adapter parses the raw string output cleanly; the response
+      // surfaces the live-adapter's parsed text, not the harness spy's return.
+      if (result.status === 'completed') {
+        const output = result.output as { response: string };
+        expect(output.response).toBe('raw model output');
+      }
+    });
+  });
+
+  describe('RC-1 regression — live adapter used even when attach-time harness bound to different vendor', () => {
+    it('uses ollama adapter for parseResponse when provider is ollama, even if harness responseParser is bound to text adapter', async () => {
+      // Reproduces the BT R3 Mode A divergence: harness is composed at attach
+      // time with a vendor that does not match the live provider's vendor at
+      // invoke time. Pre-fix: the harness spy was invoked and returned a wrong
+      // shape, causing assistant text to render as "[object Object]". Post-fix:
+      // the live adapter's parseResponse is invoked instead.
+      const harnessSpy = vi.fn();
+      const ollamaOutput = { role: 'assistant', content: 'hello world' };
+      const provider = createModelProvider([ollamaOutput]);
+      // Override getConfig() so the live provider reports vendor: 'ollama'.
+      (provider.getConfig as unknown as () => ReturnType<IModelProvider['getConfig']>) = () => ({
+        id: PROVIDER_ID,
+        name: 'ollama',
+        type: 'ollama',
+        modelId: 'llama3',
+        isLocal: true,
+        capabilities: [],
+        vendor: 'ollama',
+      } as ReturnType<IModelProvider['getConfig']>);
+
+      const outbox = new InMemoryGatewayOutboxSink();
+      const gateway = new AgentGateway({
+        agentClass: 'Cortex::Principal',
+        agentId: AGENT_ID,
+        toolSurface: createToolSurface(undefined, []),
+        modelProvider: provider,
+        harness: { responseParser: harnessSpy, loopConfig: { singleTurn: true } },
+        outbox,
+        now: () => NOW,
+        nowMs: () => Date.parse(NOW),
+        idFactory: () => AGENT_ID,
+      });
+
+      const result = await gateway.run(createBaseInput());
+
+      // 1. Harness spy NOT called (the fix removes this call path).
+      expect(harnessSpy).not.toHaveBeenCalled();
+      // 2. Result is completed with the correctly-parsed response.
+      expect(result.status).toBe('completed');
+      if (result.status === 'completed') {
+        const output = result.output as { response: string };
+        // 3. Response is the actual content text, NOT "[object Object]".
+        expect(output.response).toBe('hello world');
+        expect(output.response).not.toBe('[object Object]');
+      }
     });
   });
 

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -31,7 +31,7 @@ import {
   type WitnessActor,
   type WitnessEventId,
 } from '@nous/shared';
-import { parseModelOutput, type ParsedModelOutput } from '../output-parser.js';
+import { type ParsedModelOutput } from '../output-parser.js';
 import {
   BudgetTracker,
   estimateBudgetUnits,
@@ -283,14 +283,15 @@ export class AgentGateway implements IAgentGateway {
           rawOutput: modelResponse.output,
         });
 
-        // Strategy delegation: responseParser (harness) or parseModelOutput (built-in)
-        const usingHarnessParser = !!this.config.harness?.responseParser;
-        const parsedOutput: ParsedModelOutput = usingHarnessParser
-          ? (this.config.harness!.responseParser!(modelResponse.output, traceId) as ParsedModelOutput)
-          : parseModelOutput(modelResponse.output, traceId);
+        // Adapter-based parsing: use the same adapter resolved at line 241 for
+        // formatRequest() so format and parse come from the same adapter for the
+        // live provider within one turn. The harness `responseParser` field is
+        // retained on the type for back-compat (see O-1 in SP 1.11 Out-of-Scope)
+        // but is no longer read here.
+        const parsedOutput: ParsedModelOutput = adapter.parseResponse(modelResponse.output, traceId);
 
         this.log.debug('parser selection', {
-          usingHarnessParser,
+          adapterProviderSignature: this.cachedAdapterProviderSignature,
           outputType: typeof modelResponse.output,
           parsedResponse: parsedOutput.response.slice(0, 100),
           parsedToolCalls: parsedOutput.toolCalls.length,

--- a/self/ui/src/components/chat/cards/status-card.tsx
+++ b/self/ui/src/components/chat/cards/status-card.tsx
@@ -44,6 +44,7 @@ export function StatusCard({
   const result = StatusCardSchema.safeParse(props)
   if (!result.success) {
     console.warn('[StatusCard] Validation failed:', result.error.format(), 'Received props:', props)
+    console.trace('[StatusCard] Invalid props emitter stack')
     return (
       <div
         data-testid="status-card-invalid"

--- a/self/ui/src/panels/ChatPanel.tsx
+++ b/self/ui/src/panels/ChatPanel.tsx
@@ -101,6 +101,7 @@ export function ChatPanel(props: ChatPanelProps) {
     const [messages, setMessages] = useState<ChatMessage[]>([])
     const [input, setInput] = useState('')
     const [sending, setSending] = useState(false)
+    const [queuedMessages, setQueuedMessages] = useState<string[]>([])
     const [historyError, setHistoryError] = useState<string | null>(null)
 
     // --- Unread response badge ---
@@ -211,18 +212,24 @@ export function ChatPanel(props: ChatPanelProps) {
     }, [chatApi])
 
     // --- Send ---
-    const send = async () => {
-        if (!input.trim() || sending || !chatApi?.send) return
-        const userMsg = input.trim()
-        setInput('')
+
+    // invoke() performs the actual chatApi.send call. Shared by:
+    //   - immediate-send path (called from send() when no turn is in flight)
+    //   - drain path (called from the queue-drain effect after a turn ends)
+    // The skipUserAppend flag suppresses the user-message append in the
+    // drain path because the enqueue path already appended the entry
+    // (with queued=true) at submission time.
+    const invoke = async (userMsg: string, skipUserAppend = false) => {
         setSending(true)
         onSendStart?.()
 
-        const userEntry: ChatMessage = { role: 'user', content: userMsg, timestamp: new Date().toISOString() }
-        setMessages(prev => [...prev, userEntry])
+        if (!skipUserAppend) {
+            const userEntry: ChatMessage = { role: 'user', content: userMsg, timestamp: new Date().toISOString() }
+            setMessages(prev => [...prev, userEntry])
+        }
 
         try {
-            const result = await chatApi.send(userMsg)
+            const result = await chatApi!.send(userMsg)
             // Reconcile: authoritative response replaces streaming buffer
             setStreamingContent('')
             setStreamingThinking('')
@@ -245,6 +252,51 @@ export function ChatPanel(props: ChatPanelProps) {
             setSending(false)
         }
     }
+
+    // send() is the input-event entry point. Dispatches to either:
+    //   - enqueue (if a turn is currently in flight: sending=true)
+    //   - immediate invoke (if idle)
+    // Both paths share the !input.trim() and !chatApi?.send guards.
+    const send = () => {
+        if (!input.trim() || !chatApi?.send) return
+        const userMsg = input.trim()
+        setInput('')
+
+        if (sending) {
+            // Enqueue — FIFO order preserved by array push at tail
+            setQueuedMessages(prev => [...prev, userMsg])
+            setMessages(prev => [...prev, {
+                role: 'user',
+                content: userMsg,
+                timestamp: new Date().toISOString(),
+                queued: true,
+            }])
+            return
+        }
+
+        invoke(userMsg)
+    }
+
+    // Queue drain: fires on the sending: true → false transition.
+    // Pops the FIFO head of queuedMessages, clears the queued flag on the
+    // matching message-list entry, and invokes the pop'd message via the
+    // shared invoke() helper with skipUserAppend=true (the enqueue path
+    // already appended the entry).
+    useEffect(() => {
+        if (sending || queuedMessages.length === 0) return
+        const [next, ...rest] = queuedMessages
+        setQueuedMessages(rest)
+        // Clear the queued flag on the oldest queued user-message entry (FIFO).
+        setMessages(prev => {
+            const idx = prev.findIndex(m => m.queued && m.role === 'user')
+            if (idx < 0) return prev
+            const copy = [...prev]
+            const { queued: _queued, ...rest2 } = copy[idx]
+            copy[idx] = rest2 as ChatMessage
+            return copy
+        })
+        invoke(next, true)
+    }, [sending, queuedMessages])
 
     // --- Input focus/blur forwarding ---
     const handleFocus = useCallback(() => {

--- a/self/ui/src/panels/__tests__/ChatPanel.queue.test.tsx
+++ b/self/ui/src/panels/__tests__/ChatPanel.queue.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { describe, expect, it, beforeAll, vi } from 'vitest'
+import { ChatPanel } from '../ChatPanel'
+import type { ChatAPI } from '../ChatPanel'
+
+beforeAll(() => {
+  // jsdom does not implement scrollIntoView
+  Element.prototype.scrollIntoView = () => {}
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function makeChatApi(send: (m: string) => Promise<{ response: string; traceId: string }>): ChatAPI {
+  return {
+    send: send as ChatAPI['send'],
+    getHistory: vi.fn().mockResolvedValue([]),
+  }
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function getTextarea(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText(/What can I help you with/i) as HTMLTextAreaElement
+}
+
+function getSendButton(): HTMLButtonElement {
+  return screen.getByTitle(/Send message/i) as HTMLButtonElement
+}
+
+async function submitMessage(value: string) {
+  const ta = getTextarea()
+  await act(async () => {
+    fireEvent.change(ta, { target: { value } })
+  })
+  await act(async () => {
+    fireEvent.keyDown(ta, { key: 'Enter', shiftKey: false })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChatPanel — RC-3 queue-while-thinking', () => {
+  // T1 — Tier 2 behavior
+  it('keeps textarea interactive during sending', async () => {
+    const inFlight = createDeferred<{ response: string; traceId: string }>()
+    const api = makeChatApi(() => inFlight.promise)
+
+    render(<ChatPanel chatApi={api} />)
+    await flush()
+
+    await submitMessage('first message')
+    await flush()
+
+    const ta = getTextarea()
+    // Post-RC-3: textarea is NOT disabled while a turn is in flight.
+    expect(ta.hasAttribute('disabled')).toBe(false)
+  })
+
+  // T2 — Tier 2 behavior
+  it('keeps Send button interactive during sending with non-empty input', async () => {
+    const inFlight = createDeferred<{ response: string; traceId: string }>()
+    const api = makeChatApi(() => inFlight.promise)
+
+    render(<ChatPanel chatApi={api} />)
+    await flush()
+
+    await submitMessage('first message')
+    await flush()
+
+    // Type a new message while the first is in flight.
+    const ta = getTextarea()
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'second message' } })
+    })
+
+    const btn = getSendButton()
+    // Send button is enabled because input is non-empty + canSend is true.
+    expect(btn.hasAttribute('disabled')).toBe(false)
+  })
+
+  // T3 — Tier 2 behavior
+  it('renders queued marker on enqueued message', async () => {
+    const inFlight = createDeferred<{ response: string; traceId: string }>()
+    const api = makeChatApi(() => inFlight.promise)
+
+    render(<ChatPanel chatApi={api} />)
+    await flush()
+
+    // First message — drains immediately (sending: false → true).
+    await submitMessage('first')
+    await flush()
+
+    // Second message — queued (sending: true at submit time).
+    await submitMessage('second')
+    await flush()
+
+    // The second user message is in the DOM.
+    expect(screen.getByText('first')).toBeTruthy()
+    // The queued message bubble carries data-queued="true".
+    const queued = document.querySelector('[data-queued="true"]')
+    expect(queued).not.toBeNull()
+    expect(queued?.textContent).toContain('second')
+  })
+
+  // T4 — Tier 2 behavior — FIFO drain
+  it('drains queue in FIFO order after each turn completes', async () => {
+    const deferreds = [
+      createDeferred<{ response: string; traceId: string }>(),
+      createDeferred<{ response: string; traceId: string }>(),
+      createDeferred<{ response: string; traceId: string }>(),
+    ]
+    let callIndex = 0
+    const sendSpy = vi.fn((_msg: string) => {
+      const d = deferreds[callIndex]
+      callIndex += 1
+      return d.promise
+    })
+    const api = makeChatApi(sendSpy)
+
+    render(<ChatPanel chatApi={api} />)
+    await flush()
+
+    // Submit three messages in succession.
+    await submitMessage('m1')
+    await flush()
+    await submitMessage('m2')
+    await flush()
+    await submitMessage('m3')
+    await flush()
+
+    // Only the first call should be made so far; m2 and m3 are queued.
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0]).toBe('m1')
+
+    // Resolve the first; drain should pop m2.
+    // Empty traceId avoids ThoughtSummary tRPC dependency in this unit test.
+    await act(async () => {
+      deferreds[0].resolve({ response: 'r1', traceId: '' })
+    })
+    await flush()
+    expect(sendSpy).toHaveBeenCalledTimes(2)
+    expect(sendSpy.mock.calls[1][0]).toBe('m2')
+
+    // Resolve the second; drain should pop m3.
+    await act(async () => {
+      deferreds[1].resolve({ response: 'r2', traceId: '' })
+    })
+    await flush()
+    expect(sendSpy).toHaveBeenCalledTimes(3)
+    expect(sendSpy.mock.calls[2][0]).toBe('m3')
+
+    // Resolve the third; queue should be empty.
+    await act(async () => {
+      deferreds[2].resolve({ response: 'r3', traceId: '' })
+    })
+    await flush()
+    expect(sendSpy).toHaveBeenCalledTimes(3)
+  })
+
+  // T5 — Tier 2 behavior — no double-submit
+  it('does not double-submit when a second send fires mid-flight', async () => {
+    const inFlight = createDeferred<{ response: string; traceId: string }>()
+    const sendSpy = vi.fn((_msg: string) => inFlight.promise)
+    const api = makeChatApi(sendSpy)
+
+    render(<ChatPanel chatApi={api} />)
+    await flush()
+
+    await submitMessage('first')
+    await flush()
+    await submitMessage('second')
+    await flush()
+
+    // chatApi.send is called exactly once; the second message is queued.
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0]).toBe('first')
+
+    // Second message present in DOM with queued marker.
+    const queued = document.querySelector('[data-queued="true"]')
+    expect(queued).not.toBeNull()
+    expect(queued?.textContent).toContain('second')
+  })
+
+  // T6 — Tier 3 invariant — queued flag clears at drain
+  it('clears queued flag on drain', async () => {
+    const first = createDeferred<{ response: string; traceId: string }>()
+    const second = createDeferred<{ response: string; traceId: string }>()
+    let i = 0
+    const deferreds = [first, second]
+    const api = makeChatApi(() => deferreds[i++].promise)
+
+    render(<ChatPanel chatApi={api} />)
+    await flush()
+
+    await submitMessage('first')
+    await flush()
+    await submitMessage('second')
+    await flush()
+
+    // Sanity: second is queued.
+    expect(document.querySelector('[data-queued="true"]')).not.toBeNull()
+
+    // Resolve first turn; drain should clear queued flag on 'second'.
+    // Empty traceId avoids ThoughtSummary tRPC dependency in this unit test.
+    await act(async () => {
+      first.resolve({ response: 'r1', traceId: '' })
+    })
+    await flush()
+
+    // After drain, the queued attribute should no longer be present.
+    expect(document.querySelector('[data-queued="true"]')).toBeNull()
+  })
+
+  // T7 — Tier 3 regression guard — useAgentActivity untouched
+  it('preserves useAgentActivity activity-indicator unchanged (mount + unmount no-throw)', async () => {
+    // This is a low-risk regression guard: render + unmount the panel and
+    // ensure no exception is thrown. The useAgentActivity subscription is
+    // wired at render time; if RC-3 inadvertently broke its subscription,
+    // we'd see an effect-cleanup throw or a render throw here.
+    const api = makeChatApi(() => new Promise(() => {}))
+    const { unmount } = render(<ChatPanel chatApi={api} />)
+    await flush()
+    expect(() => unmount()).not.toThrow()
+  })
+})

--- a/self/ui/src/panels/chat/ChatInput.tsx
+++ b/self/ui/src/panels/chat/ChatInput.tsx
@@ -13,7 +13,9 @@ interface ChatInputProps {
 
 export function ChatInput({
     input,
-    sending,
+    // `sending` retained on ChatInputProps for interface stability post-RC-3.
+    // Disable behavior moved out of this component (see SP 1.11 SDS § RC-3).
+    sending: _sending,
     canSend,
     onInputChange,
     onSend,
@@ -36,7 +38,7 @@ export function ChatInput({
         }
     }
 
-    const isDisabled = sending || !input.trim() || !canSend
+    const isDisabled = !input.trim() || !canSend
 
     return (
         <div style={styles.wrapper}>
@@ -50,7 +52,7 @@ export function ChatInput({
                         onFocus={onFocus}
                         onBlur={onBlur}
                         placeholder="What can I help you with?"
-                        disabled={sending}
+                        disabled={false}
                         style={styles.textarea}
                         rows={1}
                     />
@@ -67,7 +69,7 @@ export function ChatInput({
                         title="Send message"
                         style={{
                             ...styles.sendButton,
-                            cursor: sending ? 'not-allowed' : 'pointer',
+                            cursor: isDisabled ? 'not-allowed' : 'pointer',
                             opacity: isDisabled ? 0.5 : 1,
                         }}
                     >

--- a/self/ui/src/panels/chat/ChatMessageList.tsx
+++ b/self/ui/src/panels/chat/ChatMessageList.tsx
@@ -86,9 +86,18 @@ function ChatMessageRow({
     onCardAction,
 }: ChatMessageRowProps) {
     if (message.role === 'user') {
+        const isQueued = message.queued === true
         return (
             <div style={styles.rowUser}>
-                <div style={styles.bubbleUser}>{message.content}</div>
+                <div
+                    data-queued={isQueued ? 'true' : undefined}
+                    style={isQueued ? { ...styles.bubbleUser, ...styles.bubbleUserQueued } : styles.bubbleUser}
+                >
+                    {message.content}
+                    {isQueued && (
+                        <span style={styles.queuedMarker}> queued</span>
+                    )}
+                </div>
             </div>
         )
     }
@@ -223,6 +232,16 @@ const styles = {
         padding: 'var(--nous-space-md) var(--nous-space-xl)',
         background: 'var(--nous-surface-nested)',
         border: '1px solid var(--nous-border)'
+    },
+    bubbleUserQueued: {
+        opacity: 0.6,
+        fontStyle: 'italic' as const,
+    },
+    queuedMarker: {
+        marginLeft: 'var(--nous-space-xs)',
+        fontStyle: 'italic' as const,
+        color: 'var(--nous-fg-muted)',
+        fontSize: 'var(--nous-font-size-xs)',
     },
     thinkingDetails: {
         maxWidth: '100%',

--- a/self/ui/src/panels/chat/types.ts
+++ b/self/ui/src/panels/chat/types.ts
@@ -14,6 +14,7 @@ export interface ChatMessage {
     result?: ActionResult
   }
   cards?: Array<{ type: string; props: Record<string, unknown> }>
+  queued?: boolean
 }
 
 export interface ActionResult {


### PR DESCRIPTION
## Summary

Sub-phase 1.11 ships the three Principal-ratified BT Round 3 root-cause fixes for WR-159 (chat-experience-quality):

- **RC-1 (cortex-core)** — Gateway resolves the response parser per turn from the live-provider adapter (`adapter.parseResponse(...)`), eliminating the `[object Object]` rendering that occurred when the attach-time harness was bound to a different vendor than the active provider. Removes the now-unused `parseModelOutput` named import per SDS Review Note 1.
- **RC-2 (ui)** — Adds a `console.trace` diagnostic immediately after the existing `console.warn` at the StatusCard validation failure. Phase A diagnostic that surfaces the emitter stack for surgical Phase B repair if BT R4 reproduces.
- **RC-3 (ui)** — Unlocks the chat input textarea and Send button during the thinking sub-phase; refactors `ChatPanel.send()` into a synchronous dispatcher + async `invoke()` helper; adds a FIFO queue (`queuedMessages`) with a queue-drain effect on `sending: true → false` transitions; renders queued user messages with a `data-queued="true"` attribute, dimmed/italic styling, and a `queued` text marker.

Three atomic commits in dependency order: RC-1 → RC-2 → RC-3.

## Verification

- `pnpm typecheck` Pass
- `pnpm lint` Pass — net 2 warnings reduced vs SP 1.10 baseline
- `pnpm test` Pass — **5420 / 5420** (up from 5412 baseline by exactly +8: 7 new RC-3 queue tests + 1 new RC-1 Mode A regression test)
- `pnpm build` Pass — `tsdown` packages, `electron-vite` desktop, Next.js web, CLI all clean
- Installer verification — Deferred (Approved); SP 1.11 is a UI-and-gateway fix sub-phase with no installer-affecting changes

## Worklog

- Goals — Approved
- SDS — Approved With Notes (Note 1 integrated into Commit 1)
- Implementation Plan — Approved
- Completion Report — **Approved With Notes**
- Path: `.worklog/sprints/feat/chat-experience-quality/phase-1/phase-1.11/`

## Test plan

- [ ] BT Round 4 — Principal verifies on phase branch:
  - [ ] RC-1 — three sample prompts (text, thinking, tool-call) render meaningful assistant output with Ollama as active Principal provider
  - [ ] RC-1 — server logs show non-zero `responseLength` for every Principal turn
  - [ ] RC-2 — DevTools console emits the trace identifying the StatusCard emitter (or absence-of-reproduction closes Phase A)
  - [ ] RC-3 — textarea and Send button stay interactive during thinking
  - [ ] RC-3 — submitted-while-thinking messages are visibly queued and drained in FIFO order without double-submit
  - [ ] RC-3 — SP 1.10 RC-2 activity-indicator clears on `turn-complete` (regression check)