### PR TITLE
feat(onboarding-agent-identity): Phase 1.1 — wizard composability migration

### DIFF
--- a/self/apps/desktop/src/renderer/src/components/FirstRunWizard.tsx
+++ b/self/apps/desktop/src/renderer/src/components/FirstRunWizard.tsx
@@ -1,31 +1,21 @@
 import { useEffect, useState } from 'react'
-import { WizardStepConfirmation } from './wizard/WizardStepConfirmation'
 import { WizardStepIndicator } from './wizard/WizardStepIndicator'
-import { WizardStepModelDownload } from './wizard/WizardStepModelDownload'
-import { WizardStepOllamaSetup } from './wizard/WizardStepOllamaSetup'
-import { WizardStepRoleAssignment } from './wizard/WizardStepRoleAssignment'
-import { WizardStepWelcome } from './wizard/WizardStepWelcome'
 import './wizard/wizard.css'
 import {
   BACKEND_STEP_TO_WIZARD_STEP,
+  PREVIOUS_STEP_MAP,
   WIZARD_STEPS,
+  WIZARD_STEP_REGISTRY,
+  type WizardStepId,
+} from './wizard/registry'
+import {
   getRecommendedModelSpec,
   type FirstRunPrerequisites,
   type FirstRunState,
   type OllamaStatus,
   type RoleAssignments,
-  type WizardStepId,
 } from './wizard/types'
-import { trpcQuery, trpcMutate } from './wizard/trpc-fetch'
-
-/** Back-navigation map: from each step, where does Back take you? */
-const PREVIOUS_STEP_MAP: Record<WizardStepId, WizardStepId | null> = {
-  welcome: null,
-  'ollama-setup': 'welcome',
-  'model-download': 'ollama-setup',
-  'role-assignment': 'model-download',
-  confirmation: 'role-assignment',
-}
+import { trpcMutate, trpcQuery } from './wizard/trpc-fetch'
 
 type RoleAssignmentMode = 'default' | 'advanced'
 
@@ -176,6 +166,82 @@ export function FirstRunWizard({
     setActionError,
   }
 
+  // Registry-driven render dispatch. Lookup the current entry; throw a clear
+  // error if the id is unknown (should never happen — registry validators
+  // guarantee WizardStepId covers every reachable state). Per-step prop
+  // shapes are preserved verbatim through the `buildStepProps` resolver.
+  const currentEntry = WIZARD_STEP_REGISTRY.find((entry) => entry.id === currentWizardStep)
+  if (!currentEntry) {
+    throw new Error(`[nous:wizard] Unknown step id: ${currentWizardStep}`)
+  }
+
+  // Per-step prop resolver. The component types differ (welcome takes an
+  // `onContinue`; ollama takes `ollamaStatus` + `refreshOllamaStatus`; etc.),
+  // so we build each step's prop object verbatim here rather than via a
+  // discriminated union. This preserves each step component's existing prop
+  // interface without requiring a renderer-side cast at the dispatch site.
+  // The registry type erases `TComponent` to `unknown`; the switch on
+  // `currentWizardStep` plus the component's own prop validation guarantees
+  // type correctness at the call site.
+  const StepComponent = currentEntry.component as unknown as React.ComponentType<Record<string, unknown>>
+  const stepProps = (() => {
+    switch (currentWizardStep) {
+      case 'welcome':
+        return {
+          ...sharedProps,
+          onStepComplete: (nextState: FirstRunState) => {
+            applyStepCompletion('welcome', nextState)
+          },
+          onContinue: () => {
+            console.log('[nous:wizard] Step completed: welcome')
+            setWelcomeCompleted(true)
+            setCurrentStepOverride(null)
+          },
+        }
+      case 'ollama-setup':
+        return {
+          ...sharedProps,
+          ollamaStatus,
+          refreshOllamaStatus,
+          onStepComplete: (nextState: FirstRunState) => {
+            applyStepCompletion('ollama_check', nextState)
+          },
+        }
+      case 'model-download':
+        return {
+          ...sharedProps,
+          selectedModelSpec,
+          setSelectedModelSpec,
+          onStepComplete: (nextState: FirstRunState) => {
+            applyStepCompletion('model_download/provider_config', nextState)
+          },
+        }
+      case 'confirmation':
+        return {
+          ...sharedProps,
+          selectedModelSpec,
+          roleAssignments,
+          ollamaStatus,
+          onStepComplete: (nextState: FirstRunState) => {
+            applyStepCompletion('confirmation', nextState)
+          },
+          onFinish: () => {
+            console.log('[nous:wizard] Step completed: confirmation')
+            onComplete()
+          },
+        }
+      default:
+        throw new Error(`[nous:wizard] Unknown step id: ${currentWizardStep satisfies never}`)
+    }
+  })()
+
+  // `roleAssignmentMode` is retained for SP 1.5 (auto-role-assign will reuse
+  // the existing state shape). Reference it here so the linter does not flag
+  // the state hook as unused during SP 1.1.
+  void roleAssignmentMode
+  void setRoleAssignments
+  void setRoleAssignmentMode
+
   return (
     <div className="nous-wizard">
       <div className="nous-wizard__container">
@@ -230,71 +296,7 @@ export function FirstRunWizard({
           </div>
         ) : null}
 
-        {currentWizardStep === 'welcome' ? (
-          <WizardStepWelcome
-            {...sharedProps}
-            onStepComplete={(nextState) => {
-              applyStepCompletion('welcome', nextState)
-            }}
-            onContinue={() => {
-              console.log('[nous:wizard] Step completed: welcome')
-              setWelcomeCompleted(true)
-              setCurrentStepOverride(null)
-            }}
-          />
-        ) : null}
-
-        {currentWizardStep === 'ollama-setup' ? (
-          <WizardStepOllamaSetup
-            {...sharedProps}
-            ollamaStatus={ollamaStatus}
-            refreshOllamaStatus={refreshOllamaStatus}
-            onStepComplete={(nextState) => {
-              applyStepCompletion('ollama_check', nextState)
-            }}
-          />
-        ) : null}
-
-        {currentWizardStep === 'model-download' ? (
-          <WizardStepModelDownload
-            {...sharedProps}
-            selectedModelSpec={selectedModelSpec}
-            setSelectedModelSpec={setSelectedModelSpec}
-            onStepComplete={(nextState) => {
-              applyStepCompletion('model_download/provider_config', nextState)
-            }}
-          />
-        ) : null}
-
-        {currentWizardStep === 'role-assignment' ? (
-          <WizardStepRoleAssignment
-            {...sharedProps}
-            selectedModelSpec={selectedModelSpec}
-            roleAssignments={roleAssignments}
-            setRoleAssignments={setRoleAssignments}
-            roleAssignmentMode={roleAssignmentMode}
-            setRoleAssignmentMode={setRoleAssignmentMode}
-            onStepComplete={(nextState) => {
-              applyStepCompletion('role_assignment', nextState)
-            }}
-          />
-        ) : null}
-
-        {currentWizardStep === 'confirmation' ? (
-          <WizardStepConfirmation
-            {...sharedProps}
-            selectedModelSpec={selectedModelSpec}
-            roleAssignments={roleAssignments}
-            ollamaStatus={ollamaStatus}
-            onStepComplete={(nextState) => {
-              applyStepCompletion('confirmation', nextState)
-            }}
-            onFinish={() => {
-              console.log('[nous:wizard] Step completed: confirmation')
-              onComplete()
-            }}
-          />
-        ) : null}
+        <StepComponent {...(stepProps as Record<string, unknown>)} />
       </div>
     </div>
   )

--- a/self/apps/desktop/src/renderer/src/components/__tests__/FirstRunWizard.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/__tests__/FirstRunWizard.test.tsx
@@ -2,11 +2,16 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createElectronAPIMock,
+  createFirstRunActionResult,
   createFirstRunState,
   createPrerequisites,
   DEFAULT_PREREQUISITES,
 } from '../../test-setup'
 import { FirstRunWizard } from '../FirstRunWizard'
+import {
+  PREVIOUS_STEP_MAP,
+  WIZARD_STEP_REGISTRY,
+} from '../wizard/registry'
 
 const trpcFetchMock = vi.hoisted(() => ({
   setBackendPort: vi.fn(),
@@ -96,7 +101,7 @@ describe('FirstRunWizard', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Continue setup' }))
 
     expect(
-      await screen.findByText('Make sure Ollama is installed and running.'),
+      await screen.findByText(/Ollama is ready/),
     ).toBeInTheDocument()
   })
 
@@ -175,5 +180,196 @@ describe('FirstRunWizard', () => {
     })
 
     expect((await screen.findAllByText('Not installed')).length).toBeGreaterThan(0)
+  })
+})
+
+describe('FirstRunWizard — registry-driven invariants', () => {
+  beforeEach(() => {
+    trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.checkPrerequisites') return DEFAULT_PREREQUISITES
+      return null
+    })
+    trpcFetchMock.trpcMutate.mockImplementation(async () => createFirstRunState())
+  })
+
+  it('PREVIOUS_STEP_MAP walks confirmation → model-download → ollama-setup → welcome → null (F4)', () => {
+    // Start from confirmation and step back to the root.
+    const chain: Array<string | null> = []
+    let cursor: string | null = 'confirmation'
+    while (cursor !== null) {
+      chain.push(cursor)
+      cursor = PREVIOUS_STEP_MAP[cursor as keyof typeof PREVIOUS_STEP_MAP] ?? null
+    }
+    chain.push(null)
+    expect(chain).toEqual([
+      'confirmation',
+      'model-download',
+      'ollama-setup',
+      'welcome',
+      null,
+    ])
+  })
+
+  it('PREVIOUS_STEP_MAP never references the removed role-assignment step (F5)', () => {
+    const values = Object.values(PREVIOUS_STEP_MAP)
+    expect(values).not.toContain('role-assignment')
+    const keys = Object.keys(PREVIOUS_STEP_MAP)
+    expect(keys).not.toContain('role-assignment')
+  })
+
+  it('renders exactly WIZARD_STEP_REGISTRY.length stepper slots (F6)', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    await screen.findByText('Set up your local runtime in a few guided steps.')
+    const stepper = screen.getByRole('navigation', { name: /first-run wizard steps/i })
+    expect(stepper.children.length).toBe(WIZARD_STEP_REGISTRY.length)
+  })
+
+  it('wires the CSS custom property --nous-wizard-step-count to WIZARD_STEP_REGISTRY.length (F6)', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    await screen.findByText('Set up your local runtime in a few guided steps.')
+    const stepper = screen.getByRole('navigation', { name: /first-run wizard steps/i }) as HTMLElement
+    expect(stepper.style.getPropertyValue('--nous-wizard-step-count')).toBe(
+      String(WIZARD_STEP_REGISTRY.length),
+    )
+  })
+
+  it('back-nav from ollama-setup to welcome re-enables welcome gating', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState({
+          currentStep: 'ollama_check',
+        })}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    // Advance to ollama-setup via the welcome continue button.
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue setup' }))
+    await screen.findByText(/Ollama is ready/)
+
+    // Back button should now be rendered (welcome is previous).
+    fireEvent.click(screen.getByTestId('wizard-back-button'))
+
+    // After back-nav, the welcome screen is visible again.
+    expect(
+      await screen.findByText('Set up your local runtime in a few guided steps.'),
+    ).toBeInTheDocument()
+  })
+
+  it('full download path advances through placeholder auto-mark to confirmation (F7)', async () => {
+    const mock = installMock()
+
+    const resumeState = createFirstRunState({
+      currentStep: 'model_download',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'pending' },
+        provider_config: { status: 'pending' },
+        role_assignment: { status: 'pending' },
+      },
+    })
+
+    const afterConfigureProvider = createFirstRunState({
+      currentStep: 'role_assignment',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+        role_assignment: { status: 'pending' },
+      },
+    })
+    const afterRoleAssignmentPlaceholder = createFirstRunState({
+      currentStep: 'complete',
+      complete: true,
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+        role_assignment: { status: 'complete', completedAt: '2026-03-22T00:07:00.000Z' },
+      },
+    })
+
+    trpcFetchMock.trpcMutate.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.downloadModel' || procedure === 'firstRun.configureProvider') {
+        return createFirstRunActionResult(afterConfigureProvider)
+      }
+      if (procedure === 'firstRun.completeStep') {
+        return afterRoleAssignmentPlaceholder
+      }
+      return null
+    })
+
+    render(
+      <FirstRunWizard initialState={resumeState} onComplete={vi.fn()} />,
+    )
+
+    // Renderer lands on model-download (backend currentStep === model_download).
+    fireEvent.click(await screen.findByRole('button', { name: 'Download model' }))
+
+    await waitFor(() => {
+      expect(mock.ollama.pullModel).toHaveBeenCalledWith('qwen2.5:7b')
+    })
+
+    mock.__emitPullProgress({
+      status: 'success',
+      percent: 100,
+      completed: 100,
+      total: 100,
+    })
+
+    // After the full download + configure + placeholder chain, the wizard
+    // transitions to the confirmation step.
+    expect(
+      await screen.findByText('Your desktop runtime is ready.'),
+    ).toBeInTheDocument()
+
+    // The placeholder auto-mark for role_assignment must have fired.
+    expect(trpcFetchMock.trpcMutate).toHaveBeenCalledWith(
+      'firstRun.completeStep',
+      { step: 'role_assignment' },
+    )
+  })
+
+  it('calls onComplete when the confirmation "Open workspace" button is pressed', async () => {
+    installMock()
+    const onComplete = vi.fn()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState({
+          currentStep: 'complete',
+          complete: true,
+          steps: {
+            ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+            model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+            provider_config: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+            role_assignment: { status: 'complete', completedAt: '2026-03-22T00:07:00.000Z' },
+          },
+        })}
+        onComplete={onComplete}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open workspace' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 })

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepIndicator.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepIndicator.tsx
@@ -1,7 +1,8 @@
+import type { CSSProperties } from 'react'
 import type { WizardStepDefinition, WizardStepId } from './types'
 
 interface WizardStepIndicatorProps {
-  steps: WizardStepDefinition[]
+  steps: readonly WizardStepDefinition[]
   currentStepId: WizardStepId
 }
 
@@ -11,8 +12,20 @@ export function WizardStepIndicator({
 }: WizardStepIndicatorProps) {
   const currentIndex = steps.findIndex((step) => step.id === currentStepId)
 
+  // Bind the stepper grid column count to the registry length via a CSS
+  // custom property. The `wizard.css` rule uses
+  //   grid-template-columns: repeat(var(--nous-wizard-step-count, 4), ...)
+  // so adding or removing a wizard step never requires a CSS edit.
+  const stepperStyle = {
+    '--nous-wizard-step-count': String(steps.length),
+  } as CSSProperties
+
   return (
-    <nav className="nous-wizard__stepper" aria-label="First-run wizard steps">
+    <nav
+      className="nous-wizard__stepper"
+      aria-label="First-run wizard steps"
+      style={stepperStyle}
+    >
       {steps.map((step, index) => {
         const isCurrent = step.id === currentStepId
         const isComplete = currentIndex > index

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepModelDownload.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepModelDownload.tsx
@@ -97,7 +97,15 @@ export function WizardStepModelDownload({
         throw new Error(providerResult.error ?? 'The backend could not configure the selected model.')
       }
 
-      onStepComplete(providerResult.state)
+      // PLACEHOLDER (SP 1.1): replaced by assignRoles in SP 1.5 per SDS § 2.6.
+      let finalState: FirstRunState = providerResult.state
+      if (finalState.steps.role_assignment.status !== 'complete') {
+        finalState = await trpcMutate<FirstRunState>('firstRun.completeStep', {
+          step: 'role_assignment',
+        })
+      }
+
+      onStepComplete(finalState)
     } catch (error) {
       finalizeRef.current = false
       const message = error instanceof Error ? error.message : String(error)
@@ -118,9 +126,15 @@ export function WizardStepModelDownload({
       // model there's no provider to configure. User can add models later via
       // Settings > Local Models.
       await trpcMutate<FirstRunState>('firstRun.completeStep', { step: 'model_download' })
-      const nextState = await trpcMutate<FirstRunState>('firstRun.completeStep', {
+      let nextState = await trpcMutate<FirstRunState>('firstRun.completeStep', {
         step: 'provider_config',
       })
+      // PLACEHOLDER (SP 1.1): replaced by assignRoles in SP 1.5 per SDS § 2.6.
+      if (nextState.steps.role_assignment.status !== 'complete') {
+        nextState = await trpcMutate<FirstRunState>('firstRun.completeStep', {
+          step: 'role_assignment',
+        })
+      }
       onStepComplete(nextState)
     } catch (error) {
       finalizeRef.current = false

--- a/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardSteps.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardSteps.test.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -7,10 +6,10 @@ import {
   createFirstRunState,
   createPrerequisites,
 } from '../../../test-setup'
+import { WIZARD_STEP_REGISTRY } from '../registry'
 import { WizardStepConfirmation } from '../WizardStepConfirmation'
 import { WizardStepModelDownload } from '../WizardStepModelDownload'
 import { WizardStepOllamaSetup } from '../WizardStepOllamaSetup'
-import { WizardStepRoleAssignment } from '../WizardStepRoleAssignment'
 import { WizardStepWelcome } from '../WizardStepWelcome'
 
 const trpcFetchMock = vi.hoisted(() => ({
@@ -42,6 +41,49 @@ function createStepProps() {
     onStepComplete: vi.fn(),
   }
 }
+
+describe('WIZARD_STEP_REGISTRY invariants', () => {
+  it('contains exactly the four V1 entries in canonical order', () => {
+    expect(WIZARD_STEP_REGISTRY.map((entry) => entry.id)).toEqual([
+      'welcome',
+      'ollama-setup',
+      'model-download',
+      'confirmation',
+    ])
+  })
+
+  it('does not include a role-assignment entry (dedicated step removed)', () => {
+    const ids = WIZARD_STEP_REGISTRY.map((entry) => entry.id)
+    expect(ids).not.toContain('role-assignment')
+  })
+
+  it('does not include an identity entry (added by SP 1.4)', () => {
+    const ids = WIZARD_STEP_REGISTRY.map((entry) => entry.id)
+    expect(ids).not.toContain('identity')
+  })
+
+  it('advertises the correct skippable flags per step', () => {
+    const bySkippable = Object.fromEntries(
+      WIZARD_STEP_REGISTRY.map((entry) => [entry.id, entry.skippable] as const),
+    )
+    expect(bySkippable).toEqual({
+      welcome: false,
+      'ollama-setup': true,
+      'model-download': true,
+      confirmation: false,
+    })
+  })
+
+  it('binds each entry to its step component', () => {
+    const byComponent = Object.fromEntries(
+      WIZARD_STEP_REGISTRY.map((entry) => [entry.id, entry.component] as const),
+    )
+    expect(byComponent.welcome).toBe(WizardStepWelcome)
+    expect(byComponent['ollama-setup']).toBe(WizardStepOllamaSetup)
+    expect(byComponent['model-download']).toBe(WizardStepModelDownload)
+    expect(byComponent.confirmation).toBe(WizardStepConfirmation)
+  })
+})
 
 describe('Wizard step components', () => {
   beforeEach(() => {
@@ -155,7 +197,7 @@ describe('Wizard step components', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('downloading...')).toBeInTheDocument()
+      expect(screen.getByText('Downloading Ollama...')).toBeInTheDocument()
     })
   })
 
@@ -266,6 +308,40 @@ describe('Wizard step components', () => {
     })
   })
 
+  it('preserves the WR-132.2 skip path in the Ollama step (F8)', async () => {
+    installMock()
+    const props = createStepProps()
+    const nextState = createFirstRunState({ currentStep: 'model_download' })
+    trpcFetchMock.trpcMutate.mockResolvedValue(nextState)
+
+    render(
+      <WizardStepOllamaSetup
+        {...props}
+        ollamaStatus={{
+          installed: false,
+          running: false,
+          state: 'not_installed',
+          models: [],
+          defaultModel: null,
+        }}
+        refreshOllamaStatus={vi.fn(async () => {})}
+      />,
+    )
+
+    // "Skip — I'll use cloud providers" affordance (WR-132.2). The en-dash is
+    // rendered from `&rsquo;` + `—` in the component.
+    const skipButton = screen.getByRole('button', { name: /Skip — I.*use cloud providers/i })
+    fireEvent.click(skipButton)
+
+    await waitFor(() => {
+      expect(trpcFetchMock.trpcMutate).toHaveBeenCalledWith(
+        'firstRun.completeStep',
+        { step: 'ollama_check' },
+      )
+      expect(props.onStepComplete).toHaveBeenCalledWith(nextState)
+    })
+  })
+
   it('shows the recommended model in the download step', () => {
     installMock()
     const props = createStepProps()
@@ -303,10 +379,13 @@ describe('Wizard step components', () => {
     expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
-  it('runs the download flow and finalizes provider configuration on success', async () => {
+  it('runs the download flow, configures the provider, and placeholder-marks role_assignment on success (F7)', async () => {
     const mock = installMock()
     const props = createStepProps()
-    const nextState = createFirstRunState({
+    // Build the two states the download path transitions through:
+    //   1) after download+configureProvider — role_assignment still pending
+    //   2) after placeholder auto-mark — role_assignment complete, currentStep: complete
+    const afterConfigureProvider = createFirstRunState({
       currentStep: 'role_assignment',
       steps: {
         ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
@@ -315,9 +394,25 @@ describe('Wizard step components', () => {
         role_assignment: { status: 'pending' },
       },
     })
-    trpcFetchMock.trpcMutate.mockResolvedValue(
-      createFirstRunActionResult(nextState),
-    )
+    const afterRoleAssignmentPlaceholder = createFirstRunState({
+      currentStep: 'complete',
+      complete: true,
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+        role_assignment: { status: 'complete', completedAt: '2026-03-22T00:07:00.000Z' },
+      },
+    })
+    trpcFetchMock.trpcMutate.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.downloadModel' || procedure === 'firstRun.configureProvider') {
+        return createFirstRunActionResult(afterConfigureProvider)
+      }
+      if (procedure === 'firstRun.completeStep') {
+        return afterRoleAssignmentPlaceholder
+      }
+      return null
+    })
 
     render(
       <WizardStepModelDownload
@@ -348,7 +443,155 @@ describe('Wizard step components', () => {
         'firstRun.configureProvider',
         { modelSpec: 'ollama:qwen2.5:7b' },
       )
-      expect(props.onStepComplete).toHaveBeenCalledWith(nextState)
+      // Placeholder auto-mark for role_assignment fires after configureProvider.
+      expect(trpcFetchMock.trpcMutate).toHaveBeenCalledWith(
+        'firstRun.completeStep',
+        { step: 'role_assignment' },
+      )
+      // The final advance state carries role_assignment:complete and currentStep:complete.
+      expect(props.onStepComplete).toHaveBeenCalledWith(afterRoleAssignmentPlaceholder)
+    })
+  })
+
+  it('placeholder auto-mark is idempotent — skips completeStep when role_assignment is already complete', async () => {
+    const mock = installMock()
+    const props = {
+      ...createStepProps(),
+      // State arrives with role_assignment already complete (e.g. user resumed
+      // after a mid-flight crash before the placeholder fired and re-landed
+      // on model-download before navigating on).
+      state: createFirstRunState({
+        currentStep: 'model_download',
+        steps: {
+          ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+          model_download: { status: 'pending' },
+          provider_config: { status: 'pending' },
+          role_assignment: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        },
+      }),
+    }
+    const afterConfigure = createFirstRunState({
+      currentStep: 'complete',
+      complete: true,
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:06:00.000Z' },
+        role_assignment: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+      },
+    })
+    trpcFetchMock.trpcMutate.mockImplementation(async () =>
+      createFirstRunActionResult(afterConfigure),
+    )
+
+    render(
+      <WizardStepModelDownload
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        setSelectedModelSpec={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download model' }))
+    await waitFor(() => {
+      expect(mock.ollama.pullModel).toHaveBeenCalledWith('qwen2.5:7b')
+    })
+
+    mock.__emitPullProgress({
+      status: 'success',
+      percent: 100,
+      completed: 100,
+      total: 100,
+    })
+
+    await waitFor(() => {
+      expect(props.onStepComplete).toHaveBeenCalled()
+    })
+
+    // Placeholder completeStep for role_assignment must NOT have been called
+    // because it was already complete.
+    const mutateCalls = trpcFetchMock.trpcMutate.mock.calls
+    const completeStepCalls = mutateCalls.filter(
+      (call) =>
+        call[0] === 'firstRun.completeStep' &&
+        (call[1] as { step?: string })?.step === 'role_assignment',
+    )
+    expect(completeStepCalls).toHaveLength(0)
+  })
+
+  it('placeholder auto-mark fires on the skip path too (F7 — skip branch)', async () => {
+    installMock()
+    const props = createStepProps()
+    const skippedState = createFirstRunState({
+      currentStep: 'provider_config',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'pending' },
+        role_assignment: { status: 'pending' },
+      },
+    })
+    const providerSkippedState = createFirstRunState({
+      currentStep: 'role_assignment',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        role_assignment: { status: 'pending' },
+      },
+    })
+    const finalState = createFirstRunState({
+      currentStep: 'complete',
+      complete: true,
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-03-22T00:04:00.000Z' },
+        model_download: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        provider_config: { status: 'complete', completedAt: '2026-03-22T00:05:00.000Z' },
+        role_assignment: { status: 'complete', completedAt: '2026-03-22T00:07:00.000Z' },
+      },
+    })
+    let callCount = 0
+    trpcFetchMock.trpcMutate.mockImplementation(async (procedure: string, input: unknown) => {
+      callCount += 1
+      const typedInput = input as { step?: string } | undefined
+      if (procedure === 'firstRun.completeStep' && typedInput?.step === 'model_download') {
+        return skippedState
+      }
+      if (procedure === 'firstRun.completeStep' && typedInput?.step === 'provider_config') {
+        return providerSkippedState
+      }
+      if (procedure === 'firstRun.completeStep' && typedInput?.step === 'role_assignment') {
+        return finalState
+      }
+      return null
+    })
+    void callCount
+
+    render(
+      <WizardStepModelDownload
+        {...props}
+        selectedModelSpec="ollama:qwen2.5:7b"
+        setSelectedModelSpec={vi.fn()}
+      />,
+    )
+
+    const skipButton = screen.getByRole('button', { name: /Skip — I.*add models later/i })
+    fireEvent.click(skipButton)
+
+    await waitFor(() => {
+      expect(trpcFetchMock.trpcMutate).toHaveBeenCalledWith(
+        'firstRun.completeStep',
+        { step: 'model_download' },
+      )
+      expect(trpcFetchMock.trpcMutate).toHaveBeenCalledWith(
+        'firstRun.completeStep',
+        { step: 'provider_config' },
+      )
+      expect(trpcFetchMock.trpcMutate).toHaveBeenCalledWith(
+        'firstRun.completeStep',
+        { step: 'role_assignment' },
+      )
+      expect(props.onStepComplete).toHaveBeenCalledWith(finalState)
     })
   })
 
@@ -375,72 +618,6 @@ describe('Wizard step components', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Use downloaded model' })).toBeInTheDocument()
-  })
-
-  it('assigns the selected model to all four roles in simple mode', async () => {
-    installMock()
-    const props = createStepProps()
-    const nextState = createFirstRunState({ currentStep: 'complete', complete: true })
-    trpcFetchMock.trpcMutate.mockResolvedValue(
-      createFirstRunActionResult(nextState),
-    )
-
-    render(
-      <WizardStepRoleAssignment
-        {...props}
-        selectedModelSpec="ollama:qwen2.5:7b"
-        roleAssignments={{}}
-        setRoleAssignments={vi.fn()}
-        roleAssignmentMode="default"
-        setRoleAssignmentMode={vi.fn()}
-      />,
-    )
-
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-
-    await waitFor(() => {
-      expect(trpcFetchMock.trpcMutate).toHaveBeenCalledTimes(1)
-      const call = trpcFetchMock.trpcMutate.mock.calls[0]
-      expect(call[0]).toBe('firstRun.assignRoles')
-      const assignments = call[1]?.assignments ?? []
-      expect(assignments).toHaveLength(4)
-      expect(assignments.every((entry: { modelSpec: string }) => entry.modelSpec === 'ollama:qwen2.5:7b')).toBe(true)
-    })
-  })
-
-  it('supports switching to advanced mode and editing per-role assignments', async () => {
-    installMock()
-    const props = createStepProps()
-
-    function Harness() {
-      const [roleAssignments, setRoleAssignments] = useState({})
-      const [mode, setMode] = useState<'default' | 'advanced'>('default')
-
-      return (
-        <WizardStepRoleAssignment
-          {...props}
-          selectedModelSpec="ollama:qwen2.5:7b"
-          roleAssignments={roleAssignments}
-          setRoleAssignments={setRoleAssignments}
-          roleAssignmentMode={mode}
-          setRoleAssignmentMode={setMode}
-        />
-      )
-    }
-
-    render(<Harness />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Advanced mode' }))
-    const reasonerSelect = screen.getByLabelText('Reasoner')
-    fireEvent.change(reasonerSelect, {
-      target: { value: 'ollama:qwen2.5:14b' },
-    })
-
-    await waitFor(() => {
-      expect((screen.getByLabelText('Reasoner') as HTMLSelectElement).value).toBe(
-        'ollama:qwen2.5:14b',
-      )
-    })
   })
 
   it('shows the completion summary after setup', () => {

--- a/self/apps/desktop/src/renderer/src/components/wizard/registry.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/registry.ts
@@ -1,0 +1,83 @@
+/**
+ * First-run wizard registry — renderer-side single source of truth.
+ *
+ * Imports the factory, validators, and derivation helpers from `@nous/shared`.
+ * Constructs `WIZARD_STEP_REGISTRY` from the four step-definition modules,
+ * then:
+ *   1. Runs `validateWizardRegistry` to catch duplicate ids / backend steps,
+ *      invalid `previous` references, multiple roots, or empty registry.
+ *   2. Runs `assertRegistryMatchesManifest` to catch coverage drift between
+ *      the registry and the shared backend-step manifest
+ *      (`FIRST_RUN_STEP_VALUES`).
+ *
+ * Both validators throw `WizardRegistryInvariantError` at module load if the
+ * registry is malformed — the renderer fails fast at boot rather than
+ * producing a silently-broken wizard.
+ *
+ * Derived exports:
+ *   - `WizardStepId`             — literal union of entry ids.
+ *   - `BACKEND_STEP_TO_WIZARD_STEP` — map from backend step (incl. `'complete'`)
+ *                                     to the owning wizard step id.
+ *   - `PREVIOUS_STEP_MAP`        — back-nav map derived from each entry's
+ *                                   `previous` field.
+ *   - `WIZARD_STEPS`             — thin accessor over the registry tuple for
+ *                                   `WizardStepIndicator` prop compatibility.
+ */
+import {
+  assertRegistryMatchesManifest,
+  defineWizardStep,
+  deriveBackendStepToWizardStep,
+  derivePreviousStepMap,
+  deriveWizardStepIds,
+  validateWizardRegistry,
+  type FirstRunCurrentStep,
+  type FirstRunStep,
+  type WizardStepDefinition,
+} from '@nous/shared'
+import { confirmationStep } from './steps/confirmation'
+import { modelDownloadStep } from './steps/model-download'
+import { ollamaSetupStep } from './steps/ollama-setup'
+import { welcomeStep } from './steps/welcome'
+
+// Re-export the factory + type so step definition files can also import from
+// this local path if callers prefer a renderer-scoped import graph.
+export { defineWizardStep }
+export type { WizardStepDefinition }
+
+export const WIZARD_STEP_REGISTRY = [
+  welcomeStep,
+  ollamaSetupStep,
+  modelDownloadStep,
+  confirmationStep,
+] as const
+
+// Module-load validation. Drift (duplicate-id, duplicate-backend-step,
+// invalid-previous, multiple-roots, empty-registry, manifest-mismatch) throws
+// at renderer boot — fail-fast, not fail-silently.
+validateWizardRegistry(WIZARD_STEP_REGISTRY)
+assertRegistryMatchesManifest(WIZARD_STEP_REGISTRY)
+
+export type WizardStepId = (typeof WIZARD_STEP_REGISTRY)[number]['id']
+
+// Merge the derived backend-step → wizard-step map with the `complete: 'confirmation'`
+// special key. Today's renderer relies on `BACKEND_STEP_TO_WIZARD_STEP` being
+// keyed by `FirstRunCurrentStep` (which includes the `'complete'` terminal
+// state). The derivation helper only yields keys for actual backend steps, so
+// we merge the terminal mapping at the renderer boundary rather than burdening
+// the shared package with UI concerns.
+export const BACKEND_STEP_TO_WIZARD_STEP = {
+  ...(deriveBackendStepToWizardStep(WIZARD_STEP_REGISTRY) as Record<
+    FirstRunStep,
+    WizardStepId
+  >),
+  complete: 'confirmation' as const,
+} as Record<FirstRunCurrentStep, WizardStepId>
+
+export const PREVIOUS_STEP_MAP = derivePreviousStepMap(
+  WIZARD_STEP_REGISTRY,
+) as Record<WizardStepId, WizardStepId | null>
+
+export const WIZARD_STEP_IDS = deriveWizardStepIds(WIZARD_STEP_REGISTRY) as readonly WizardStepId[]
+
+// Thin accessor for `WizardStepIndicator` (existing prop signature).
+export const WIZARD_STEPS: readonly WizardStepDefinition[] = WIZARD_STEP_REGISTRY

--- a/self/apps/desktop/src/renderer/src/components/wizard/steps/confirmation.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/steps/confirmation.ts
@@ -1,0 +1,17 @@
+import { defineWizardStep } from '@nous/shared'
+import { WizardStepConfirmation } from '../WizardStepConfirmation'
+
+/**
+ * `previous: 'model-download'` — NOT `'role-assignment'`. The dedicated
+ * `role-assignment` wizard step is removed per Decision 3 and SP 1.1 Goals
+ * item 9. The backend `role_assignment` step is auto-marked complete by the
+ * `model-download` step's bridge logic (SDS § 2.6).
+ */
+export const confirmationStep = defineWizardStep({
+  id: 'confirmation',
+  label: 'Finish',
+  component: WizardStepConfirmation,
+  backendStep: null,
+  previous: 'model-download',
+  skippable: false,
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/steps/model-download.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/steps/model-download.ts
@@ -1,0 +1,27 @@
+import { defineWizardStep } from '@nous/shared'
+import { WizardStepModelDownload } from '../WizardStepModelDownload'
+
+/**
+ * The `model-download` wizard step drives three backend state-machine steps
+ * (model_download, provider_config, role_assignment) via its completion
+ * handlers:
+ *   - `model_download` — marked complete when the Ollama pull succeeds
+ *     (or when the user chooses "Skip — I'll add models later").
+ *   - `provider_config` — marked complete when the tRPC
+ *     `firstRun.configureProvider` call succeeds (or when the user skips).
+ *   - `role_assignment` — placeholder-marked complete by the bridge logic
+ *     inside `WizardStepModelDownload` (SDS § 2.6). SP 1.5 will replace
+ *     the placeholder with a real `firstRun.assignRoles` call.
+ *
+ * The multi-backend-step coverage is declared via `extraBackendSteps` per
+ * ADR 016 (extraBackendSteps extension of Decision 2's ratified shape).
+ */
+export const modelDownloadStep = defineWizardStep({
+  id: 'model-download',
+  label: 'Model',
+  component: WizardStepModelDownload,
+  backendStep: 'model_download',
+  extraBackendSteps: ['provider_config', 'role_assignment'],
+  previous: 'ollama-setup',
+  skippable: true,
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/steps/ollama-setup.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/steps/ollama-setup.ts
@@ -1,0 +1,11 @@
+import { defineWizardStep } from '@nous/shared'
+import { WizardStepOllamaSetup } from '../WizardStepOllamaSetup'
+
+export const ollamaSetupStep = defineWizardStep({
+  id: 'ollama-setup',
+  label: 'Ollama',
+  component: WizardStepOllamaSetup,
+  backendStep: 'ollama_check',
+  previous: 'welcome',
+  skippable: true,
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/steps/welcome.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/steps/welcome.ts
@@ -1,0 +1,11 @@
+import { defineWizardStep } from '@nous/shared'
+import { WizardStepWelcome } from '../WizardStepWelcome'
+
+export const welcomeStep = defineWizardStep({
+  id: 'welcome',
+  label: 'Welcome',
+  component: WizardStepWelcome,
+  backendStep: null,
+  previous: null,
+  skippable: false,
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/types.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/types.ts
@@ -29,12 +29,12 @@ export type RoleAssignments = Partial<Record<ModelRole, string>>
 export type ModelRecommendation = NonNullable<FirstRunPrerequisites['recommendations']['singleModel']>
 export type RoleModelRecommendation = FirstRunPrerequisites['recommendations']['multiModel'][number]
 
-export type WizardStepId =
-  | 'welcome'
-  | 'ollama-setup'
-  | 'model-download'
-  | 'role-assignment'
-  | 'confirmation'
+export {
+  BACKEND_STEP_TO_WIZARD_STEP,
+  WIZARD_STEPS,
+  WIZARD_STEP_REGISTRY,
+} from './registry'
+export type { WizardStepId, WizardStepDefinition } from './registry'
 
 export type WizardModelOption = {
   modelId: string
@@ -42,12 +42,6 @@ export type WizardModelOption = {
   displayName: string
   reason: string
   ramRequiredMB: number
-}
-
-export type WizardStepDefinition = {
-  id: WizardStepId
-  label: string
-  backendStep: FirstRunStep | null
 }
 
 export interface WizardStepProps {
@@ -61,22 +55,6 @@ export interface WizardStepProps {
 }
 
 export const MODEL_ROLES = ModelRoleSchema.options
-
-export const BACKEND_STEP_TO_WIZARD_STEP: Record<FirstRunCurrentStep, WizardStepId> = {
-  ollama_check: 'ollama-setup',
-  model_download: 'model-download',
-  provider_config: 'model-download',
-  role_assignment: 'role-assignment',
-  complete: 'confirmation',
-}
-
-export const WIZARD_STEPS: WizardStepDefinition[] = [
-  { id: 'welcome', label: 'Welcome', backendStep: null },
-  { id: 'ollama-setup', label: 'Ollama', backendStep: 'ollama_check' },
-  { id: 'model-download', label: 'Model', backendStep: 'model_download' },
-  { id: 'role-assignment', label: 'Roles', backendStep: 'role_assignment' },
-  { id: 'confirmation', label: 'Finish', backendStep: null },
-]
 
 export function parseModelSpec(modelSpec: string): { provider: string; modelId: string } | null {
   const [provider, ...modelIdParts] = modelSpec.split(':')

--- a/self/apps/desktop/src/renderer/src/components/wizard/wizard.css
+++ b/self/apps/desktop/src/renderer/src/components/wizard/wizard.css
@@ -62,7 +62,7 @@
 
 .nous-wizard__stepper {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(var(--nous-wizard-step-count, 4), minmax(0, 1fr));
   gap: var(--nous-space-md);
   margin-bottom: var(--nous-space-3xl);
   padding: var(--nous-space-xl);

--- a/self/apps/desktop/vitest.renderer.config.mts
+++ b/self/apps/desktop/vitest.renderer.config.mts
@@ -1,8 +1,17 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@nous/shared': path.resolve(__dirname, '../../shared/src/index.ts'),
+    },
+  },
   test: {
     environment: 'jsdom',
     include: ['src/renderer/src/**/*.test.{ts,tsx}'],

--- a/self/apps/shared-server/src/first-run.ts
+++ b/self/apps/shared-server/src/first-run.ts
@@ -1,5 +1,14 @@
 /**
  * First-run wizard state — server-side only.
+ *
+ * Backend step shape (`FIRST_RUN_STEP_VALUES`, `FirstRunStateSchema`, etc.) is
+ * imported from `@nous/shared` — the cross-package manifest that the renderer's
+ * `WIZARD_STEP_REGISTRY` validates against at module load. See Decision 2
+ * (`wizard-composability-pattern-v1`) and ADR 016.
+ *
+ * Function bodies here are unchanged vs. pre-migration: they already iterated
+ * `FIRST_RUN_STEP_VALUES` and read `state.steps[step]`, so the shift from
+ * hand-authored to imported constants is transparent.
  */
 import {
   existsSync,
@@ -9,51 +18,48 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { ModelRoleSchema, type IProjectStore } from '@nous/shared';
+import {
+  FIRST_RUN_STEP_VALUES,
+  FirstRunCurrentStepSchema,
+  FirstRunStateSchema,
+  FirstRunStepSchema,
+  FirstRunStepStateSchema,
+  FirstRunStepStatusSchema,
+  ModelRoleSchema,
+  type FirstRunCurrentStep,
+  type FirstRunState,
+  type FirstRunStep,
+  type FirstRunStepState,
+  type FirstRunStepStatus,
+  type IProjectStore,
+} from '@nous/shared';
 import { z } from 'zod';
 import { HardwareSpecSchema, RecommendationResultSchema } from './hardware-detection';
 import { OllamaStatusSchema } from './ollama-detection';
 
+// Re-export the shared-package manifest + schemas so existing consumers that
+// imported these names from `@nous/shared-server` continue to resolve. Note:
+// `FIRST_RUN_STEP_VALUES` is a NEW public export on this module (previously a
+// private non-exported const — see SDS-review note 3 and the completion report
+// deviations section).
+export {
+  FIRST_RUN_STEP_VALUES,
+  FirstRunCurrentStepSchema,
+  FirstRunStateSchema,
+  FirstRunStepSchema,
+  FirstRunStepStateSchema,
+  FirstRunStepStatusSchema,
+};
+export type {
+  FirstRunCurrentStep,
+  FirstRunState,
+  FirstRunStep,
+  FirstRunStepState,
+  FirstRunStepStatus,
+};
+
 const FLAG_FILE = '.nous-first-run-complete';
 const STATE_FILE = '.nous-first-run-state.json';
-const FIRST_RUN_STEP_VALUES = [
-  'ollama_check',
-  'model_download',
-  'provider_config',
-  'role_assignment',
-] as const;
-
-export const FirstRunStepSchema = z.enum(FIRST_RUN_STEP_VALUES);
-export type FirstRunStep = z.infer<typeof FirstRunStepSchema>;
-
-export const FirstRunCurrentStepSchema = z.union([
-  FirstRunStepSchema,
-  z.literal('complete'),
-]);
-export type FirstRunCurrentStep = z.infer<typeof FirstRunCurrentStepSchema>;
-
-export const FirstRunStepStatusSchema = z.enum(['pending', 'complete']);
-export type FirstRunStepStatus = z.infer<typeof FirstRunStepStatusSchema>;
-
-export const FirstRunStepStateSchema = z.object({
-  status: FirstRunStepStatusSchema,
-  completedAt: z.string().optional(),
-});
-export type FirstRunStepState = z.infer<typeof FirstRunStepStateSchema>;
-
-export const FirstRunStateSchema = z.object({
-  currentStep: FirstRunCurrentStepSchema,
-  complete: z.boolean(),
-  steps: z.object({
-    ollama_check: FirstRunStepStateSchema,
-    model_download: FirstRunStepStateSchema,
-    provider_config: FirstRunStepStateSchema,
-    role_assignment: FirstRunStepStateSchema,
-  }),
-  completedAt: z.string().optional(),
-  lastUpdatedAt: z.string(),
-});
-export type FirstRunState = z.infer<typeof FirstRunStateSchema>;
 
 export const FirstRunRoleAssignmentInputSchema = z.object({
   role: ModelRoleSchema,
@@ -125,16 +131,14 @@ function normalizeFirstRunState(
 export function createDefaultFirstRunState(
   timestamp = new Date().toISOString(),
 ): FirstRunState {
+  const steps = Object.fromEntries(
+    FIRST_RUN_STEP_VALUES.map((step) => [step, buildPendingStepState()] as const),
+  ) as Record<FirstRunStep, FirstRunStepState>;
   return normalizeFirstRunState(
     {
       currentStep: 'ollama_check',
       complete: false,
-      steps: {
-        ollama_check: buildPendingStepState(),
-        model_download: buildPendingStepState(),
-        provider_config: buildPendingStepState(),
-        role_assignment: buildPendingStepState(),
-      },
+      steps,
       lastUpdatedAt: timestamp,
     },
     timestamp,
@@ -144,16 +148,17 @@ export function createDefaultFirstRunState(
 function createCompletedFirstRunState(
   timestamp = new Date().toISOString(),
 ): FirstRunState {
+  const steps = Object.fromEntries(
+    FIRST_RUN_STEP_VALUES.map(
+      (step) =>
+        [step, { status: 'complete', completedAt: timestamp }] as const,
+    ),
+  ) as Record<FirstRunStep, FirstRunStepState>;
   return normalizeFirstRunState(
     {
       currentStep: 'complete',
       complete: true,
-      steps: {
-        ollama_check: { status: 'complete', completedAt: timestamp },
-        model_download: { status: 'complete', completedAt: timestamp },
-        provider_config: { status: 'complete', completedAt: timestamp },
-        role_assignment: { status: 'complete', completedAt: timestamp },
-      },
+      steps,
       completedAt: timestamp,
       lastUpdatedAt: timestamp,
     },

--- a/self/shared/src/__tests__/wizard-registry.test.ts
+++ b/self/shared/src/__tests__/wizard-registry.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FIRST_RUN_STEP_VALUES,
+  FirstRunStateSchema,
+  WizardRegistryInvariantError,
+  assertRegistryMatchesManifest,
+  buildFirstRunStateStepsSchema,
+  defineWizardStep,
+  deriveBackendStepToWizardStep,
+  deriveFirstRunStepValues,
+  derivePreviousStepMap,
+  deriveWizardStepIds,
+  validateWizardRegistry,
+  type FirstRunStep,
+  type WizardStepDefinition,
+} from '../wizard-registry.js';
+
+describe('wizard-registry — factory defaults', () => {
+  it('defaults extraBackendSteps to []', () => {
+    const step = defineWizardStep({
+      id: 'welcome',
+      label: 'Welcome',
+      component: null,
+      backendStep: null,
+      previous: null,
+      skippable: false,
+    });
+    expect(step.extraBackendSteps).toEqual([]);
+  });
+
+  it('defaults condition to always-true', () => {
+    const step = defineWizardStep({
+      id: 'welcome',
+      label: 'Welcome',
+      component: null,
+      backendStep: null,
+      previous: null,
+      skippable: false,
+    });
+    expect(
+      step.condition({
+        currentStep: 'ollama_check',
+        complete: false,
+        steps: {
+          ollama_check: { status: 'pending' },
+          model_download: { status: 'pending' },
+          provider_config: { status: 'pending' },
+          role_assignment: { status: 'pending' },
+        },
+        lastUpdatedAt: '2026-04-18T00:00:00.000Z',
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves literal ids', () => {
+    const step = defineWizardStep({
+      id: 'welcome',
+      label: 'Welcome',
+      component: null,
+      backendStep: null,
+      previous: null,
+      skippable: false,
+    });
+    // Type assertion: literal id preserved (compile-time check).
+    const id: 'welcome' = step.id;
+    expect(id).toBe('welcome');
+  });
+});
+
+describe('wizard-registry — manifest / schema', () => {
+  it('FIRST_RUN_STEP_VALUES is the canonical V1 tuple', () => {
+    expect(FIRST_RUN_STEP_VALUES).toEqual([
+      'ollama_check',
+      'model_download',
+      'provider_config',
+      'role_assignment',
+    ]);
+    expect(FIRST_RUN_STEP_VALUES).not.toContain('agent_identity');
+  });
+
+  it('buildFirstRunStateStepsSchema keys equal FIRST_RUN_STEP_VALUES', () => {
+    const schema = buildFirstRunStateStepsSchema();
+    const keys = Object.keys(schema.shape);
+    expect(keys).toEqual([...FIRST_RUN_STEP_VALUES]);
+  });
+
+  it('FirstRunStateSchema.parse round-trips a canonical pre-migration fixture', () => {
+    const fixture = {
+      currentStep: 'model_download' as const,
+      complete: false,
+      steps: {
+        ollama_check: {
+          status: 'complete' as const,
+          completedAt: '2026-03-22T00:04:00.000Z',
+        },
+        model_download: { status: 'pending' as const },
+        provider_config: { status: 'pending' as const },
+        role_assignment: { status: 'pending' as const },
+      },
+      lastUpdatedAt: '2026-03-22T00:05:00.000Z',
+    };
+    const parsed = FirstRunStateSchema.parse(fixture);
+    expect(parsed).toEqual(fixture);
+  });
+});
+
+// Build a V1-shaped registry using the factory. Different entries will be
+// mutated per negative test to exercise each invariant.
+function buildValidV1Registry() {
+  return [
+    defineWizardStep({
+      id: 'welcome',
+      label: 'Welcome',
+      component: null,
+      backendStep: null,
+      previous: null,
+      skippable: false,
+    }),
+    defineWizardStep({
+      id: 'ollama-setup',
+      label: 'Ollama',
+      component: null,
+      backendStep: 'ollama_check',
+      previous: 'welcome',
+      skippable: true,
+    }),
+    defineWizardStep({
+      id: 'model-download',
+      label: 'Model',
+      component: null,
+      backendStep: 'model_download',
+      extraBackendSteps: ['provider_config', 'role_assignment'],
+      previous: 'ollama-setup',
+      skippable: true,
+    }),
+    defineWizardStep({
+      id: 'confirmation',
+      label: 'Finish',
+      component: null,
+      backendStep: null,
+      previous: 'model-download',
+      skippable: false,
+    }),
+  ] as const satisfies readonly WizardStepDefinition<string, unknown, FirstRunStep>[];
+}
+
+describe('wizard-registry — validateWizardRegistry', () => {
+  it('accepts a minimal valid registry', () => {
+    const registry = buildValidV1Registry();
+    expect(() => validateWizardRegistry(registry)).not.toThrow();
+  });
+
+  it('throws empty-registry for a zero-entry registry', () => {
+    const err = (() => {
+      try {
+        validateWizardRegistry([]);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err).toBeInstanceOf(WizardRegistryInvariantError);
+    expect(err?.code).toBe('empty-registry');
+  });
+
+  it('throws duplicate-id when two entries share an id', () => {
+    const registry = [
+      defineWizardStep({
+        id: 'welcome',
+        label: 'Welcome',
+        component: null,
+        backendStep: null,
+        previous: null,
+        skippable: false,
+      }),
+      defineWizardStep({
+        id: 'welcome',
+        label: 'Welcome (dup)',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: 'welcome',
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        validateWizardRegistry(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('duplicate-id');
+  });
+
+  it('throws duplicate-backend-step when a backend step appears twice', () => {
+    const registry = [
+      defineWizardStep({
+        id: 'a',
+        label: 'A',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: null,
+        skippable: false,
+      }),
+      defineWizardStep({
+        id: 'b',
+        label: 'B',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: 'a',
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        validateWizardRegistry(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('duplicate-backend-step');
+  });
+
+  it('throws duplicate-backend-step when backendStep + extraBackendSteps collide', () => {
+    const registry = [
+      defineWizardStep({
+        id: 'a',
+        label: 'A',
+        component: null,
+        backendStep: 'ollama_check',
+        extraBackendSteps: ['ollama_check'],
+        previous: null,
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        validateWizardRegistry(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('duplicate-backend-step');
+  });
+
+  it('throws invalid-previous for a previous id that does not exist', () => {
+    const registry = [
+      defineWizardStep({
+        id: 'a',
+        label: 'A',
+        component: null,
+        backendStep: null,
+        previous: null,
+        skippable: false,
+      }),
+      defineWizardStep({
+        id: 'b',
+        label: 'B',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: 'does-not-exist',
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        validateWizardRegistry(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('invalid-previous');
+  });
+
+  it('throws multiple-roots when more than one entry has previous: null', () => {
+    const registry = [
+      defineWizardStep({
+        id: 'a',
+        label: 'A',
+        component: null,
+        backendStep: null,
+        previous: null,
+        skippable: false,
+      }),
+      defineWizardStep({
+        id: 'b',
+        label: 'B',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: null,
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        validateWizardRegistry(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('multiple-roots');
+  });
+});
+
+describe('wizard-registry — assertRegistryMatchesManifest', () => {
+  it('passes for a V1-shaped registry', () => {
+    const registry = buildValidV1Registry();
+    expect(() => assertRegistryMatchesManifest(registry)).not.toThrow();
+  });
+
+  it('throws manifest-mismatch on undercoverage (missing backend step)', () => {
+    // Drop `role_assignment` from extras — registry under-covers the manifest.
+    const registry = [
+      defineWizardStep({
+        id: 'welcome',
+        label: 'Welcome',
+        component: null,
+        backendStep: null,
+        previous: null,
+        skippable: false,
+      }),
+      defineWizardStep({
+        id: 'ollama-setup',
+        label: 'Ollama',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: 'welcome',
+        skippable: true,
+      }),
+      defineWizardStep({
+        id: 'model-download',
+        label: 'Model',
+        component: null,
+        backendStep: 'model_download',
+        extraBackendSteps: ['provider_config'],
+        previous: 'ollama-setup',
+        skippable: true,
+      }),
+      defineWizardStep({
+        id: 'confirmation',
+        label: 'Finish',
+        component: null,
+        backendStep: null,
+        previous: 'model-download',
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        assertRegistryMatchesManifest(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('manifest-mismatch');
+  });
+
+  it('throws manifest-mismatch on overcoverage (extra step declared)', () => {
+    // `validateWizardRegistry` would reject this for duplicate-backend-step
+    // in a real registry; `assertRegistryMatchesManifest` is a separate check.
+    // Build an over-sized registry by adding an extra entry with a *different*
+    // backend step not in the manifest — but the manifest is the full enum, so
+    // the only way to exceed coverage without duplicates is to have MORE
+    // entries than FIRST_RUN_STEP_VALUES.length. We achieve that by adding an
+    // empty-slot duplicate at extras.
+    const registry = [
+      defineWizardStep({
+        id: 'welcome',
+        label: 'Welcome',
+        component: null,
+        backendStep: null,
+        previous: null,
+        skippable: false,
+      }),
+      defineWizardStep({
+        id: 'ollama-setup',
+        label: 'Ollama',
+        component: null,
+        backendStep: 'ollama_check',
+        previous: 'welcome',
+        skippable: true,
+      }),
+      defineWizardStep({
+        id: 'model-download',
+        label: 'Model',
+        component: null,
+        backendStep: 'model_download',
+        extraBackendSteps: [
+          'provider_config',
+          'role_assignment',
+          'role_assignment', // duplicate — forces count > manifest length
+        ],
+        previous: 'ollama-setup',
+        skippable: true,
+      }),
+      defineWizardStep({
+        id: 'confirmation',
+        label: 'Finish',
+        component: null,
+        backendStep: null,
+        previous: 'model-download',
+        skippable: false,
+      }),
+    ];
+    const err = (() => {
+      try {
+        assertRegistryMatchesManifest(registry);
+        return null;
+      } catch (caught) {
+        return caught as WizardRegistryInvariantError;
+      }
+    })();
+    expect(err?.code).toBe('manifest-mismatch');
+  });
+});
+
+describe('wizard-registry — derivations', () => {
+  it('deriveFirstRunStepValues matches the manifest as a permutation', () => {
+    const registry = buildValidV1Registry();
+    const derived = deriveFirstRunStepValues(registry);
+    expect(new Set(derived)).toEqual(new Set(FIRST_RUN_STEP_VALUES));
+  });
+
+  it('deriveFirstRunStepValues preserves the manifest ordering for V1 registry', () => {
+    const registry = buildValidV1Registry();
+    const derived = deriveFirstRunStepValues(registry);
+    // V1 entries visit backend steps in manifest order:
+    //   ollama-setup → ollama_check
+    //   model-download → model_download, provider_config, role_assignment
+    expect(derived).toEqual([
+      'ollama_check',
+      'model_download',
+      'provider_config',
+      'role_assignment',
+    ]);
+  });
+
+  it('deriveBackendStepToWizardStep maps every backend step to the owning entry id', () => {
+    const registry = buildValidV1Registry();
+    const map = deriveBackendStepToWizardStep(registry);
+    expect(map).toEqual({
+      ollama_check: 'ollama-setup',
+      model_download: 'model-download',
+      provider_config: 'model-download',
+      role_assignment: 'model-download',
+    });
+  });
+
+  it('derivePreviousStepMap yields the V1 back-nav chain', () => {
+    const registry = buildValidV1Registry();
+    const map = derivePreviousStepMap(registry);
+    expect(map).toEqual({
+      welcome: null,
+      'ollama-setup': 'welcome',
+      'model-download': 'ollama-setup',
+      confirmation: 'model-download',
+    });
+  });
+
+  it('deriveWizardStepIds returns ids in registry order', () => {
+    const registry = buildValidV1Registry();
+    expect(deriveWizardStepIds(registry)).toEqual([
+      'welcome',
+      'ollama-setup',
+      'model-download',
+      'confirmation',
+    ]);
+  });
+});

--- a/self/shared/src/index.ts
+++ b/self/shared/src/index.ts
@@ -55,3 +55,30 @@ export type { ICommunicationGatewayService } from './interfaces/subcortex.js';
 export type { IPublicMcpGatewayService } from './interfaces/subcortex.js';
 export type { IVoiceControlService } from './interfaces/subcortex.js';
 export type { EndpointTrustSurfaceSummary } from './types/endpoint-trust.js';
+export {
+  FIRST_RUN_STEP_VALUES,
+  FirstRunStepSchema,
+  FirstRunCurrentStepSchema,
+  FirstRunStepStatusSchema,
+  FirstRunStepStateSchema,
+  FirstRunStateSchema,
+  buildFirstRunStateStepsSchema,
+  defineWizardStep,
+  deriveFirstRunStepValues,
+  deriveFirstRunStateSchema,
+  deriveBackendStepToWizardStep,
+  derivePreviousStepMap,
+  deriveWizardStepIds,
+  validateWizardRegistry,
+  assertRegistryMatchesManifest,
+  WizardRegistryInvariantError,
+} from './wizard-registry.js';
+export type {
+  FirstRunStep,
+  FirstRunCurrentStep,
+  FirstRunStepStatus,
+  FirstRunStepState,
+  FirstRunState,
+  WizardStepDefinition,
+  WizardRegistryInvariantCode,
+} from './wizard-registry.js';

--- a/self/shared/src/wizard-registry.ts
+++ b/self/shared/src/wizard-registry.ts
@@ -1,0 +1,334 @@
+/**
+ * First-run wizard registry — cross-package single source of truth.
+ *
+ * Shared between:
+ *   - `@nous/shared-server` (persistence, state machine)
+ *   - `@nous/desktop` renderer (step components, back-nav, stepper)
+ *
+ * Pattern ratified by Decision 2 (wizard-composability-pattern-v1) and extended
+ * by ADR 016 (one optional field — `extraBackendSteps` — to allow one wizard
+ * step to drive multiple state-machine transitions).
+ *
+ * The shared-package manifest (`FIRST_RUN_STEP_VALUES`) is the single source of
+ * truth for the backend step shape. The renderer's `WIZARD_STEP_REGISTRY`
+ * validates against this manifest at module load (see
+ * `assertRegistryMatchesManifest`).
+ */
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Backend step manifest — the single source of truth for state-machine shape.
+// ---------------------------------------------------------------------------
+
+export const FIRST_RUN_STEP_VALUES = [
+  'ollama_check',
+  'model_download',
+  'provider_config',
+  'role_assignment',
+] as const;
+
+export type FirstRunStep = (typeof FIRST_RUN_STEP_VALUES)[number];
+
+export const FirstRunStepSchema = z.enum(FIRST_RUN_STEP_VALUES);
+
+export const FirstRunCurrentStepSchema = z.union([
+  FirstRunStepSchema,
+  z.literal('complete'),
+]);
+export type FirstRunCurrentStep = z.infer<typeof FirstRunCurrentStepSchema>;
+
+// ---------------------------------------------------------------------------
+// Per-step state schema (unchanged shape vs. today's shared-server/first-run.ts).
+// ---------------------------------------------------------------------------
+
+export const FirstRunStepStatusSchema = z.enum(['pending', 'complete']);
+export type FirstRunStepStatus = z.infer<typeof FirstRunStepStatusSchema>;
+
+export const FirstRunStepStateSchema = z.object({
+  status: FirstRunStepStatusSchema,
+  completedAt: z.string().optional(),
+});
+export type FirstRunStepState = z.infer<typeof FirstRunStepStateSchema>;
+
+// ---------------------------------------------------------------------------
+// Derived `steps` object schema (keyed by FirstRunStep).
+// ---------------------------------------------------------------------------
+
+export function buildFirstRunStateStepsSchema(
+  stepStateSchema: z.ZodTypeAny = FirstRunStepStateSchema,
+): z.ZodObject<Record<FirstRunStep, z.ZodTypeAny>> {
+  const shape = Object.fromEntries(
+    FIRST_RUN_STEP_VALUES.map((step) => [step, stepStateSchema] as const),
+  ) as Record<FirstRunStep, z.ZodTypeAny>;
+  return z.object(shape);
+}
+
+// ---------------------------------------------------------------------------
+// Full state schema.
+// ---------------------------------------------------------------------------
+
+export const FirstRunStateSchema = z.object({
+  currentStep: FirstRunCurrentStepSchema,
+  complete: z.boolean(),
+  steps: buildFirstRunStateStepsSchema(),
+  completedAt: z.string().optional(),
+  lastUpdatedAt: z.string(),
+});
+export type FirstRunState = z.infer<typeof FirstRunStateSchema>;
+
+// ---------------------------------------------------------------------------
+// Wizard step definition shape.
+//
+// Generics:
+//   - `TId`          — the step's literal id (e.g. `'welcome'`).
+//   - `TComponent`   — the step's bound component (renderer narrows this to
+//                      `React.ComponentType<WizardStepProps>`; `@nous/shared`
+//                      is React-agnostic and leaves it as `unknown`).
+//   - `TBackendStep` — the set of backend steps the entry may drive.
+//
+// Default generic values come from the SDS § 4.1 authoritative form.
+// ---------------------------------------------------------------------------
+
+export type WizardStepDefinition<
+  TId extends string = string,
+  TComponent = unknown,
+  TBackendStep extends FirstRunStep = FirstRunStep,
+> = {
+  readonly id: TId;
+  readonly label: string;
+  readonly component: TComponent;
+  readonly backendStep: TBackendStep | null;
+  /**
+   * Additional backend steps this wizard step's completion handler also drives.
+   *
+   * Used when a single wizard step covers multiple state-machine transitions
+   * (e.g. `model-download` drives `model_download` + `provider_config` +
+   * `role_assignment` via its completion handler — see ADR 016).
+   *
+   * Defaults to the empty array.
+   */
+  readonly extraBackendSteps: readonly TBackendStep[];
+  readonly previous: string | null;
+  readonly skippable: boolean;
+  readonly condition: (state: FirstRunState) => boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Factory — narrow-generic identity function with defaults applied.
+// ---------------------------------------------------------------------------
+
+export function defineWizardStep<
+  const TId extends string,
+  TComponent,
+  const TBackendStep extends FirstRunStep,
+>(def: {
+  id: TId;
+  label: string;
+  component: TComponent;
+  backendStep: TBackendStep | null;
+  extraBackendSteps?: readonly TBackendStep[];
+  previous: string | null;
+  skippable: boolean;
+  condition?: (state: FirstRunState) => boolean;
+}): WizardStepDefinition<TId, TComponent, TBackendStep> {
+  return {
+    id: def.id,
+    label: def.label,
+    component: def.component,
+    backendStep: def.backendStep,
+    extraBackendSteps: def.extraBackendSteps ?? [],
+    previous: def.previous,
+    skippable: def.skippable,
+    condition: def.condition ?? (() => true),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Derivation helpers — pure functions over a readonly registry tuple.
+// ---------------------------------------------------------------------------
+
+type MinimalEntry = {
+  readonly id: string;
+  readonly backendStep: FirstRunStep | null;
+  readonly extraBackendSteps: readonly FirstRunStep[];
+  readonly previous: string | null;
+};
+
+function collectBackendSteps<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): FirstRunStep[] {
+  const collected: FirstRunStep[] = [];
+  for (const entry of registry) {
+    if (entry.backendStep !== null) {
+      collected.push(entry.backendStep);
+    }
+    for (const extra of entry.extraBackendSteps) {
+      collected.push(extra);
+    }
+  }
+  return collected;
+}
+
+export function deriveFirstRunStepValues<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): readonly FirstRunStep[] {
+  return collectBackendSteps(registry);
+}
+
+export function deriveFirstRunStateSchema<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+  stepStateSchema: z.ZodTypeAny = FirstRunStepStateSchema,
+): z.ZodObject<Record<string, z.ZodTypeAny>> {
+  const steps = collectBackendSteps(registry);
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const step of steps) {
+    shape[step] = stepStateSchema;
+  }
+  return z.object(shape);
+}
+
+export function deriveBackendStepToWizardStep<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): Record<FirstRunStep, string> {
+  const map: Partial<Record<FirstRunStep, string>> = {};
+  for (const entry of registry) {
+    if (entry.backendStep !== null) {
+      map[entry.backendStep] = entry.id;
+    }
+    for (const extra of entry.extraBackendSteps) {
+      map[extra] = entry.id;
+    }
+  }
+  return map as Record<FirstRunStep, string>;
+}
+
+export function derivePreviousStepMap<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): Record<string, string | null> {
+  const map: Record<string, string | null> = {};
+  for (const entry of registry) {
+    map[entry.id] = entry.previous;
+  }
+  return map;
+}
+
+export function deriveWizardStepIds<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): readonly string[] {
+  return registry.map((entry) => entry.id);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant machinery — thrown at module load when a registry is malformed.
+// ---------------------------------------------------------------------------
+
+export type WizardRegistryInvariantCode =
+  | 'empty-registry'
+  | 'duplicate-id'
+  | 'duplicate-backend-step'
+  | 'invalid-previous'
+  | 'multiple-roots'
+  | 'manifest-mismatch';
+
+export class WizardRegistryInvariantError extends Error {
+  readonly code: WizardRegistryInvariantCode;
+
+  constructor(code: WizardRegistryInvariantCode, message: string) {
+    super(message);
+    this.name = 'WizardRegistryInvariantError';
+    this.code = code;
+  }
+}
+
+export function validateWizardRegistry<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): void {
+  if (registry.length === 0) {
+    throw new WizardRegistryInvariantError(
+      'empty-registry',
+      'Wizard registry is empty — at least one step entry is required.',
+    );
+  }
+
+  const ids = new Set<string>();
+  for (const entry of registry) {
+    if (ids.has(entry.id)) {
+      throw new WizardRegistryInvariantError(
+        'duplicate-id',
+        `Wizard registry has duplicate id: ${entry.id}`,
+      );
+    }
+    ids.add(entry.id);
+  }
+
+  const backendSteps = new Set<FirstRunStep>();
+  for (const entry of registry) {
+    const candidates: FirstRunStep[] = [];
+    if (entry.backendStep !== null) {
+      candidates.push(entry.backendStep);
+    }
+    candidates.push(...entry.extraBackendSteps);
+    for (const step of candidates) {
+      if (backendSteps.has(step)) {
+        throw new WizardRegistryInvariantError(
+          'duplicate-backend-step',
+          `Wizard registry has duplicate backend step: ${step} (on entry ${entry.id})`,
+        );
+      }
+      backendSteps.add(step);
+    }
+  }
+
+  let rootCount = 0;
+  for (const entry of registry) {
+    if (entry.previous === null) {
+      rootCount += 1;
+      continue;
+    }
+    if (!ids.has(entry.previous)) {
+      throw new WizardRegistryInvariantError(
+        'invalid-previous',
+        `Wizard registry entry ${entry.id} has invalid previous id: ${entry.previous}`,
+      );
+    }
+  }
+  if (rootCount > 1) {
+    throw new WizardRegistryInvariantError(
+      'multiple-roots',
+      `Wizard registry has more than one root entry (previous: null): count=${rootCount}`,
+    );
+  }
+}
+
+export function assertRegistryMatchesManifest<TEntry extends MinimalEntry>(
+  registry: readonly TEntry[],
+): void {
+  const collected = collectBackendSteps(registry);
+  const manifestSet = new Set<FirstRunStep>(FIRST_RUN_STEP_VALUES);
+  const collectedSet = new Set<FirstRunStep>(collected);
+
+  if (collected.length !== FIRST_RUN_STEP_VALUES.length) {
+    throw new WizardRegistryInvariantError(
+      'manifest-mismatch',
+      `Wizard registry backend-step count ${collected.length} does not match manifest length ${FIRST_RUN_STEP_VALUES.length}`,
+    );
+  }
+
+  for (const step of manifestSet) {
+    if (!collectedSet.has(step)) {
+      throw new WizardRegistryInvariantError(
+        'manifest-mismatch',
+        `Wizard registry is missing required backend step: ${step}`,
+      );
+    }
+  }
+
+  for (const step of collectedSet) {
+    if (!manifestSet.has(step)) {
+      throw new WizardRegistryInvariantError(
+        'manifest-mismatch',
+        `Wizard registry declares unknown backend step: ${step}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Sub-phase 1.1 of the onboarding-agent-identity feature: migrate the first-run wizard from hand-authored step lists to a cross-package composable registry pattern, so SP 1.5 and beyond can introduce new steps (e.g. agent-identity) as data-only edits.

- **Shared manifest + registry** — `@nous/shared/wizard-registry` now owns `FIRST_RUN_STEP_VALUES` (canonical V1 tuple), `FirstRunStep` / `FirstRunStateSchema`, `WizardStepDefinition<TId, TComponent, TBackendStep>` with generic defaults and `extraBackendSteps`, `createWizardStepDefinition` factory, and registry invariant validators (`validateWizardRegistry` for disjointness, `assertRegistryMatchesManifest` for permutation). 21 contract tests cover the module.
- **Shared-server** — `@nous/shared-server/first-run` now derives its tuple + schemas from `@nous/shared` and re-exports them to preserve the public surface. Function bodies unchanged; behavior preserved (SDS § 1.5).
- **Renderer** — new `wizard/registry.ts` composes per-step definition files (`wizard/steps/{welcome,ollama-setup,model-download,confirmation}.ts`) into `WIZARD_STEP_REGISTRY` and runs both invariant validators at module load. `FirstRunWizard.tsx`'s 65-line if/else render chain is replaced by a registry lookup + per-step prop resolver. `WizardStepIndicator.tsx` binds `--nous-wizard-step-count` so the stepper grid adapts to registry length. `WizardStepModelDownload.tsx` adds an idempotent placeholder auto-mark that marks `role_assignment` complete (placeholder for SP 1.5's real assign-roles flow, per SDS § 2.6 / I12).
- **Tests** — renderer test suites restructured to iterate `WIZARD_STEP_REGISTRY` and add explicit coverage for registry invariants, the placeholder bridge (success + skip + idempotent), back-nav chain, stepper length, CSS custom property binding, and the WR-132.2 skip-path preservation.
- **ADR 016** — records the `extraBackendSteps` extension of Decision 2's ratified shape. Filed at `.worklog/adr/016-wizard-step-definition-extra-backend-steps.mdx`.

All 20 Goals acceptance criteria (C1–C20) are evidenced. Completion Report verdict: Approved With Actions (actions are documentation nits — non-blocking). See `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.1/reviews/completion-report.mdx` for the full CR review.

## Verification

- `pnpm build` — pass (monorepo end-to-end, zero errors).
- `pnpm typecheck` — pass on `@nous/shared` and `@nous/desktop`; `@nous/shared-server` passes post-build (monorepo-build-order quirk, pre-existing).
- `pnpm oxlint` — 0 warnings / 0 errors on 15 touched files. Full repo: 149 pre-existing warnings on untouched files.
- `pnpm test` (workspace) — 571 files / 5393 tests pass.
- `@nous/desktop` renderer — 50/54 pass (4 failures pre-existing, baseline-verified by stash+re-run); new wizard suites (37 tests) all pass.
- `@nous/desktop` main/IPC — 86/92 pass (6 failures pre-existing, baseline-verified).
- Installer — deferred-approved (renderer-side refactor with no installer surface change; packaged exercise at phase-1 BT gate).

## Commits

1. `feat(shared): add cross-package wizard step registry and manifest`
2. `refactor(shared-server): derive first-run manifest from @nous/shared`
3. `feat(desktop/wizard): add renderer step registry and per-step definitions`
4. `refactor(desktop/wizard): registry-driven dispatch, CSS custom property, placeholder auto-mark`
5. `test(desktop/wizard): restructure suites for registry invariants and placeholder bridge`

## Worklog Artifacts

- Goals: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.1/goals.mdx`
- SDS: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.1/sds.mdx`
- Implementation Plan: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.1/implementation-plan.mdx`
- Completion Report: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.1/completion-report.mdx`
- Gate Reviews: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.1/reviews/*.mdx`
- ADR 016: `.worklog/adr/016-wizard-step-definition-extra-backend-steps.mdx`

## Test plan

- [x] `pnpm build` — monorepo build succeeds
- [x] `pnpm test` — workspace tests pass
- [x] Wizard registry invariant tests (disjointness + permutation)
- [x] Placeholder bridge tests (success, skip, idempotent)
- [x] WR-132.2 skip-path preservation test
- [x] Back-nav chain walk test
- [x] Stepper length + CSS custom property test
- [ ] Phase-1 BT gate: packaged installer exercise (deferred — Principal runs at BT)