### PR TITLE
feat(WR-161 SP 1.2): personality trait registry and PersonalityConfig type system

### DIFF
--- a/self/cortex/core/src/__tests__/gateway-runtime/agent-profile.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/agent-profile.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentProfile,
   type PromptConfig,
 } from '../../gateway-runtime/prompt-strategy.js';
+import type { PersonalityConfig } from '../../gateway-runtime/personality/index.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -15,6 +16,27 @@ const ALL_AGENT_CLASSES: AgentClass[] = [
   'Cortex::System',
   'Orchestrator',
   'Worker',
+];
+
+const NON_BALANCED_PRESETS: PersonalityConfig['preset'][] = [
+  'professional',
+  'efficient',
+  'thorough',
+];
+
+const ALL_PRESETS: PersonalityConfig['preset'][] = [
+  'balanced',
+  ...NON_BALANCED_PRESETS,
+];
+
+const REPRESENTATIVE_OVERRIDE: PersonalityConfig = {
+  preset: 'professional',
+  overrides: { candor: 'standard' },
+};
+
+const CONFIGS_FOR_DIMENSION_ISOLATION: PersonalityConfig[] = [
+  ...ALL_PRESETS.map((preset) => ({ preset }) as PersonalityConfig),
+  REPRESENTATIVE_OVERRIDE,
 ];
 
 // ---------------------------------------------------------------------------
@@ -45,15 +67,16 @@ describe('resolveAgentProfile — contract tests', () => {
   );
 
   it('PromptConfig accepts personalityConfig field (type-level)', () => {
-    // Compile-time check: if this compiles, the type contract is satisfied
+    // Compile-time check: concrete PersonalityConfig satisfies the field type
+    // (post-SP 1.2 the field is narrow, not `unknown`).
     const config: PromptConfig = {
       identity: 'test',
       taskFrame: 'test',
       toolPolicy: 'omit',
       guardrails: [],
-      personalityConfig: { name: 'test' },
+      personalityConfig: { preset: 'balanced' },
     };
-    expect(config.personalityConfig).toEqual({ name: 'test' });
+    expect(config.personalityConfig).toEqual({ preset: 'balanced' });
   });
 
   it('PromptConfig accepts missing personalityConfig (backward compat)', () => {
@@ -68,66 +91,154 @@ describe('resolveAgentProfile — contract tests', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tier 2 — Behavior Tests
+// Tier 2 — Behavior Tests (R9 split)
 // ---------------------------------------------------------------------------
 
-describe('resolveAgentProfile — behavior tests', () => {
-  describe('personality override', () => {
-    it('with non-null personality: identity and outputContract pass through personality functions', () => {
-      const withPersonality = resolveAgentProfile('Cortex::Principal', undefined, { style: 'casual' });
-      const withoutPersonality = resolveAgentProfile('Cortex::Principal');
-      // Currently no-op — both return same values
-      expect(withPersonality.identity).toBe(withoutPersonality.identity);
-      expect(withPersonality.outputContract).toBe(withoutPersonality.outputContract);
-    });
-
-    it('with null/undefined personality: identity unchanged', () => {
-      const withNull = resolveAgentProfile('Worker', undefined, null);
-      const withUndefined = resolveAgentProfile('Worker');
-      // null is treated as no personality (null == null is falsy for != null check)
-      expect(withUndefined.identity).toBe(withNull.identity);
-    });
-
-    it('personality never affects guardrails', () => {
-      for (const agentClass of ALL_AGENT_CLASSES) {
-        const withPersonality = resolveAgentProfile(agentClass, undefined, { style: 'casual' });
-        const withoutPersonality = resolveAgentProfile(agentClass);
-        expect(withPersonality.guardrails).toEqual(withoutPersonality.guardrails);
-      }
-    });
-
-    it('personality never affects mechanical dimensions', () => {
-      for (const agentClass of ALL_AGENT_CLASSES) {
-        const withPersonality = resolveAgentProfile(agentClass, undefined, { style: 'casual' });
-        const withoutPersonality = resolveAgentProfile(agentClass);
-        expect(withPersonality.contextBudget).toEqual(withoutPersonality.contextBudget);
-        expect(withPersonality.loopShape).toBe(withoutPersonality.loopShape);
-        expect(withPersonality.toolConcurrency).toEqual(withoutPersonality.toolConcurrency);
-        expect(withPersonality.escalationRules).toEqual(withoutPersonality.escalationRules);
-        expect(withPersonality.compactionStrategy).toBe(withoutPersonality.compactionStrategy);
-      }
-    });
-
-    it('personalityConfig field appears on returned profile when provided', () => {
-      const personality = { name: 'TestBot', style: 'formal' };
-      const profile = resolveAgentProfile('Worker', undefined, personality);
-      expect(profile.personalityConfig).toBe(personality);
-    });
-
-    it('personalityConfig is undefined when not provided', () => {
-      const profile = resolveAgentProfile('Worker');
-      expect(profile.personalityConfig).toBeUndefined();
-    });
+describe('resolveAgentProfile — personality override', () => {
+  // Block A — `{ preset: 'balanced' }` byte-identity (T2.5, I2, R9 Block A, Goals C13).
+  describe('{ preset: "balanced" } byte-identity (Block A)', () => {
+    it.each(ALL_AGENT_CLASSES)(
+      '%s: identity strictly equal to no-personality baseline',
+      (agentClass) => {
+        const balanced = resolveAgentProfile(agentClass, undefined, {
+          preset: 'balanced',
+        });
+        const baseline = resolveAgentProfile(agentClass);
+        expect(balanced.identity).toBe(baseline.identity);
+      },
+    );
   });
 
-  describe('provider axis', () => {
-    it('unknown provider returns same dimensions as default', () => {
-      const defaultProfile = resolveAgentProfile('Worker');
-      const unknownProvider = resolveAgentProfile('Worker', 'unknown-provider-xyz');
-      expect(unknownProvider.loopShape).toBe(defaultProfile.loopShape);
-      expect(unknownProvider.outputContract).toBe(defaultProfile.outputContract);
-      expect(unknownProvider.escalationRules).toEqual(defaultProfile.escalationRules);
-    });
+  // Block B — non-balanced presets produce a different identity (R9 Block B, Goals C11).
+  // Full fragment-concatenation assertions live in
+  // `integration-with-apply-personality.test.ts`; this block asserts that
+  // agent-profile.test.ts sees a difference at the public surface.
+  describe('non-balanced presets produce a different identity (Block B)', () => {
+    for (const preset of NON_BALANCED_PRESETS) {
+      it.each(ALL_AGENT_CLASSES)(
+        `${preset}: %s identity differs from the no-personality baseline`,
+        (agentClass) => {
+          const withPersonality = resolveAgentProfile(agentClass, undefined, {
+            preset,
+          });
+          const baseline = resolveAgentProfile(agentClass);
+          expect(withPersonality.identity).not.toBe(baseline.identity);
+        },
+      );
+    }
+  });
+
+  // Block C — mechanical dimensions isolation (T2.3, I4, Goals C15).
+  describe('dimension isolation — mechanical', () => {
+    for (const config of CONFIGS_FOR_DIMENSION_ISOLATION) {
+      const label = config.overrides
+        ? `${config.preset} + overrides`
+        : config.preset;
+      it.each(ALL_AGENT_CLASSES)(
+        `${label}: %s preserves mechanical dimensions`,
+        (agentClass) => {
+          const withPersonality = resolveAgentProfile(
+            agentClass,
+            undefined,
+            config,
+          );
+          const baseline = resolveAgentProfile(agentClass);
+          expect(withPersonality.contextBudget).toEqual(baseline.contextBudget);
+          expect(withPersonality.compactionStrategy).toBe(
+            baseline.compactionStrategy,
+          );
+          expect(withPersonality.loopShape).toBe(baseline.loopShape);
+          expect(withPersonality.toolConcurrency).toEqual(
+            baseline.toolConcurrency,
+          );
+          expect(withPersonality.escalationRules).toEqual(
+            baseline.escalationRules,
+          );
+        },
+      );
+    }
+  });
+
+  // Block D — guardrails isolation (T2.4, I4, Goals C16).
+  describe('dimension isolation — guardrails', () => {
+    for (const config of CONFIGS_FOR_DIMENSION_ISOLATION) {
+      const label = config.overrides
+        ? `${config.preset} + overrides`
+        : config.preset;
+      it.each(ALL_AGENT_CLASSES)(
+        `${label}: %s guardrails deep-equal baseline`,
+        (agentClass) => {
+          const withPersonality = resolveAgentProfile(
+            agentClass,
+            undefined,
+            config,
+          );
+          const baseline = resolveAgentProfile(agentClass);
+          expect(withPersonality.guardrails).toEqual(baseline.guardrails);
+        },
+      );
+    }
+  });
+
+  // Block E — outputContract enum invariance (T2.6, I3, Goals C17).
+  describe('outputContract enum invariance', () => {
+    for (const config of CONFIGS_FOR_DIMENSION_ISOLATION) {
+      const label = config.overrides
+        ? `${config.preset} + overrides`
+        : config.preset;
+      it.each(ALL_AGENT_CLASSES)(
+        `${label}: %s outputContract identical to baseline`,
+        (agentClass) => {
+          const withPersonality = resolveAgentProfile(
+            agentClass,
+            undefined,
+            config,
+          );
+          const baseline = resolveAgentProfile(agentClass);
+          expect(withPersonality.outputContract).toBe(baseline.outputContract);
+        },
+      );
+    }
+  });
+
+  // T3.2 edge — null personality routes through the same pre-existing guard
+  // as undefined (the `!= null` check on resolveAgentProfile line ~301).
+  it('with null/undefined personality: identity unchanged', () => {
+    // null is treated as no personality (null == null is falsy for != null check)
+    const withNull = resolveAgentProfile(
+      'Worker',
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exercising the JS-level guard
+      null as any,
+    );
+    const withUndefined = resolveAgentProfile('Worker');
+    expect(withUndefined.identity).toBe(withNull.identity);
+  });
+
+  // T2.7 — personalityConfig pass-through by reference on the returned profile
+  // (preserves SP 1.1 semantics).
+  it('personalityConfig field appears on returned profile when provided', () => {
+    const personality: PersonalityConfig = {
+      preset: 'professional',
+      overrides: { candor: 'standard' },
+    };
+    const profile = resolveAgentProfile('Worker', undefined, personality);
+    expect(profile.personalityConfig).toBe(personality);
+  });
+
+  it('personalityConfig is undefined when not provided', () => {
+    const profile = resolveAgentProfile('Worker');
+    expect(profile.personalityConfig).toBeUndefined();
+  });
+});
+
+describe('resolveAgentProfile — provider axis', () => {
+  it('unknown provider returns same dimensions as default', () => {
+    const defaultProfile = resolveAgentProfile('Worker');
+    const unknownProvider = resolveAgentProfile('Worker', 'unknown-provider-xyz');
+    expect(unknownProvider.loopShape).toBe(defaultProfile.loopShape);
+    expect(unknownProvider.outputContract).toBe(defaultProfile.outputContract);
+    expect(unknownProvider.escalationRules).toEqual(defaultProfile.escalationRules);
   });
 });
 

--- a/self/cortex/core/src/__tests__/gateway-runtime/personality/integration-with-apply-personality.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/personality/integration-with-apply-personality.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentClass } from '@nous/shared';
+import { resolveAgentProfile } from '../../../gateway-runtime/prompt-strategy.js';
+import {
+  PRESETS,
+  TRAIT_REGISTRY,
+  type PersonalityPreset,
+  type TraitAxes,
+  type TraitValueDefinition,
+} from '../../../gateway-runtime/personality/index.js';
+
+const ALL_AGENT_CLASSES: AgentClass[] = [
+  'Cortex::Principal',
+  'Cortex::System',
+  'Orchestrator',
+  'Worker',
+];
+
+const NON_BALANCED_PRESETS: PersonalityPreset[] = [
+  'professional',
+  'efficient',
+  'thorough',
+];
+
+const ALL_PRESETS: PersonalityPreset[] = ['balanced', ...NON_BALANCED_PRESETS];
+
+// Mirrors the production iteration order in `collectFragmentsByTarget` /
+// `applyPersonalityToIdentity`: TRAIT_REGISTRY tuple order, identity-targeted
+// fragments first, then outputContract-targeted fragments. See SDS § 3.3.3.
+function expectedIdentityFragments(axes: TraitAxes): string[] {
+  const identity: string[] = [];
+  const outputContract: string[] = [];
+  for (const trait of TRAIT_REGISTRY) {
+    const values = trait.values as Record<string, TraitValueDefinition>;
+    const selectedKey = axes[trait.id as keyof TraitAxes];
+    const injection = values[selectedKey].injection;
+    if (injection == null) continue;
+    if (injection.target === 'identity') {
+      identity.push(injection.fragment);
+    } else {
+      outputContract.push(injection.fragment);
+    }
+  }
+  return [...identity, ...outputContract];
+}
+
+// ---------------------------------------------------------------------------
+// Block A — `{ preset: 'balanced' }` byte-identity (T2.5, I2, R9 Block A, C13)
+// ---------------------------------------------------------------------------
+
+describe('{ preset: "balanced" } byte-identity (Block A)', () => {
+  it.each(ALL_AGENT_CLASSES)(
+    '%s: balanced identity strictly equal to no-personality baseline',
+    (agentClass) => {
+      const balanced = resolveAgentProfile(agentClass, undefined, {
+        preset: 'balanced',
+      });
+      const baseline = resolveAgentProfile(agentClass);
+      expect(balanced.identity).toBe(baseline.identity);
+    },
+  );
+
+  it('every standard-variant axis yields zero fragments', () => {
+    const fragments = expectedIdentityFragments(PRESETS.balanced);
+    expect(fragments).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block B — non-balanced presets produce expected fragment concatenation
+// (T2.1, R9 Block B, C11)
+// ---------------------------------------------------------------------------
+
+describe('non-balanced presets produce expected fragment concatenation (Block B)', () => {
+  for (const preset of NON_BALANCED_PRESETS) {
+    describe(`preset: ${preset}`, () => {
+      it.each(ALL_AGENT_CLASSES)(
+        `%s: identity = [base, ...TRAIT_REGISTRY-order fragments].join('\\n\\n')`,
+        (agentClass) => {
+          const baseline = resolveAgentProfile(agentClass);
+          const withPersonality = resolveAgentProfile(agentClass, undefined, {
+            preset,
+          });
+          const fragments = expectedIdentityFragments(PRESETS[preset]);
+          expect(fragments.length).toBeGreaterThan(0);
+          const expected = [baseline.identity, ...fragments].join('\n\n');
+          expect(withPersonality.identity).toBe(expected);
+        },
+      );
+
+      it.each(ALL_AGENT_CLASSES)(
+        `%s: identity differs from baseline`,
+        (agentClass) => {
+          const baseline = resolveAgentProfile(agentClass);
+          const withPersonality = resolveAgentProfile(agentClass, undefined, {
+            preset,
+          });
+          expect(withPersonality.identity).not.toBe(baseline.identity);
+        },
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Block C — applyPersonalityToOutputContract is a deliberate pass-through
+// (T2.2, Note 1 Option a / ADR 017, I3, C12 updated, C17)
+// ---------------------------------------------------------------------------
+
+describe('applyPersonalityToOutputContract is a deliberate pass-through', () => {
+  for (const preset of ALL_PRESETS) {
+    it.each(ALL_AGENT_CLASSES)(
+      `${preset}: %s outputContract strictly equal to baseline`,
+      (agentClass) => {
+        const baseline = resolveAgentProfile(agentClass);
+        const withPersonality = resolveAgentProfile(agentClass, undefined, {
+          preset,
+        });
+        expect(withPersonality.outputContract).toBe(baseline.outputContract);
+      },
+    );
+  }
+
+  it.each(ALL_AGENT_CLASSES)(
+    'preset + overrides: %s outputContract strictly equal to baseline',
+    (agentClass) => {
+      const baseline = resolveAgentProfile(agentClass);
+      const withOverrides = resolveAgentProfile(agentClass, undefined, {
+        preset: 'professional',
+        overrides: { candor: 'standard' },
+      });
+      expect(withOverrides.outputContract).toBe(baseline.outputContract);
+    },
+  );
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/personality/registry.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/personality/registry.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  defineTrait,
+  TRAIT_REGISTRY,
+  type TraitAxes,
+  type TraitValueDefinition,
+} from '../../../gateway-runtime/personality/index.js';
+
+// ---------------------------------------------------------------------------
+// T1.1 — Registry tuple order (SDS I5, Goals C4)
+// ---------------------------------------------------------------------------
+
+describe('TRAIT_REGISTRY tuple order', () => {
+  it('declared order is thoroughness → initiative → candor → communicationStyle → codeStyle', () => {
+    expect(TRAIT_REGISTRY.map((t) => t.id)).toEqual([
+      'thoroughness',
+      'initiative',
+      'candor',
+      'communicationStyle',
+      'codeStyle',
+    ]);
+  });
+
+  it('registry length is 5', () => {
+    expect(TRAIT_REGISTRY).toHaveLength(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.2 — TraitAxes structural equivalence (SDS I5, Goals C5)
+// ---------------------------------------------------------------------------
+
+describe('TraitAxes structural equivalence (type-level)', () => {
+  type Expected = {
+    thoroughness: 'strict' | 'standard';
+    initiative: 'collaborative' | 'compliant';
+    candor: 'strict' | 'standard';
+    communicationStyle: 'detailed' | 'concise';
+    codeStyle: 'minimal' | 'standard';
+  };
+
+  it('TraitAxes is assignable both directions against the expected shape', () => {
+    expectTypeOf<TraitAxes>().toMatchTypeOf<Expected>();
+    expectTypeOf<Expected>().toMatchTypeOf<TraitAxes>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.3 — defineTrait inference (SDS I6, Goals C3)
+// ---------------------------------------------------------------------------
+
+describe('defineTrait inference (type-level)', () => {
+  it('preserves literal types on id, default, and value keys', () => {
+    const sampleTrait = defineTrait({
+      id: 'sample',
+      label: 'Sample',
+      description: 'type-inference sanity check',
+      default: 'a',
+      values: {
+        a: {
+          label: 'A',
+          description: 'a value',
+          injection: { target: 'identity', fragment: 'alpha' },
+        },
+        b: {
+          label: 'B',
+          description: 'b value',
+          injection: null,
+        },
+      },
+    });
+
+    // `default` keeps its literal-union typing (not `string`).
+    expectTypeOf(sampleTrait.default).toEqualTypeOf<'a' | 'b'>();
+    // `id` keeps its literal type (not `string`).
+    expectTypeOf(sampleTrait.id).toEqualTypeOf<'sample'>();
+    // The factory is identity-shaped at runtime.
+    expect(sampleTrait.id).toBe('sample');
+    expect(sampleTrait.default).toBe('a');
+    expect(sampleTrait.values.a.injection).toEqual({
+      target: 'identity',
+      fragment: 'alpha',
+    });
+    expect(sampleTrait.values.b.injection).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.4 — Registry shape validity (SDS I5 extended, Goals C4)
+// ---------------------------------------------------------------------------
+
+describe('TRAIT_REGISTRY runtime shape validity', () => {
+  for (const trait of TRAIT_REGISTRY) {
+    describe(`trait: ${trait.id}`, () => {
+      it('has a non-empty id, label, and description', () => {
+        expect(trait.id.length).toBeGreaterThan(0);
+        expect(trait.label.length).toBeGreaterThan(0);
+        expect(trait.description.length).toBeGreaterThan(0);
+      });
+
+      it('default value is present in values', () => {
+        const values = trait.values as Record<string, TraitValueDefinition>;
+        expect(Object.prototype.hasOwnProperty.call(values, trait.default)).toBe(
+          true,
+        );
+      });
+
+      it('every value has a non-empty label and description', () => {
+        const values = trait.values as Record<string, TraitValueDefinition>;
+        for (const [, value] of Object.entries(values)) {
+          expect(value.label.length).toBeGreaterThan(0);
+          expect(value.description.length).toBeGreaterThan(0);
+        }
+      });
+
+      it('every injection is null or a well-formed { target, fragment }', () => {
+        const values = trait.values as Record<string, TraitValueDefinition>;
+        for (const [, value] of Object.entries(values)) {
+          if (value.injection === null) continue;
+          expect(['identity', 'outputContract']).toContain(
+            value.injection.target,
+          );
+          expect(typeof value.injection.fragment).toBe('string');
+          expect(value.injection.fragment.length).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T1.5 — Standard-variant nullity (SDS I10, R4 mitigation)
+// ---------------------------------------------------------------------------
+
+const STANDARD_VARIANT_BY_TRAIT: Record<string, string> = {
+  thoroughness: 'standard',
+  initiative: 'compliant',
+  candor: 'standard',
+  communicationStyle: 'concise',
+  codeStyle: 'standard',
+};
+
+describe('standard-variant nullity (SDS I10)', () => {
+  for (const trait of TRAIT_REGISTRY) {
+    it(`${trait.id}.${STANDARD_VARIANT_BY_TRAIT[trait.id]} has injection: null`, () => {
+      const values = trait.values as Record<string, TraitValueDefinition>;
+      const standardKey = STANDARD_VARIANT_BY_TRAIT[trait.id];
+      expect(standardKey).toBeDefined();
+      expect(values[standardKey].injection).toBeNull();
+    });
+  }
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/personality/resolver.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/personality/resolver.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PRESETS,
+  resolvePersonality,
+  type PersonalityPreset,
+  type TraitAxes,
+} from '../../../gateway-runtime/personality/index.js';
+
+// ---------------------------------------------------------------------------
+// T1.6 — PRESETS byte-equality (SDS I1, Goals C6)
+// ---------------------------------------------------------------------------
+
+describe('PRESETS byte-equality (SDS § 3.4 / Decision 1 § Presets as Trait Value Maps)', () => {
+  it('balanced matches Decision 1 verbatim', () => {
+    expect(PRESETS.balanced).toEqual({
+      thoroughness: 'standard',
+      initiative: 'compliant',
+      candor: 'standard',
+      communicationStyle: 'concise',
+      codeStyle: 'standard',
+    } satisfies TraitAxes);
+  });
+
+  it('professional matches Decision 1 verbatim', () => {
+    expect(PRESETS.professional).toEqual({
+      thoroughness: 'strict',
+      initiative: 'collaborative',
+      candor: 'strict',
+      communicationStyle: 'detailed',
+      codeStyle: 'minimal',
+    } satisfies TraitAxes);
+  });
+
+  it('efficient matches Decision 1 verbatim', () => {
+    expect(PRESETS.efficient).toEqual({
+      thoroughness: 'standard',
+      initiative: 'compliant',
+      candor: 'standard',
+      communicationStyle: 'concise',
+      codeStyle: 'minimal',
+    } satisfies TraitAxes);
+  });
+
+  it('thorough matches Decision 1 verbatim', () => {
+    expect(PRESETS.thorough).toEqual({
+      thoroughness: 'strict',
+      initiative: 'compliant',
+      candor: 'strict',
+      communicationStyle: 'detailed',
+      codeStyle: 'standard',
+    } satisfies TraitAxes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.7 — resolvePersonality: preset → axes (Goals C14 baseline)
+// ---------------------------------------------------------------------------
+
+const ALL_PRESETS: PersonalityPreset[] = [
+  'balanced',
+  'professional',
+  'efficient',
+  'thorough',
+];
+
+describe('resolvePersonality — preset → axes', () => {
+  for (const preset of ALL_PRESETS) {
+    it(`${preset} resolves to PRESETS[${preset}]`, () => {
+      expect(resolvePersonality({ preset })).toEqual(PRESETS[preset]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T1.8 — resolvePersonality: overrides win (Goals C14)
+// ---------------------------------------------------------------------------
+
+describe('resolvePersonality — overrides win on specified axes', () => {
+  it('candor override replaces the professional preset value', () => {
+    expect(
+      resolvePersonality({
+        preset: 'professional',
+        overrides: { candor: 'standard' },
+      }),
+    ).toEqual({ ...PRESETS.professional, candor: 'standard' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.9 — resolvePersonality: multiple overrides (Goals C14 extended)
+// ---------------------------------------------------------------------------
+
+describe('resolvePersonality — multiple overrides', () => {
+  it('overrides on two axes both apply; unset axes retain preset values', () => {
+    const axes = resolvePersonality({
+      preset: 'thorough',
+      overrides: { initiative: 'collaborative', codeStyle: 'minimal' },
+    });
+    expect(axes).toEqual({
+      ...PRESETS.thorough,
+      initiative: 'collaborative',
+      codeStyle: 'minimal',
+    });
+    // Unset axes retain preset values.
+    expect(axes.thoroughness).toBe(PRESETS.thorough.thoroughness);
+    expect(axes.candor).toBe(PRESETS.thorough.candor);
+    expect(axes.communicationStyle).toBe(PRESETS.thorough.communicationStyle);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.3 — All-axes override collapses to another preset (Goals C14 edge)
+// ---------------------------------------------------------------------------
+
+describe('resolvePersonality — all-axes override collapses to another preset', () => {
+  it('balanced + full override set equals professional preset', () => {
+    expect(
+      resolvePersonality({
+        preset: 'balanced',
+        overrides: {
+          thoroughness: 'strict',
+          initiative: 'collaborative',
+          candor: 'strict',
+          communicationStyle: 'detailed',
+          codeStyle: 'minimal',
+        },
+      }),
+    ).toEqual(PRESETS.professional);
+  });
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/personality/shared-interface-compatibility.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/personality/shared-interface-compatibility.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type {
+  PersonalityConfig as CortexPersonalityConfig,
+  PersonalityPreset as CortexPersonalityPreset,
+  TraitAxes as CortexTraitAxes,
+} from '../../../gateway-runtime/personality/index.js';
+import type {
+  PersonalityConfig as SharedPersonalityConfig,
+  PersonalityPreset as SharedPersonalityPreset,
+  TraitAxes as SharedTraitAxes,
+} from '@nous/shared';
+
+// ---------------------------------------------------------------------------
+// T1.10 — Structural mirror drift detector (SDS F7, Goals C10)
+//
+// The @nous/shared structural mirror adjacent to PromptFormatterInput is a
+// self-contained declaration. This test asserts bidirectional assignment
+// compatibility between the cortex canonical `PersonalityConfig` surface and
+// the shared structural mirror. If either surface drifts (e.g. a new trait
+// axis is added in cortex but not mirrored in @nous/shared), the type
+// assertions below fail at build time.
+// ---------------------------------------------------------------------------
+
+describe('shared ↔ cortex PersonalityConfig structural compatibility', () => {
+  it('cortex PersonalityConfig is assignable to the shared mirror', () => {
+    expectTypeOf<CortexPersonalityConfig>().toMatchTypeOf<SharedPersonalityConfig>();
+  });
+
+  it('shared PersonalityConfig is assignable to the cortex canonical', () => {
+    expectTypeOf<SharedPersonalityConfig>().toMatchTypeOf<CortexPersonalityConfig>();
+  });
+
+  it('PersonalityPreset unions are bidirectionally assignable', () => {
+    expectTypeOf<CortexPersonalityPreset>().toMatchTypeOf<SharedPersonalityPreset>();
+    expectTypeOf<SharedPersonalityPreset>().toMatchTypeOf<CortexPersonalityPreset>();
+  });
+
+  it('TraitAxes shapes are bidirectionally assignable', () => {
+    expectTypeOf<CortexTraitAxes>().toMatchTypeOf<SharedTraitAxes>();
+    expectTypeOf<SharedTraitAxes>().toMatchTypeOf<CortexTraitAxes>();
+  });
+
+  it('round-trips a concrete value through the shared mirror boundary', () => {
+    const cortexValue: CortexPersonalityConfig = {
+      preset: 'professional',
+      overrides: { candor: 'standard' },
+    };
+    const viaShared = ((c: SharedPersonalityConfig): SharedPersonalityConfig => c)(
+      cortexValue,
+    );
+    const backToCortex: CortexPersonalityConfig = viaShared;
+    expect(backToCortex).toEqual(cortexValue);
+    expect(backToCortex.preset).toBe('professional');
+    expect(backToCortex.overrides?.candor).toBe('standard');
+  });
+});

--- a/self/cortex/core/src/gateway-runtime/harness-gateway-factory.ts
+++ b/self/cortex/core/src/gateway-runtime/harness-gateway-factory.ts
@@ -26,6 +26,7 @@ import type {
   TraceId,
 } from '@nous/shared';
 import type { ParsedModelOutput } from '../output-parser.js';
+import type { PersonalityConfig } from './personality/index.js';
 import { resolveAgentProfile } from './prompt-strategy.js';
 import { resolveAdapter } from '../agent-gateway/adapters/index.js';
 import { composeFromProfile } from './prompt-composer.js';
@@ -52,7 +53,7 @@ export interface HarnessGatewayCreateArgs {
   toolSurface: IScopedMcpToolSurface;
   lifecycleHooks?: IGatewayLifecycleHooks;
   providerType: string;
-  personalityConfig?: unknown;
+  personalityConfig?: PersonalityConfig;
   baseSystemPromptOverride?: string;
   outbox?: IGatewayOutboxSink;
   dispatchIntent?: DispatchIntent;

--- a/self/cortex/core/src/gateway-runtime/personality/index.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Personality module barrel (WR-128 / SP 1.2).
+ *
+ * Every public symbol listed in Goals C2 (`PersonalityConfig`,
+ * `PersonalityPreset`, `TraitAxes`, `TRAIT_REGISTRY`, `PRESETS`,
+ * `resolvePersonality`) is resolvable from a single import of this file.
+ * No symbol is re-exported from more than one underlying file.
+ */
+
+export type {
+  TraitInjection,
+  TraitValueDefinition,
+  TraitDefinition,
+  TraitAxes,
+} from './registry.js';
+export { defineTrait, TRAIT_REGISTRY } from './registry.js';
+
+export type { PersonalityPreset, PersonalityConfig } from './presets.js';
+export { PRESETS } from './presets.js';
+
+export type { FragmentsByTarget } from './resolver.js';
+export { resolvePersonality, collectFragmentsByTarget } from './resolver.js';

--- a/self/cortex/core/src/gateway-runtime/personality/presets.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/presets.ts
@@ -1,0 +1,57 @@
+/**
+ * Personality presets (WR-128 / SP 1.2).
+ *
+ * `PRESETS` is byte-equal to Decision 1 § Presets as Trait Value Maps and
+ * SDS § 3.4. `{ preset: 'balanced' }` yields every trait at its baseline
+ * variant — all `injection: null` — so identity concatenation is a no-op
+ * (SDS I2).
+ */
+import type { TraitAxes } from './registry.js';
+
+export type PersonalityPreset =
+  | 'balanced'
+  | 'professional'
+  | 'efficient'
+  | 'thorough';
+
+export const PRESETS: Record<PersonalityPreset, TraitAxes> = {
+  balanced: {
+    thoroughness: 'standard',
+    initiative: 'compliant',
+    candor: 'standard',
+    communicationStyle: 'concise',
+    codeStyle: 'standard',
+  },
+  professional: {
+    thoroughness: 'strict',
+    initiative: 'collaborative',
+    candor: 'strict',
+    communicationStyle: 'detailed',
+    codeStyle: 'minimal',
+  },
+  efficient: {
+    thoroughness: 'standard',
+    initiative: 'compliant',
+    candor: 'standard',
+    communicationStyle: 'concise',
+    codeStyle: 'minimal',
+  },
+  thorough: {
+    thoroughness: 'strict',
+    initiative: 'compliant',
+    candor: 'strict',
+    communicationStyle: 'detailed',
+    codeStyle: 'standard',
+  },
+};
+
+/**
+ * User-selected personality configuration: one of four presets, optionally
+ * with per-axis overrides shallow-merged on top. SP 1.2 is the canonical
+ * definition site; `@nous/shared` carries a structural mirror adjacent to
+ * `PromptFormatterInput` (SDS § 1.4, ADR 018).
+ */
+export interface PersonalityConfig {
+  readonly preset: PersonalityPreset;
+  readonly overrides?: Partial<TraitAxes>;
+}

--- a/self/cortex/core/src/gateway-runtime/personality/registry.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/registry.ts
@@ -1,0 +1,98 @@
+/**
+ * Personality trait registry (WR-128 / SP 1.2).
+ *
+ * Canonical home for the trait definition shape, the `defineTrait` factory,
+ * the ordered `TRAIT_REGISTRY` tuple, and the derived `TraitAxes` type.
+ *
+ * The registry is the generative surface: `TraitAxes` is derived from
+ * `TRAIT_REGISTRY`'s `as const` narrowness so that adding a new trait axis is
+ * a single-file edit (mirrors SP 1.1's `defineWizardStep` pattern).
+ *
+ * Invariants (enforced by `__tests__/gateway-runtime/personality/registry.test.ts`):
+ *   - Tuple order is load-bearing: identity / outputContract fragment
+ *     concatenation iterates this array in declared order.
+ *   - Every trait's "baseline" variant (`standard` / `compliant` / `concise`)
+ *     has `injection: null`. This is the registry-level invariant that makes
+ *     `{ preset: 'balanced' }` a byte-identity no-op at the identity surface.
+ */
+
+// ── Shape types ──────────────────────────────────────────────────────
+
+/**
+ * Where a trait value's prompt fragment is directed.
+ *   - `identity`:       self-presentation guidance concatenated into the
+ *                       agent's identity block.
+ *   - `outputContract`: task-output guidance. Under the SDS § 0 Note 1
+ *                       resolution (Option a, ADR 017), these fragments also
+ *                       surface via the identity block at the
+ *                       `resolveAgentProfile` boundary — the `target` field
+ *                       preserves the intent-level distinction so a future
+ *                       refactor can split them back out.
+ */
+export type TraitInjection =
+  | { readonly target: 'identity' | 'outputContract'; readonly fragment: string }
+  | null;
+
+export interface TraitValueDefinition {
+  readonly label: string;
+  readonly description: string;
+  readonly injection: TraitInjection;
+}
+
+export interface TraitDefinition<
+  TId extends string = string,
+  TValues extends Record<string, TraitValueDefinition> = Record<string, TraitValueDefinition>,
+> {
+  readonly id: TId;
+  readonly label: string;
+  readonly description: string;
+  readonly default: keyof TValues & string;
+  readonly values: TValues;
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+/**
+ * Identity function typed as a generic inferrer. Pure type-level helper —
+ * no runtime transformation. `const` generics preserve the literal-type
+ * narrowness of trait ids and value keys so `TraitAxes` (below) can be
+ * derived precisely from the registry. Mirrors SP 1.1's `defineWizardStep`
+ * precedent (SDS § 3.2.2, Note 3).
+ */
+export function defineTrait<
+  const TId extends string,
+  const TValues extends Record<string, TraitValueDefinition>,
+>(spec: {
+  readonly id: TId;
+  readonly label: string;
+  readonly description: string;
+  readonly default: keyof TValues & string;
+  readonly values: TValues;
+}): TraitDefinition<TId, TValues> {
+  return spec as TraitDefinition<TId, TValues>;
+}
+
+// ── Trait imports (tuple order is load-bearing) ──────────────────────
+
+import { thoroughnessTrait } from './traits/thoroughness.js';
+import { initiativeTrait } from './traits/initiative.js';
+import { candorTrait } from './traits/candor.js';
+import { communicationStyleTrait } from './traits/communication-style.js';
+import { codeStyleTrait } from './traits/code-style.js';
+
+export const TRAIT_REGISTRY = [
+  thoroughnessTrait,
+  initiativeTrait,
+  candorTrait,
+  communicationStyleTrait,
+  codeStyleTrait,
+] as const;
+
+/**
+ * Derived trait-axes type: `{ [traitId]: traitValueKey }` with literal types
+ * for each axis's value union. Collapse to `{ [id: string]: string }` is a
+ * build-time regression — SDS I5 / I6 / F1.
+ */
+export type TraitAxes = {
+  -readonly [T in typeof TRAIT_REGISTRY[number] as T['id']]: keyof T['values'] & string;
+};

--- a/self/cortex/core/src/gateway-runtime/personality/resolver.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/resolver.ts
@@ -1,0 +1,51 @@
+/**
+ * Personality resolver (WR-128 / SP 1.2).
+ *
+ * `resolvePersonality`     — collapses `PersonalityConfig` into a concrete
+ *                            `TraitAxes` by shallow-merging overrides onto
+ *                            the preset base.
+ * `collectFragmentsByTarget` — given effective axes, returns two fragment
+ *                            lists (identity / outputContract) built in
+ *                            `TRAIT_REGISTRY` tuple order (SDS I5).
+ *
+ * Under Note 1 Option (a) / ADR 017, the caller (`applyPersonalityToIdentity`)
+ * concatenates both lists onto the identity block; `applyPersonalityToOutputContract`
+ * is a deliberate pass-through on the enum surface.
+ */
+import {
+  TRAIT_REGISTRY,
+  type TraitAxes,
+  type TraitValueDefinition,
+} from './registry.js';
+import { PRESETS, type PersonalityConfig } from './presets.js';
+
+export function resolvePersonality(config: PersonalityConfig): TraitAxes {
+  return { ...PRESETS[config.preset], ...config.overrides };
+}
+
+export interface FragmentsByTarget {
+  readonly identity: readonly string[];
+  readonly outputContract: readonly string[];
+}
+
+export function collectFragmentsByTarget(axes: TraitAxes): FragmentsByTarget {
+  const identity: string[] = [];
+  const outputContract: string[] = [];
+  // The heterogeneous tuple narrows `trait.values` to a union whose shared
+  // index signature is `never`. We widen to the common structural type
+  // (`Record<string, TraitValueDefinition>`) for the per-trait lookup; the
+  // per-trait `defineTrait` signature still preserves narrowness for external
+  // consumers (SDS I6).
+  for (const trait of TRAIT_REGISTRY) {
+    const values = trait.values as Record<string, TraitValueDefinition>;
+    const selectedValueKey = axes[trait.id as keyof TraitAxes];
+    const injection = values[selectedValueKey].injection;
+    if (injection == null) continue;
+    if (injection.target === 'identity') {
+      identity.push(injection.fragment);
+    } else if (injection.target === 'outputContract') {
+      outputContract.push(injection.fragment);
+    }
+  }
+  return { identity, outputContract };
+}

--- a/self/cortex/core/src/gateway-runtime/personality/traits/candor.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/traits/candor.ts
@@ -1,0 +1,44 @@
+/**
+ * Candor trait (WR-128 / SP 1.2).
+ *
+ * Controls how explicitly the agent reports incomplete work, failed checks,
+ * and unverified outcomes.
+ * Variants:
+ *   - strict:   attaches an outputContract-targeted fragment that mandates
+ *               faithful outcome reporting and forbids defensive hedging.
+ *   - standard: injection: null (default — baseline reporting behavior).
+ *
+ * Fragment wording is ratified verbatim by SDS § 3.5 for this sub-phase.
+ */
+import { defineTrait } from '../registry.js';
+
+export const candorTrait = defineTrait({
+  id: 'candor',
+  label: 'Candor',
+  description:
+    'How explicitly does the agent report incomplete work, failed checks, or unverified outcomes?',
+  default: 'standard',
+  values: {
+    strict: {
+      label: 'Strict',
+      description: 'Report outcomes faithfully and plainly.',
+      injection: {
+        target: 'outputContract',
+        fragment:
+          'Report outcomes faithfully: if tests fail, say so with the ' +
+          'relevant output; if you did not run a verification step, say ' +
+          'that rather than implying it succeeded. Never claim all tests ' +
+          'pass when output shows failures, never suppress failing checks ' +
+          'to manufacture a green result, and never characterize incomplete ' +
+          'work as done. When a task is complete, state it plainly — do ' +
+          'not hedge confirmed results with unnecessary disclaimers. The ' +
+          'goal is an accurate report, not a defensive one.',
+      },
+    },
+    standard: {
+      label: 'Standard',
+      description: 'Default reporting behavior.',
+      injection: null,
+    },
+  },
+});

--- a/self/cortex/core/src/gateway-runtime/personality/traits/code-style.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/traits/code-style.ts
@@ -1,0 +1,44 @@
+/**
+ * Code-style trait (WR-128 / SP 1.2).
+ *
+ * Controls how the agent authors code comments and presents code.
+ * Variants:
+ *   - minimal:  attaches an identity-targeted fragment that keeps comments
+ *               focused on non-obvious WHYs.
+ *   - standard: injection: null (default — baseline commenting behavior).
+ *
+ * Filename is hyphenated; the trait id is camelCase (`codeStyle`) per
+ * SDS § 1.3 and Decision 1.
+ * Fragment wording is ratified verbatim by SDS § 3.5.
+ */
+import { defineTrait } from '../registry.js';
+
+export const codeStyleTrait = defineTrait({
+  id: 'codeStyle',
+  label: 'Code Style',
+  description: 'How the agent authors code comments and presents code.',
+  default: 'standard',
+  values: {
+    minimal: {
+      label: 'Minimal',
+      description: 'Comment only when the WHY is non-obvious.',
+      injection: {
+        target: 'identity',
+        fragment:
+          'Default to writing no comments. Only add one when the WHY is ' +
+          'non-obvious: a hidden constraint, a subtle invariant, a ' +
+          'workaround for a specific bug, behavior that would surprise a ' +
+          'reader. Do not explain WHAT the code does — well-named ' +
+          'identifiers already do that. Do not reference the current task, ' +
+          'fix, or callers — those belong in the PR description. Do not ' +
+          'remove existing comments unless you are removing the code they ' +
+          'describe or know they are wrong.',
+      },
+    },
+    standard: {
+      label: 'Standard',
+      description: 'Default commenting behavior.',
+      injection: null,
+    },
+  },
+});

--- a/self/cortex/core/src/gateway-runtime/personality/traits/communication-style.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/traits/communication-style.ts
@@ -1,0 +1,44 @@
+/**
+ * Communication-style trait (WR-128 / SP 1.2).
+ *
+ * Controls the prose style the agent uses for user-facing text.
+ * Variants:
+ *   - detailed: attaches an outputContract-targeted fragment that mandates
+ *               readable prose and calibrated length.
+ *   - concise:  injection: null (default — short, task-fit responses).
+ *
+ * Filename is hyphenated; the trait id is camelCase (`communicationStyle`)
+ * per SDS § 1.3 and Decision 1.
+ * Fragment wording is ratified verbatim by SDS § 3.5.
+ */
+import { defineTrait } from '../registry.js';
+
+export const communicationStyleTrait = defineTrait({
+  id: 'communicationStyle',
+  label: 'Communication Style',
+  description: 'Prose style for user-facing text.',
+  default: 'concise',
+  values: {
+    detailed: {
+      label: 'Detailed',
+      description: 'Complete sentences; expand terms that help.',
+      injection: {
+        target: 'outputContract',
+        fragment:
+          'When sending user-facing text, you are writing for a person, ' +
+          'not logging to a console. Assume users can only see your text ' +
+          'output. Use complete, grammatically correct sentences without ' +
+          'unexplained jargon. Expand technical terms where they help. ' +
+          'Match responses to the task: a simple question gets a direct ' +
+          'answer in prose, not headers and numbered sections. Keep ' +
+          'communication clear and concise, free of fluff. Avoid filler ' +
+          'or stating the obvious. Get straight to the point.',
+      },
+    },
+    concise: {
+      label: 'Concise',
+      description: 'Match response length to the task; skip filler.',
+      injection: null,
+    },
+  },
+});

--- a/self/cortex/core/src/gateway-runtime/personality/traits/initiative.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/traits/initiative.ts
@@ -1,0 +1,40 @@
+/**
+ * Initiative trait (WR-128 / SP 1.2).
+ *
+ * Controls how proactively the agent flags misconceptions and adjacent bugs
+ * versus acting strictly on the user's request.
+ * Variants:
+ *   - collaborative: attaches an identity-targeted fragment that invites the
+ *                    agent to speak up when it sees a problem.
+ *   - compliant:     injection: null (default — executes the request as stated).
+ *
+ * Fragment wording is ratified verbatim by SDS § 3.5 for this sub-phase.
+ */
+import { defineTrait } from '../registry.js';
+
+export const initiativeTrait = defineTrait({
+  id: 'initiative',
+  label: 'Initiative',
+  description:
+    "Does the agent proactively flag issues/bugs, or act strictly on the user's request?",
+  default: 'compliant',
+  values: {
+    collaborative: {
+      label: 'Collaborative',
+      description: 'Speak up about misconceptions and adjacent bugs.',
+      injection: {
+        target: 'identity',
+        fragment:
+          "If you notice the user's request is based on a misconception, or " +
+          'spot a bug adjacent to what they asked about, say so. You are a ' +
+          'collaborator, not just an executor — users benefit from your ' +
+          'judgment, not just your compliance.',
+      },
+    },
+    compliant: {
+      label: 'Compliant',
+      description: 'Act on the user request as stated.',
+      injection: null,
+    },
+  },
+});

--- a/self/cortex/core/src/gateway-runtime/personality/traits/thoroughness.ts
+++ b/self/cortex/core/src/gateway-runtime/personality/traits/thoroughness.ts
@@ -1,0 +1,39 @@
+/**
+ * Thoroughness trait (WR-128 / SP 1.2).
+ *
+ * Controls how strictly the agent verifies work before reporting it complete.
+ * Variants:
+ *   - strict:   attaches an outputContract-targeted fragment that requires
+ *               explicit verification before claiming success.
+ *   - standard: injection: null (default — matches external baseline behavior).
+ *
+ * Fragment wording is ratified verbatim by SDS § 3.5 for this sub-phase.
+ */
+import { defineTrait } from '../registry.js';
+
+export const thoroughnessTrait = defineTrait({
+  id: 'thoroughness',
+  label: 'Thoroughness',
+  description:
+    'How strictly does the agent verify work before reporting done?',
+  default: 'standard',
+  values: {
+    strict: {
+      label: 'Strict',
+      description: 'Verify before reporting complete.',
+      injection: {
+        target: 'outputContract',
+        fragment:
+          'Before reporting a task complete, verify it actually works: ' +
+          'run the test, execute the script, check the output. If you cannot ' +
+          'verify (no test exists, cannot run the code), say so explicitly ' +
+          'rather than claiming success.',
+      },
+    },
+    standard: {
+      label: 'Standard',
+      description: 'Report based on confidence; verify when convenient.',
+      injection: null,
+    },
+  },
+});

--- a/self/cortex/core/src/gateway-runtime/prompt-strategy.ts
+++ b/self/cortex/core/src/gateway-runtime/prompt-strategy.ts
@@ -7,6 +7,8 @@
  * Sub-phase 1.1 of WR-124 (Chat Response Quality).
  */
 import type { AgentClass, ToolConcurrencyConfig, ToolDefinition } from '@nous/shared';
+import type { PersonalityConfig } from './personality/index.js';
+import { collectFragmentsByTarget, resolvePersonality } from './personality/index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,9 +48,9 @@ export interface PromptConfig {
   /**
    * User-configured personality input (WR-128).
    * Affects identity wording and prose output style only.
-   * Shape TBD — WR-128 delivers the concrete type.
+   * Concrete type landed in SP 1.2 — see ./personality/index.js.
    */
-  readonly personalityConfig?: unknown;
+  readonly personalityConfig?: PersonalityConfig;
 }
 
 // ── Agent Profile types (WR-127) ─────────────────────────────────────
@@ -285,13 +287,13 @@ const DIMENSIONS_BY_CLASS: Record<AgentClass, AgentProfileDimensions> = {
  *
  * @param agentClass - One of the four canonical agent classes
  * @param providerId - Optional provider for per-provider prompt overrides
- * @param personalityConfig - Optional user personality config (WR-128)
+ * @param personalityConfig - Optional user personality config (WR-128 / SP 1.2).
  * @returns Immutable AgentProfile
  */
 export function resolveAgentProfile(
   agentClass: AgentClass,
   providerId?: string,
-  personalityConfig?: unknown,
+  personalityConfig?: PersonalityConfig,
 ): AgentProfile {
   const promptConfig = resolvePromptConfig(agentClass, providerId);
   const dimensions = DIMENSIONS_BY_CLASS[agentClass];
@@ -321,29 +323,50 @@ export function resolveAgentProfile(
 }
 
 /**
- * Apply personality overrides to the identity block.
- * WR-128 will define the concrete personality shape.
- * For now, returns the base identity unchanged (no-op until WR-128).
+ * Apply personality overrides to the identity block (WR-128 / SP 1.2).
+ *
+ * Resolves the config into effective `TraitAxes`, collects fragment lists per
+ * target via `collectFragmentsByTarget`, and concatenates all non-null
+ * fragments onto `baseIdentity` in registry tuple order. Per SDS § 0 Note 1
+ * Option (a) / ADR 017, both `identity`- and `outputContract`-targeted
+ * fragments surface here; the enum-shaped `applyPersonalityToOutputContract`
+ * below is a deliberate pass-through.
+ *
+ * `{ preset: 'balanced' }` yields zero fragments (all `standard`/`compliant`/
+ * `concise` variants have `injection: null`) and the function returns
+ * `baseIdentity` unchanged — SDS I2.
  */
 function applyPersonalityToIdentity(
   baseIdentity: string,
-  _personalityConfig: unknown,
+  personalityConfig: PersonalityConfig,
 ): string {
-  // WR-128: when concrete type is available, extract name/style overrides
-  // and merge into the identity string.
-  return baseIdentity;
+  const axes = resolvePersonality(personalityConfig);
+  const fragments = collectFragmentsByTarget(axes);
+  const allFragments = [...fragments.identity, ...fragments.outputContract];
+  if (allFragments.length === 0) return baseIdentity;
+  return [baseIdentity, ...allFragments].join('\n\n');
 }
 
 /**
- * Apply personality overrides to the output contract.
- * WR-128 will define whether personality can shift output style.
- * For now, returns the base output contract unchanged (no-op until WR-128).
+ * Apply personality overrides to the output contract (WR-128 / SP 1.2).
+ *
+ * Deliberate pass-through per SDS § 0 Note 1 Option (a) / ADR 017. The
+ * `OutputContract` is a narrow enum (`'prose' | 'structured' | 'mixed'`)
+ * surfaced to downstream consumers; no personality trait mutates the enum
+ * value. `outputContract`-targeted fragment text is surfaced by
+ * `applyPersonalityToIdentity` above.
+ *
+ * The body resolves the config and invokes `collectFragmentsByTarget` anyway
+ * so the WR-127 isolation invariant is audit-visible at this function
+ * boundary — a future drift where a well-meaning change starts mutating the
+ * enum fails loudly rather than quietly.
  */
 function applyPersonalityToOutputContract(
   baseContract: OutputContract,
-  _personalityConfig: unknown,
+  personalityConfig: PersonalityConfig,
 ): OutputContract {
-  // WR-128: when concrete type is available, check for prose style preference.
+  const axes = resolvePersonality(personalityConfig);
+  collectFragmentsByTarget(axes); // intentional — audits the invariant
   return baseContract;
 }
 

--- a/self/shared/src/interfaces/agent-gateway.ts
+++ b/self/shared/src/interfaces/agent-gateway.ts
@@ -105,6 +105,33 @@ export interface ToolConcurrencyConfig {
 
 // ── Strategy injection types (WR-127) ────────────────────────────────
 
+// Structural mirror — placed near PromptFormatterInput. NO import from @nous/cortex-core.
+// Canonical definitions live in self/cortex/core/src/gateway-runtime/personality/
+// (WR-128 / SP 1.2). The mirror exists so @nous/shared interfaces can type-narrow
+// `personalityConfig` without violating the leaf-package layering invariant
+// (@nous/shared must not import from @nous/cortex-core — SDS I7 / ADR 018).
+// Drift detected by self/cortex/core/src/__tests__/gateway-runtime/personality/
+// shared-interface-compatibility.test.ts.
+
+export type PersonalityPreset =
+  | 'balanced'
+  | 'professional'
+  | 'efficient'
+  | 'thorough';
+
+export type TraitAxes = {
+  thoroughness: 'strict' | 'standard';
+  initiative: 'collaborative' | 'compliant';
+  candor: 'strict' | 'standard';
+  communicationStyle: 'detailed' | 'concise';
+  codeStyle: 'minimal' | 'standard';
+};
+
+export interface PersonalityConfig {
+  readonly preset: PersonalityPreset;
+  readonly overrides?: Partial<TraitAxes>;
+}
+
 /** Input to the prompt formatter — agent-type axis composition */
 export interface PromptFormatterInput {
   readonly agentClass: AgentClass;
@@ -112,7 +139,7 @@ export interface PromptFormatterInput {
   readonly baseSystemPrompt?: string;
   readonly execution?: GatewayExecutionContext;
   readonly tools?: ToolDefinition[];
-  readonly personalityConfig?: unknown;
+  readonly personalityConfig?: PersonalityConfig;
 }
 
 /** Output from the prompt formatter */

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -102,6 +102,10 @@ export type {
   ContextStrategy,
   LoopConfig,
   ToolConcurrencyConfig,
+  // WR-128 / SP 1.2 personality structural mirror
+  PersonalityPreset,
+  PersonalityConfig,
+  TraitAxes,
 } from './agent-gateway.js';
 export type {
   IIngressTriggerValidator,


### PR DESCRIPTION
## Summary

WR-161 Sub-phase 1.2 ships the personality trait registry and the `PersonalityConfig` type system that Phase 1's personality work depends on.

- New `gateway-runtime/personality/` module: `TRAIT_REGISTRY` tuple, derived `TraitAxes` mapped type, `PRESETS` map, `resolvePersonality` (preset + last-write-wins overrides) and `collectFragmentsByTarget` resolver helpers, five V1 trait files (`thoroughness`, `initiative`, `candor`, `communication-style`, `code-style`).
- Cortex call-site swaps in `prompt-strategy.ts` (`PromptConfig`, `resolveAgentProfile`, `applyPersonalityToIdentity` body, `applyPersonalityToOutputContract` deliberate pass-through per ADR 017) and `harness-gateway-factory.ts` (`HarnessGatewayCreateArgs.personalityConfig`).
- `@nous/shared` structural mirror at `agent-gateway.ts` (`PersonalityPreset`, `TraitAxes`, `PersonalityConfig`) per ADR 018, swap of the fourth `unknown` slot on `PromptFormatterInput.personalityConfig`, and the `interfaces/index.ts` re-export update.
- Test suites: `personality/{registry,resolver,integration-with-apply-personality,shared-interface-compatibility}.test.ts`, plus the `agent-profile.test.ts` port to the concrete type with the R9 split (Blocks A-E).

ADRs 017 (`applyPersonalityToOutputContract` deliberate pass-through) and 018 (`PersonalityConfig` cortex canonical + `@nous/shared` structural mirror) were authored at SDS time and indexed at `.worklog/adr/index.mdx`.

## Test Plan

Behavioral Testing is deferred to Phase 1 close per Principal direction 2026-04-18 (sprint-scoped policy mirrored from SP 1.1). The four BT behaviours (preset resolution, preset + overrides merge, `{ preset: 'balanced' }` byte-identity invariant at every agent class, WR-127 dimension isolation) are mapped to in-process unit-test assertions and carry forward to the Phase 1 close BT plan.

- [x] `pnpm --filter @nous/cortex-core build` green
- [x] `pnpm --filter @nous/shared build` green
- [x] `pnpm test` 575 files / 5560 tests pass (per SP 1.2 Completion Report verification)
- [x] `pnpm vitest run` on personality + agent-profile: 5 files / 184 tests pass
- [x] `pnpm oxlint` zero new findings (one pre-existing carry-forward warning from SP 1.1)

## Artifacts

- Synthesis review: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.2/review.mdx` (Approved With Actions)
- Completion report: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.2/completion-report.mdx`
- ADR 017: `.worklog/adr/017-personality-output-contract-pass-through.mdx`
- ADR 018: `.worklog/adr/018-personality-config-canonical-location.mdx`