### PR TITLE
Phase 1.1 — Schema Extensions + Governed Write Path Consolidation

### DIFF
--- a/docs/content/docs/api/procedures.mdx
+++ b/docs/content/docs/api/procedures.mdx
@@ -12,13 +12,14 @@ description: Reference for all tRPC procedures
 | `projects.list` | query | — | `ProjectConfig[]` |
 | `projects.create` | mutation | `{ name, type? }` | `ProjectConfig` |
 | `projects.get` | query | `{ id: ProjectId }` | `ProjectConfig \| null` |
-| `projects.update` | mutation | `{ id, updates: { name?, pfcTier?, modelAssignments? } }` | — |
 | `projects.workflowSnapshot` | query | `{ projectId, runId? }` | `ProjectWorkflowSurfaceSnapshot` |
 | `projects.workflowVisualDebugSnapshot` | query | `{ projectId, runId? }` | `WorkflowVisualDebugSnapshot` |
 | `projects.workflowNodeInspect` | query | `{ projectId, runId?, nodeDefinitionId }` | `WorkflowNodeInspectProjection` |
 | `projects.dashboardSnapshot` | query | `{ projectId }` | `ProjectDashboardSnapshot` |
 | `projects.configurationSnapshot` | query | `{ projectId }` | `ProjectConfigurationSnapshot` |
 | `projects.updateConfiguration` | mutation | `ProjectConfigurationUpdateInput` | `ProjectConfigurationSnapshot` |
+| `projects.archive` | mutation | `{ projectId: ProjectId }` | `ProjectConfig` |
+| `projects.unarchive` | mutation | `{ projectId: ProjectId }` | `ProjectConfig` |
 | `projects.upsertSchedule` | mutation | `ScheduleUpsertInput` | `ScheduleDefinition` |
 | `projects.validateWorkflowDefinition` | mutation | `{ projectId, workflowDefinition }` | `WorkflowDefinitionValidationResult` |
 | `projects.saveWorkflowDefinition` | mutation | `{ projectId, workflowDefinition, setAsDefault? }` | `{ project, validation }` |
@@ -33,6 +34,9 @@ description: Reference for all tRPC procedures
 - `projects.configurationSnapshot` — Returns the current project configuration, schedule records, blocked actions, and field provenance.
 - `projects.updateConfiguration` — Applies governed project-configuration changes.
   - Rejects stale writes with `CONFLICT` when `expectedUpdatedAt` no longer matches the stored project.
+  - Accepts `updates` and `resetFields` as siblings; the handler applies `updates` first, drops every field named in `resetFields` from the stored overrides, then re-emits `buildConfigurationSnapshot`. Envelopes where a field appears in both `updates` and `resetFields` are rejected at the tRPC boundary as ambiguous intent.
+- `projects.archive` — Archives a project (flips `status` to `archived`). Opctl-gated through `archive_project`; blocked under `hard_stopped` and `resuming` control states. Returns the updated `ProjectConfig`.
+- `projects.unarchive` — Restores an archived project (flips `status` to `active`). Not opctl-gated in V1 (archived projects have no runtime activity to gate). Returns the updated `ProjectConfig`.
 - `projects.upsertSchedule` — Creates or updates a schedule bound to canonical workflow and workmode truth.
   - Returns `BAD_REQUEST` when the project has no canonical workflow definition and the caller does not supply `workflowDefinitionId`.
 - `projects.validateWorkflowDefinition` — Validates a workflow draft on the server without persisting it.

--- a/scripts/benchmark/src/families/memory-quality/retrieval.test.ts
+++ b/scripts/benchmark/src/families/memory-quality/retrieval.test.ts
@@ -60,6 +60,7 @@ function createProjectStore(config: ProjectConfig): IProjectStore {
     list: async () => [],
     update: async () => {},
     archive: async () => {},
+    unarchive: async () => {},
   };
 }
 

--- a/self/apps/shared-server/__tests__/tasks-router.test.ts
+++ b/self/apps/shared-server/__tests__/tasks-router.test.ts
@@ -80,6 +80,7 @@ function createMockContext(tasks: Record<string, unknown>[] = []) {
       create: vi.fn(),
       list: vi.fn(),
       archive: vi.fn(),
+      unarchive: vi.fn(),
     },
     taskStore: {
       save: vi.fn().mockImplementation(async (_projectId: string, task: Record<string, unknown>) => {

--- a/self/apps/shared-server/src/trpc/routers/projects.ts
+++ b/self/apps/shared-server/src/trpc/routers/projects.ts
@@ -51,16 +51,12 @@ import { router, publicProcedure } from '../trpc';
 
 const TRACE_COLLECTION = 'execution_traces';
 
-const projectUpdateInputSchema = z.object({
-  id: ProjectIdSchema,
-  updates: z
-    .object({
-      name: z.string().min(1).optional(),
-      pfcTier: z.number().min(0).max(5).optional(),
-      modelAssignments: z.record(z.string(), z.string()).optional(),
-    })
-    .partial(),
-});
+// Hardcoded defaults mirrored from the `create` handler below — used by
+// `buildFieldProvenance` to distinguish `project_override` from `system_default`
+// for fields that live directly on the stored document (no layered overrides
+// representation). See SDS §Data Model user-override detection heuristic.
+const SYSTEM_DEFAULT_PFC_TIER = 3;
+const SYSTEM_DEFAULT_RETRIEVAL_BUDGET_TOKENS = 500;
 
 function getProjectIdentity(project: ProjectConfig) {
   return {
@@ -748,6 +744,13 @@ function deriveBlockedActions(
           message: 'The project is already hard stopped.',
           evidenceRefs: ['project-control:hard_stopped'],
         },
+        {
+          action: 'archive_project',
+          allowed: false,
+          reasonCode: 'control_state_hard_stopped',
+          message: 'Archive is blocked while the project is hard stopped.',
+          evidenceRefs: ['project-control:hard_stopped'],
+        },
       ];
     case 'paused_review':
       return [
@@ -788,6 +791,12 @@ function deriveBlockedActions(
           action: 'hard_stop_project',
           allowed: true,
           message: 'Hard stop remains available while paused for review.',
+          evidenceRefs: ['project-control:paused_review'],
+        },
+        {
+          action: 'archive_project',
+          allowed: true,
+          message: 'Archive is allowed while the project is paused for review.',
           evidenceRefs: ['project-control:paused_review'],
         },
       ];
@@ -833,6 +842,13 @@ function deriveBlockedActions(
           message: 'Hard stop remains available while the project is resuming.',
           evidenceRefs: ['project-control:resuming'],
         },
+        {
+          action: 'archive_project',
+          allowed: false,
+          reasonCode: 'control_state_resuming',
+          message: 'Archive is blocked while resume work is in progress.',
+          evidenceRefs: ['project-control:resuming'],
+        },
       ];
     case 'running':
     default:
@@ -874,6 +890,12 @@ function deriveBlockedActions(
           message: 'Hard stop remains available while the project is running.',
           evidenceRefs: ['project-control:running'],
         },
+        {
+          action: 'archive_project',
+          allowed: true,
+          message: 'Archive is allowed while the project is running.',
+          evidenceRefs: ['project-control:running'],
+        },
       ];
   }
 }
@@ -896,64 +918,162 @@ function buildFieldProvenance(
     (entry) => `package-default:${entry.sourcePackageId}:${entry.sourcePackageVersion}`,
   );
 
-  const fieldSource = (section?: ProjectPackageDefaultSection) =>
-    section && packageSections.has(section) ? 'package_default' : 'project_override';
+  // Package-vs-system classifier for fields with a package-default pairing.
+  // A field is `package_default` if its canonical section has been applied
+  // via `packageDefaultIntake`, else `system_default` (the hardcoded defaults
+  // baked into the `create` handler / schema `.default(...)` clauses).
+  const packageOrSystem = (
+    section: ProjectPackageDefaultSection,
+  ): 'package_default' | 'system_default' =>
+    packageSections.has(section) ? 'package_default' : 'system_default';
+  const sectionEvidence = (fallback: string): string[] =>
+    packageEvidence.length > 0 ? packageEvidence : [fallback];
 
-  return [
+  const provenance: ProjectConfigFieldProvenance[] = [
     {
       field: 'type',
-      source: fieldSource('project_type'),
-      evidenceRefs: packageEvidence.length > 0 ? packageEvidence : ['project-config:type'],
+      source: packageOrSystem('project_type'),
+      evidenceRefs: sectionEvidence('project-config:type'),
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'pfcTier',
-      source: 'project_override',
+      // V1 user-override heuristic: value != hardcoded default -> user
+      // override. `pfcTier: 3` emits `system_default` (decision §5 new-fields
+      // subsection is explicit on this). See Known Issues in CR.
+      source:
+        project.pfcTier === SYSTEM_DEFAULT_PFC_TIER
+          ? 'system_default'
+          : 'project_override',
       evidenceRefs: ['project-config:pfcTier'],
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'governanceDefaults',
-      source: fieldSource('governance_defaults'),
-      evidenceRefs:
-        packageEvidence.length > 0 ? packageEvidence : ['project-config:governanceDefaults'],
+      source: packageOrSystem('governance_defaults'),
+      evidenceRefs: sectionEvidence('project-config:governanceDefaults'),
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'modelAssignments',
-      source: fieldSource('model_assignments'),
-      evidenceRefs:
-        packageEvidence.length > 0 ? packageEvidence : ['project-config:modelAssignments'],
+      source: packageOrSystem('model_assignments'),
+      evidenceRefs: sectionEvidence('project-config:modelAssignments'),
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'memoryAccessPolicy',
-      source: fieldSource('memory_access_policy'),
-      evidenceRefs:
-        packageEvidence.length > 0 ? packageEvidence : ['project-config:memoryAccessPolicy'],
+      source: packageOrSystem('memory_access_policy'),
+      evidenceRefs: sectionEvidence('project-config:memoryAccessPolicy'),
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'retrievalBudgetTokens',
-      source: 'project_override',
+      source:
+        project.retrievalBudgetTokens === SYSTEM_DEFAULT_RETRIEVAL_BUDGET_TOKENS
+          ? 'system_default'
+          : 'project_override',
       evidenceRefs: ['project-config:retrievalBudgetTokens'],
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'escalationPreferences',
-      source: fieldSource('escalation_preferences'),
-      evidenceRefs:
-        packageEvidence.length > 0 ? packageEvidence : ['project-config:escalationPreferences'],
+      source: packageOrSystem('escalation_preferences'),
+      evidenceRefs: sectionEvidence('project-config:escalationPreferences'),
+      lockedByPolicy: lockedConfig,
+    },
+    {
+      field: 'escalationChannels',
+      // `escalationChannels` has no package-default section pairing and no
+      // single hardcoded default (defaults come from `ctx.config.defaults`
+      // at create time). V1 posture: always emit `system_default` here;
+      // downstream UX (1.4) decides how to present "user set" semantics.
+      source: 'system_default',
+      evidenceRefs: ['project-config:escalationChannels'],
+      lockedByPolicy: lockedConfig,
+    },
+    {
+      field: 'budgetPolicy',
+      // Non-null stored budgetPolicy => user override; null/undefined =>
+      // system_default meaning "no budget enforced" (null value semantics).
+      source: project.budgetPolicy ? 'project_override' : 'system_default',
+      evidenceRefs: ['project-config:budgetPolicy'],
+      lockedByPolicy: lockedConfig,
+    },
+    {
+      field: 'name',
+      // `name` is required on `ProjectConfig` — always present. Emit
+      // `project_override` when set; never unset on a valid config.
+      source: 'project_override',
+      evidenceRefs: ['project-config:name'],
       lockedByPolicy: lockedConfig,
     },
     {
       field: 'schedules',
-      source: fieldSource('schedule_settings'),
-      evidenceRefs:
-        packageEvidence.length > 0 ? packageEvidence : ['project-schedules'],
+      source: packageSections.has('schedule_settings')
+        ? 'package_default'
+        : 'derived_read_only',
+      evidenceRefs: packageSections.has('schedule_settings')
+        ? packageEvidence
+        : ['project-schedules'],
       lockedByPolicy: lockedSchedule,
     },
+    {
+      field: 'packageDefaultIntake',
+      source: 'derived_read_only',
+      evidenceRefs: ['package-default-intake'],
+      lockedByPolicy: false,
+    },
+    {
+      field: 'createdAt',
+      source: 'derived_read_only',
+      evidenceRefs: ['project-config:createdAt'],
+      lockedByPolicy: false,
+    },
+    {
+      field: 'updatedAt',
+      source: 'derived_read_only',
+      evidenceRefs: ['project-config:updatedAt'],
+      lockedByPolicy: false,
+    },
   ];
+
+  // Optional identity fields — description, icon, iconColor — follow the
+  // ratified decision §5 new-fields mapping. `description`/`icon` are
+  // omitted from provenance when unset. `iconColor` unset emits
+  // `derived_read_only` with evidence note `avatarColorFromId`.
+  if (project.description !== undefined) {
+    provenance.push({
+      field: 'description',
+      source: 'project_override',
+      evidenceRefs: ['project-config:description'],
+      lockedByPolicy: lockedConfig,
+    });
+  }
+  if (project.icon !== undefined) {
+    provenance.push({
+      field: 'icon',
+      source: 'project_override',
+      evidenceRefs: ['project-config:icon'],
+      lockedByPolicy: lockedConfig,
+    });
+  }
+  provenance.push(
+    project.iconColor !== undefined
+      ? {
+          field: 'iconColor',
+          source: 'project_override',
+          evidenceRefs: ['project-config:iconColor'],
+          lockedByPolicy: lockedConfig,
+        }
+      : {
+          field: 'iconColor',
+          source: 'derived_read_only',
+          evidenceRefs: ['derived:avatarColorFromId'],
+          lockedByPolicy: lockedConfig,
+        },
+  );
+
+  return provenance;
 }
 
 function deriveHealthSummary(
@@ -1183,12 +1303,6 @@ export const projectsRouter = router({
       return ctx.projectStore.get(input.id);
     }),
 
-  update: publicProcedure
-    .input(projectUpdateInputSchema)
-    .mutation(async ({ ctx, input }) => {
-      await ctx.projectStore.update(input.id, input.updates);
-    }),
-
   workflowSnapshot: publicProcedure
     .input(
       z.object({
@@ -1258,9 +1372,57 @@ export const projectsRouter = router({
       const blockedActions = deriveBlockedActions(controlState);
       ensureActionAllowed(blockedActions, 'edit_project_configuration');
 
-      await ctx.projectStore.update(input.projectId, input.updates);
+      // Transactional order per settings-update-schema-extension-v1 §3:
+      //   1) apply `updates` against the stored overrides
+      //   2) drop every field named in `resetFields` (pass `undefined` so the
+      //      document-store merge + subsequent ProjectDocumentSchema.parse
+      //      strip the key for optional fields)
+      //   3) buildConfigurationSnapshot runs against the re-fetched project
+      //      and re-emits provenance
+      const persistPayload: Record<string, unknown> = { ...input.updates };
+      if (input.resetFields) {
+        for (const field of input.resetFields) {
+          persistPayload[field] = undefined;
+        }
+      }
+
+      await ctx.projectStore.update(
+        input.projectId,
+        persistPayload as Partial<ProjectConfig>,
+      );
       const updated = await getProjectOrThrow(ctx, input.projectId);
       return buildConfigurationSnapshot(ctx, updated);
+    }),
+
+  archive: publicProcedure
+    .input(z.object({ projectId: ProjectIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      await getProjectOrThrow(ctx, input.projectId);
+      const controlState = await getProjectControlState(ctx, input.projectId);
+      const blockedActions = deriveBlockedActions(controlState);
+      ensureActionAllowed(blockedActions, 'archive_project');
+      await ctx.projectStore.archive(input.projectId);
+      const archived = await ctx.projectStore.get(input.projectId);
+      if (!archived) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'archive_read_back_failed',
+        });
+      }
+      return archived;
+    }),
+
+  unarchive: publicProcedure
+    .input(z.object({ projectId: ProjectIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      // NOTE: `ctx.projectStore.list()` excludes archived projects but
+      // `ctx.projectStore.get()` still returns them, so `getProjectOrThrow`
+      // (which uses `get`) correctly maps truly missing projects to
+      // NOT_FOUND while still resolving archived projects for unarchive.
+      await getProjectOrThrow(ctx, input.projectId);
+      await ctx.projectStore.unarchive(input.projectId);
+      const unarchived = await getProjectOrThrow(ctx, input.projectId);
+      return unarchived;
     }),
 
   upsertSchedule: publicProcedure

--- a/self/apps/web/server/__tests__/projects-router.test.ts
+++ b/self/apps/web/server/__tests__/projects-router.test.ts
@@ -805,4 +805,330 @@ connections: []
     expect(result.project.workflow?.definitions).toHaveLength(1);
     expect(result.project.workflow?.definitions[0]?.version).toBe('2.0.0');
   });
+
+  // ---------------------------------------------------------------------------
+  // Sub-phase 1.1 — Schema Extensions + Governed Write Path Consolidation
+  // ---------------------------------------------------------------------------
+
+  describe('updateConfiguration — extended updates envelope', () => {
+    it('accepts each new updates field (round-trip)', async () => {
+      const ctx = createNousContext();
+      // Defensive: prior tests (e.g. line ~342 hard_stopped) mutate the shared
+      // cached ctx and never restore — force running posture for this test.
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      const updated = await caller.projects.updateConfiguration({
+        projectId,
+        updates: {
+          name: 'Renamed Project',
+          description: 'A new description for this project',
+          icon: 'lucide:Rocket',
+          iconColor: '#112233',
+          budgetPolicy: {
+            enabled: true,
+            period: 'monthly',
+            softThresholdPercent: 80,
+            hardCeilingUsd: 50,
+          },
+        },
+      });
+
+      expect(updated.config.name).toBe('Renamed Project');
+      expect(updated.config.description).toBe('A new description for this project');
+      expect(updated.config.icon).toBe('lucide:Rocket');
+      expect(updated.config.iconColor).toBe('#112233');
+      expect(updated.config.budgetPolicy?.enabled).toBe(true);
+      expect(updated.config.budgetPolicy?.hardCeilingUsd).toBe(50);
+    });
+
+    it('applies transactional order updates -> resetFields -> snapshot', async () => {
+      const ctx = createNousContext();
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      // First seed a description so we can observe reset semantics.
+      await caller.projects.updateConfiguration({
+        projectId,
+        updates: { description: 'to-be-cleared', name: 'Seed Name' },
+      });
+
+      const updated = await caller.projects.updateConfiguration({
+        projectId,
+        updates: { name: 'New Name' },
+        resetFields: ['description'],
+      });
+
+      expect(updated.config.name).toBe('New Name');
+      expect(updated.config.description).toBeUndefined();
+      // description should be omitted from provenance when unset per decision §5
+      expect(updated.fieldProvenance.some((p) => p.field === 'description')).toBe(false);
+    });
+
+    it('accepts pure-reset envelope (empty updates + non-empty resetFields)', async () => {
+      const ctx = createNousContext();
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      // Seed a description first.
+      await caller.projects.updateConfiguration({
+        projectId,
+        updates: { description: 'seeded' },
+      });
+
+      const updated = await caller.projects.updateConfiguration({
+        projectId,
+        updates: {},
+        resetFields: ['description'],
+      });
+
+      expect(updated.config.description).toBeUndefined();
+    });
+
+    it('rejects updates ∩ resetFields overlap at the tRPC boundary', async () => {
+      const ctx = createNousContext();
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      await expect(
+        caller.projects.updateConfiguration({
+          projectId,
+          updates: { name: 'AmbiguousName' },
+          resetFields: ['name'],
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('preserves CONFLICT semantics when expectedUpdatedAt mismatches', async () => {
+      const ctx = createNousContext();
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      await expect(
+        caller.projects.updateConfiguration({
+          projectId,
+          expectedUpdatedAt: '1999-01-01T00:00:00.000Z',
+          updates: { name: 'RaceyName' },
+        }),
+      ).rejects.toMatchObject({ code: 'CONFLICT' } satisfies Partial<TRPCError>);
+    });
+  });
+
+  describe('projects.update removal (atomic landing with updateConfiguration extension)', () => {
+    it('projects.update is absent from the router (calling raises NOT_FOUND)', async () => {
+      const ctx = createNousContext();
+      const caller = appRouter.createCaller(ctx);
+      // The tRPC client proxy yields a callable for any path; the router
+      // resolution happens on invocation. Calling `projects.update(...)`
+      // must raise NOT_FOUND now that the procedure is deleted.
+      await expect(
+        // @ts-expect-error projects.update was removed in sub-phase 1.1
+        caller.projects.update({ id: 'x', updates: {} }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' } satisfies Partial<TRPCError>);
+    });
+  });
+
+  describe('projects.archive and projects.unarchive', () => {
+    it('archive happy path returns the updated project metadata', async () => {
+      const ctx = createNousContext();
+      const originalGetState = ctx.opctlService.getProjectControlState;
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      try {
+        const caller = appRouter.createCaller(ctx);
+        const projectId = await createProjectWithWorkflow(ctx);
+
+        const archived = await caller.projects.archive({ projectId });
+        expect(archived.id).toBe(projectId);
+      } finally {
+        ctx.opctlService.getProjectControlState = originalGetState;
+      }
+    });
+
+    it('archive under hard_stopped throws FORBIDDEN', async () => {
+      const ctx = createNousContext();
+      const originalGetState = ctx.opctlService.getProjectControlState;
+      ctx.opctlService.getProjectControlState = async () => 'hard_stopped';
+      try {
+        const caller = appRouter.createCaller(ctx);
+        const projectId = await createProjectWithWorkflow(ctx);
+
+        await expect(
+          caller.projects.archive({ projectId }),
+        ).rejects.toMatchObject({ code: 'FORBIDDEN' } satisfies Partial<TRPCError>);
+      } finally {
+        ctx.opctlService.getProjectControlState = originalGetState;
+      }
+    });
+
+    it('archive under resuming throws FORBIDDEN (in-use posture)', async () => {
+      const ctx = createNousContext();
+      const originalGetState = ctx.opctlService.getProjectControlState;
+      ctx.opctlService.getProjectControlState = async () => 'resuming';
+      try {
+        const caller = appRouter.createCaller(ctx);
+        const projectId = await createProjectWithWorkflow(ctx);
+
+        await expect(
+          caller.projects.archive({ projectId }),
+        ).rejects.toMatchObject({ code: 'FORBIDDEN' } satisfies Partial<TRPCError>);
+      } finally {
+        ctx.opctlService.getProjectControlState = originalGetState;
+      }
+    });
+
+    it('archive under paused_review succeeds', async () => {
+      const ctx = createNousContext();
+      const originalGetState = ctx.opctlService.getProjectControlState;
+      ctx.opctlService.getProjectControlState = async () => 'paused_review';
+      try {
+        const caller = appRouter.createCaller(ctx);
+        const projectId = await createProjectWithWorkflow(ctx);
+
+        const archived = await caller.projects.archive({ projectId });
+        expect(archived.id).toBe(projectId);
+      } finally {
+        ctx.opctlService.getProjectControlState = originalGetState;
+      }
+    });
+
+    it('unarchive happy path returns the updated project metadata', async () => {
+      const ctx = createNousContext();
+      const originalGetState = ctx.opctlService.getProjectControlState;
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      try {
+        const caller = appRouter.createCaller(ctx);
+        const projectId = await createProjectWithWorkflow(ctx);
+
+        await caller.projects.archive({ projectId });
+        const unarchived = await caller.projects.unarchive({ projectId });
+        expect(unarchived.id).toBe(projectId);
+
+        // After unarchive, list() should include the project again.
+        const list = await caller.projects.list();
+        expect(list.some((p) => p.id === projectId)).toBe(true);
+      } finally {
+        ctx.opctlService.getProjectControlState = originalGetState;
+      }
+    });
+  });
+
+  describe('buildFieldProvenance — per-source-type mapping (decision §5)', () => {
+    it('emits pfcTier: 3 as system_default (regression)', async () => {
+      const ctx = createNousContext();
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      const snapshot = await caller.projects.configurationSnapshot({ projectId });
+      const pfcTier = snapshot.fieldProvenance.find((p) => p.field === 'pfcTier');
+      expect(pfcTier?.source).toBe('system_default');
+    });
+
+    it('emits iconColor unset as derived_read_only with avatarColorFromId evidence', async () => {
+      const ctx = createNousContext();
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      const snapshot = await caller.projects.configurationSnapshot({ projectId });
+      const iconColor = snapshot.fieldProvenance.find((p) => p.field === 'iconColor');
+      expect(iconColor?.source).toBe('derived_read_only');
+      expect(iconColor?.evidenceRefs).toContain('derived:avatarColorFromId');
+    });
+
+    it('emits iconColor set as project_override', async () => {
+      const ctx = createNousContext();
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      await caller.projects.updateConfiguration({
+        projectId,
+        updates: { iconColor: '#aabbcc' },
+      });
+
+      const snapshot = await caller.projects.configurationSnapshot({ projectId });
+      const iconColor = snapshot.fieldProvenance.find((p) => p.field === 'iconColor');
+      expect(iconColor?.source).toBe('project_override');
+      expect(iconColor?.evidenceRefs).toContain('project-config:iconColor');
+    });
+
+    it('emits retrievalBudgetTokens != 500 as project_override', async () => {
+      const ctx = createNousContext();
+      ctx.opctlService.getProjectControlState = async () => 'running';
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      await caller.projects.updateConfiguration({
+        projectId,
+        updates: { retrievalBudgetTokens: 750 },
+      });
+
+      const snapshot = await caller.projects.configurationSnapshot({ projectId });
+      const budget = snapshot.fieldProvenance.find(
+        (p) => p.field === 'retrievalBudgetTokens',
+      );
+      expect(budget?.source).toBe('project_override');
+    });
+
+    it('emits package_default for sections applied via packageDefaultIntake', async () => {
+      const ctx = createNousContext();
+      const projectId = randomUUID() as ProjectId;
+      await ctx.projectStore.create(createProjectConfig({
+        id: projectId,
+        name: 'Package-Sourced Project',
+        packageDefaultIntake: [
+          {
+            sourcePackageId: 'package://projects/dashboard',
+            sourcePackageVersion: '1.0.0',
+            sourceManifestRef: 'manifest://dashboard',
+            appliedSections: ['project_type', 'governance_defaults'],
+            appliedAt: new Date().toISOString(),
+          },
+        ],
+      }));
+      const caller = appRouter.createCaller(ctx);
+
+      const snapshot = await caller.projects.configurationSnapshot({ projectId });
+      const type = snapshot.fieldProvenance.find((p) => p.field === 'type');
+      const governance = snapshot.fieldProvenance.find(
+        (p) => p.field === 'governanceDefaults',
+      );
+
+      expect(type?.source).toBe('package_default');
+      expect(governance?.source).toBe('package_default');
+    });
+
+    it('emits derived_read_only for updatedAt/createdAt/packageDefaultIntake metadata fields', async () => {
+      const ctx = createNousContext();
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      const snapshot = await caller.projects.configurationSnapshot({ projectId });
+      for (const field of ['updatedAt', 'createdAt', 'packageDefaultIntake']) {
+        const entry = snapshot.fieldProvenance.find((p) => p.field === field);
+        expect(entry?.source).toBe('derived_read_only');
+        expect(entry?.lockedByPolicy).toBe(false);
+      }
+    });
+
+    it('preserves lockedByPolicy for config-gated fields under hard_stopped', async () => {
+      const ctx = createNousContext();
+      const caller = appRouter.createCaller(ctx);
+      const projectId = await createProjectWithWorkflow(ctx);
+
+      const originalGetState = ctx.opctlService.getProjectControlState;
+      ctx.opctlService.getProjectControlState = async () => 'hard_stopped';
+      try {
+        const snapshot = await caller.projects.configurationSnapshot({ projectId });
+        const name = snapshot.fieldProvenance.find((p) => p.field === 'name');
+        expect(name?.lockedByPolicy).toBe(true);
+      } finally {
+        ctx.opctlService.getProjectControlState = originalGetState;
+      }
+    });
+  });
 });

--- a/self/apps/web/test-support/project-fixtures.ts
+++ b/self/apps/web/test-support/project-fixtures.ts
@@ -29,6 +29,10 @@ export function createProjectConfig(
     workflow: overrides.workflow,
     packageDefaultIntake: overrides.packageDefaultIntake,
     retrievalBudgetTokens: overrides.retrievalBudgetTokens ?? 500,
+    budgetPolicy: overrides.budgetPolicy,
+    description: overrides.description,
+    icon: overrides.icon,
+    iconColor: overrides.iconColor,
     createdAt: overrides.createdAt ?? now,
     updatedAt: overrides.updatedAt ?? now,
   });

--- a/self/cortex/core/src/__tests__/ingress/dispatch-admission.test.ts
+++ b/self/cortex/core/src/__tests__/ingress/dispatch-admission.test.ts
@@ -67,6 +67,7 @@ function createProjectStore(): IProjectStore {
     list: async () => [projectConfig],
     update: async () => undefined,
     archive: async () => undefined,
+    unarchive: async () => undefined,
   };
 }
 

--- a/self/cortex/core/src/__tests__/ingress/ingress-pipeline-integration.test.ts
+++ b/self/cortex/core/src/__tests__/ingress/ingress-pipeline-integration.test.ts
@@ -71,6 +71,7 @@ function createProjectStore(): IProjectStore {
     list: async () => [projectConfig],
     update: async () => undefined,
     archive: async () => undefined,
+    unarchive: async () => undefined,
   };
 }
 

--- a/self/cortex/core/src/__tests__/ingress/phase-5.3-ingress-adversarial.test.ts
+++ b/self/cortex/core/src/__tests__/ingress/phase-5.3-ingress-adversarial.test.ts
@@ -71,6 +71,7 @@ function createProjectStore(): IProjectStore {
     list: async () => [projectConfig],
     update: async () => undefined,
     archive: async () => undefined,
+    unarchive: async () => undefined,
   };
 }
 

--- a/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
+++ b/self/cortex/core/src/__tests__/internal-mcp/capability-handlers.test.ts
@@ -864,6 +864,7 @@ describe('Internal MCP capability handlers', () => {
       create: vi.fn(),
       update: vi.fn(),
       archive: vi.fn(),
+      unarchive: vi.fn(),
     };
     const handlers = createCapabilityHandlers({
       agentClass: 'Cortex::System',
@@ -929,6 +930,7 @@ describe('Internal MCP capability handlers', () => {
       create: vi.fn(),
       update: vi.fn(),
       archive: vi.fn(),
+      unarchive: vi.fn(),
     };
     const handlers = createCapabilityHandlers({
       agentClass: 'Cortex::System',

--- a/self/memory/access/src/__tests__/phase-4.2-retrieval-path-verification.test.ts
+++ b/self/memory/access/src/__tests__/phase-4.2-retrieval-path-verification.test.ts
@@ -48,6 +48,7 @@ function createProjectStore(config: ProjectConfig): IProjectStore {
     list: async () => [],
     update: async () => {},
     archive: async () => {},
+    unarchive: async () => {},
   };
 }
 

--- a/self/memory/access/src/__tests__/phase-6.1-policy-leakage-regression.test.ts
+++ b/self/memory/access/src/__tests__/phase-6.1-policy-leakage-regression.test.ts
@@ -82,6 +82,7 @@ describe('Phase 6.1 — policy leakage regression', () => {
       list: vi.fn(),
       update: vi.fn(),
       archive: vi.fn(),
+      unarchive: vi.fn(),
     };
     const engine = new PolicyEnforcedRetrievalEngine({
       policyEngine: new MemoryAccessPolicyEngine(),
@@ -116,6 +117,7 @@ describe('Phase 6.1 — policy leakage regression', () => {
       list: vi.fn(),
       update: vi.fn(),
       archive: vi.fn(),
+      unarchive: vi.fn(),
     };
     const engine = new PolicyEnforcedRetrievalEngine({
       policyEngine: new MemoryAccessPolicyEngine(),
@@ -151,6 +153,7 @@ describe('Phase 6.1 — policy leakage regression', () => {
       list: vi.fn(),
       update: vi.fn(),
       archive: vi.fn(),
+      unarchive: vi.fn(),
     };
     const engine = new PolicyEnforcedRetrievalEngine({
       policyEngine: new MemoryAccessPolicyEngine(),

--- a/self/memory/access/src/__tests__/policy-enforced-retrieval-cross-project.test.ts
+++ b/self/memory/access/src/__tests__/policy-enforced-retrieval-cross-project.test.ts
@@ -101,6 +101,7 @@ function createProjectStore(configs: Map<string, ProjectConfig>): IProjectStore 
     list: vi.fn(),
     update: vi.fn(),
     archive: vi.fn(),
+    unarchive: vi.fn(),
   };
 }
 

--- a/self/memory/access/src/__tests__/policy-enforced-retrieval.test.ts
+++ b/self/memory/access/src/__tests__/policy-enforced-retrieval.test.ts
@@ -97,6 +97,7 @@ function createProjectStore(configs: Map<string, ProjectConfig>): IProjectStore 
     list: vi.fn(),
     update: vi.fn(),
     archive: vi.fn(),
+    unarchive: vi.fn(),
   };
 }
 

--- a/self/memory/knowledge-index/src/__tests__/knowledge-index-concurrency.test.ts
+++ b/self/memory/knowledge-index/src/__tests__/knowledge-index-concurrency.test.ts
@@ -92,6 +92,7 @@ describe('knowledge-index refresh concurrency', () => {
         },
         async update() {},
         async archive() {},
+        async unarchive() {},
       } as any,
       metaVectorStore: new MetaVectorStore({
         vectorStore: new InMemoryVectorStore(),

--- a/self/memory/knowledge-index/src/__tests__/knowledge-index-runtime.test.ts
+++ b/self/memory/knowledge-index/src/__tests__/knowledge-index-runtime.test.ts
@@ -57,6 +57,7 @@ function createProjectStore(projects: ProjectConfig[]) {
     },
     async update() {},
     async archive() {},
+    async unarchive() {},
   };
 }
 

--- a/self/shared/src/__tests__/types/project-surface.test.ts
+++ b/self/shared/src/__tests__/types/project-surface.test.ts
@@ -25,6 +25,16 @@ describe('ProjectBlockedActionSchema', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('accepts the archive_project action literal (sub-phase 1.1)', () => {
+    const result = ProjectBlockedActionSchema.safeParse({
+      action: 'archive_project',
+      allowed: true,
+      message: 'Archive is allowed while the project is running.',
+      evidenceRefs: ['project-control:running'],
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('ProjectHealthSummarySchema', () => {
@@ -167,6 +177,70 @@ describe('ProjectConfigurationUpdateInputSchema', () => {
       }).success,
     ).toBe(true);
 
+    expect(
+      ProjectConfigurationUpdateInputSchema.safeParse({
+        projectId: PROJECT_ID,
+        updates: {},
+      }).success,
+    ).toBe(false);
+  });
+
+  // --- Sub-phase 1.1 new updates fields (decision §2) ---
+  it('accepts new updates fields: name, description, budgetPolicy, icon, iconColor', () => {
+    const result = ProjectConfigurationUpdateInputSchema.safeParse({
+      projectId: PROJECT_ID,
+      updates: {
+        name: 'Renamed Project',
+        description: 'freshly rewritten',
+        budgetPolicy: {
+          enabled: true,
+          period: 'monthly',
+          softThresholdPercent: 80,
+          hardCeilingUsd: 100,
+        },
+        icon: 'lucide:Rocket',
+        iconColor: '#00ff00',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // --- Sub-phase 1.1 resetFields sibling (decision §3) ---
+  it('accepts non-empty resetFields alongside non-empty updates', () => {
+    const result = ProjectConfigurationUpdateInputSchema.safeParse({
+      projectId: PROJECT_ID,
+      updates: { name: 'NewName' },
+      resetFields: ['description'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty updates with non-empty resetFields (pure-reset envelope)', () => {
+    const result = ProjectConfigurationUpdateInputSchema.safeParse({
+      projectId: PROJECT_ID,
+      updates: {},
+      resetFields: ['description'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an envelope with a field present in both updates and resetFields', () => {
+    const result = ProjectConfigurationUpdateInputSchema.safeParse({
+      projectId: PROJECT_ID,
+      updates: { name: 'AmbiguousName' },
+      resetFields: ['name'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty updates + empty resetFields', () => {
+    expect(
+      ProjectConfigurationUpdateInputSchema.safeParse({
+        projectId: PROJECT_ID,
+        updates: {},
+        resetFields: [],
+      }).success,
+    ).toBe(false);
     expect(
       ProjectConfigurationUpdateInputSchema.safeParse({
         projectId: PROJECT_ID,

--- a/self/shared/src/__tests__/types/project.test.ts
+++ b/self/shared/src/__tests__/types/project.test.ts
@@ -215,6 +215,76 @@ describe('ProjectConfigSchema', () => {
     }
   });
 
+  // --- Sub-phase 1.1 new optional fields (decision §1) ---
+  it('accepts optional description (<=500 chars)', () => {
+    const result = ProjectConfigSchema.safeParse({
+      ...validConfig,
+      description: 'A project for deal scouting across the Pacific Northwest.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects description longer than 500 chars', () => {
+    const result = ProjectConfigSchema.safeParse({
+      ...validConfig,
+      description: 'x'.repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts optional icon with lucide: and emoji: prefixes (permissive)', () => {
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, icon: 'lucide:Rocket' }).success,
+    ).toBe(true);
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, icon: 'emoji:🚀' }).success,
+    ).toBe(true);
+    // Permissive: any string shape is accepted (malformed values fall back at render time)
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, icon: 'anything-goes' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects icon longer than 64 chars', () => {
+    const result = ProjectConfigSchema.safeParse({
+      ...validConfig,
+      icon: 'x'.repeat(65),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts hex iconColor and rejects malformed values', () => {
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, iconColor: '#0099ff' }).success,
+    ).toBe(true);
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, iconColor: '#AABBCC' }).success,
+    ).toBe(true);
+    // V1 does not accept shorthand #RGB
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, iconColor: '#abc' }).success,
+    ).toBe(false);
+    // Other malformed inputs
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, iconColor: 'red' }).success,
+    ).toBe(false);
+    expect(
+      ProjectConfigSchema.safeParse({ ...validConfig, iconColor: '0099ff' }).success,
+    ).toBe(false);
+  });
+
+  it('pre-1.1 stored configs without description/icon/iconColor parse unchanged', () => {
+    // Same shape as validConfig (which lacks the three new fields) — regression
+    // check for Goals acceptance criterion #1.
+    const result = ProjectConfigSchema.safeParse(validConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBeUndefined();
+      expect(result.data.icon).toBeUndefined();
+      expect(result.data.iconColor).toBeUndefined();
+    }
+  });
+
   it('accepts optional workflow configuration with embedded definitions', () => {
     const result = ProjectConfigSchema.safeParse({
       ...validConfig,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -355,6 +355,9 @@ export interface IProjectStore {
 
   /** Archive a project */
   archive(id: ProjectId): Promise<void>;
+
+  /** Unarchive a project — flip status from 'archived' to 'active'. */
+  unarchive(id: ProjectId): Promise<void>;
 }
 
 export interface ITaskStore {

--- a/self/shared/src/types/project-surface.ts
+++ b/self/shared/src/types/project-surface.ts
@@ -13,6 +13,7 @@ import {
   ProjectIdentityContractSchema,
   ProjectPackageDefaultIntakeSchema,
 } from './project.js';
+import { BudgetPolicySchema } from './cost.js';
 import {
   InAppEscalationRecordSchema,
   ProjectEscalationQueueSnapshotSchema,
@@ -32,6 +33,7 @@ export const ProjectBlockedActionSchema = z.object({
     'resume_project',
     'pause_project',
     'hard_stop_project',
+    'archive_project',
   ]),
   allowed: z.boolean(),
   reasonCode: z.string().min(1).optional(),
@@ -115,28 +117,68 @@ export type ProjectConfigurationSnapshot = z.infer<
   typeof ProjectConfigurationSnapshotSchema
 >;
 
-export const ProjectConfigurationUpdateInputSchema = z.object({
-  projectId: ProjectIdSchema,
-  expectedUpdatedAt: z.string().datetime().optional(),
-  updates: z
-    .object({
-      type: ProjectConfigSchema.shape.type.optional(),
-      pfcTier: ProjectConfigSchema.shape.pfcTier.optional(),
-      governanceDefaults: ProjectConfigSchema.shape.governanceDefaults.optional(),
-      modelAssignments: ProjectConfigSchema.shape.modelAssignments.optional(),
-      memoryAccessPolicy: ProjectConfigSchema.shape.memoryAccessPolicy.optional(),
-      retrievalBudgetTokens:
-        ProjectConfigSchema.shape.retrievalBudgetTokens.optional(),
-      escalationPreferences:
-        ProjectConfigSchema.shape.escalationPreferences.optional(),
-    })
-    .refine((value) => Object.keys(value).length > 0, {
-      message: 'At least one configuration field must be updated',
-    }),
-});
+export const ProjectConfigurationUpdateInputSchema = z
+  .object({
+    projectId: ProjectIdSchema,
+    expectedUpdatedAt: z.string().datetime().optional(),
+    updates: z
+      .object({
+        type: ProjectConfigSchema.shape.type.optional(),
+        pfcTier: ProjectConfigSchema.shape.pfcTier.optional(),
+        governanceDefaults: ProjectConfigSchema.shape.governanceDefaults.optional(),
+        modelAssignments: ProjectConfigSchema.shape.modelAssignments.optional(),
+        memoryAccessPolicy: ProjectConfigSchema.shape.memoryAccessPolicy.optional(),
+        retrievalBudgetTokens:
+          ProjectConfigSchema.shape.retrievalBudgetTokens.optional(),
+        escalationPreferences:
+          ProjectConfigSchema.shape.escalationPreferences.optional(),
+        // New in sub-phase 1.1 — settings-update-schema-extension-v1 §2:
+        name: ProjectConfigSchema.shape.name.optional(),
+        description: ProjectConfigSchema.shape.description,
+        budgetPolicy: BudgetPolicySchema.optional(),
+        icon: ProjectConfigSchema.shape.icon,
+        iconColor: ProjectConfigSchema.shape.iconColor,
+      })
+      .default({}),
+    // New in sub-phase 1.1 — settings-update-schema-extension-v1 §3:
+    resetFields: z.array(z.string().min(1)).optional(),
+  })
+  .refine(
+    (value) =>
+      Object.keys(value.updates).length > 0 ||
+      (value.resetFields?.length ?? 0) > 0,
+    {
+      message:
+        'At least one configuration field must be updated or reset',
+    },
+  )
+  .refine(
+    (value) => {
+      const updatesKeys = new Set(Object.keys(value.updates));
+      const resetFields = value.resetFields ?? [];
+      for (const field of resetFields) {
+        if (updatesKeys.has(field)) return false;
+      }
+      return true;
+    },
+    {
+      message:
+        'Fields cannot appear in both updates and resetFields (ambiguous intent)',
+    },
+  );
 export type ProjectConfigurationUpdateInput = z.infer<
   typeof ProjectConfigurationUpdateInputSchema
 >;
+/**
+ * Typed alias for the inferred `updates` object — exported to let callers
+ * type the `resetFields` array as `Array<keyof ProjectConfigUpdates>`.
+ * Runtime validation of membership is not enforced at the Zod layer (the
+ * handler silently no-ops on unknown keys and the refine above guarantees
+ * updates/resetFields disjointness). See SDS §Data Model.
+ */
+export type ProjectConfigUpdates = z.infer<
+  typeof ProjectConfigurationUpdateInputSchema
+>['updates'];
 
 export const MobileOperationsSnapshotSchema = z.object({
   project: ProjectIdentityContractSchema,

--- a/self/shared/src/types/project.ts
+++ b/self/shared/src/types/project.ts
@@ -222,6 +222,9 @@ export const ProjectConfigSchema = z.object({
   packageDefaultIntake: z.array(ProjectPackageDefaultIntakeSchema).default([]),
   retrievalBudgetTokens: z.number().positive().default(500),
   budgetPolicy: BudgetPolicySchema.optional(),
+  description: z.string().max(500).optional(),
+  icon: z.string().max(64).optional(),
+  iconColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });

--- a/self/subcortex/escalation/src/__tests__/escalation-service.test.ts
+++ b/self/subcortex/escalation/src/__tests__/escalation-service.test.ts
@@ -67,6 +67,7 @@ function createProjectStore(): IProjectStore {
     },
     async update(): Promise<void> {},
     async archive(): Promise<void> {},
+    async unarchive(): Promise<void> {},
   };
 }
 

--- a/self/subcortex/mao/src/__tests__/mao-projection-service.test.ts
+++ b/self/subcortex/mao/src/__tests__/mao-projection-service.test.ts
@@ -457,6 +457,7 @@ function createProjectStoreMock(projectIds: ProjectId[] = []): IProjectStore {
     list: async () => projects,
     update: async () => {},
     archive: async () => {},
+    unarchive: async () => {},
   } as IProjectStore;
 }
 

--- a/self/subcortex/projects/src/__tests__/document-project-store.test.ts
+++ b/self/subcortex/projects/src/__tests__/document-project-store.test.ts
@@ -110,6 +110,46 @@ describe('DocumentProjectStore', () => {
     expect(got?.name).toBe('Test Project');
   });
 
+  it('unarchive() flips status back to active and bumps updatedAt', async () => {
+    await store.create(createProjectConfig());
+    await store.archive(PROJECT_ID);
+
+    const beforeUnarchive = await store.get(PROJECT_ID);
+    expect(beforeUnarchive).not.toBeNull();
+
+    // Small async gap so `new Date().toISOString()` yields a different stamp.
+    await new Promise((resolve) => setTimeout(resolve, 2));
+
+    await store.unarchive(PROJECT_ID);
+
+    const list = await store.list();
+    expect(list.length).toBe(1);
+    expect(list[0]?.name).toBe('Test Project');
+
+    const got = await store.get(PROJECT_ID);
+    expect(got).not.toBeNull();
+    expect(got?.updatedAt).not.toBe(beforeUnarchive?.updatedAt);
+  });
+
+  it('unarchive() throws on missing project', async () => {
+    await expect(
+      store.unarchive(
+        '00000000-0000-0000-0000-000000000099' as ProjectId,
+      ),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('archive -> unarchive -> list round-trip returns project to active list', async () => {
+    await store.create(createProjectConfig());
+    await store.archive(PROJECT_ID);
+    expect((await store.list()).length).toBe(0);
+
+    await store.unarchive(PROJECT_ID);
+    const list = await store.list();
+    expect(list.length).toBe(1);
+    expect(list[0]?.id).toBe(PROJECT_ID);
+  });
+
   it('update() merges changes', async () => {
     await store.create(createProjectConfig());
     await store.update(PROJECT_ID, {

--- a/self/subcortex/projects/src/document-project-store.ts
+++ b/self/subcortex/projects/src/document-project-store.ts
@@ -96,4 +96,24 @@ export class DocumentProjectStore implements IProjectStore {
 
     console.info(`[nous:project] archive projectId=${id}`);
   }
+
+  async unarchive(id: ProjectId): Promise<void> {
+    const existing = await this.documentStore.get<Record<string, unknown>>(
+      COLLECTION,
+      id,
+    );
+    if (!existing) {
+      throw new Error(`Project ${id} not found`);
+    }
+
+    const merged = {
+      ...existing,
+      status: 'active' as const,
+      updatedAt: new Date().toISOString(),
+    };
+    const validated = ProjectDocumentSchema.parse(merged);
+    await this.documentStore.put(COLLECTION, id, validated);
+
+    console.info(`[nous:project] unarchive projectId=${id}`);
+  }
 }

--- a/self/subcortex/scheduler/src/__tests__/scheduler-discovery-refresh-integration.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-discovery-refresh-integration.test.ts
@@ -48,6 +48,7 @@ function createProjectStore(projects: ProjectConfig[]): IProjectStore {
     },
     async update(): Promise<void> {},
     async archive(): Promise<void> {},
+    async unarchive(): Promise<void> {},
   };
 }
 

--- a/self/subcortex/scheduler/src/__tests__/scheduler-gateway-integration.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-gateway-integration.test.ts
@@ -40,6 +40,7 @@ function createProjectStore(projectConfig: ProjectConfig): IProjectStore {
     },
     async update(): Promise<void> {},
     async archive(): Promise<void> {},
+    async unarchive(): Promise<void> {},
   };
 }
 

--- a/self/subcortex/scheduler/src/__tests__/scheduler-recovery.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-recovery.test.ts
@@ -40,6 +40,7 @@ function createProjectStore(projectConfig: ProjectConfig): IProjectStore {
     },
     async update(): Promise<void> {},
     async archive(): Promise<void> {},
+    async unarchive(): Promise<void> {},
   };
 }
 

--- a/self/subcortex/scheduler/src/__tests__/scheduler-service.test.ts
+++ b/self/subcortex/scheduler/src/__tests__/scheduler-service.test.ts
@@ -47,6 +47,7 @@ function createProjectStore(projectConfig: ProjectConfig): IProjectStore {
     },
     async update(): Promise<void> {},
     async archive(): Promise<void> {},
+    async unarchive(): Promise<void> {},
   };
 }
 

--- a/self/ui/src/components/shell/__tests__/types.test.ts
+++ b/self/ui/src/components/shell/__tests__/types.test.ts
@@ -92,6 +92,48 @@ describe('shell type schemas', () => {
     ).toBe(false)
   })
 
+  // --- Sub-phase 1.1: retype icon -> string, add archived/color ---
+  it('accepts icon as string (sub-phase 1.1 retype)', () => {
+    expect(
+      ProjectItemSchema.safeParse({
+        id: 'project-1',
+        name: 'Project One',
+        icon: 'lucide:Rocket',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('accepts archived boolean and hex color', () => {
+    expect(
+      ProjectItemSchema.safeParse({
+        id: 'project-1',
+        name: 'Project One',
+        archived: true,
+        color: '#00aaff',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects malformed color (not #RRGGBB)', () => {
+    expect(
+      ProjectItemSchema.safeParse({
+        id: 'project-1',
+        name: 'Project One',
+        color: '#abc',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects oversized icon (> 64 chars)', () => {
+    expect(
+      ProjectItemSchema.safeParse({
+        id: 'project-1',
+        name: 'Project One',
+        icon: 'x'.repeat(65),
+      }).success,
+    ).toBe(false)
+  })
+
   it('parses a valid flyout item and rejects an invalid one', () => {
     expect(
       FlyoutItemSchema.safeParse({

--- a/self/ui/src/components/shell/types.ts
+++ b/self/ui/src/components/shell/types.ts
@@ -41,7 +41,15 @@ export type RailSection = z.infer<typeof RailSectionSchema>
 export const ProjectItemSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
-  icon: optionalReactNodeSchema.optional(),
+  // Retyped in sub-phase 1.1 from `optionalReactNodeSchema.optional()` to a
+  // string carrying the discriminated `lucide:<Name>` / `emoji:<unicode>`
+  // convention (or any other permissive string). Renderers dispatch on the
+  // prefix and fall back to initial-letter when the value is malformed.
+  // 64-char cap mirrors `ProjectConfigSchema.shape.icon`.
+  icon: z.string().max(64).optional(),
+  // Hex-only color regex mirrors `ProjectConfigSchema.shape.iconColor`.
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  archived: z.boolean().optional(),
 })
 export type ProjectItem = z.infer<typeof ProjectItemSchema>
 


### PR DESCRIPTION
## Summary

Phase 1.1 of the Project Model & Settings feature.

- Extends the project schema (`description`, `icon`, `iconColor`) and the configuration update envelope (`name`, `description`, `budgetPolicy`, `icon`, `iconColor` + `resetFields`).
- Replaces `projects.update` with the extended `projects.updateConfiguration` (atomic landing per Manifest §10) and adds `projects.archive` / `projects.unarchive` endpoints with the corresponding opctl posture and provenance four-source mapping.
- Extends `IProjectStore` with `unarchive`, implements it in `DocumentProjectStore`, and updates 21 mock stub sites across 18 test files.
- Adds the `sub-phase 1.1` regression block to `projects-router.test.ts` (round-trips, transactional reset order, CONFLICT preservation, archive control-state matrix, provenance per source type).

## Review

Completion Report verdict: **Approved With Notes** — see `.worklog/sprints/feat/project-model-and-settings/phase-1/phase-1.1/reviews/completion-report.mdx`.

Two minor non-blocking notes (mock count 21 vs 22, `name` provenance V1 posture) are documentation-only and carried forward to phase-close audit + 1.4 design inputs.

## Test plan

- [x] `pnpm typecheck` clean across `@nous/shared`, `@nous/subcortex-projects`, `@nous/shared-server`, `@nous/ui`, `@nous/web`
- [x] `pnpm lint` — 149 warnings / 0 errors (matches baseline)
- [x] Targeted vitest runs: `@nous/shared` (1067 tests), `@nous/subcortex-projects` (69 tests), `@nous/ui` shell types (31 tests), `@nous/web` projects-router (42 tests)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>