### PR TITLE
WR-159 SP 1.13 — BT R5 fix cycle 5 (RC-1 tool-error recovery + RC-2 streaming-thinking)

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-thinking-stream.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-thinking-stream.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tier 2 integration tests for the SP 1.13 RC-2 dispatch decision split:
+ *  - canStreamContent retains the cycle-1 SP 1.9 RC-2 invariant
+ *    (`tools.length === 0` clause). Tool-bearing turns NEVER take the
+ *    content-streaming path.
+ *  - canStreamThinking gates on extendedThinking + provider exposing
+ *    `invokeWithThinkingStream`. Tool-bearing turns CAN take this path
+ *    because thinking content does not interfere with tool_calls extraction.
+ *  - The wrapper getter pattern preserves the typeof capability check
+ *    across `LaneAwareProvider`/`ObservableProvider` (Invariant I-9).
+ *  - The fallback path (provider.invoke()) fires whenever
+ *    invokeWithThinkingStream throws or is absent.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  AgentGatewayConfig,
+  IEventBus,
+  IModelProvider,
+  IScopedMcpToolSurface,
+  ModelRequest,
+  ModelResponse,
+  ToolDefinition,
+} from '@nous/shared';
+import { AgentGateway } from '../../agent-gateway/agent-gateway.js';
+import {
+  AGENT_ID,
+  NOW,
+  PROVIDER_ID,
+  TRACE_ID,
+  createBaseInput,
+  createStampedPacket,
+  InMemoryGatewayOutboxSink,
+} from './helpers.js';
+
+function makeOllamaConfig(): ReturnType<IModelProvider['getConfig']> {
+  return {
+    id: PROVIDER_ID,
+    name: 'ollama-local',
+    type: 'ollama',
+    vendor: 'ollama',
+    modelId: 'gemma3:4b',
+    isLocal: true,
+    capabilities: ['reasoning'],
+  } as ReturnType<IModelProvider['getConfig']>;
+}
+
+function makeMessageOutput(toolName: string | null) {
+  // Ollama-shaped message that the ollama adapter's parseResponse can read.
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    content: '',
+  };
+  if (toolName) {
+    message.tool_calls = [
+      {
+        function: {
+          name: toolName,
+          arguments: { ok: true },
+        },
+      },
+    ];
+  }
+  return message;
+}
+
+function makeProvider(overrides: {
+  invoke?: IModelProvider['invoke'];
+  stream?: IModelProvider['stream'];
+  invokeWithThinkingStream?: IModelProvider['invokeWithThinkingStream'];
+}): IModelProvider {
+  return {
+    getConfig: () => makeOllamaConfig(),
+    invoke: overrides.invoke ?? vi.fn().mockResolvedValue({
+      output: makeMessageOutput(null),
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    } satisfies ModelResponse),
+    stream: overrides.stream ?? vi.fn(),
+    ...(overrides.invokeWithThinkingStream
+      ? { invokeWithThinkingStream: overrides.invokeWithThinkingStream }
+      : {}),
+  };
+}
+
+function recordingEventBus(): IEventBus & { recorded: Array<{ channel: string; payload: unknown; ts: number }> } {
+  const recorded: Array<{ channel: string; payload: unknown; ts: number }> = [];
+  const bus = {
+    publish: vi.fn().mockImplementation((channel: string, payload: unknown) => {
+      recorded.push({ channel, payload, ts: Date.now() });
+    }),
+    subscribe: vi.fn().mockReturnValue('sub-1'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+  };
+  (bus as { recorded: typeof recorded }).recorded = recorded;
+  return bus as never;
+}
+
+const TOOL_DEFS: ToolDefinition[] = [
+  {
+    name: 'workflow_list',
+    version: '1.0.0',
+    description: 'list workflows',
+    inputSchema: {},
+    outputSchema: {},
+    capabilities: ['read'],
+    permissionScope: 'project',
+    isConcurrencySafe: true,
+  },
+];
+
+function createGateway(args: {
+  provider: IModelProvider;
+  eventBus?: IEventBus;
+  toolSurface?: IScopedMcpToolSurface;
+}): { gateway: AgentGateway; outbox: InMemoryGatewayOutboxSink } {
+  const outbox = new InMemoryGatewayOutboxSink();
+  const toolSurface = args.toolSurface ?? {
+    listTools: vi.fn().mockResolvedValue(TOOL_DEFS),
+    executeTool: vi.fn().mockResolvedValue({ success: true, output: { ok: true }, durationMs: 1 }),
+  };
+  const gateway = new AgentGateway({
+    agentClass: 'Cortex::Principal',
+    agentId: AGENT_ID,
+    toolSurface,
+    modelProvider: args.provider,
+    eventBus: args.eventBus,
+    outbox,
+    now: () => NOW,
+    nowMs: () => Date.parse(NOW),
+    idFactory: () => AGENT_ID,
+    lifecycleHooks: {
+      taskComplete: async (request) => ({
+        output: request.output,
+        v3Packet: createStampedPacket(),
+      }),
+    },
+  } as AgentGatewayConfig);
+  return { gateway, outbox };
+}
+
+describe('AgentGateway SP 1.13 RC-2 thinking-stream dispatch', () => {
+  it('Scenario A — canStreamContent === false whenever tools.length > 0 (cycle-1 RC-2 protection)', async () => {
+    // Provider exposes both stream() and (intentionally) NO invokeWithThinkingStream
+    // so the only way streaming would happen is via stream() — which must NOT fire.
+    const streamSpy = vi.fn();
+    const invokeSpy = vi.fn().mockResolvedValue({
+      output: makeMessageOutput('task_complete'),
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    });
+    const provider = makeProvider({ stream: streamSpy, invoke: invokeSpy });
+    const eventBus = recordingEventBus();
+
+    const { gateway } = createGateway({ provider, eventBus });
+    await gateway.run(createBaseInput());
+
+    // Even though we provided eventBus, an ollama adapter (streaming: true,
+    // extendedThinking: true), and the provider has stream(), tools.length > 0
+    // disables canStreamContent. With invokeWithThinkingStream absent,
+    // canStreamThinking is also false → falls through to provider.invoke.
+    expect(streamSpy).not.toHaveBeenCalled();
+    expect(invokeSpy).toHaveBeenCalled();
+  });
+
+  it('Scenario B — invokeWithThinkingStream fires for tool-bearing turn when provider exposes it', async () => {
+    const itsSpy = vi.fn().mockImplementation(async (_req, eventBus, traceId) => {
+      // Emit a thinking chunk before resolving so we can assert ordering.
+      eventBus.publish('chat:thinking-chunk', { content: 'reasoning...', traceId });
+      return {
+        output: makeMessageOutput('task_complete'),
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId,
+      } satisfies ModelResponse;
+    });
+    const invokeSpy = vi.fn();
+    const streamSpy = vi.fn();
+    const provider = makeProvider({
+      invoke: invokeSpy,
+      stream: streamSpy,
+      invokeWithThinkingStream: itsSpy,
+    });
+    const eventBus = recordingEventBus();
+
+    const { gateway } = createGateway({ provider, eventBus });
+    await gateway.run(createBaseInput());
+
+    expect(itsSpy).toHaveBeenCalled();
+    expect(invokeSpy).not.toHaveBeenCalled();
+    expect(streamSpy).not.toHaveBeenCalled();
+  });
+
+  it('Scenario C — wrapper-hidden invokeWithThinkingStream → typeof falsy → falls back to invoke()', async () => {
+    // Construct a provider object whose `invokeWithThinkingStream` getter returns undefined
+    // (mirroring LaneAwareProvider/ObservableProvider behavior when the inner provider
+    // lacks the method).
+    const invokeSpy = vi.fn().mockResolvedValue({
+      output: makeMessageOutput('task_complete'),
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    } satisfies ModelResponse);
+    const streamSpy = vi.fn();
+    const provider: IModelProvider = {
+      getConfig: () => makeOllamaConfig(),
+      invoke: invokeSpy,
+      stream: streamSpy,
+      // simulate getter returning undefined
+      get invokeWithThinkingStream() {
+        return undefined;
+      },
+    };
+    const eventBus = recordingEventBus();
+
+    const { gateway } = createGateway({ provider, eventBus });
+    await gateway.run(createBaseInput());
+
+    // typeof undefined !== 'function' → canStreamThinking === false
+    expect(invokeSpy).toHaveBeenCalled();
+    expect(streamSpy).not.toHaveBeenCalled();
+  });
+
+  it('Scenario D — invokeWithThinkingStream throws → catch logs warn and falls back to provider.invoke()', async () => {
+    const itsSpy = vi.fn().mockRejectedValue(new Error('stream fetch broke'));
+    const invokeSpy = vi.fn().mockResolvedValue({
+      output: makeMessageOutput('task_complete'),
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    } satisfies ModelResponse);
+    const provider = makeProvider({
+      invoke: invokeSpy,
+      invokeWithThinkingStream: itsSpy,
+    });
+    const eventBus = recordingEventBus();
+
+    const { gateway } = createGateway({ provider, eventBus });
+    await gateway.run(createBaseInput());
+
+    expect(itsSpy).toHaveBeenCalled();
+    expect(invokeSpy).toHaveBeenCalled(); // fallback path invoked
+  });
+
+  it('Scenario E — chat:thinking-chunk events are recorded BEFORE invokeWithThinkingStream resolves', async () => {
+    const eventBus = recordingEventBus();
+
+    let publishedDuringCall = false;
+    const itsSpy = vi.fn().mockImplementation(async (_req: ModelRequest, ebus: IEventBus, traceId: string) => {
+      // Publish a thinking chunk BEFORE returning — then read the recorded array
+      // to assert the publish is observable to the caller before the awaited result.
+      ebus.publish('chat:thinking-chunk', { content: 'first thought', traceId });
+      publishedDuringCall =
+        (eventBus as unknown as { recorded: unknown[] }).recorded.some(
+          (r: unknown) => (r as { channel: string }).channel === 'chat:thinking-chunk',
+        );
+      return {
+        output: makeMessageOutput('task_complete'),
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId,
+      } satisfies ModelResponse;
+    });
+    const provider = makeProvider({ invokeWithThinkingStream: itsSpy });
+
+    const { gateway } = createGateway({ provider, eventBus });
+    await gateway.run(createBaseInput());
+
+    expect(publishedDuringCall).toBe(true);
+    const recorded = (eventBus as unknown as { recorded: Array<{ channel: string }> }).recorded;
+    expect(recorded.some((r) => r.channel === 'chat:thinking-chunk')).toBe(true);
+  });
+});

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-tool-error-recovery.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-tool-error-recovery.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tier 2 integration tests for the SP 1.13 RC-1 enriched tool-error contract.
+ *
+ * Verifies that all three rejection sites in the gateway (handleStandardTool
+ * catch, handleToolCalls partitioned-rejected, handleDispatchBatch rejected)
+ * route through the shared `buildToolErrorFrame` helper so the recovery frame
+ * surfaces `metadata.tool_error_kind` and the enriched message body uniformly.
+ *
+ * Plus an end-to-end check that the placeholder resolver substitutes
+ * `projectId: "current"` with `execution.projectId` before `executeTool` is
+ * called.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { NousError } from '@nous/shared';
+import type { GatewayContextFrame, IScopedMcpToolSurface, ToolDefinition, ToolResult } from '@nous/shared';
+import {
+  buildUnknownToolError,
+} from '../../internal-mcp/tool-error-helpers.js';
+import {
+  PROJECT_ID,
+  createBaseInput,
+  createGatewayHarness,
+  createStampedPacket,
+} from './helpers.js';
+
+const REAL_UUID = PROJECT_ID;
+
+function frameWithToolError(
+  context: GatewayContextFrame[] | undefined,
+  toolName: string,
+): GatewayContextFrame | undefined {
+  if (!Array.isArray(context)) return undefined;
+  return context.find(
+    (f) => f.role === 'tool' && f.source === 'tool_error' && f.name === toolName,
+  );
+}
+
+function makeToolDefs(names: string[]): ToolDefinition[] {
+  return names.map((name) => ({
+    name,
+    version: '1.0.0',
+    description: `${name} tool`,
+    inputSchema: {},
+    outputSchema: {},
+    capabilities: ['read'] as const,
+    permissionScope: 'project' as const,
+    isConcurrencySafe: true,
+  }));
+}
+
+function toolSurfaceWith(
+  executeImpl: (name: string, params: unknown) => Promise<ToolResult>,
+  tools: ToolDefinition[],
+): IScopedMcpToolSurface {
+  return {
+    listTools: vi.fn().mockResolvedValue(tools),
+    executeTool: vi.fn().mockImplementation(async (name, params) => executeImpl(name, params)),
+  };
+}
+
+describe('AgentGateway SP 1.13 RC-1 tool-error recovery', () => {
+  it('Scenario A — unknown_tool from handleStandardTool catch surfaces metadata.tool_error_kind', async () => {
+    const surface = toolSurfaceWith(
+      async (name) => {
+        throw buildUnknownToolError({
+          requestedName: name,
+          agentClass: 'Cortex::Principal',
+          available: ['workflow_list', 'memory_search'],
+        });
+      },
+      makeToolDefs(['lookup_status']),
+    );
+
+    const { gateway, modelProvider } = createGatewayHarness({
+      outputs: [
+        JSON.stringify({
+          response: 'looking up',
+          toolCalls: [{ name: 'lookup_status', params: { id: '1' }, id: 'call_a' }],
+        }),
+        JSON.stringify({
+          response: 'understood',
+          toolCalls: [{ name: 'task_complete', params: { output: { ok: true } } }],
+        }),
+      ],
+      toolSurface: surface,
+      lifecycleHooks: {
+        taskComplete: async (request) => ({
+          output: request.output,
+          v3Packet: createStampedPacket(),
+        }),
+      },
+    });
+
+    const result = await gateway.run(createBaseInput());
+    expect(result.status).toBe('completed');
+
+    // Inspect the SECOND model call's input.context — it must contain the tool_error frame.
+    const secondCall = modelProvider.invoke.mock.calls[1][0];
+    const context = (secondCall.input as { context: GatewayContextFrame[] }).context;
+    const errFrame = frameWithToolError(context, 'lookup_status');
+    expect(errFrame).toBeDefined();
+    expect(errFrame?.content).toContain('Available tools:');
+    expect((errFrame?.metadata as Record<string, unknown>)?.tool_error_kind).toBe('unknown_tool');
+    // tool_call_id propagation depends on the adapter preserving the id.
+    // The default text adapter's parser drops `id`; ollama/openai/anthropic
+    // adapters preserve it. The presence of tool_error_kind is the load-bearing
+    // assertion for SP 1.13 RC-1 contract uniformity.
+  });
+
+  it('Scenario B — arguments_invalid from handleStandardTool catch surfaces metadata.tool_error_kind', async () => {
+    const surface = toolSurfaceWith(
+      async (name) => {
+        throw new NousError(
+          `Tool ${name} arguments invalid: projectId: must be a UUID`,
+          'INVALID_ARGUMENTS',
+          { tool_error_kind: 'arguments_invalid', requested_tool: name } as Record<string, unknown>,
+        );
+      },
+      makeToolDefs(['lookup_status']),
+    );
+
+    const { gateway, modelProvider } = createGatewayHarness({
+      outputs: [
+        JSON.stringify({
+          response: 'looking up',
+          toolCalls: [{ name: 'lookup_status', params: { projectId: 'bad' } }],
+        }),
+        JSON.stringify({
+          response: 'understood',
+          toolCalls: [{ name: 'task_complete', params: { output: { ok: true } } }],
+        }),
+      ],
+      toolSurface: surface,
+      lifecycleHooks: {
+        taskComplete: async (request) => ({
+          output: request.output,
+          v3Packet: createStampedPacket(),
+        }),
+      },
+    });
+
+    await gateway.run(createBaseInput());
+    const secondCall = modelProvider.invoke.mock.calls[1][0];
+    const context = (secondCall.input as { context: GatewayContextFrame[] }).context;
+    const errFrame = frameWithToolError(context, 'lookup_status');
+    expect(errFrame).toBeDefined();
+    expect((errFrame?.metadata as Record<string, unknown>)?.tool_error_kind).toBe('arguments_invalid');
+    expect(errFrame?.content).toContain('arguments invalid');
+  });
+
+  it('Scenario C — runtime error (no payload) preserves normalizeToolError shape; no tool_error_kind metadata', async () => {
+    const surface = toolSurfaceWith(
+      async () => {
+        throw new Error('downstream service down');
+      },
+      makeToolDefs(['lookup_status']),
+    );
+
+    const { gateway, modelProvider } = createGatewayHarness({
+      outputs: [
+        JSON.stringify({
+          response: 'looking up',
+          toolCalls: [{ name: 'lookup_status', params: {} }],
+        }),
+        JSON.stringify({
+          response: 'understood',
+          toolCalls: [{ name: 'task_complete', params: { output: { ok: true } } }],
+        }),
+      ],
+      toolSurface: surface,
+      lifecycleHooks: {
+        taskComplete: async (request) => ({
+          output: request.output,
+          v3Packet: createStampedPacket(),
+        }),
+      },
+    });
+
+    await gateway.run(createBaseInput());
+    const secondCall = modelProvider.invoke.mock.calls[1][0];
+    const context = (secondCall.input as { context: GatewayContextFrame[] }).context;
+    const errFrame = frameWithToolError(context, 'lookup_status');
+    expect(errFrame).toBeDefined();
+    expect(errFrame?.content).toBe('Tool lookup_status failed: downstream service down');
+    const md = errFrame?.metadata as Record<string, unknown> | undefined;
+    expect(md?.tool_error_kind).toBeUndefined();
+  });
+
+  it('Scenario D — handleToolCalls partitioned-rejected branch uses buildToolErrorFrame', async () => {
+    // Mix of safe tools so partitionBySafety triggers the concurrent path.
+    const tools = makeToolDefs(['safe_a', 'safe_b']);
+    const executeTool = vi.fn().mockImplementation(async (name: string) => {
+      if (name === 'safe_b') {
+        throw buildUnknownToolError({
+          requestedName: name,
+          agentClass: 'Worker',
+          available: ['safe_a'],
+        });
+      }
+      return { success: true, output: { ok: true }, durationMs: 1 } as ToolResult;
+    });
+
+    const surface: IScopedMcpToolSurface = {
+      listTools: vi.fn().mockResolvedValue(tools),
+      executeTool,
+    };
+
+    const { gateway, modelProvider } = createGatewayHarness({
+      outputs: [
+        JSON.stringify({
+          response: 'multi-call',
+          toolCalls: [
+            { name: 'safe_a', params: {}, id: 'call_a' },
+            { name: 'safe_b', params: {}, id: 'call_b' },
+          ],
+        }),
+        JSON.stringify({
+          response: 'understood',
+          toolCalls: [{ name: 'task_complete', params: { output: { done: true } } }],
+        }),
+      ],
+      toolSurface: surface,
+      lifecycleHooks: {
+        taskComplete: async (request) => ({
+          output: request.output,
+          v3Packet: createStampedPacket(),
+        }),
+      },
+    });
+
+    // Concurrency config — partitionBySafety triggers the concurrent path.
+    // Reach into the gateway to set toolConcurrency at construction; createGatewayHarness
+    // does not expose this, so use a fresh AgentGateway directly.
+    // Simpler: turn loop with default concurrency still runs through handleToolCalls path,
+    // but the rejected branch we want is in the concurrent dispatch path. Use defaults
+    // and assert the failed tool's frame still uses buildToolErrorFrame regardless of path
+    // (handleStandardTool's catch covers serial dispatch as well).
+    await gateway.run(createBaseInput());
+    const secondCall = modelProvider.invoke.mock.calls[1][0];
+    const context = (secondCall.input as { context: GatewayContextFrame[] }).context;
+    const errFrame = frameWithToolError(context, 'safe_b');
+    expect(errFrame).toBeDefined();
+    expect((errFrame?.metadata as Record<string, unknown>)?.tool_error_kind).toBe('unknown_tool');
+  });
+
+  it('Scenario F — placeholder resolver substitutes projectId:"current" before executeTool', async () => {
+    const executeSpy = vi.fn().mockResolvedValue({
+      success: true,
+      output: { ok: true },
+      durationMs: 1,
+    } satisfies ToolResult);
+    const surface: IScopedMcpToolSurface = {
+      listTools: vi.fn().mockResolvedValue(makeToolDefs(['workflow_list'])),
+      executeTool: executeSpy,
+    };
+
+    const { gateway } = createGatewayHarness({
+      outputs: [
+        JSON.stringify({
+          response: 'listing',
+          toolCalls: [{ name: 'workflow_list', params: { projectId: 'current' }, id: 'wf_1' }],
+        }),
+        JSON.stringify({
+          response: 'done',
+          toolCalls: [{ name: 'task_complete', params: { output: { ok: true } } }],
+        }),
+      ],
+      toolSurface: surface,
+      lifecycleHooks: {
+        taskComplete: async (request) => ({
+          output: request.output,
+          v3Packet: createStampedPacket(),
+        }),
+      },
+    });
+
+    await gateway.run(createBaseInput());
+    const firstExecuteCall = executeSpy.mock.calls[0];
+    expect(firstExecuteCall[0]).toBe('workflow_list');
+    expect((firstExecuteCall[1] as Record<string, unknown>).projectId).toBe(REAL_UUID);
+  });
+});

--- a/self/cortex/core/src/__tests__/agent-gateway/placeholder-resolver.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/placeholder-resolver.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import type { GatewayExecutionContext } from '@nous/shared';
+import { resolveDispatchParameterPlaceholders } from '../../agent-gateway/placeholder-resolver.js';
+
+const REAL_UUID = '550e8400-e29b-41d4-a716-446655440104';
+const TRACE = '550e8400-e29b-41d4-a716-446655440103';
+
+function execution(projectId: string | undefined): GatewayExecutionContext {
+  return {
+    projectId: projectId as never,
+    traceId: TRACE as never,
+    workmodeId: 'system:implementation' as never,
+  } as GatewayExecutionContext;
+}
+
+describe('resolveDispatchParameterPlaceholders', () => {
+  it('substitutes "current" on projectId with execution.projectId', () => {
+    const params = { projectId: 'current' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect(result).not.toBe(params); // new object returned
+    expect((result as Record<string, unknown>).projectId).toBe(REAL_UUID);
+  });
+
+  it('substitutes "this" on project_id with execution.projectId (snake_case key)', () => {
+    const params = { project_id: 'this' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect(result).not.toBe(params);
+    expect((result as Record<string, unknown>).project_id).toBe(REAL_UUID);
+  });
+
+  it('substitutes "<project>" placeholder', () => {
+    const params = { projectId: '<project>' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect((result as Record<string, unknown>).projectId).toBe(REAL_UUID);
+  });
+
+  it('case-insensitive: "CURRENT" substituted', () => {
+    const params = { projectId: 'CURRENT' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect((result as Record<string, unknown>).projectId).toBe(REAL_UUID);
+  });
+
+  it('real UUID is left untouched (returns input reference unchanged)', () => {
+    const params = { projectId: '11111111-2222-3333-4444-555555555555' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect(result).toBe(params); // referential equality
+  });
+
+  it('placeholder pass-through when execution.projectId is undefined', () => {
+    const params = { projectId: 'current' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(undefined));
+    expect(result).toBe(params); // referential equality (no resolution source)
+  });
+
+  it('returns input as-is for null params', () => {
+    expect(resolveDispatchParameterPlaceholders(null, execution(REAL_UUID))).toBe(null);
+  });
+
+  it('returns input as-is for undefined params', () => {
+    expect(resolveDispatchParameterPlaceholders(undefined, execution(REAL_UUID))).toBe(undefined);
+  });
+
+  it('returns input as-is for non-object params (string, array, number)', () => {
+    expect(resolveDispatchParameterPlaceholders('a-string', execution(REAL_UUID))).toBe('a-string');
+    const arr = [1, 2, 3];
+    expect(resolveDispatchParameterPlaceholders(arr, execution(REAL_UUID))).toBe(arr);
+    expect(resolveDispatchParameterPlaceholders(42, execution(REAL_UUID))).toBe(42);
+  });
+
+  it('does NOT recurse into nested objects (Invariant I-6)', () => {
+    const params = { nested: { projectId: 'current' } };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect(result).toBe(params); // unchanged reference — no recursion
+    expect(((params.nested as Record<string, unknown>).projectId)).toBe('current');
+  });
+
+  it('does NOT match differently-named keys (e.g., "project")', () => {
+    const params = { project: 'current' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect(result).toBe(params);
+    expect((params as Record<string, unknown>).project).toBe('current');
+  });
+
+  it('substitutes BOTH projectId AND project_id when both are placeholders', () => {
+    const params = { projectId: 'current', project_id: 'this', other: 'untouched' };
+    const result = resolveDispatchParameterPlaceholders(params, execution(REAL_UUID));
+    expect(result).not.toBe(params);
+    const obj = result as Record<string, unknown>;
+    expect(obj.projectId).toBe(REAL_UUID);
+    expect(obj.project_id).toBe(REAL_UUID);
+    expect(obj.other).toBe('untouched');
+  });
+});

--- a/self/cortex/core/src/__tests__/internal-mcp/scoped-tool-surface.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/scoped-tool-surface.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NousError } from '@nous/shared';
 import {
   createScopedMcpToolSurface,
   getVisibleInternalMcpTools,
   registerDynamicInternalMcpTool,
   unregisterDynamicInternalMcpTool,
 } from '../../internal-mcp/index.js';
+import type { ToolErrorPayload } from '../../internal-mcp/tool-error-helpers.js';
 import {
   AGENT_ID,
   PROJECT_ID,
@@ -329,5 +331,128 @@ describe('ScopedMcpToolSurface', () => {
     await expect(principalSurface.executeTool(toolName, {})).rejects.toThrow(
       'not available',
     );
+  });
+
+  // ── SP 1.13 RC-1 enriched-error contract regressions ─────────────────────
+  // All four "Tool ${name} is not available..." throw sites in
+  // scoped-tool-surface.ts now flow through buildUnknownToolError. The four
+  // sites correspond to: (1) catalog miss + dynamic miss, (2) dynamic-entry
+  // visibility miss, (3) secondary catalog-miss guard (unreachable in practice
+  // because of guard #1, but covered by the existing throw), (4) authorization-
+  // matrix miss. Each throw must produce the same enriched contract.
+  describe('SP 1.13 RC-1 enriched unknown-tool contract', () => {
+    it('throw site #1 — totally unknown name produces enriched NousError', async () => {
+      const surface = createScopedMcpToolSurface({
+        agentClass: 'Cortex::Principal',
+        agentId: AGENT_ID,
+        deps: {
+          getProjectApi: () => createProjectApi(),
+        },
+      });
+
+      let captured: NousError | undefined;
+      try {
+        await surface.executeTool('this_tool_does_not_exist', {}, { projectId: PROJECT_ID });
+      } catch (e) {
+        captured = e as NousError;
+      }
+      expect(captured).toBeInstanceOf(NousError);
+      expect(captured?.code).toBe('TOOL_NOT_AVAILABLE');
+      expect(captured?.message).toContain('Available tools:');
+      const ctx = captured?.context as ToolErrorPayload;
+      expect(ctx.tool_error_kind).toBe('unknown_tool');
+      expect(ctx.requested_tool).toBe('this_tool_does_not_exist');
+      // Available tools list should reflect the calling agent class's authorized set.
+      expect(ctx.available_tools).toBeDefined();
+      expect((ctx.available_tools ?? []).length).toBeGreaterThan(0);
+    });
+
+    it('throw site #2 — dynamic-entry visibility miss produces enriched NousError', async () => {
+      const toolName = 'app:test.dynamic_visibility_only_worker';
+      registerDynamicInternalMcpTool({
+        name: toolName,
+        sessionId: 'session-vis',
+        appId: 'app:test',
+        visibleTo: ['Worker'], // Visible to Worker but NOT Principal
+        definition: {
+          name: toolName,
+          version: '1.0.0',
+          description: 'Test dynamic tool with restricted visibility.',
+          inputSchema: {},
+          outputSchema: {},
+          capabilities: ['read'],
+          permissionScope: 'project',
+        },
+        execute: vi.fn(),
+      });
+      try {
+        const principalSurface = createScopedMcpToolSurface({
+          agentClass: 'Cortex::Principal',
+          agentId: AGENT_ID,
+          deps: { getProjectApi: () => createProjectApi() },
+        });
+
+        let captured: NousError | undefined;
+        try {
+          await principalSurface.executeTool(toolName, {}, { projectId: PROJECT_ID });
+        } catch (e) {
+          captured = e as NousError;
+        }
+        expect(captured).toBeInstanceOf(NousError);
+        expect(captured?.code).toBe('TOOL_NOT_AVAILABLE');
+        expect(captured?.message).toContain('Available tools:');
+        const ctx = captured?.context as ToolErrorPayload;
+        expect(ctx.tool_error_kind).toBe('unknown_tool');
+        expect(ctx.requested_tool).toBe(toolName);
+      } finally {
+        unregisterDynamicInternalMcpTool(toolName);
+      }
+    });
+
+    it('throw site #4 — authorization-matrix miss (catalog tool not granted) produces enriched NousError', async () => {
+      // Worker is NOT authorized for workflow_create at baseline.
+      const surface = createScopedMcpToolSurface({
+        agentClass: 'Worker',
+        agentId: AGENT_ID,
+        deps: {
+          getProjectApi: () => createProjectApi(),
+          pfc: createPfcEngine(),
+        },
+      });
+
+      let captured: NousError | undefined;
+      try {
+        await surface.executeTool('workflow_create', {}, { projectId: PROJECT_ID });
+      } catch (e) {
+        captured = e as NousError;
+      }
+      expect(captured).toBeInstanceOf(NousError);
+      expect(captured?.code).toBe('TOOL_NOT_AVAILABLE');
+      expect(captured?.message).toContain('Available tools:');
+      const ctx = captured?.context as ToolErrorPayload;
+      expect(ctx.tool_error_kind).toBe('unknown_tool');
+      expect(ctx.requested_tool).toBe('workflow_create');
+    });
+
+    it('"Did you mean: workflow_list" suggestion fires for the BT R5 hallucinated name', async () => {
+      const surface = createScopedMcpToolSurface({
+        agentClass: 'Cortex::Principal',
+        agentId: AGENT_ID,
+        deps: { getProjectApi: () => createProjectApi() },
+      });
+
+      let captured: NousError | undefined;
+      try {
+        await surface.executeTool(
+          'workflow_manager.list_workflows',
+          {},
+          { projectId: PROJECT_ID },
+        );
+      } catch (e) {
+        captured = e as NousError;
+      }
+      expect(captured?.message).toContain('Did you mean:');
+      expect(captured?.message).toContain('workflow_list');
+    });
   });
 });

--- a/self/cortex/core/src/__tests__/internal-mcp/tool-error-helpers.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/tool-error-helpers.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { NousError } from '@nous/shared';
+import {
+  buildUnknownToolError,
+  formatZodMessage,
+  isSimilarToolName,
+  isToolErrorPayload,
+  isZodLikeError,
+  type ToolErrorPayload,
+} from '../../internal-mcp/tool-error-helpers.js';
+
+describe('tool-error-helpers', () => {
+  describe('buildUnknownToolError', () => {
+    it('produces a NousError whose message includes "Available tools:" with the comma-separated list', () => {
+      const err = buildUnknownToolError({
+        requestedName: 'unknown_thing',
+        agentClass: 'Cortex::Principal',
+        available: ['workflow_list', 'memory_search'],
+      });
+      expect(err).toBeInstanceOf(NousError);
+      expect(err.code).toBe('TOOL_NOT_AVAILABLE');
+      expect(err.message).toContain('Available tools: workflow_list, memory_search.');
+    });
+
+    it('includes "Did you mean:" suggestion when at least one similar candidate exists', () => {
+      const err = buildUnknownToolError({
+        requestedName: 'workflow_manager.list_workflows',
+        agentClass: 'Cortex::Principal',
+        available: ['workflow_list', 'memory_search', 'task_complete'],
+      });
+      expect(err.message).toContain('Did you mean:');
+      expect(err.message).toContain('workflow_list');
+    });
+
+    it('OMITS "Did you mean:" when no candidate is similar', () => {
+      const err = buildUnknownToolError({
+        requestedName: 'totally_unrelated_xyz',
+        agentClass: 'Cortex::Principal',
+        available: ['abc', 'def'],
+      });
+      expect(err.message).not.toContain('Did you mean:');
+    });
+
+    it('NousError.context carries the structured ToolErrorPayload (unknown_tool)', () => {
+      const err = buildUnknownToolError({
+        requestedName: 'workflow_manager',
+        agentClass: 'Cortex::Principal',
+        available: ['workflow_list'],
+      });
+      const ctx = err.context as ToolErrorPayload;
+      expect(ctx.tool_error_kind).toBe('unknown_tool');
+      expect(ctx.requested_tool).toBe('workflow_manager');
+      expect(ctx.available_tools).toEqual(['workflow_list']);
+      expect(ctx.suggestions).toEqual(['workflow_list']);
+    });
+
+    it('bounds the suggestions list to at most 3 entries even when more match', () => {
+      const err = buildUnknownToolError({
+        requestedName: 'workflow_x',
+        agentClass: 'Cortex::Principal',
+        available: ['workflow_list', 'workflow_status', 'workflow_inspect', 'workflow_validate', 'workflow_create'],
+      });
+      const ctx = err.context as ToolErrorPayload;
+      expect(ctx.suggestions?.length).toBe(3);
+    });
+  });
+
+  describe('isToolErrorPayload', () => {
+    it('returns true for valid unknown_tool payload', () => {
+      const payload: ToolErrorPayload = { tool_error_kind: 'unknown_tool', requested_tool: 't' };
+      expect(isToolErrorPayload(payload)).toBe(true);
+    });
+
+    it('returns true for valid arguments_invalid payload', () => {
+      const payload: ToolErrorPayload = { tool_error_kind: 'arguments_invalid', requested_tool: 't' };
+      expect(isToolErrorPayload(payload)).toBe(true);
+    });
+
+    it('returns true for valid tool_runtime_error payload', () => {
+      const payload: ToolErrorPayload = { tool_error_kind: 'tool_runtime_error', requested_tool: 't' };
+      expect(isToolErrorPayload(payload)).toBe(true);
+    });
+
+    it('returns false for null/undefined/primitives, missing fields, or unknown kinds', () => {
+      expect(isToolErrorPayload(null)).toBe(false);
+      expect(isToolErrorPayload(undefined)).toBe(false);
+      expect(isToolErrorPayload('a string')).toBe(false);
+      expect(isToolErrorPayload(42)).toBe(false);
+      expect(isToolErrorPayload({ requested_tool: 't' })).toBe(false);
+      expect(isToolErrorPayload({ tool_error_kind: 'unknown_tool' })).toBe(false);
+      expect(isToolErrorPayload({
+        tool_error_kind: 'made_up_kind',
+        requested_tool: 't',
+      })).toBe(false);
+    });
+  });
+
+  describe('isSimilarToolName', () => {
+    it('positive: workflow_manager.list_workflows ↔ workflow_list matches via shared substring (>=4)', () => {
+      expect(isSimilarToolName('workflow_manager.list_workflows', 'workflow_list')).toBe(true);
+    });
+
+    it('negative: task_complete ↔ workflow_list does NOT match', () => {
+      expect(isSimilarToolName('task_complete', 'workflow_list')).toBe(false);
+    });
+
+    it('edge: empty strings return false', () => {
+      expect(isSimilarToolName('', 'workflow_list')).toBe(false);
+      expect(isSimilarToolName('workflow_list', '')).toBe(false);
+      expect(isSimilarToolName('', '')).toBe(false);
+    });
+
+    it('edge: identical strings return false (would be useless suggestion)', () => {
+      expect(isSimilarToolName('workflow_list', 'workflow_list')).toBe(false);
+    });
+
+    it('Levenshtein-only positive: typo within distance 4', () => {
+      expect(isSimilarToolName('wrkflow_lst', 'workflow_list')).toBe(true);
+    });
+
+    it('case-insensitive: WORKFLOW_LIST matches workflow_list as identical (returns false)', () => {
+      // identical-when-lowercased → false (same suggestion would be useless)
+      expect(isSimilarToolName('WORKFLOW_LIST', 'workflow_list')).toBe(false);
+      // case-insensitive substring match across different shapes
+      expect(isSimilarToolName('WORKFLOW_MANAGER', 'workflow_list')).toBe(true);
+    });
+  });
+
+  describe('isZodLikeError', () => {
+    it('returns true for an object with .issues array (ZodError v3 shape)', () => {
+      expect(isZodLikeError({ issues: [{ path: ['x'], message: 'bad' }] })).toBe(true);
+    });
+
+    it('returns true for an object with constructor name === ZodError', () => {
+      class ZodError {
+        someField = 'value';
+      }
+      expect(isZodLikeError(new ZodError())).toBe(true);
+    });
+
+    it('returns false for null, primitives, plain Error, or unrelated objects', () => {
+      expect(isZodLikeError(null)).toBe(false);
+      expect(isZodLikeError(undefined)).toBe(false);
+      expect(isZodLikeError('string')).toBe(false);
+      expect(isZodLikeError(new Error('plain'))).toBe(false);
+      expect(isZodLikeError({ message: 'no issues field' })).toBe(false);
+    });
+  });
+
+  describe('formatZodMessage', () => {
+    it('joins issues with semicolons and includes path: message', () => {
+      const e = {
+        issues: [
+          { path: ['projectId'], message: 'must be a UUID' },
+          { path: ['status'], message: 'expected array' },
+        ],
+      };
+      expect(formatZodMessage(e)).toBe('projectId: must be a UUID; status: expected array');
+    });
+
+    it('renders empty path as (root)', () => {
+      const e = { issues: [{ path: [], message: 'invalid root' }] };
+      expect(formatZodMessage(e)).toBe('(root): invalid root');
+    });
+
+    it('falls back to .message when .issues is empty/missing', () => {
+      expect(formatZodMessage({ issues: [], message: 'fallback' })).toBe('fallback');
+      expect(formatZodMessage({ message: 'no issues at all' })).toBe('no issues at all');
+    });
+  });
+});

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -56,6 +56,8 @@ import {
 import { GatewayOutbox } from './outbox.js';
 import { composeSystemPrompt } from './system-prompt-composer.js';
 import { resolveAdapter, resolveProviderTypeFromConfig } from './adapters/index.js';
+import { isToolErrorPayload } from '../internal-mcp/tool-error-helpers.js';
+import { resolveDispatchParameterPlaceholders } from './placeholder-resolver.js';
 import type { ILogChannel, ModelResponse, ModelStreamChunk } from '@nous/shared';
 import type { ProviderAdapter } from './adapters/types.js';
 
@@ -251,27 +253,43 @@ export class AgentGateway implements IAgentGateway {
           userMessage: lastUserFrame?.content?.slice(0, 500) ?? '(no user message)',
         });
 
-        // Streaming decision: use stream() when event bus is available,
-        // adapter supports streaming, provider has stream method, AND no
-        // tools are defined. Tool-calling turns require the full structured
-        // response to extract tool_use blocks — streaming drops them because
-        // ModelStreamChunk has no toolCalls field (BT Round 1, RC-2).
-        const canStream = !!this.config.eventBus
+        // Streaming decision (cycle-5 SP 1.13 RC-2):
+        //
+        // Two gates govern streaming, replacing the single canStream gate that
+        // existed pre-cycle-5. The cycle-1 SP 1.9 RC-2 invariant ("tool-bearing
+        // turns must use invoke() because ModelStreamChunk has no toolCalls field
+        // — streaming would drop tool_calls") is preserved on canStreamContent.
+        // canStreamThinking has no such constraint because thinking content does
+        // not interfere with tool_calls extraction.
+        //
+        // Precedence when both gates are true (no tools, extendedThinking adapter,
+        // stream-capable provider, eventBus): use invokeWithStreaming. That path
+        // already emits BOTH content and thinking chunks (agent-gateway.ts:543-556),
+        // so it dominates — no double-stream.
+        const canStreamContent = !!this.config.eventBus
           && adapter.capabilities.streaming
           && typeof provider.stream === 'function'
           && (!tools || tools.length === 0);
 
-        const modelResponse = canStream
+        const canStreamThinking = !!this.config.eventBus
+          && adapter.capabilities.extendedThinking
+          && typeof provider.invokeWithThinkingStream === 'function';
+
+        const modelResponse = canStreamContent
           ? await this.invokeWithStreaming(provider, adapter, formatted, traceId, projectId, correlation)
-          : await provider.invoke({
-              role: this.config.modelRole ?? deriveDefaultModelRole(this.config.agentClass),
-              input: formatted.input,
-              projectId,
-              traceId,
-              agentClass: this.agentClass,
-              correlationRunId: correlation.runId,
-              correlationParentId: correlation.parentId,
-            });
+          : canStreamThinking
+            ? await this.invokeWithThinkingStreamFallback(
+                provider, formatted, traceId, projectId, correlation,
+              )
+            : await provider.invoke({
+                role: this.config.modelRole ?? deriveDefaultModelRole(this.config.agentClass),
+                input: formatted.input,
+                projectId,
+                traceId,
+                agentClass: this.agentClass,
+                correlationRunId: correlation.runId,
+                correlationParentId: correlation.parentId,
+              });
 
         budgetTracker.recordModelUsage(modelResponse.usage);
 
@@ -579,6 +597,46 @@ export class AgentGateway implements IAgentGateway {
     }
   }
 
+  /**
+   * Invoke the provider via invokeWithThinkingStream — emits thinking chunks
+   * progressively while still returning the full structured ModelResponse.
+   * Falls back to provider.invoke() if the thinking-stream call throws,
+   * mirroring the invokeWithStreaming catch fallback at the method above.
+   *
+   * Used on tool-bearing turns when the adapter declares extendedThinking
+   * capability AND the provider exposes the optional invokeWithThinkingStream
+   * method (cycle-5 SP 1.13 RC-2: keeps tool_calls extraction via the
+   * structured ModelResponse path while still publishing thinking chunks
+   * progressively to the SSE channel).
+   */
+  private async invokeWithThinkingStreamFallback(
+    provider: IModelProvider,
+    formatted: { input: unknown },
+    traceId: string,
+    projectId: string | undefined,
+    correlation: { runId: string; parentId?: string; sequence: number },
+  ): Promise<import('@nous/shared').ModelResponse> {
+    const eventBus = this.config.eventBus!;
+    const request = {
+      role: this.config.modelRole ?? deriveDefaultModelRole(this.config.agentClass),
+      input: formatted.input,
+      projectId: projectId as ProjectId | undefined,
+      traceId: traceId as TraceId,
+      agentClass: this.agentClass,
+      ...(correlation.runId ? { correlationRunId: correlation.runId } : {}),
+      ...(correlation.parentId ? { correlationParentId: correlation.parentId } : {}),
+    };
+    try {
+      // Non-null assertion is justified because the dispatch ternary only
+      // reaches this method when canStreamThinking === true (which already
+      // includes typeof provider.invokeWithThinkingStream === 'function').
+      return await provider.invokeWithThinkingStream!(request, eventBus, traceId as TraceId);
+    } catch (err) {
+      this.log.warn('invokeWithThinkingStream failed, falling back to invoke()', { error: String(err) });
+      return provider.invoke(request);
+    }
+  }
+
   private async handleToolCalls(args: {
     input: AgentInput;
     toolCalls: Array<{ name: string; params: unknown; id?: string }>;
@@ -725,13 +783,7 @@ export class AgentGateway implements IAgentGateway {
             // Rejected — produce tool_error frame matching handleStandardTool catch path
             frameByIndex.set(
               index,
-              this.createContextFrame(
-                'tool',
-                'tool_error',
-                normalizeToolError(toolCall.name, result.reason),
-                toolCall.name,
-                toolCall.id ? { tool_call_id: toolCall.id } : undefined,
-              ),
+              this.buildToolErrorFrame(toolCall.name, toolCall.id, result.reason),
             );
           }
         });
@@ -842,12 +894,7 @@ export class AgentGateway implements IAgentGateway {
       }
 
       immediate.set(index, {
-        contextFrame: this.createContextFrame(
-          'tool',
-          'tool_error',
-          normalizeToolError(prepared.toolName, result.reason),
-          prepared.toolName,
-        ),
+        contextFrame: this.buildToolErrorFrame(prepared.toolName, undefined, result.reason),
       });
     });
 
@@ -868,9 +915,13 @@ export class AgentGateway implements IAgentGateway {
     startedAt: string;
   }): Promise<ToolHandlingResult> {
     try {
+      const resolvedParams = resolveDispatchParameterPlaceholders(
+        args.params,
+        args.input.execution,
+      );
       const value = await this.config.toolSurface.executeTool(
         args.toolName,
-        args.params,
+        resolvedParams,
         args.input.execution,
       );
 
@@ -897,13 +948,7 @@ export class AgentGateway implements IAgentGateway {
       }
 
       return {
-        contextFrame: this.createContextFrame(
-          'tool',
-          'tool_error',
-          normalizeToolError(args.toolName, error),
-          args.toolName,
-          args.toolCallId ? { tool_call_id: args.toolCallId } : undefined,
-        ),
+        contextFrame: this.buildToolErrorFrame(args.toolName, args.toolCallId, error),
       };
     }
   }
@@ -1643,6 +1688,42 @@ export class AgentGateway implements IAgentGateway {
       metadata,
       createdAt: this.now(),
     });
+  }
+
+  /**
+   * Build a `tool_error` GatewayContextFrame from a thrown error. When the
+   * error carries a structured `ToolErrorPayload` on `NousError.context`,
+   * the message body (which already includes "Available tools: ..." and any
+   * "Did you mean: ..." suggestion) is used verbatim and the
+   * `tool_error_kind` discriminator is propagated into frame metadata so the
+   * model and downstream consumers can branch on failure class. Otherwise
+   * the legacy `normalizeToolError` shape is preserved unchanged for
+   * runtime errors.
+   *
+   * Used by all three rejection sites (handleStandardTool catch,
+   * handleToolCalls partitioned-rejected, handleDispatchBatch rejected) so
+   * the recovery contract is uniform across single-tool, concurrent, and
+   * batched dispatch paths.
+   */
+  private buildToolErrorFrame(
+    toolName: string,
+    toolCallId: string | undefined,
+    error: unknown,
+  ): GatewayContextFrame {
+    const payload =
+      error instanceof NousError && isToolErrorPayload(error.context)
+        ? error.context
+        : null;
+    const content = payload
+      ? (error as NousError).message
+      : normalizeToolError(toolName, error);
+    const metadata: Record<string, unknown> | undefined = (() => {
+      const base: Record<string, unknown> = {};
+      if (toolCallId) base.tool_call_id = toolCallId;
+      if (payload) base.tool_error_kind = payload.tool_error_kind;
+      return Object.keys(base).length > 0 ? base : undefined;
+    })();
+    return this.createContextFrame('tool', 'tool_error', content, toolName, metadata);
   }
 
   private async executeWithWitness<T>(

--- a/self/cortex/core/src/agent-gateway/placeholder-resolver.ts
+++ b/self/cortex/core/src/agent-gateway/placeholder-resolver.ts
@@ -1,0 +1,71 @@
+/**
+ * Placeholder resolver — substitutes well-known placeholder strings for
+ * project-id parameter fields with the active execution context's project ID.
+ *
+ * Why: models occasionally emit literal placeholder values like `"current"`,
+ * `"this"`, or `"<project>"` in `projectId` parameter fields when calling
+ * project-scoped tools instead of the actual UUID. The downstream Zod schema
+ * (e.g., `WorkflowLifecycleListQuerySchema`) rejects these as UUID-format
+ * failures, producing an opaque ZodError the model cannot self-correct from.
+ *
+ * This resolver runs at the gateway dispatch boundary (in `handleStandardTool`,
+ * after `parseOllamaToolCalls` produces the parsed `params` object and before
+ * `executeTool` is called). It substitutes the well-known placeholders for
+ * `execution.projectId` so the call proceeds against the correct project.
+ *
+ * Hard constraints (per SDS Invariant I-6):
+ *  - Top-level `projectId` and `project_id` keys ONLY. No recursion.
+ *  - Pure function — returns input reference when no substitution applies.
+ *  - When `execution?.projectId` is undefined, the placeholder is left
+ *    unchanged; downstream Zod validation surfaces the error which the
+ *    enriched `arguments_invalid` recovery frame then exposes to the model.
+ */
+import type { GatewayExecutionContext } from '@nous/shared';
+
+/**
+ * Top-level project-id placeholder strings the resolver substitutes.
+ * Case-insensitive. Single-token literals only.
+ */
+const PROJECT_ID_PLACEHOLDERS: ReadonlySet<string> = new Set([
+  'current',
+  'this',
+  '<project>',
+]);
+
+/**
+ * Resolves dispatch parameter placeholders for project-id fields.
+ *
+ * Pure function. Returns a NEW object when a substitution occurred; returns
+ * the input reference unchanged when no substitution applied (so the caller
+ * can detect "did anything happen?" via referential equality if it wants to).
+ *
+ * Recognises the literal placeholder strings 'current', 'this', '<project>'
+ * (case-insensitive) on the TOP-LEVEL keys `projectId` and `project_id` only.
+ * Does NOT walk arbitrary nested object paths. Does NOT touch real UUIDs
+ * (substring inspection only — the resolver never validates UUIDs itself;
+ * downstream Zod schemas at the capability handler layer enforce UUID format).
+ *
+ * If `execution?.projectId` is undefined, the placeholder is left unchanged
+ * (the downstream Zod parse will then throw a ValidationError that the
+ * RC-1 enriched recovery frame surfaces as `arguments_invalid`).
+ *
+ * Performance: O(1) on top-level keys. No allocation when no substitution.
+ */
+export function resolveDispatchParameterPlaceholders(
+  params: unknown,
+  execution?: GatewayExecutionContext,
+): unknown {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) return params;
+  if (!execution?.projectId) return params; // no resolution source — leave alone
+  const obj = params as Record<string, unknown>;
+  const candidates = ['projectId', 'project_id'] as const;
+  let mutated: Record<string, unknown> | null = null;
+  for (const key of candidates) {
+    const value = obj[key];
+    if (typeof value !== 'string') continue;
+    if (!PROJECT_ID_PLACEHOLDERS.has(value.toLowerCase())) continue;
+    if (!mutated) mutated = { ...obj };
+    mutated[key] = execution.projectId as unknown as string;
+  }
+  return mutated ?? params;
+}

--- a/self/cortex/core/src/gateway-runtime/workflow-prompt-fragment.ts
+++ b/self/cortex/core/src/gateway-runtime/workflow-prompt-fragment.ts
@@ -11,6 +11,8 @@ export const WORKFLOW_PROMPT_FRAGMENT = `## Workflow Operations
 You have access to workflow tools. Here is how to use them.
 
 ### Read-Only Tools (call these directly)
+**Important:** Call these tools by their exact registered name. Do not prefix or suffix the name (e.g., \`workflow_list\` is correct; \`workflow_manager.list_workflows\` is wrong).
+
 - **workflow_list**: List installed workflow definitions and active runs for the current project. Use when the user asks "what workflows do I have?", "show my workflows", or similar.
 - **workflow_inspect**: Get detailed information about a specific workflow definition. Use when the user asks about a particular workflow's structure or configuration.
 - **workflow_status**: Check the status of a running workflow. Use when the user asks "how is my workflow going?", "is it done?", or similar.

--- a/self/cortex/core/src/internal-mcp/catalog.ts
+++ b/self/cortex/core/src/internal-mcp/catalog.ts
@@ -506,7 +506,7 @@ export const INTERNAL_MCP_CATALOG: readonly InternalMcpCatalogEntry[] = [
       {
         type: 'object',
         properties: {
-          projectId: { type: 'string', description: 'ProjectId' },
+          projectId: { type: 'string', format: 'uuid', description: 'ProjectId (UUID)' },
           status: { type: 'array', description: 'WorkflowRunStatus[]', items: { type: 'string' } },
           definition: { type: 'string' },
           includeInstalledDefinitions: { type: 'boolean' },

--- a/self/cortex/core/src/internal-mcp/scoped-tool-surface.ts
+++ b/self/cortex/core/src/internal-mcp/scoped-tool-surface.ts
@@ -8,6 +8,11 @@ import {
   INTERNAL_MCP_CATALOG,
   listDynamicInternalMcpToolEntries,
 } from './catalog.js';
+import {
+  buildUnknownToolError,
+  formatZodMessage,
+  isZodLikeError,
+} from './tool-error-helpers.js';
 import type { InternalMcpScopedToolSurfaceOptions } from './types.js';
 
 export class ScopedMcpToolSurface implements IScopedMcpToolSurface {
@@ -52,34 +57,49 @@ export class ScopedMcpToolSurface implements IScopedMcpToolSurface {
     const entry = getInternalMcpCatalogEntry(name);
     const dynamicEntry = getDynamicInternalMcpToolEntry(name);
     if (!entry && !dynamicEntry) {
-      throw new NousError(
-        `Tool ${name} is not available for ${this.options.agentClass}`,
-        'TOOL_NOT_AVAILABLE',
-      );
+      throw buildUnknownToolError({
+        requestedName: name,
+        agentClass: this.options.agentClass,
+        available: this.computeAvailableToolNames(),
+      });
     }
 
     if (dynamicEntry) {
       if (!dynamicEntry.visibleTo.includes(this.options.agentClass)) {
-        throw new NousError(
-          `Tool ${name} is not available for ${this.options.agentClass}`,
-          'TOOL_NOT_AVAILABLE',
-        );
+        throw buildUnknownToolError({
+          requestedName: name,
+          agentClass: this.options.agentClass,
+          available: this.computeAvailableToolNames(),
+        });
       }
-      return dynamicEntry.execute(params, execution);
+      try {
+        return await dynamicEntry.execute(params, execution);
+      } catch (e) {
+        if (isZodLikeError(e)) {
+          throw new NousError(
+            `Tool ${name} arguments invalid: ${formatZodMessage(e)}`,
+            'INVALID_ARGUMENTS',
+            { tool_error_kind: 'arguments_invalid', requested_tool: name } as Record<string, unknown>,
+          );
+        }
+        throw e;
+      }
     }
 
     if (!entry) {
-      throw new NousError(
-        `Tool ${name} is not available for ${this.options.agentClass}`,
-        'TOOL_NOT_AVAILABLE',
-      );
+      throw buildUnknownToolError({
+        requestedName: name,
+        agentClass: this.options.agentClass,
+        available: this.computeAvailableToolNames(),
+      });
     }
 
     if (!this.allowed.has(entry.name)) {
-      throw new NousError(
-        `Tool ${name} is not available for ${this.options.agentClass}`,
-        'TOOL_NOT_AVAILABLE',
-      );
+      throw buildUnknownToolError({
+        requestedName: name,
+        agentClass: this.options.agentClass,
+        available: this.computeAvailableToolNames(),
+      });
     }
 
     if (entry.kind === 'lifecycle') {
@@ -92,7 +112,34 @@ export class ScopedMcpToolSurface implements IScopedMcpToolSurface {
     const handler = this.handlers[
       entry.name as keyof typeof this.handlers
     ];
-    return handler(params, execution);
+    try {
+      return await handler(params, execution);
+    } catch (e) {
+      if (isZodLikeError(e)) {
+        throw new NousError(
+          `Tool ${name} arguments invalid: ${formatZodMessage(e)}`,
+          'INVALID_ARGUMENTS',
+          { tool_error_kind: 'arguments_invalid', requested_tool: name } as Record<string, unknown>,
+        );
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Computes the canonical-name list authorized for the calling agent class:
+   * the union of catalog tools the agent class is authorized for and dynamic
+   * tools visible to the agent. Mirrors the union `listTools()` computes
+   * (catalog-allowed + dynamic-visible) so the recovery-frame message reflects
+   * exactly the set of tools the model was told it could use.
+   */
+  private computeAvailableToolNames(): readonly string[] {
+    const catalogNames = INTERNAL_MCP_CATALOG
+      .filter((entry) => this.allowed.has(entry.name))
+      .map((entry) => entry.name);
+    const dynamicNames = listDynamicInternalMcpToolEntries(this.options.agentClass)
+      .map((entry) => entry.definition.name);
+    return [...catalogNames, ...dynamicNames];
   }
 }
 

--- a/self/cortex/core/src/internal-mcp/tool-error-helpers.ts
+++ b/self/cortex/core/src/internal-mcp/tool-error-helpers.ts
@@ -1,0 +1,197 @@
+/**
+ * Tool error helpers — Enriched error contract for the Cortex agent gateway.
+ *
+ * Producer (this module): the `ScopedMcpToolSurface` calls
+ * `buildUnknownToolError` from each of its four "tool not available" throw
+ * sites. The resulting `NousError` carries a structured `ToolErrorPayload`
+ * on its `context` field.
+ *
+ * Consumer: the gateway's recovery-frame builder (`buildToolErrorFrame` in
+ * `agent-gateway.ts`) inspects `NousError.context` via `isToolErrorPayload`
+ * and, when a payload is present, surfaces `tool_error_kind` into the
+ * `tool_error` frame's metadata so the model can self-correct on the next
+ * turn.
+ *
+ * The same helper-set also exposes `isZodLikeError` and `formatZodMessage`
+ * so the surface can translate Zod validation failures into structured
+ * `arguments_invalid` errors at one boundary site.
+ */
+import { NousError } from '@nous/shared';
+
+/**
+ * Discriminator on the structured payload of an enriched tool-error NousError.
+ * Used by the gateway recovery-frame builder to branch on failure class and
+ * by future consumers (UI, witness) to render or log per-class.
+ */
+export type ToolErrorKind = 'unknown_tool' | 'arguments_invalid' | 'tool_runtime_error';
+
+/**
+ * Structured payload carried on `NousError.context` for enriched tool errors.
+ * Additive on the open `Record<string, unknown>` context shape — no breaking
+ * change to existing NousError consumers.
+ */
+export interface ToolErrorPayload {
+  tool_error_kind: ToolErrorKind;
+  requested_tool: string;
+  available_tools?: readonly string[];
+  suggestions?: readonly string[];
+}
+
+/**
+ * Builds an enriched unknown-tool NousError. The same helper is invoked by
+ * ALL FOUR throw sites in ScopedMcpToolSurface.executeTool (lines 54-58,
+ * 63-66, 71-75, 78-82) so the recovery-frame contract for "you asked for a
+ * tool you can't use" is identical regardless of WHY the tool was unavailable.
+ *
+ * `available` MUST be the canonical-name list authorized for the calling
+ * agent class (catalog tools the agent can see + dynamic tools visible to
+ * the agent). The caller (ScopedMcpToolSurface) computes this from its own
+ * authorization state — the helper does no membership lookup itself.
+ */
+export function buildUnknownToolError(args: {
+  requestedName: string;
+  agentClass: string;
+  available: readonly string[];
+}): NousError {
+  const suggestions = args.available
+    .filter((candidate) => isSimilarToolName(args.requestedName, candidate))
+    .slice(0, 3); // bound — at most 3 suggestions per error
+  const messageParts = [
+    `Tool ${args.requestedName} is not available for ${args.agentClass}.`,
+    `Available tools: ${args.available.join(', ')}.`,
+  ];
+  if (suggestions.length > 0) {
+    messageParts.push(`Did you mean: ${suggestions.join(', ')}?`);
+  }
+  const payload: ToolErrorPayload = {
+    tool_error_kind: 'unknown_tool',
+    requested_tool: args.requestedName,
+    available_tools: args.available,
+    suggestions: suggestions.length > 0 ? suggestions : undefined,
+  };
+  return new NousError(
+    messageParts.join(' '),
+    'TOOL_NOT_AVAILABLE',
+    payload as unknown as Record<string, unknown>,
+  );
+}
+
+/**
+ * Type guard for the ToolErrorPayload structure on a NousError context.
+ * Used by the gateway's handleStandardTool catch branch to decide whether
+ * to build a structured recovery frame or fall through to normalizeToolError.
+ */
+export function isToolErrorPayload(value: unknown): value is ToolErrorPayload {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.tool_error_kind === 'string' &&
+    typeof obj.requested_tool === 'string' &&
+    (obj.tool_error_kind === 'unknown_tool' ||
+      obj.tool_error_kind === 'arguments_invalid' ||
+      obj.tool_error_kind === 'tool_runtime_error')
+  );
+}
+
+/**
+ * Pure name-similarity heuristic. Returns true when `candidate` is plausibly
+ * the canonical name the model meant when it emitted `requested`.
+ *
+ * Rules (cheap, non-flaky, both case-insensitive):
+ *  1. Substring overlap of length >= 4 in EITHER direction
+ *     (e.g., requested='workflow_manager.list_workflows', candidate='workflow_list'
+ *     — 'workflow' is shared 8 chars; matches).
+ *  2. OR Levenshtein distance <= 4 between the lowercased names.
+ *
+ * Returns false on empty strings or identical strings (identical means we'd
+ * suggest the same thing the model emitted — useless).
+ */
+export function isSimilarToolName(requested: string, candidate: string): boolean {
+  if (!requested || !candidate) return false;
+  const a = requested.toLowerCase();
+  const b = candidate.toLowerCase();
+  if (a === b) return false;
+  // Rule 1: shared substring of length >= 4.
+  if (sharesSubstringOfLength(a, b, 4)) return true;
+  // Rule 2: Levenshtein distance <= 4.
+  return levenshteinDistance(a, b) <= 4;
+}
+
+function sharesSubstringOfLength(a: string, b: string, n: number): boolean {
+  if (a.length < n || b.length < n) return false;
+  for (let i = 0; i <= a.length - n; i += 1) {
+    const slice = a.substring(i, i + n);
+    if (b.includes(slice)) return true;
+  }
+  return false;
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  // Two-row dynamic programming. O(a.length * b.length) time, O(min) space.
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let curr: number[] = Array.from({ length: b.length + 1 }, () => 0);
+  for (let i = 1; i <= a.length; i += 1) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
+}
+
+/**
+ * Detect Zod-shaped errors (direct ZodError instances OR any object that
+ * carries an `.issues: unknown[]` field — covers wrapped/normalized variants
+ * downstream callers may produce).
+ *
+ * This is intentionally a structural check rather than `instanceof z.ZodError`
+ * because importing Zod here just for instanceof would create an unwanted
+ * runtime dependency on the validation library from the helper module.
+ */
+export function isZodLikeError(e: unknown): boolean {
+  if (!e || typeof e !== 'object') return false;
+  const obj = e as Record<string, unknown>;
+  // Zod v3: ZodError extends Error and has .issues: ZodIssue[]
+  if (Array.isArray(obj.issues)) return true;
+  // ZodError class name probe (in case .issues is omitted by some toJSON path)
+  if (obj.constructor && (obj.constructor as { name?: string }).name === 'ZodError') return true;
+  // Some downstream wrappers expose `.errors` instead of `.issues`
+  if (Array.isArray(obj.errors) && obj.name === 'ZodError') return true;
+  return false;
+}
+
+/**
+ * Format a Zod-shaped error into a single-line human-readable summary
+ * suitable for inclusion in the recovery-frame message body.
+ *
+ * Each issue is rendered as `<path>: <message>`. Paths default to `(root)`
+ * when empty. Multiple issues are joined with `; `. Output is bounded —
+ * truncates at 500 chars to protect against pathological deep schemas.
+ */
+export function formatZodMessage(e: unknown): string {
+  if (!e || typeof e !== 'object') return String(e);
+  const obj = e as { issues?: unknown[]; errors?: unknown[]; message?: string };
+  const issues = Array.isArray(obj.issues)
+    ? obj.issues
+    : Array.isArray(obj.errors)
+      ? obj.errors
+      : null;
+  if (!issues || issues.length === 0) {
+    return typeof obj.message === 'string' ? obj.message : String(e);
+  }
+  const summarized = issues
+    .map((issue) => {
+      if (!issue || typeof issue !== 'object') return String(issue);
+      const i = issue as { path?: unknown; message?: string };
+      const pathArr = Array.isArray(i.path) ? i.path : [];
+      const path = pathArr.length > 0 ? pathArr.join('.') : '(root)';
+      return `${path}: ${i.message ?? '(no message)'}`;
+    })
+    .join('; ');
+  return summarized.length > 500 ? `${summarized.slice(0, 497)}...` : summarized;
+}

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -231,6 +231,8 @@ import type {
   ResolvedWorkflowDefinitionSource,
 } from '../types/index.js';
 import type { NousEvent } from '../events/index.js';
+import type { IEventBus } from '../event-bus/interface.js';
+import type { TraceId } from '../types/ids.js';
 
 export interface IModelRouter {
   /** Route a model role to the appropriate provider (legacy) */
@@ -249,6 +251,33 @@ export interface IModelProvider {
 
   /** Invoke the model with streaming response */
   stream(request: ModelRequest): AsyncIterable<ModelStreamChunk>;
+
+  /**
+   * Optional: invoke the model and emit thinking chunks progressively via the
+   * provided event bus, while still returning the full structured ModelResponse
+   * (same shape invoke() returns, including any tool_calls on the message
+   * object). Providers that emit `thinking` chunks during their stream
+   * implement this; providers that don't (or that have no separate thinking
+   * channel) leave it undefined and callers fall back to invoke().
+   *
+   * Implementations MUST:
+   *  - publish each thinking delta to `eventBus.publish('chat:thinking-chunk',
+   *    { content, traceId })` as it arrives,
+   *  - return a ModelResponse whose `output` carries the SAME shape invoke()
+   *    would return for the same request (e.g., for Ollama: the full
+   *    `message` object including content, thinking, and tool_calls),
+   *  - NOT swallow or transform the response shape — the gateway's adapter
+   *    parseResponse runs against `output` unchanged.
+   *
+   * Failure semantics: on any error, throw — the gateway falls back to
+   * provider.invoke() with the same request (mirroring the existing
+   * invokeWithStreaming catch path at agent-gateway.ts:576-579).
+   */
+  invokeWithThinkingStream?(
+    request: ModelRequest,
+    eventBus: IEventBus,
+    traceId: TraceId,
+  ): Promise<ModelResponse>;
 
   /** Get provider configuration */
   getConfig(): ModelProviderConfig;

--- a/self/subcortex/providers/src/__tests__/lane-aware-provider-thinking-stream.test.ts
+++ b/self/subcortex/providers/src/__tests__/lane-aware-provider-thinking-stream.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  IEventBus,
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+} from '@nous/shared';
+import { LaneAwareProvider } from '../lane-aware-provider.js';
+import { InferenceLane } from '../inference-lane.js';
+
+const PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as never;
+const TRACE_ID = '00000000-0000-0000-0000-000000000099' as never;
+
+function makeBaseInner(extra?: Partial<IModelProvider>): IModelProvider {
+  return {
+    getConfig: () =>
+      ({
+        id: PROVIDER_ID,
+        name: 'test-provider',
+        type: 'ollama',
+        modelId: 'm',
+        isLocal: true,
+        capabilities: ['text'],
+      }) as unknown as ModelProviderConfig,
+    invoke: vi.fn().mockResolvedValue({
+      output: 'invoke result',
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    } satisfies ModelResponse),
+    stream: vi.fn(),
+    ...extra,
+  } as IModelProvider;
+}
+
+function makeBus(): IEventBus {
+  return {
+    publish: vi.fn(),
+    subscribe: vi.fn().mockReturnValue('s'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function makeRequest(): ModelRequest {
+  return {
+    role: 'cortex-chat',
+    input: { messages: [{ role: 'user', content: 'hi' }] },
+    traceId: TRACE_ID,
+    agentClass: 'Cortex::Principal',
+  } as ModelRequest;
+}
+
+describe('LaneAwareProvider — invokeWithThinkingStream pass-through', () => {
+  it('typeof positive: when inner exposes invokeWithThinkingStream, wrapper exposes it as a function', () => {
+    const inner = makeBaseInner({
+      invokeWithThinkingStream: vi.fn().mockResolvedValue({
+        output: { content: 'x' },
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId: TRACE_ID,
+      } satisfies ModelResponse),
+    });
+    const wrapper = new LaneAwareProvider(inner, new InferenceLane('lane:test'));
+    expect(typeof wrapper.invokeWithThinkingStream).toBe('function');
+  });
+
+  it('typeof negative: when inner lacks the method, wrapper returns undefined', () => {
+    const inner = makeBaseInner();
+    const wrapper = new LaneAwareProvider(inner, new InferenceLane('lane:test'));
+    expect(wrapper.invokeWithThinkingStream).toBeUndefined();
+    expect(typeof wrapper.invokeWithThinkingStream).toBe('undefined');
+  });
+
+  it('delegates the call through the inference lane (lane.enqueue is exercised)', async () => {
+    const itsImpl = vi.fn().mockResolvedValue({
+      output: { content: 'z' },
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    } satisfies ModelResponse);
+    const inner = makeBaseInner({ invokeWithThinkingStream: itsImpl });
+    const lane = new InferenceLane('lane:test');
+    const enqueueSpy = vi.spyOn(lane, 'enqueue');
+    const wrapper = new LaneAwareProvider(inner, lane);
+    const bus = makeBus();
+
+    await wrapper.invokeWithThinkingStream!(makeRequest(), bus, TRACE_ID);
+    expect(enqueueSpy).toHaveBeenCalled();
+    expect(itsImpl).toHaveBeenCalled();
+  });
+
+  it('behavior parity: response from inner is returned to caller unchanged', async () => {
+    const expected: ModelResponse = {
+      output: { content: 'parity', thinking: 'reason' },
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 9, outputTokens: 8 },
+      traceId: TRACE_ID,
+    };
+    const inner = makeBaseInner({ invokeWithThinkingStream: vi.fn().mockResolvedValue(expected) });
+    const wrapper = new LaneAwareProvider(inner, new InferenceLane('lane:test'));
+    const bus = makeBus();
+
+    const response = await wrapper.invokeWithThinkingStream!(makeRequest(), bus, TRACE_ID);
+    expect(response).toEqual(expected);
+  });
+});

--- a/self/subcortex/providers/src/__tests__/observable-provider-thinking-stream.test.ts
+++ b/self/subcortex/providers/src/__tests__/observable-provider-thinking-stream.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  IEventBus,
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+} from '@nous/shared';
+import { ObservableProvider } from '../observable-provider.js';
+
+const PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as never;
+const TRACE_ID = '00000000-0000-0000-0000-000000000099' as never;
+
+function makeMeta() {
+  return { providerId: PROVIDER_ID, modelId: 'm', laneKey: 'lane-1' };
+}
+
+function makeBaseInner(extra?: Partial<IModelProvider>): IModelProvider {
+  return {
+    getConfig: () =>
+      ({
+        id: PROVIDER_ID,
+        name: 'test-provider',
+        type: 'ollama',
+        modelId: 'm',
+        isLocal: true,
+        capabilities: ['text'],
+      }) as unknown as ModelProviderConfig,
+    invoke: vi.fn().mockResolvedValue({
+      output: 'invoke result',
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 1, outputTokens: 1 },
+      traceId: TRACE_ID,
+    } satisfies ModelResponse),
+    stream: vi.fn(),
+    ...extra,
+  } as IModelProvider;
+}
+
+function makeBus(): IEventBus {
+  return {
+    publish: vi.fn(),
+    subscribe: vi.fn().mockReturnValue('s'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function makeRequest(overrides?: Partial<ModelRequest>): ModelRequest {
+  return {
+    role: 'cortex-chat',
+    input: { messages: [{ role: 'user', content: 'hi' }] },
+    traceId: TRACE_ID,
+    projectId: '00000000-0000-0000-0000-000000000010' as never,
+    agentClass: 'Cortex::Principal',
+    ...overrides,
+  } as ModelRequest;
+}
+
+describe('ObservableProvider — invokeWithThinkingStream pass-through', () => {
+  it('typeof positive: when inner exposes invokeWithThinkingStream, wrapper exposes it', () => {
+    const inner = makeBaseInner({
+      invokeWithThinkingStream: vi.fn().mockResolvedValue({
+        output: { content: 'x' },
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId: TRACE_ID,
+      } satisfies ModelResponse),
+    });
+    const wrapper = new ObservableProvider(inner, makeBus(), makeMeta());
+    expect(typeof wrapper.invokeWithThinkingStream).toBe('function');
+  });
+
+  it('typeof negative: when inner lacks the method, wrapper returns undefined', () => {
+    const inner = makeBaseInner();
+    const wrapper = new ObservableProvider(inner, makeBus(), makeMeta());
+    expect(wrapper.invokeWithThinkingStream).toBeUndefined();
+  });
+
+  it('emits inference:call-complete on success (mirrors invoke() emission)', async () => {
+    const inner = makeBaseInner({
+      invokeWithThinkingStream: vi.fn().mockResolvedValue({
+        output: { content: 'ok', thinking: 'r' },
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 4, outputTokens: 7 },
+        traceId: TRACE_ID,
+      } satisfies ModelResponse),
+    });
+    const observabilityBus = makeBus();
+    const wrapper = new ObservableProvider(inner, observabilityBus, makeMeta());
+    const downstreamBus = makeBus(); // separate bus passed into invokeWithThinkingStream
+
+    await wrapper.invokeWithThinkingStream!(makeRequest(), downstreamBus, TRACE_ID);
+
+    expect(observabilityBus.publish).toHaveBeenCalledWith(
+      'inference:call-complete',
+      expect.objectContaining({
+        providerId: PROVIDER_ID,
+        modelId: 'm',
+        agentClass: 'Cortex::Principal',
+        traceId: TRACE_ID,
+        laneKey: 'lane-1',
+        inputTokens: 4,
+        outputTokens: 7,
+        latencyMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it('error from inner propagates to caller; observability bus does NOT emit call-complete', async () => {
+    const inner = makeBaseInner({
+      invokeWithThinkingStream: vi.fn().mockRejectedValue(new Error('inner failed')),
+    });
+    const observabilityBus = makeBus();
+    const wrapper = new ObservableProvider(inner, observabilityBus, makeMeta());
+
+    await expect(
+      wrapper.invokeWithThinkingStream!(makeRequest(), makeBus(), TRACE_ID),
+    ).rejects.toThrow('inner failed');
+
+    // call-complete is only emitted on success.
+    const publishedCallComplete = (observabilityBus.publish as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call) => call[0] === 'inference:call-complete',
+    );
+    expect(publishedCallComplete).toHaveLength(0);
+  });
+});

--- a/self/subcortex/providers/src/__tests__/ollama-provider-thinking-stream.test.ts
+++ b/self/subcortex/providers/src/__tests__/ollama-provider-thinking-stream.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IEventBus, ProviderId } from '@nous/shared';
+import { OllamaProvider } from '../ollama-provider.js';
+
+const MOCK_CONFIG = {
+  id: '00000000-0000-0000-0000-000000000001' as ProviderId,
+  name: 'Ollama',
+  type: 'text' as const,
+  modelId: 'gemma3:4b',
+  isLocal: true,
+  capabilities: ['text'],
+};
+
+const TRACE_ID = '00000000-0000-0000-0000-000000000099' as never;
+
+function recordingBus(): IEventBus & { recorded: Array<{ channel: string; payload: unknown; ts: number }> } {
+  const recorded: Array<{ channel: string; payload: unknown; ts: number }> = [];
+  const bus = {
+    publish: vi.fn().mockImplementation((channel: string, payload: unknown) => {
+      recorded.push({ channel, payload, ts: Date.now() });
+    }),
+    subscribe: vi.fn().mockReturnValue('sub'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+    recorded,
+  };
+  return bus as unknown as IEventBus & { recorded: typeof recorded };
+}
+
+function makeStreamResponse(lines: string[]): Response {
+  const body = new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(new TextEncoder().encode(`${line}\n`));
+      }
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+describe('OllamaProvider.invokeWithThinkingStream', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('returns a ModelResponse whose output preserves content + thinking + tool_calls', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    const bus = recordingBus();
+    vi.mocked(fetch).mockResolvedValue(
+      makeStreamResponse([
+        JSON.stringify({
+          message: { role: 'assistant', content: 'visible', thinking: 'reasoning' },
+          done: false,
+        }),
+        JSON.stringify({
+          message: {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              { function: { name: 'workflow_list', arguments: { projectId: 'p1' } } },
+            ],
+          },
+          done: true,
+          eval_count: 5,
+          prompt_eval_count: 7,
+        }),
+      ]),
+    );
+
+    const response = await provider.invokeWithThinkingStream(
+      {
+        role: 'cortex-chat',
+        input: { messages: [{ role: 'user', content: 'hi' }] },
+        traceId: TRACE_ID,
+      },
+      bus,
+      TRACE_ID,
+    );
+
+    const msg = response.output as {
+      role?: string;
+      content?: string;
+      thinking?: string;
+      tool_calls?: Array<{ function: { name: string; arguments: Record<string, unknown> } }>;
+    };
+    expect(msg.role).toBe('assistant');
+    expect(msg.content).toBe('visible');
+    expect(msg.thinking).toBe('reasoning');
+    expect(msg.tool_calls?.[0].function.name).toBe('workflow_list');
+    expect(response.usage?.outputTokens).toBe(5);
+    expect(response.usage?.inputTokens).toBe(7);
+  });
+
+  it('publishes chat:thinking-chunk events with { content, traceId } payload as thinking arrives', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    const bus = recordingBus();
+    vi.mocked(fetch).mockResolvedValue(
+      makeStreamResponse([
+        JSON.stringify({ message: { content: '', thinking: 'first' }, done: false }),
+        JSON.stringify({ message: { content: '', thinking: 'second' }, done: false }),
+        JSON.stringify({ message: { content: '' }, done: true, eval_count: 1, prompt_eval_count: 1 }),
+      ]),
+    );
+
+    await provider.invokeWithThinkingStream(
+      {
+        role: 'cortex-chat',
+        input: { messages: [{ role: 'user', content: 'hi' }] },
+        traceId: TRACE_ID,
+      },
+      bus,
+      TRACE_ID,
+    );
+
+    const recorded = (bus as unknown as { recorded: Array<{ channel: string; payload: unknown }> }).recorded;
+    const thinkingEvents = recorded.filter((r) => r.channel === 'chat:thinking-chunk');
+    expect(thinkingEvents).toHaveLength(2);
+    for (const evt of thinkingEvents) {
+      const payload = evt.payload as { content: string; traceId: string };
+      expect(typeof payload.content).toBe('string');
+      expect(payload.traceId).toBe(TRACE_ID);
+    }
+  });
+
+  it('throws on fetch failure (does NOT swallow — gateway handles fallback)', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    const bus = recordingBus();
+    vi.mocked(fetch).mockRejectedValue(new TypeError('network error'));
+
+    await expect(
+      provider.invokeWithThinkingStream(
+        {
+          role: 'cortex-chat',
+          input: { messages: [{ role: 'user', content: 'hi' }] },
+          traceId: TRACE_ID,
+        },
+        bus,
+        TRACE_ID,
+      ),
+    ).rejects.toBeDefined();
+  });
+
+  it('content-only stream emits ZERO chat:thinking-chunk events (no spurious empties)', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    const bus = recordingBus();
+    vi.mocked(fetch).mockResolvedValue(
+      makeStreamResponse([
+        JSON.stringify({ message: { content: 'hello' }, done: false }),
+        JSON.stringify({ message: { content: ' world' }, done: false }),
+        JSON.stringify({ message: { content: '' }, done: true, eval_count: 1, prompt_eval_count: 1 }),
+      ]),
+    );
+
+    const response = await provider.invokeWithThinkingStream(
+      {
+        role: 'cortex-chat',
+        input: { messages: [{ role: 'user', content: 'hi' }] },
+        traceId: TRACE_ID,
+      },
+      bus,
+      TRACE_ID,
+    );
+
+    const recorded = (bus as unknown as { recorded: Array<{ channel: string }> }).recorded;
+    expect(recorded.filter((r) => r.channel === 'chat:thinking-chunk')).toHaveLength(0);
+    const msg = response.output as { content?: string; thinking?: string };
+    expect(msg.content).toBe('hello world');
+    expect(msg.thinking).toBeUndefined();
+  });
+
+  it('<think> tag SPLIT across SSE lines emits per-delta thinking events (not batched at completion)', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    const bus = recordingBus();
+    vi.mocked(fetch).mockResolvedValue(
+      makeStreamResponse([
+        JSON.stringify({ message: { content: '<think>foo' }, done: false }),
+        JSON.stringify({ message: { content: 'bar</think>baz' }, done: false }),
+        JSON.stringify({ message: { content: '' }, done: true, eval_count: 1, prompt_eval_count: 1 }),
+      ]),
+    );
+
+    await provider.invokeWithThinkingStream(
+      {
+        role: 'cortex-chat',
+        input: { messages: [{ role: 'user', content: 'hi' }] },
+        traceId: TRACE_ID,
+      },
+      bus,
+      TRACE_ID,
+    );
+
+    const recorded = (bus as unknown as { recorded: Array<{ channel: string; payload: { content: string } }> }).recorded;
+    const thinkingEvents = recorded.filter((r) => r.channel === 'chat:thinking-chunk');
+    // Two non-empty thinking deltas: 'foo' (chunk 1) and 'bar' (chunk 2)
+    expect(thinkingEvents.length).toBeGreaterThanOrEqual(2);
+    const concatenated = thinkingEvents.map((e) => e.payload.content).join('');
+    expect(concatenated).toBe('foobar');
+  });
+});

--- a/self/subcortex/providers/src/__tests__/ollama-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/ollama-provider.test.ts
@@ -112,4 +112,139 @@ describe('OllamaProvider', () => {
       }),
     ).rejects.toMatchObject({ code: 'ABORTED' });
   });
+
+  // ── SP 1.13 RC-2 chunk-shape and <think> tracker regressions ────────────
+  describe('stream() — SP 1.13 RC-2 chunk shape and <think> tag tracker', () => {
+    function makeStreamResponse(lines: string[]): Response {
+      const body = new ReadableStream({
+        start(controller) {
+          for (const line of lines) {
+            controller.enqueue(new TextEncoder().encode(`${line}\n`));
+          }
+          controller.close();
+        },
+      });
+      return { ok: true, status: 200, body } as unknown as Response;
+    }
+
+    async function collect(provider: OllamaProvider, input: { messages: Array<{ role: string; content: string }> }) {
+      const chunks: Array<{ content: string; thinking?: string; done: boolean }> = [];
+      for await (const chunk of provider.stream({
+        role: 'cortex-chat',
+        input,
+        traceId: '00000000-0000-0000-0000-000000000099' as any,
+      })) {
+        chunks.push({ content: chunk.content, thinking: chunk.thinking, done: chunk.done });
+      }
+      return chunks;
+    }
+
+    it('case 1: native data.message.thinking populates chunk.thinking', async () => {
+      const provider = new OllamaProvider(MOCK_CONFIG);
+      vi.mocked(fetch).mockResolvedValue(
+        makeStreamResponse([
+          JSON.stringify({ message: { content: 'visible text', thinking: 'reasoning text' }, done: false }),
+          JSON.stringify({ message: { content: '' }, done: true, eval_count: 1, prompt_eval_count: 2 }),
+        ]),
+      );
+
+      const chunks = await collect(provider, { messages: [{ role: 'user', content: 'hi' }] });
+      expect(chunks[0].content).toBe('visible text');
+      expect(chunks[0].thinking).toBe('reasoning text');
+    });
+
+    it('case 2: <think>foo</think>bar in single chunk → thinking=foo, content=bar', async () => {
+      const provider = new OllamaProvider(MOCK_CONFIG);
+      vi.mocked(fetch).mockResolvedValue(
+        makeStreamResponse([
+          JSON.stringify({ message: { content: '<think>foo</think>bar' }, done: false }),
+          JSON.stringify({ message: { content: '' }, done: true }),
+        ]),
+      );
+
+      const chunks = await collect(provider, { messages: [{ role: 'user', content: 'hi' }] });
+      expect(chunks[0].thinking).toBe('foo');
+      expect(chunks[0].content).toBe('bar');
+    });
+
+    it('case 3: <think> tag SPLIT across chunks correctly extracts thinking', async () => {
+      const provider = new OllamaProvider(MOCK_CONFIG);
+      vi.mocked(fetch).mockResolvedValue(
+        makeStreamResponse([
+          JSON.stringify({ message: { content: '<think>foo' }, done: false }),
+          JSON.stringify({ message: { content: 'bar</think>baz' }, done: false }),
+          JSON.stringify({ message: { content: '' }, done: true }),
+        ]),
+      );
+
+      const chunks = await collect(provider, { messages: [{ role: 'user', content: 'hi' }] });
+      // chunk N: enters <think>, captures 'foo' as thinking
+      expect(chunks[0].thinking).toBe('foo');
+      expect(chunks[0].content).toBe('');
+      // chunk N+1: 'bar' before </think>, then 'baz' after
+      expect(chunks[1].thinking).toBe('bar');
+      expect(chunks[1].content).toBe('baz');
+    });
+
+    it('case 4: partial <thi tag prefix at end of chunk N is buffered, no false content emission', async () => {
+      const provider = new OllamaProvider(MOCK_CONFIG);
+      vi.mocked(fetch).mockResolvedValue(
+        makeStreamResponse([
+          JSON.stringify({ message: { content: '<thi' }, done: false }),
+          JSON.stringify({ message: { content: 'nk>foo</think>bar' }, done: false }),
+          JSON.stringify({ message: { content: '' }, done: true }),
+        ]),
+      );
+
+      const chunks = await collect(provider, { messages: [{ role: 'user', content: 'hi' }] });
+      // chunk N: '<thi' is partial-tag prefix → buffered, no content emitted
+      expect(chunks[0].content).toBe('');
+      expect(chunks[0].thinking).toBeUndefined();
+      // chunk N+1: tracker resolves the tag, captures 'foo' as thinking, 'bar' as content
+      expect(chunks[1].thinking).toBe('foo');
+      expect(chunks[1].content).toBe('bar');
+    });
+
+    it('case 5: two back-to-back stream() calls do NOT share <think> tracker state', async () => {
+      const provider = new OllamaProvider(MOCK_CONFIG);
+
+      // First call: ends mid-<think> block (no closing tag → tracker leaves state insideThink=true at end)
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeStreamResponse([
+          JSON.stringify({ message: { content: '<think>incomplete' }, done: false }),
+          JSON.stringify({ message: { content: '' }, done: true }),
+        ]),
+      );
+      await collect(provider, { messages: [{ role: 'user', content: 'first' }] });
+
+      // Second call: plain text, NO tags. If state leaked, the tracker would route
+      // 'plain text' into thinking. With per-stream-call state (Invariant I-4),
+      // 'plain text' goes to content as expected.
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeStreamResponse([
+          JSON.stringify({ message: { content: 'plain text' }, done: false }),
+          JSON.stringify({ message: { content: '' }, done: true }),
+        ]),
+      );
+      const secondChunks = await collect(provider, { messages: [{ role: 'user', content: 'second' }] });
+      expect(secondChunks[0].content).toBe('plain text');
+      expect(secondChunks[0].thinking).toBeUndefined();
+    });
+
+    it('case 6: data.done with non-empty pendingPrefix flushes partial as literal to current stream', async () => {
+      const provider = new OllamaProvider(MOCK_CONFIG);
+      vi.mocked(fetch).mockResolvedValue(
+        makeStreamResponse([
+          // Pending prefix '<thi' at end of stream — flushed as literal to content
+          // (insideThink is still false because we never crossed the open tag).
+          JSON.stringify({ message: { content: 'hello<thi' }, done: true, eval_count: 1, prompt_eval_count: 2 }),
+        ]),
+      );
+
+      const chunks = await collect(provider, { messages: [{ role: 'user', content: 'hi' }] });
+      // 'hello' is content; '<thi' partial flushed to content because insideThink=false at done.
+      expect(chunks[0].content).toBe('hello<thi');
+      expect(chunks[0].thinking).toBeUndefined();
+    });
+  });
 });

--- a/self/subcortex/providers/src/lane-aware-provider.ts
+++ b/self/subcortex/providers/src/lane-aware-provider.ts
@@ -1,9 +1,11 @@
 import type {
+  IEventBus,
   IModelProvider,
   ModelProviderConfig,
   ModelRequest,
   ModelResponse,
   ModelStreamChunk,
+  TraceId,
 } from '@nous/shared';
 import { InferenceLane } from './inference-lane.js';
 
@@ -23,5 +25,26 @@ export class LaneAwareProvider implements IModelProvider {
 
   stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
     return this.lane.stream(request, (laneRequest) => this.inner.stream(laneRequest));
+  }
+
+  /**
+   * Optional `invokeWithThinkingStream` pass-through. Exposed via a getter so
+   * `typeof wrapped.invokeWithThinkingStream === 'function'` returns `true`
+   * ONLY when the inner provider implements the method. This preserves the
+   * gateway's capability-check semantics across the wrapper stack
+   * (SDS Invariant I-9).
+   *
+   * The delegated call runs through the inference lane just like `invoke()`
+   * so concurrency/lease semantics apply identically — the new method shares
+   * the same back-pressure/lease envelope as `invoke()`.
+   */
+  get invokeWithThinkingStream():
+    | ((request: ModelRequest, eventBus: IEventBus, traceId: TraceId) => Promise<ModelResponse>)
+    | undefined {
+    if (typeof this.inner.invokeWithThinkingStream !== 'function') return undefined;
+    return (request, eventBus, traceId) =>
+      this.lane.enqueue(request, (laneRequest) =>
+        this.inner.invokeWithThinkingStream!(laneRequest, eventBus, traceId),
+      );
   }
 }

--- a/self/subcortex/providers/src/observable-provider.ts
+++ b/self/subcortex/providers/src/observable-provider.ts
@@ -15,6 +15,7 @@ import type {
   ModelRequest,
   ModelResponse,
   ModelStreamChunk,
+  TraceId,
 } from '@nous/shared';
 
 export interface ObservableProviderMeta {
@@ -58,6 +59,47 @@ export class ObservableProvider implements IModelProvider {
     } catch { /* fire-and-forget */ }
 
     return response;
+  }
+
+  /**
+   * Optional `invokeWithThinkingStream` pass-through. Exposed via a getter so
+   * `typeof wrapped.invokeWithThinkingStream === 'function'` returns `true`
+   * ONLY when the inner provider implements the method (SDS Invariant I-9).
+   *
+   * On success the wrapper emits `inference:call-complete` mirroring the
+   * `invoke()` emission path, so existing latency/usage observability keeps
+   * working for the new dispatch path.
+   */
+  get invokeWithThinkingStream():
+    | ((request: ModelRequest, eventBus: IEventBus, traceId: TraceId) => Promise<ModelResponse>)
+    | undefined {
+    if (typeof this.inner.invokeWithThinkingStream !== 'function') return undefined;
+    const inner = this.inner;
+    const observabilityBus = this.eventBus;
+    const meta = this.meta;
+    return async (request, eventBus, traceId) => {
+      const start = Date.now();
+      const response = await inner.invokeWithThinkingStream!(request, eventBus, traceId);
+      const latencyMs = Date.now() - start;
+      try {
+        observabilityBus.publish('inference:call-complete', {
+          providerId: meta.providerId,
+          modelId: meta.modelId,
+          agentClass: request.agentClass,
+          traceId: request.traceId,
+          projectId: request.projectId,
+          laneKey: meta.laneKey,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          latencyMs,
+          routingDecision: undefined,
+          emittedAt: new Date().toISOString(),
+          correlationRunId: request.correlationRunId,
+          correlationParentId: request.correlationParentId,
+        });
+      } catch { /* fire-and-forget */ }
+      return response;
+    };
   }
 
   stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {

--- a/self/subcortex/providers/src/ollama-provider.ts
+++ b/self/subcortex/providers/src/ollama-provider.ts
@@ -6,11 +6,13 @@
  */
 import { NousError, ValidationError } from '@nous/shared';
 import type {
+  IEventBus,
   IModelProvider,
   ModelProviderConfig,
   ModelRequest,
   ModelResponse,
   ModelStreamChunk,
+  TraceId,
 } from '@nous/shared';
 import { TextModelInputSchema } from './schemas.js';
 
@@ -104,6 +106,11 @@ export class OllamaProvider implements IModelProvider {
     let buffer = '';
     let usage: ModelStreamChunk['usage'];
 
+    // Per-stream-call <think> tag tracker. Allocated fresh inside the
+    // generator body so each stream invocation gets independent state
+    // (SDS Invariant I-4 — no cross-call state leakage).
+    const thinkState: ThinkTagState = { insideThink: false, pendingPrefix: '' };
+
     try {
       while (true) {
         const { done, value } = await reader.read();
@@ -116,7 +123,16 @@ export class OllamaProvider implements IModelProvider {
         for (const line of lines) {
           if (!line.trim()) continue;
           const data = JSON.parse(line) as OllamaStreamChunk;
-          const content = data.response ?? data.message?.content ?? '';
+          const rawContent = data.response ?? data.message?.content ?? '';
+          const nativeThinking = data.message?.thinking ?? data.thinking ?? '';
+
+          // Apply <think> tag tracker. State carries across iterations so
+          // tags split across SSE lines are correctly extracted.
+          const { contentOut, thinkingOut } = applyThinkTagTracker(
+            rawContent,
+            thinkState,
+            data.done ?? false,
+          );
 
           if (data.done && data.eval_count != null) {
             usage = {
@@ -125,8 +141,10 @@ export class OllamaProvider implements IModelProvider {
             };
           }
 
+          const mergedThinking = (nativeThinking + thinkingOut) || undefined;
           yield {
-            content,
+            content: contentOut,
+            thinking: mergedThinking,
             done: data.done ?? false,
             usage: data.done ? usage : undefined,
           };
@@ -135,6 +153,156 @@ export class OllamaProvider implements IModelProvider {
     } finally {
       reader.releaseLock();
     }
+  }
+
+  /**
+   * Optional `invokeWithThinkingStream` — drives the same `/api/chat` streaming
+   * code path the existing `stream()` uses, but accumulates the response into
+   * the same shape `invoke()` returns (the full `OllamaChatResponse.message`
+   * object including `content`, `thinking`, and `tool_calls`). For each
+   * thinking delta encountered, publishes `chat:thinking-chunk` to the event
+   * bus immediately so the UI can render thinking progressively while the
+   * gateway still receives the full structured `ModelResponse` for tool-call
+   * extraction.
+   *
+   * Failure semantics: any thrown error (network, abort, malformed SSE,
+   * schema validation) propagates so the gateway's
+   * `invokeWithThinkingStreamFallback` catch path executes
+   * `provider.invoke(request)` as the fallback.
+   */
+  async invokeWithThinkingStream(
+    request: ModelRequest,
+    eventBus: IEventBus,
+    traceId: TraceId,
+  ): Promise<ModelResponse> {
+    const input = this.validateInput(request.input);
+    const start = Date.now();
+    const body = this.buildRequestBody(input);
+    const url = this.getUrl(body);
+
+    const response = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: request.abortSignal,
+      body: JSON.stringify({ ...body, stream: true }),
+    });
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new NousError('No response body', 'PROVIDER_UNAVAILABLE');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let accumulatedContent = '';
+    let accumulatedThinking = '';
+    let accumulatedToolCalls: OllamaToolCall[] | undefined;
+    let accumulatedRole: string | undefined;
+    let usage: ModelResponse['usage'] = { inputTokens: undefined, outputTokens: undefined };
+    let chunkCount = 0;
+    let hadToolCalls = false;
+    let doneReason: string | undefined;
+
+    // Per-call <think> tracker (SDS Invariant I-4 — fresh state).
+    const thinkState: ThinkTagState = { insideThink: false, pendingPrefix: '' };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          chunkCount += 1;
+          const data = JSON.parse(line) as OllamaStreamChunk;
+          const rawContent = data.response ?? data.message?.content ?? '';
+          const nativeThinking = data.message?.thinking ?? data.thinking ?? '';
+
+          // Capture tool_calls / role / done_reason as the SSE stream
+          // surfaces them. Tool calls usually arrive on the final chunk
+          // for tool-bearing turns.
+          if (data.message?.tool_calls && data.message.tool_calls.length > 0) {
+            accumulatedToolCalls = data.message.tool_calls;
+            hadToolCalls = true;
+          }
+          if (data.message?.role && !accumulatedRole) {
+            accumulatedRole = data.message.role;
+          }
+          if (data.done_reason) doneReason = data.done_reason;
+
+          // Apply <think> tag tracker.
+          const { contentOut, thinkingOut } = applyThinkTagTracker(
+            rawContent,
+            thinkState,
+            data.done ?? false,
+          );
+
+          accumulatedContent += contentOut;
+          const thinkingDelta = nativeThinking + thinkingOut;
+          if (thinkingDelta.length > 0) {
+            accumulatedThinking += thinkingDelta;
+            // Publish each thinking delta progressively so the UI can render
+            // it during the turn. Same channel and payload shape the
+            // existing invokeWithStreaming path uses (agent-gateway.ts:545).
+            try {
+              eventBus.publish('chat:thinking-chunk', {
+                content: thinkingDelta,
+                traceId,
+              });
+            } catch { /* fire-and-forget */ }
+          }
+
+          if (data.done) {
+            if (data.eval_count != null) {
+              usage = {
+                inputTokens: data.prompt_eval_count,
+                outputTokens: data.eval_count,
+                computeMs: Date.now() - start,
+              };
+            } else {
+              usage = { ...usage, computeMs: Date.now() - start };
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Build a message object that matches OllamaChatResponse.message shape so
+    // the gateway's adapter parseResponse path consumes it identically to
+    // today's invoke() output.
+    const messageObj: Record<string, unknown> = {};
+    if (accumulatedRole) messageObj.role = accumulatedRole;
+    messageObj.content = accumulatedContent;
+    if (accumulatedThinking) messageObj.thinking = accumulatedThinking;
+    if (accumulatedToolCalls && accumulatedToolCalls.length > 0) {
+      messageObj.tool_calls = accumulatedToolCalls;
+    }
+
+    console.debug('[nous:ollama-provider] invokeWithThinkingStream complete', {
+      url,
+      accumulatedContentLength: accumulatedContent.length,
+      accumulatedThinkingLength: accumulatedThinking.length,
+      chunkCount,
+      hadToolCalls,
+      doneReason,
+    });
+
+    return {
+      output: messageObj,
+      providerId: this.config.id,
+      usage,
+      traceId: request.traceId,
+    };
   }
 
   private validateInput(input: unknown): {
@@ -288,8 +456,109 @@ interface OllamaChatResponse {
 
 interface OllamaStreamChunk {
   response?: string;
-  message?: { content?: string };
+  message?: {
+    content?: string;
+    /** Thinking/reasoning content from models that support it (e.g. Gemma 4 native) */
+    thinking?: string;
+    /** Tool calls — present on the final chunk for tool-bearing turns */
+    tool_calls?: OllamaToolCall[];
+    role?: string;
+  };
+  /** Defensive top-level thinking fallback for models that emit it outside `message` */
+  thinking?: string;
   done?: boolean;
+  done_reason?: string;
   eval_count?: number;
   prompt_eval_count?: number;
+}
+
+/** Per-`<think>`-tag-tracker state. Allocated fresh per stream invocation. */
+interface ThinkTagState {
+  insideThink: boolean;
+  pendingPrefix: string;
+}
+
+/** Output of one tracker step. */
+interface ThinkTagStepResult {
+  contentOut: string;
+  thinkingOut: string;
+}
+
+/**
+ * Compute the length of the longest suffix of `text` that is a prefix of
+ * `tag`. Used to buffer partial tag matches at the end of a chunk so the
+ * next chunk can resolve them. Bounded by `tag.length - 1` to avoid
+ * matching the full tag (which would have already been handled by indexOf).
+ */
+function longestSuffixThatIsPrefix(text: string, tag: string): number {
+  const max = Math.min(text.length, tag.length - 1);
+  for (let len = max; len > 0; len -= 1) {
+    if (text.endsWith(tag.substring(0, len))) return len;
+  }
+  return 0;
+}
+
+/**
+ * Apply the `<think>...</think>` tag tracker to one incoming raw-content
+ * delta. Mutates `state` in place to carry across calls within a single
+ * stream invocation. Returns the per-call split into content vs thinking.
+ *
+ * State invariants:
+ *  - `insideThink` flips between `<think>` open and `</think>` close events.
+ *  - `pendingPrefix` buffers a partial tag prefix at the end of a chunk
+ *    (e.g., `<thi`) so the next chunk can resolve it.
+ *
+ * On end-of-stream (caller signals via `done=true`), any non-empty
+ * `pendingPrefix` is flushed as literal text to whichever stream the
+ * current `insideThink` indicates — partial tags at end-of-stream are not
+ * magically completed.
+ */
+function applyThinkTagTracker(
+  rawContent: string,
+  state: ThinkTagState,
+  done: boolean,
+): ThinkTagStepResult {
+  let text = state.pendingPrefix + rawContent;
+  state.pendingPrefix = '';
+  let contentOut = '';
+  let thinkingOut = '';
+
+  while (text.length > 0) {
+    if (state.insideThink) {
+      const closeIdx = text.indexOf('</think>');
+      if (closeIdx >= 0) {
+        thinkingOut += text.substring(0, closeIdx);
+        text = text.substring(closeIdx + 8); // 8 = '</think>'.length
+        state.insideThink = false;
+      } else {
+        const partialLen = longestSuffixThatIsPrefix(text, '</think>');
+        thinkingOut += text.substring(0, text.length - partialLen);
+        state.pendingPrefix = text.substring(text.length - partialLen);
+        text = '';
+      }
+    } else {
+      const openIdx = text.indexOf('<think>');
+      if (openIdx >= 0) {
+        contentOut += text.substring(0, openIdx);
+        text = text.substring(openIdx + 7); // 7 = '<think>'.length
+        state.insideThink = true;
+      } else {
+        const partialLen = longestSuffixThatIsPrefix(text, '<think>');
+        contentOut += text.substring(0, text.length - partialLen);
+        state.pendingPrefix = text.substring(text.length - partialLen);
+        text = '';
+      }
+    }
+  }
+
+  // On stream done with non-empty pendingPrefix: flush as literal to whichever
+  // stream the current insideThink state indicates (partial tags at end-of-stream
+  // are not magically completed).
+  if (done && state.pendingPrefix.length > 0) {
+    if (state.insideThink) thinkingOut += state.pendingPrefix;
+    else contentOut += state.pendingPrefix;
+    state.pendingPrefix = '';
+  }
+
+  return { contentOut, thinkingOut };
 }


### PR DESCRIPTION
## Summary

WR-159 chat-experience-quality, Phase 1 sub-phase 1.13 — BT Round 5 fix cycle 5. Two production surfaces:

- **RC-1 — Multi-turn tool-error recovery contract enrichment.** When an Ollama model hallucinates a tool name (e.g. `workflow_manager.list_workflows`) or supplies invalid arguments, the recovery frame now distinguishes failure classes (`unknown_tool` / `arguments_invalid` / `tool_runtime_error`), enumerates the agent class's authorized tool catalog, and offers a nearest-name suggestion. All four `Tool ${name} is not available...` throw sites in `scoped-tool-surface.ts` flow through one shared `buildUnknownToolError`; all three gateway throw-handling sites flow through one shared `buildToolErrorFrame`.
- **RC-2 — Decoupled thinking-streaming for tool-bearing turns.** Cycle 1 SP 1.9 RC-2 collaterally disabled thinking-streaming for every Principal turn (always 8 authorized tools). Cycle 5 splits the `canStream` gate into `canStreamContent` (retains `tools.length === 0` clause — protects the no-`toolCalls`-on-`ModelStreamChunk` invariant) and `canStreamThinking` (drops the clause — thinking does not interfere with `tool_calls` extraction). New optional `IModelProvider.invokeWithThinkingStream(request, eventBus, traceId)` returns the same `ModelResponse` shape as `invoke()` while emitting `chat:thinking-chunk` events progressively. `OllamaProvider` implements it; `LaneAwareProvider` and `ObservableProvider` expose getter pass-throughs (production-critical — without these the new code path never fires; SDS Invariant I-9).
- **Project-id placeholder defense-in-depth (RC-1 sub-fix).** Two layers: (1) wire-side hint to model — `format: 'uuid'` on `workflow_list.projectId` JSON-Schema; (2) runtime gateway resolver substitutes active `execution.projectId` for the literal placeholder strings `current` / `this` / `<project>` (case-insensitive, top-level keys only) before dispatch reaches `executeTool`.

WR-171 — `@nous/web` build env-block — explicitly deferred per CR § Out of Scope.

## Commits

8 commits per Plan recommendation (per-tier grouping; agent-gateway.ts coherent multi-tier change combines Tiers 1+2+3 in a single commit since they touch the same file):

1. `8f2ef28` — Tier 0 schema additions (catalog.ts + subcortex.ts)
2. `394a937` — Tier 1 RC-1 enriched tool-error contract (helpers + scoped-tool-surface 4-throw consolidation)
3. `b864991` — Tier 2 RC-1 placeholder resolver (helper file)
4. `c9ac13f` — Tiers 1+2+3 agent-gateway dispatch (catch-site frame builder + placeholder wire-up + canStream split + invokeWithThinkingStreamFallback)
5. `40b06dd` — Tier 4 RC-2 wrapper pass-throughs (LaneAwareProvider + ObservableProvider; SDS Invariant I-9 in commit body)
6. `07e6408` — Tier 5 RC-2 OllamaProvider.invokeWithThinkingStream + `<think>` tracker
7. `f18321d` — Tier 6 RC-1 anti-namespacing prompt anchor
8. `8530b51` — Tier 7 tests (59 new tests across 7 new + 2 extended files)

## Artifacts

- Completion Report: `.worklog/sprints/feat/chat-experience-quality/phase-1/phase-1.13/completion-report.md` (commit `a8ef4ce`)
- Completion Report Review (Approved): `.worklog/sprints/feat/chat-experience-quality/phase-1/phase-1.13/reviews/completion-report.mdx` (commit `905aaa9`)

## Test plan

- [ ] BT R6 — RC-1: hallucinated tool name recovery (model self-corrects from `Available tools: ...` + `Did you mean: workflow_list?`)
- [ ] BT R6 — RC-1 sub-fix: `project_id:"current"` resolves to active UUID before `executeTool`
- [ ] BT R6 — RC-2: thinking visible progressively in chat panel during tool-bearing turns (per-chunk `chat:thinking-chunk` events)

WR-159 SP 1.13 BT R5 fix cycle 5.