### PR TITLE
fix(WR-159): SP 1.12 — BT Round 4 fix — Ollama tool-result roundtrip (RC-1)

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
@@ -271,7 +271,7 @@ describe('createOllamaAdapter', () => {
             type: 'function',
             function: {
               name: 'get_weather',
-              arguments: '{"city":"NYC"}',
+              arguments: { city: 'NYC' },
             },
           },
         ],
@@ -338,7 +338,7 @@ describe('createOllamaAdapter', () => {
         tool_calls: [{
           id: 'call_w',
           type: 'function',
-          function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+          function: { name: 'get_weather', arguments: { city: 'NYC' } },
         }],
       });
       expect(messages[3]).toEqual({
@@ -346,6 +346,60 @@ describe('createOllamaAdapter', () => {
         content: '72°F and sunny',
         tool_call_id: 'call_w',
       });
+    });
+
+    it('BT R4 RC-1 regression — arguments passed as object (Ollama /api/chat wire format)', () => {
+      // Regression test for BT R4 RC-1 (WR-159 phase 1.12).
+      //
+      // Ollama's NATIVE /api/chat endpoint decodes tool_calls[].function.arguments
+      // via the Go ToolCallFunctionArguments.UnmarshalJSON which expects a JSON
+      // OBJECT (orderedmap-backed map[string]any), NOT a JSON-string-of-an-object.
+      // See ollama/ollama:main api/types.go lines 240-249 (ToolCallFunctionArguments
+      // declaration) and 307-310 (UnmarshalJSON via json.Unmarshal into orderedmap).
+      //
+      // Pre-fix, ollama-adapter.ts:269 wrapped tc.input in JSON.stringify, which
+      // produced a string-shaped value Ollama's parser rejected with HTTP 400
+      // "Value looks like object, but can't find closing '}' symbol".
+      // BT R4 turn 3 evidence: .worklog/sprints/feat/chat-experience-quality/phase-1/behavioral-testing/round-4.mdx
+      //
+      // Positive assertion: arguments deep-equals the expected object.
+      // Negative assertion: arguments is NOT a string. The negative assertion
+      // catches future naive refactors that re-introduce stringification.
+      const adapter = createOllamaAdapter('gemma4:12b');
+      const result = adapter.formatRequest({
+        systemPrompt: 'p',
+        context: [
+          {
+            role: 'assistant' as const,
+            content: 'Let me check.',
+            source: 'model_output' as const,
+            createdAt: new Date().toISOString(),
+            metadata: {
+              tool_calls: [
+                { id: 'call_x', name: 'workflow_list', input: { projectId: 'p1' } },
+              ],
+            },
+          },
+          {
+            role: 'tool' as const,
+            content: 'tool result content',
+            source: 'tool_result' as const,
+            createdAt: new Date().toISOString(),
+            metadata: { tool_call_id: 'call_x' },
+          },
+        ],
+      });
+      const input = result.input as Record<string, unknown>;
+      const messages = input.messages as Array<Record<string, unknown>>;
+      // system + assistant(tool_calls) + tool(tool_call_id) — three messages.
+      const assistantMsg = messages[1] as Record<string, unknown>;
+      const toolCalls = assistantMsg.tool_calls as Array<Record<string, unknown>>;
+      const fn = toolCalls[0].function as Record<string, unknown>;
+      // Positive: arguments is the exact object the gateway provided.
+      expect(fn.arguments).toEqual({ projectId: 'p1' });
+      // Negative: arguments is NOT a string (catches future refactors that
+      // re-introduce JSON.stringify).
+      expect(typeof fn.arguments).not.toBe('string');
     });
 
     it('does not emit tool_calls for assistant frame without metadata.tool_calls', () => {

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-tool-roundtrip.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-tool-roundtrip.test.ts
@@ -179,7 +179,7 @@ describe('Adapter tool round-trip formatting', () => {
           type: 'function',
           function: {
             name: 'get_weather',
-            arguments: '{"city":"NYC"}',
+            arguments: { city: 'NYC' },
           },
         }],
       });

--- a/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
@@ -266,7 +266,7 @@ export function createOllamaAdapter(modelId?: string, log?: ILogChannel): Provid
               type: 'function' as const,
               function: {
                 name: tc.name,
-                arguments: (() => { try { return JSON.stringify(tc.input ?? {}); } catch { return '{}'; } })(),
+                arguments: (tc.input && typeof tc.input === 'object') ? tc.input : {},
               },
             }));
           messages.push({

--- a/self/subcortex/providers/src/schemas.ts
+++ b/self/subcortex/providers/src/schemas.ts
@@ -41,7 +41,7 @@ const MessageSchema = z.object({
     type: z.literal('function'),
     function: z.object({
       name: z.string(),
-      arguments: z.string(),
+      arguments: z.union([z.string(), z.record(z.unknown())]),
     }),
   })).optional(),
 });


### PR DESCRIPTION
## Summary

Fix Ollama NATIVE endpoint tool_calls.arguments shape mismatch identified in BT Round 4 (WR-159, sub-phase 1.12).

- `ollama-adapter.ts:269` now passes `tc.input` directly as a JSON object (with type guard), matching Ollama's Go-typed `ToolCallFunctionArguments` schema for `/api/chat`.
- `schemas.ts:44` relaxes `MessageSchema.tool_calls[].function.arguments` to `z.union([z.string(), z.record(z.unknown())])` so both OpenAI string and Ollama object shapes pass boundary validation.
- Test corrections in `ollama-adapter.test.ts` (2 fixes + new BT R4 regression test with negative `typeof !== 'string'` assertion) and `agent-gateway-tool-roundtrip.test.ts:182` (omitted assertion flagged by fresh-eyes RCM review).

Completion Report Approved (clean — no notes).

## Evidence

- BT R4: `.worklog/sprints/feat/chat-experience-quality/phase-1/behavioral-testing/round-4.mdx`
- Completion report: `.worklog/sprints/feat/chat-experience-quality/phase-1/phase-1.12/completion-report.md`

## Test plan

- [ ] Principal runs BT Round 5 against the merged phase branch to confirm Ollama tool-result roundtrip succeeds end-to-end