### PR TITLE
feat(onboarding-agent-identity): Phase 1.3 - persistence and prompt routing

### DIFF
--- a/docs/content/docs/api/procedures.mdx
+++ b/docs/content/docs/api/procedures.mdx
@@ -374,6 +374,11 @@ Response excerpt:
 |----------|------|-------|--------|
 | `firstRun.status` | query | — | `{ complete: boolean }` |
 | `firstRun.complete` | mutation | — | — |
+| `firstRun.writeIdentity` | mutation | `{ name, personality, profile }` | `FirstRunActionResult` |
+| `firstRun.resetWizard` | mutation | — | `FirstRunActionResult` |
+
+- `firstRun.writeIdentity` — Writes the agent identity step payload to `nous-config.json5` via the three `agent` block writers (`setAgentName`, `setPersonalityConfig`, `setUserProfile`) and then marks `'agent_identity'` complete in the wizard state. All three input fields (`name`, `personality`, `profile`) are required — the input schema is `.strict()` and rejects partial submissions before reaching the writers. Input shape is JSON-serializable (no `Date`, `Map`, `Set`, or function values) per the desktop wizard's raw-fetch transport constraint. Sibling preservation across the `agent.*` block is a property of the underlying writers when driven individually (e.g. by hand-edits or future per-field procedures); it is not surfaced through `firstRun.writeIdentity`, which accepts only the full identity-step payload as a single batched submission per SP 1.3 (Decisions 3 + 7). The wizard UI that submits this payload is `WizardStepIdentity` (lands in SP 1.4).
+- `firstRun.resetWizard` — Resets the first-run wizard. Clears the entire `agent` block via `clearAgentBlock` and then resets wizard state via `resetFirstRunState`. Leaves `providers` and `modelRoleAssignments` untouched. After reset, the agent-block readers return their typed defaults (`"Nous"`, `{ preset: "balanced" }`, `{}`, `false`) and the wizard restarts from the first step.
 
 ## witness
 

--- a/docs/content/docs/configuration/config-schema.mdx
+++ b/docs/content/docs/configuration/config-schema.mdx
@@ -18,6 +18,7 @@ Nous uses JSON5 for configuration. The config file is validated at load time wit
 | `pfcTierPresets` | Capability definitions per tier |
 | `modelRoleAssignments` | Which provider fulfills which model role |
 | `providers` | Provider configurations (Ollama, OpenAI-compatible, etc.) |
+| `agent` | Agent identity, personality, welcome-message tracking, and user profile (optional; absent in default config — populated by the first-run wizard or by hand-editing) |
 | `defaults` | Default project settings |
 | `storage` | Storage backends and options |
 | `security` | Trace sensitivity, optional settings |
@@ -109,6 +110,40 @@ Saved Principal and System model selections are restored into this structure at 
 - **endpoint** (optional): Use the provider base URL (for example `https://api.openai.com` or `https://api.anthropic.com`), not the full `/v1/chat/completions` path.
 
 Provider types: `text`, `image`, `video`, `vision`, `embedding`, `external-api`.
+
+## Agent
+
+The `agent` block stores agent identity and personality settings authored by the first-run wizard (lands in SP 1.4) or by direct hand-edit of the JSON5 file. This `agent` section is independent of the top-level `profile` (deployment profile) section above — they share no fields.
+
+```json5
+{
+  "agent": {
+    "name": "Nia",
+    "personality": {
+      "preset": "balanced",
+      "overrides": { "thoroughness": "strict" }
+    },
+    "welcomeMessageSent": true,
+    "profile": {
+      "displayName": "Andrew",
+      "role": "Software engineer",
+      "primaryUseCase": "Architecture exploration",
+      "expertise": "advanced"
+    }
+  }
+}
+```
+
+- **`name`** (string, optional) — Display name for the agent. When absent, readers return the typed default `"Nous"`.
+- **`personality`** (object, optional) — Personality preset plus optional per-axis overrides. `preset` is one of `balanced`, `professional`, `efficient`, `thorough`. `overrides` is a partial map of `TraitAxes` (`thoroughness`, `initiative`, `candor`, `communicationStyle`, `codeStyle`). When absent, readers return the typed default `{ preset: "balanced" }` and the production prompt path is byte-identical to the pre-personality baseline (regression-parity invariant).
+- **`welcomeMessageSent`** (boolean, optional) — Tracks whether the welcome message has been delivered (consumed by the welcome-message wiring in SP 1.6). When absent, readers return the typed default `false`.
+- **`profile`** (object, optional) — Typed user-profile sub-fields, all optional: `displayName`, `role`, `primaryUseCase`, `expertise` (`'beginner' | 'intermediate' | 'advanced'`). When absent, readers return the typed default `{}`. The schema is additive over time — new fields may be added in future sub-phases without breaking existing configs; renames or removals are migrations.
+
+**Read-time defaults — never persisted on read.** The entire `agent` block is absent from the default system config. Readers (`getAgentName`, `getPersonalityConfig`, `getUserProfile`, `getWelcomeMessageSent`) synthesize their typed defaults at read time without writing to disk. The `agent` key first appears in `nous-config.json5` only after the user completes the first-run identity step (lands in SP 1.4) or hand-edits the file.
+
+**Reset semantics.** The `firstRun.resetWizard` tRPC mutation clears the entire `agent` block while leaving `providers` and `modelRoleAssignments` untouched. After reset, all four readers return their typed defaults again.
+
+**JSON5 comment caveat.** Writes to `nous-config.json5` (e.g. when the wizard's `firstRun.writeIdentity` procedure runs) emit JSON, not JSON5 — any comments you add to the file by hand are lost on the next write. This is a pre-existing Phase 1 tradeoff documented in the `ConfigManager` source. Hand-editors who rely on comments should be aware that wizard-driven writes will strip them.
 
 ## Storage
 

--- a/self/apps/shared-server/__tests__/first-run-identity.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-identity.test.ts
@@ -1,0 +1,177 @@
+// First-run identity-write tRPC procedure tests
+// (Goals C26-C28; SDS § 6.6 T1-T4 + F1).
+//
+// Per implementation plan task 31. Note: the plan's path was
+// `src/__tests__/trpc/first-run.identity.test.ts`; the shared-server's
+// vitest config uses the `__tests__/...test.ts` glob so this file lives at
+// `self/apps/shared-server/__tests__/first-run-identity.test.ts` to be
+// picked up. Documented as a deviation in the Completion Report.
+//
+// Uses a real ConfigManager with a temp-file configPath and a real dataDir
+// for wizard state. Calls the tRPC procedure via the router's caller.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ConfigManager, DEFAULT_SYSTEM_CONFIG } from '@nous/autonomic-config';
+import { firstRunRouter } from '../src/trpc/routers/first-run';
+import { getFirstRunState } from '../src/first-run';
+
+let testDirs: string[] = [];
+
+function createScaffold() {
+  const dir = join(
+    tmpdir(),
+    'nous-fr-identity-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(dir, { recursive: true });
+  testDirs.push(dir);
+
+  const configPath = join(dir, 'nous-config.json');
+  writeFileSync(
+    configPath,
+    JSON.stringify(DEFAULT_SYSTEM_CONFIG, null, 2),
+    'utf-8',
+  );
+  const config = new ConfigManager({ configPath });
+  return {
+    dir,
+    configPath,
+    config,
+  };
+}
+
+function makeContext(scaffold: ReturnType<typeof createScaffold>) {
+  return {
+    dataDir: scaffold.dir,
+    config: scaffold.config,
+  } as unknown as Parameters<typeof firstRunRouter.createCaller>[0];
+}
+
+beforeEach(() => {
+  testDirs = [];
+});
+
+afterEach(() => {
+  for (const dir of testDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe('firstRun.writeIdentity (SP 1.3 — Decisions 3 + 7)', () => {
+  // T1 (C26)
+  it('happy path: writers persist values; getWelcomeMessageSent unchanged', async () => {
+    const scaffold = createScaffold();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    const result = await caller.writeIdentity({
+      name: 'Nia',
+      personality: { preset: 'professional' },
+      profile: {
+        displayName: 'Andrew',
+        expertise: 'advanced',
+      },
+    });
+
+    expect(result.success).toBe(true);
+
+    expect(scaffold.config.getAgentName()).toBe('Nia');
+    expect(scaffold.config.getPersonalityConfig()).toEqual({
+      preset: 'professional',
+    });
+    expect(scaffold.config.getUserProfile()).toEqual({
+      displayName: 'Andrew',
+      expertise: 'advanced',
+    });
+    // welcomeMessageSent reader should still return its default — writeIdentity
+    // only writes name/personality/profile per SDS § 3.5.
+    expect(scaffold.config.getWelcomeMessageSent()).toBe(false);
+  });
+
+  // T2 (C27)
+  it('input payload is JSON-serializable end-to-end', async () => {
+    const scaffold = createScaffold();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    const input = {
+      name: 'Nia',
+      personality: { preset: 'balanced' as const },
+      profile: { displayName: 'Andrew' },
+    };
+    // Round-trip through JSON to prove no Date/Map/Set/function values would
+    // survive — the wizard's `trpc-fetch.ts` uses raw fetch (no SuperJSON)
+    // so the procedure must accept what JSON.parse(JSON.stringify(input))
+    // produces.
+    const roundTripped = JSON.parse(JSON.stringify(input));
+    const result = await caller.writeIdentity(roundTripped);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid input shape (Zod failure at procedure boundary)', async () => {
+    const scaffold = createScaffold();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    // tRPC throws when input fails Zod parsing. We assert the procedure
+    // rejects rather than silently accepting an invalid preset.
+    await expect(
+      caller.writeIdentity({
+        name: 'Nia',
+        personality: { preset: 'invalid' as 'balanced' },
+        profile: {},
+      }),
+    ).rejects.toThrow();
+  });
+
+  // T3 (C28)
+  it("marks 'agent_identity' complete on successful write", async () => {
+    const scaffold = createScaffold();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    await caller.writeIdentity({
+      name: 'Nia',
+      personality: { preset: 'balanced' },
+      profile: {},
+    });
+
+    const state = await getFirstRunState(scaffold.dir);
+    expect(state.steps.agent_identity.status).toBe('complete');
+    expect(typeof state.steps.agent_identity.completedAt).toBe('string');
+  });
+
+  // T4 (F1) — partial-write resilience
+  it('F1 partial-write: invalid name fails before writers run; disk unchanged', async () => {
+    const scaffold = createScaffold();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    const beforeContent = readFileSync(scaffold.configPath, 'utf-8');
+
+    // Empty name fails Zod input validation at the procedure boundary
+    // (PersonalityConfigSchema requires preset; WriteIdentityInputSchema
+    // requires name.min(1)). The procedure rejects before any writer runs.
+    await expect(
+      caller.writeIdentity({
+        name: '',
+        personality: { preset: 'balanced' },
+        profile: {},
+      }),
+    ).rejects.toThrow();
+
+    expect(readFileSync(scaffold.configPath, 'utf-8')).toBe(beforeContent);
+    // No agent_identity step state file should be written.
+    const stateFile = join(scaffold.dir, '.nous-first-run-state.json');
+    if (existsSync(stateFile)) {
+      const state = await getFirstRunState(scaffold.dir);
+      expect(state.steps.agent_identity.status).toBe('pending');
+    }
+  });
+});

--- a/self/apps/shared-server/__tests__/first-run-reset.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-reset.test.ts
@@ -1,0 +1,170 @@
+// First-run resetWizard tRPC procedure tests
+// (Goals C17-C19; SDS § 6.3 / § 0 Note 1 Option B).
+//
+// Per implementation plan task 32. The vitest config picks up tests under
+// the `__tests__/...test.ts` glob; the file lives at
+// `self/apps/shared-server/__tests__/first-run-reset.test.ts` for
+// compatibility (deviation from the plan's `src/__tests__/trpc/...` path
+// documented in the Completion Report).
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ConfigManager, DEFAULT_SYSTEM_CONFIG } from '@nous/autonomic-config';
+import { firstRunRouter } from '../src/trpc/routers/first-run';
+
+let testDirs: string[] = [];
+
+const SAMPLE_PROVIDER = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: 'Test Provider',
+  type: 'text' as const,
+  modelId: 'test-model',
+  isLocal: false,
+  capabilities: ['chat'],
+};
+
+const SAMPLE_ROLE_ASSIGNMENT = {
+  role: 'cortex-chat' as const,
+  providerId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+};
+
+function createScaffoldWithProviders() {
+  const dir = join(
+    tmpdir(),
+    'nous-fr-reset-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(dir, { recursive: true });
+  testDirs.push(dir);
+
+  const configPath = join(dir, 'nous-config.json');
+  const initialConfig = {
+    ...DEFAULT_SYSTEM_CONFIG,
+    providers: [SAMPLE_PROVIDER],
+    modelRoleAssignments: [SAMPLE_ROLE_ASSIGNMENT],
+    agent: {
+      name: 'Nia',
+      personality: { preset: 'professional' as const },
+      welcomeMessageSent: true,
+      profile: {
+        displayName: 'Andrew',
+        expertise: 'advanced' as const,
+      },
+    },
+  };
+  writeFileSync(configPath, JSON.stringify(initialConfig, null, 2), 'utf-8');
+  const config = new ConfigManager({ configPath });
+
+  return { dir, configPath, config };
+}
+
+function makeContext(scaffold: ReturnType<typeof createScaffoldWithProviders>) {
+  return {
+    dataDir: scaffold.dir,
+    config: scaffold.config,
+  } as unknown as Parameters<typeof firstRunRouter.createCaller>[0];
+}
+
+beforeEach(() => {
+  testDirs = [];
+});
+
+afterEach(() => {
+  for (const dir of testDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe('firstRun.resetWizard (SP 1.3 — Decision 7 Option B)', () => {
+  // C17
+  it('clears the entire `agent` block; readers return defaults; wizard state is default', async () => {
+    const scaffold = createScaffoldWithProviders();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    // Pre-state: full agent block present
+    expect(scaffold.config.getAgentName()).toBe('Nia');
+    expect(scaffold.config.getPersonalityConfig()).toEqual({
+      preset: 'professional',
+    });
+
+    const newState = await caller.resetWizard();
+
+    // Wizard state is default
+    expect(newState.complete).toBe(false);
+    expect(newState.currentStep).toBe('ollama_check');
+
+    // All four agent readers return defaults (block cleared)
+    expect(scaffold.config.getAgentName()).toBe('Nous');
+    expect(scaffold.config.getPersonalityConfig()).toEqual({
+      preset: 'balanced',
+    });
+    expect(scaffold.config.getUserProfile()).toEqual({});
+    expect(scaffold.config.getWelcomeMessageSent()).toBe(false);
+  });
+
+  // C18
+  it('does not modify providers or modelRoleAssignments (sibling preservation)', async () => {
+    const scaffold = createScaffoldWithProviders();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    const beforeRaw = JSON.parse(readFileSync(scaffold.configPath, 'utf-8')) as {
+      providers: unknown[];
+      modelRoleAssignments: unknown[];
+    };
+    const providersBefore = JSON.stringify(beforeRaw.providers);
+    const roleAssignmentsBefore = JSON.stringify(beforeRaw.modelRoleAssignments);
+
+    await caller.resetWizard();
+
+    const afterRaw = JSON.parse(readFileSync(scaffold.configPath, 'utf-8')) as {
+      providers: unknown[];
+      modelRoleAssignments: unknown[];
+      agent?: unknown;
+    };
+
+    expect(JSON.stringify(afterRaw.providers)).toBe(providersBefore);
+    expect(JSON.stringify(afterRaw.modelRoleAssignments)).toBe(
+      roleAssignmentsBefore,
+    );
+    // `agent` key is gone entirely.
+    expect('agent' in afterRaw).toBe(false);
+  });
+
+  // C19 — three sub-assertions
+  it('reset clears block, post-reset readers return defaults, then writeIdentity re-populates', async () => {
+    const scaffold = createScaffoldWithProviders();
+    const caller = firstRunRouter.createCaller(makeContext(scaffold));
+
+    // (a) reset clears the block
+    await caller.resetWizard();
+    const cleared = JSON.parse(readFileSync(scaffold.configPath, 'utf-8'));
+    expect('agent' in cleared).toBe(false);
+
+    // (b) post-reset readers return defaults
+    expect(scaffold.config.getAgentName()).toBe('Nous');
+    expect(scaffold.config.getPersonalityConfig()).toEqual({
+      preset: 'balanced',
+    });
+    expect(scaffold.config.getUserProfile()).toEqual({});
+    expect(scaffold.config.getWelcomeMessageSent()).toBe(false);
+
+    // (c) running a fresh writeIdentity re-populates the block
+    const result = await caller.writeIdentity({
+      name: 'Sigma',
+      personality: { preset: 'efficient' },
+      profile: { displayName: 'Test User' },
+    });
+    expect(result.success).toBe(true);
+    expect(scaffold.config.getAgentName()).toBe('Sigma');
+    expect(scaffold.config.getPersonalityConfig()).toEqual({
+      preset: 'efficient',
+    });
+    expect(scaffold.config.getUserProfile()).toEqual({
+      displayName: 'Test User',
+    });
+  });
+});

--- a/self/apps/shared-server/__tests__/first-run-state.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-state.test.ts
@@ -40,6 +40,9 @@ describe('first-run state', () => {
     expect(state.currentStep).toBe('ollama_check');
     expect(state.complete).toBe(false);
     expect(state.steps.ollama_check.status).toBe('pending');
+    // SP 1.3 — `agent_identity` added to FIRST_RUN_STEP_VALUES per
+    // SDS § 0 Note 2; the default state includes it as pending.
+    expect(state.steps.agent_identity.status).toBe('pending');
     expect(state.steps.model_download.status).toBe('pending');
     expect(state.steps.provider_config.status).toBe('pending');
     expect(state.steps.role_assignment.status).toBe('pending');
@@ -69,7 +72,9 @@ describe('first-run state', () => {
     const state = await getFirstRunState(dir);
 
     expect(state.steps.ollama_check.status).toBe('complete');
-    expect(state.currentStep).toBe('model_download');
+    // SP 1.3 — `agent_identity` was inserted between ollama_check and
+    // model_download in FIRST_RUN_STEP_VALUES (SDS § 0 Note 2 / § 1.4).
+    expect(state.currentStep).toBe('agent_identity');
   });
 
   it('marks the entire wizard complete after the final step and writes the legacy flag', async () => {
@@ -81,6 +86,7 @@ describe('first-run state', () => {
     } = await loadModule();
 
     await markStepComplete(dir, 'ollama_check');
+    await markStepComplete(dir, 'agent_identity');
     await markStepComplete(dir, 'model_download');
     await markStepComplete(dir, 'provider_config');
     await markStepComplete(dir, 'role_assignment');

--- a/self/apps/shared-server/__tests__/first-run-wizard.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-wizard.test.ts
@@ -79,8 +79,17 @@ vi.mock('../src/bootstrap', () => ({
   upsertProviderConfig: bootstrapMock.upsertProviderConfig,
 }));
 
+// SP 1.3 — `agent_identity` added to FIRST_RUN_STEP_VALUES per SDS § 0 Note 2.
+// Treat it as already-complete in this fixture (existing pre-SP-1.3 wizard
+// scenarios bypass the identity step).
 function createWizardState(
-  currentStep: 'ollama_check' | 'model_download' | 'provider_config' | 'role_assignment' | 'complete',
+  currentStep:
+    | 'ollama_check'
+    | 'agent_identity'
+    | 'model_download'
+    | 'provider_config'
+    | 'role_assignment'
+    | 'complete',
 ) {
   const completed = currentStep === 'complete';
   return {
@@ -91,15 +100,24 @@ function createWizardState(
         status:
           currentStep === 'ollama_check' ? 'pending' : 'complete',
       },
+      agent_identity: {
+        status:
+          currentStep === 'ollama_check' || currentStep === 'agent_identity'
+            ? 'pending'
+            : 'complete',
+      },
       model_download: {
         status:
-          currentStep === 'ollama_check' || currentStep === 'model_download'
+          currentStep === 'ollama_check' ||
+          currentStep === 'agent_identity' ||
+          currentStep === 'model_download'
             ? 'pending'
             : 'complete',
       },
       provider_config: {
         status:
           currentStep === 'ollama_check' ||
+          currentStep === 'agent_identity' ||
           currentStep === 'model_download' ||
           currentStep === 'provider_config'
             ? 'pending'
@@ -189,6 +207,21 @@ function createMockContext() {
           allowRemoteProviders: false,
         },
       }),
+      // SP 1.3 — IConfig agent-block readers/writers (Decision 7).
+      // Stubbed out for the mocked first-run.ts paths exercised by this
+      // suite (downloadModel / configureProvider / completeStep /
+      // resetWizard). The new writeIdentity procedure has dedicated
+      // integration tests in `first-run-identity.test.ts` with a real
+      // ConfigManager.
+      getAgentName: vi.fn().mockReturnValue('Nous'),
+      getPersonalityConfig: vi.fn().mockReturnValue({ preset: 'balanced' }),
+      getUserProfile: vi.fn().mockReturnValue({}),
+      getWelcomeMessageSent: vi.fn().mockReturnValue(false),
+      setAgentName: vi.fn().mockResolvedValue(undefined),
+      setPersonalityConfig: vi.fn().mockResolvedValue(undefined),
+      setUserProfile: vi.fn().mockResolvedValue(undefined),
+      setWelcomeMessageSent: vi.fn().mockResolvedValue(undefined),
+      clearAgentBlock: vi.fn().mockResolvedValue(undefined),
     },
   } as any;
 }

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -513,6 +513,19 @@ function configWithFallback(base: ConfigManager) {
     getSection: base.getSection.bind(base),
     update: base.update.bind(base),
     reload: base.reload.bind(base),
+    // SP 1.3 — IConfig agent-block readers/writers (Decision 7).
+    // The fallback wrapper delegates straight through to the underlying
+    // ConfigManager — the fallback only affects mock provider hydration in
+    // `get()`, not the new agent-identity surface.
+    getAgentName: base.getAgentName.bind(base),
+    getPersonalityConfig: base.getPersonalityConfig.bind(base),
+    getUserProfile: base.getUserProfile.bind(base),
+    getWelcomeMessageSent: base.getWelcomeMessageSent.bind(base),
+    setAgentName: base.setAgentName.bind(base),
+    setPersonalityConfig: base.setPersonalityConfig.bind(base),
+    setUserProfile: base.setUserProfile.bind(base),
+    setWelcomeMessageSent: base.setWelcomeMessageSent.bind(base),
+    clearAgentBlock: base.clearAgentBlock.bind(base),
   };
 }
 
@@ -1311,6 +1324,14 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     recoveryLedgerStore,
     recoveryOrchestrator,
     logger,
+    // SP 1.3 — Decision 4 production wiring of PersonalityConfig.
+    // The cortex-runtime call sites (cortex-runtime.ts:308-310 / 335-336)
+    // consume `configReader.getPersonalityConfig()` for the Principal/System
+    // baseSystemPrompt composition. With this dep wired, prompt routing
+    // honors the user's persisted personality on every gateway boot; without
+    // it, the call sites fall back to `{ preset: 'balanced' }` (byte-identical
+    // to the pre-migration path per SDS Invariant I5; F8).
+    configReader: appConfig,
   });
 
   // WR-138 row #8 / CPAL § 6: attach providers exactly once after

--- a/self/apps/shared-server/src/trpc/routers/first-run.ts
+++ b/self/apps/shared-server/src/trpc/routers/first-run.ts
@@ -3,6 +3,10 @@
  */
 import { z } from 'zod';
 import type { ModelProviderConfig, ProviderId } from '@nous/shared';
+import {
+  PersonalityConfigSchema,
+  UserProfileSchema,
+} from '@nous/autonomic-config';
 import { router, publicProcedure } from '../trpc';
 import { detectHardware, recommendModels } from '../../hardware-detection';
 import { detectOllama, pullOllamaModel } from '../../ollama-detection';
@@ -25,6 +29,20 @@ import {
   updateRoleAssignment,
   upsertProviderConfig,
 } from '../../bootstrap';
+
+// SP 1.3 — JSON-serializable identity-step payload for the wizard's
+// `WizardStepIdentity` (SP 1.4) submit at sub-stage C completion.
+//
+// Strict mode (`PersonalityConfigSchema`/`UserProfileSchema` use `.strict()`,
+// and the input schema below adds its own `.strict()`) prevents the wizard
+// from silently submitting unknown fields. No Date/Map/Set/function values
+// — primitives only — per the wizard's `trpc-fetch.ts` raw-fetch transport
+// constraint (SDS Invariant I12).
+const WriteIdentityInputSchema = z.object({
+  name: z.string().min(1).max(120),
+  personality: PersonalityConfigSchema,
+  profile: UserProfileSchema,
+}).strict();
 
 function getProfilePolicy(ctx: { config: { get(): unknown } }) {
   const config = ctx.config.get() as {
@@ -233,7 +251,50 @@ export const firstRunRouter = router({
       return markStepComplete(ctx.dataDir, input.step);
     }),
 
+  // SP 1.3 — Decision 7 identity-persistence-schema-v1 / Decisions 3 + 7
+  // intersection. Single-batched identity-write procedure invoked once when
+  // the wizard's identity step (sub-stage C — Decision 3) completes. Calls
+  // the IConfig writers added in SP 1.3 (`setAgentName`,
+  // `setPersonalityConfig`, `setUserProfile`), then marks the
+  // `agent_identity` backend step complete. Per SDS § 0 Note 2 Posture (i),
+  // the literal `'agent_identity'` is in `FIRST_RUN_STEP_VALUES` (added in
+  // SP 1.3), so the markStepComplete call typechecks.
+  //
+  // No payload echo in logs (SDS § 5 security posture #3): only the error
+  // message surfaces in `console.warn`.
+  writeIdentity: publicProcedure
+    .input(WriteIdentityInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await ctx.config.setAgentName(input.name);
+        await ctx.config.setPersonalityConfig(input.personality);
+        await ctx.config.setUserProfile(input.profile);
+        const state = await markStepComplete(ctx.dataDir, 'agent_identity');
+        return FirstRunActionResultSchema.parse({
+          success: true,
+          state,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[nous:first-run] writeIdentity failed: ${message}`);
+        return actionFailure(ctx, message);
+      }
+    }),
+
   resetWizard: publicProcedure.mutation(async ({ ctx }) => {
+    // SP 1.3 § 0 Note 1 Option B — clear `agent` block first, then reset
+    // wizard state. Order rationale (folds SDS-review Should-Fix #1):
+    //   - Clear-first matches the wizard's natural data-then-state flow on
+    //     the `writeIdentity` companion procedure (writers run first, then
+    //     `markStepComplete`).
+    //   - Both operations are idempotent: re-clearing an absent `agent`
+    //     block is a no-op (ConfigManager.clearAgentBlock early-returns);
+    //     deleting a non-existent wizard-state file is fine. A partial
+    //     failure between the two steps (F2) is recoverable on retry.
+    //   - `resetFirstRunState(ctx.dataDir)` is unchanged from today — the
+    //     helper lives at `self/apps/shared-server/src/first-run.ts`
+    //     (folds SDS-review Note 5 line-citation alignment).
+    await ctx.config.clearAgentBlock();
     return resetFirstRunState(ctx.dataDir);
   }),
 });

--- a/self/autonomic/config/src/__tests__/agent-block-readers-writers.test.ts
+++ b/self/autonomic/config/src/__tests__/agent-block-readers-writers.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Reader/writer behaviour tests for the SP 1.3 `agent` block
+ * (Goals C6-C16; SDS § 6.1 Blocks A-G).
+ *
+ * Uses a real ConfigManager with a temp-file configPath (vitest tmpdir
+ * pattern, per Goals R8 / SDS § 6.1). Each test starts with a fresh temp
+ * file containing a baseline `nous-config.json5` (no `agent` block) — this
+ * exercises the actual on-disk path so we distinguish "block absent" from
+ * "block present with default-valued fields".
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, readFileSync, statSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ConfigError } from '@nous/shared';
+import { ConfigManager } from '../config-manager.js';
+import { DEFAULT_SYSTEM_CONFIG } from '../defaults.js';
+import type {
+  PersonalityConfig,
+  TraitAxesOverrides,
+  UserProfile,
+} from '../schema.js';
+
+const TEST_DIR = join(
+  tmpdir(),
+  'nous-agent-block-test-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+);
+
+function writeBaselineConfig(path: string, extra: Record<string, unknown> = {}): void {
+  const config = { ...DEFAULT_SYSTEM_CONFIG, ...extra };
+  writeFileSync(path, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+function freshConfig(name = 'config.json'): { path: string; manager: ConfigManager } {
+  const path = join(TEST_DIR, name);
+  writeBaselineConfig(path);
+  const manager = new ConfigManager({ configPath: path });
+  return { path, manager };
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+// ── Block A — Reader defaults (C6-C9) ──────────────────────────────────
+
+describe('SP 1.3 Block A — Reader defaults (C6-C9)', () => {
+  it('A1 — getAgentName() returns "Nous" when agent block absent', () => {
+    const { manager } = freshConfig();
+    expect(manager.getAgentName()).toBe('Nous');
+  });
+
+  it('A2 — getPersonalityConfig() returns { preset: "balanced" } when absent', () => {
+    const { manager } = freshConfig();
+    const config = manager.getPersonalityConfig();
+    expect(config).toEqual({ preset: 'balanced' });
+    // Frozen-sentinel reference stability: every call returns the same
+    // (frozen) reference. This is module-level — a separate call from a
+    // separate manager instance still returns the same sentinel.
+    expect(manager.getPersonalityConfig()).toBe(config);
+  });
+
+  it('A3 — getUserProfile() returns {} when agent block absent', () => {
+    const { manager } = freshConfig();
+    expect(manager.getUserProfile()).toEqual({});
+  });
+
+  it('A4 — getWelcomeMessageSent() returns false when absent', () => {
+    const { manager } = freshConfig();
+    expect(manager.getWelcomeMessageSent()).toBe(false);
+  });
+});
+
+// ── Block B — Reader purity (C10) ──────────────────────────────────────
+
+describe('SP 1.3 Block B — Reader purity (C10)', () => {
+  it('B1 — readers do not write to disk', async () => {
+    const { path, manager } = freshConfig();
+    const beforeMtime = statSync(path).mtimeMs;
+    const beforeContent = readFileSync(path, 'utf-8');
+
+    // Sequential reads — should NOT touch disk.
+    manager.getAgentName();
+    manager.getPersonalityConfig();
+    manager.getUserProfile();
+    manager.getWelcomeMessageSent();
+
+    // Wait a tick so any spurious mtime change would surface.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const afterMtime = statSync(path).mtimeMs;
+    const afterContent = readFileSync(path, 'utf-8');
+
+    expect(afterMtime).toBe(beforeMtime);
+    expect(afterContent).toBe(beforeContent);
+    // The file must NOT have gained an `agent` key.
+    const parsed = JSON.parse(afterContent) as { agent?: unknown };
+    expect(parsed.agent).toBeUndefined();
+  });
+});
+
+// ── Block C — Reader values when block is present ──────────────────────
+
+describe('SP 1.3 Block C — Reader values when block is present', () => {
+  it('C1 — partial block { name: "Nia" }: name set, others default', () => {
+    const path = join(TEST_DIR, 'partial-name.json');
+    writeBaselineConfig(path, { agent: { name: 'Nia' } });
+    const manager = new ConfigManager({ configPath: path });
+
+    expect(manager.getAgentName()).toBe('Nia');
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'balanced' });
+    expect(manager.getUserProfile()).toEqual({});
+    expect(manager.getWelcomeMessageSent()).toBe(false);
+  });
+
+  it('C2 — partial block { personality: { preset: "professional" } }: only personality set', () => {
+    const path = join(TEST_DIR, 'partial-personality.json');
+    writeBaselineConfig(path, {
+      agent: { personality: { preset: 'professional' } },
+    });
+    const manager = new ConfigManager({ configPath: path });
+
+    expect(manager.getAgentName()).toBe('Nous');
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'professional' });
+    expect(manager.getUserProfile()).toEqual({});
+    expect(manager.getWelcomeMessageSent()).toBe(false);
+  });
+
+  it('C3 — full block: all readers return persisted values', () => {
+    const path = join(TEST_DIR, 'full.json');
+    writeBaselineConfig(path, {
+      agent: {
+        name: 'Nia',
+        personality: { preset: 'thorough' },
+        welcomeMessageSent: true,
+        profile: {
+          displayName: 'Andrew',
+          role: 'Engineer',
+          expertise: 'advanced',
+        },
+      },
+    });
+    const manager = new ConfigManager({ configPath: path });
+
+    expect(manager.getAgentName()).toBe('Nia');
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'thorough' });
+    expect(manager.getUserProfile()).toEqual({
+      displayName: 'Andrew',
+      role: 'Engineer',
+      expertise: 'advanced',
+    });
+    expect(manager.getWelcomeMessageSent()).toBe(true);
+  });
+});
+
+// ── Block D — Writer creates block on first write (C11) ────────────────
+
+describe('SP 1.3 Block D — Writer creates block on first write (C11)', () => {
+  it('D1 — setAgentName creates agent block on first write', async () => {
+    const { path, manager } = freshConfig();
+    await manager.setAgentName('Nia');
+
+    expect(manager.getAgentName()).toBe('Nia');
+    const onDisk = JSON.parse(readFileSync(path, 'utf-8')) as {
+      agent?: { name?: string };
+    };
+    expect(onDisk.agent).toEqual({ name: 'Nia' });
+  });
+
+  it('D2 — setPersonalityConfig creates agent block on first write', async () => {
+    const { path, manager } = freshConfig();
+    const next: PersonalityConfig = { preset: 'thorough' };
+    await manager.setPersonalityConfig(next);
+
+    expect(manager.getPersonalityConfig()).toEqual(next);
+    const onDisk = JSON.parse(readFileSync(path, 'utf-8')) as {
+      agent?: { personality?: PersonalityConfig };
+    };
+    expect(onDisk.agent).toEqual({ personality: { preset: 'thorough' } });
+  });
+
+  it('D3 — setUserProfile and setWelcomeMessageSent create block on first write', async () => {
+    const a = freshConfig('a.json');
+    await a.manager.setUserProfile({ displayName: 'Andrew' });
+    expect(a.manager.getUserProfile()).toEqual({ displayName: 'Andrew' });
+    const aOnDisk = JSON.parse(readFileSync(a.path, 'utf-8')) as {
+      agent?: { profile?: UserProfile };
+    };
+    expect(aOnDisk.agent).toEqual({ profile: { displayName: 'Andrew' } });
+
+    const b = freshConfig('b.json');
+    await b.manager.setWelcomeMessageSent(true);
+    expect(b.manager.getWelcomeMessageSent()).toBe(true);
+    const bOnDisk = JSON.parse(readFileSync(b.path, 'utf-8')) as {
+      agent?: { welcomeMessageSent?: boolean };
+    };
+    expect(bOnDisk.agent).toEqual({ welcomeMessageSent: true });
+  });
+});
+
+// ── Block E — Sibling preservation (C12, C13, C14) ─────────────────────
+
+describe('SP 1.3 Block E — Sibling preservation (C12-C14)', () => {
+  it('E1 — setAgentName then setPersonalityConfig preserves name', async () => {
+    const { manager } = freshConfig();
+    await manager.setAgentName('Nia');
+    await manager.setPersonalityConfig({ preset: 'efficient' });
+
+    expect(manager.getAgentName()).toBe('Nia'); // preserved
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'efficient' });
+  });
+
+  it('E2 — all four writers in sequence: every reader returns its set value', async () => {
+    const { manager } = freshConfig();
+    await manager.setAgentName('Nia');
+    await manager.setPersonalityConfig({ preset: 'professional' });
+    await manager.setUserProfile({ displayName: 'Andrew', expertise: 'advanced' });
+    await manager.setWelcomeMessageSent(true);
+
+    expect(manager.getAgentName()).toBe('Nia');
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'professional' });
+    expect(manager.getUserProfile()).toEqual({
+      displayName: 'Andrew',
+      expertise: 'advanced',
+    });
+    expect(manager.getWelcomeMessageSent()).toBe(true);
+  });
+
+  it('E3 — overwriting one field leaves the other three intact', async () => {
+    const { manager } = freshConfig();
+    await manager.setAgentName('Nia');
+    await manager.setPersonalityConfig({ preset: 'professional' });
+    await manager.setUserProfile({ displayName: 'Andrew' });
+    await manager.setWelcomeMessageSent(true);
+
+    // Overwrite name only.
+    await manager.setAgentName('Other');
+    expect(manager.getAgentName()).toBe('Other');
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'professional' });
+    expect(manager.getUserProfile()).toEqual({ displayName: 'Andrew' });
+    expect(manager.getWelcomeMessageSent()).toBe(true);
+  });
+});
+
+// ── Block F — clearAgentBlock (C15) ────────────────────────────────────
+
+describe('SP 1.3 Block F — clearAgentBlock (C15)', () => {
+  it('F1 — clearAgentBlock removes the entire agent block; readers return defaults', async () => {
+    const path = join(TEST_DIR, 'clear-full.json');
+    writeBaselineConfig(path, {
+      agent: {
+        name: 'Nia',
+        personality: { preset: 'thorough' },
+        welcomeMessageSent: true,
+        profile: { displayName: 'Andrew' },
+      },
+    });
+    const manager = new ConfigManager({ configPath: path });
+
+    await manager.clearAgentBlock();
+
+    expect(manager.getAgentName()).toBe('Nous');
+    expect(manager.getPersonalityConfig()).toEqual({ preset: 'balanced' });
+    expect(manager.getUserProfile()).toEqual({});
+    expect(manager.getWelcomeMessageSent()).toBe(false);
+
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    expect('agent' in parsed).toBe(false);
+  });
+
+  it('F2 — clearAgentBlock is a no-op when block already absent', async () => {
+    const { path, manager } = freshConfig();
+    const beforeMtime = statSync(path).mtimeMs;
+    const beforeContent = readFileSync(path, 'utf-8');
+
+    await manager.clearAgentBlock();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const afterMtime = statSync(path).mtimeMs;
+    const afterContent = readFileSync(path, 'utf-8');
+
+    expect(afterMtime).toBe(beforeMtime);
+    expect(afterContent).toBe(beforeContent);
+  });
+
+  it('F3 — clearAgentBlock preserves all other top-level keys bit-for-bit', async () => {
+    const path = join(TEST_DIR, 'clear-with-providers.json');
+    writeBaselineConfig(path, {
+      agent: { name: 'Nia' },
+      providers: [
+        {
+          id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          name: 'Test Provider',
+          type: 'text',
+          modelId: 'test-model',
+          isLocal: false,
+          capabilities: ['chat'],
+        },
+      ],
+    });
+    const manager = new ConfigManager({ configPath: path });
+
+    const beforeContent = readFileSync(path, 'utf-8');
+    const beforeParsed = JSON.parse(beforeContent) as Record<string, unknown>;
+    const beforeWithoutAgent = { ...beforeParsed };
+    delete beforeWithoutAgent.agent;
+
+    await manager.clearAgentBlock();
+
+    const afterParsed = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    expect('agent' in afterParsed).toBe(false);
+    expect(JSON.stringify(afterParsed)).toBe(JSON.stringify(beforeWithoutAgent));
+  });
+});
+
+// ── Block G — Writer Zod validation (C16) ──────────────────────────────
+
+describe('SP 1.3 Block G — Writer Zod validation (C16)', () => {
+  it('G1 — setAgentName("") throws ConfigError; on-disk unchanged', async () => {
+    const { path, manager } = freshConfig();
+    const beforeContent = readFileSync(path, 'utf-8');
+
+    await expect(manager.setAgentName('')).rejects.toThrow(ConfigError);
+
+    expect(readFileSync(path, 'utf-8')).toBe(beforeContent);
+    expect(manager.getAgentName()).toBe('Nous'); // still default
+  });
+
+  it('G2 — setPersonalityConfig with invalid preset throws; on-disk unchanged', async () => {
+    const { path, manager } = freshConfig();
+    const beforeContent = readFileSync(path, 'utf-8');
+
+    await expect(
+      manager.setPersonalityConfig({ preset: 'invalid' as PersonalityConfig['preset'] }),
+    ).rejects.toThrow(ConfigError);
+
+    expect(readFileSync(path, 'utf-8')).toBe(beforeContent);
+  });
+
+  it('G3 — setPersonalityConfig with unknown override key throws (.strict)', async () => {
+    const { path, manager } = freshConfig();
+    const beforeContent = readFileSync(path, 'utf-8');
+
+    await expect(
+      manager.setPersonalityConfig({
+        preset: 'balanced',
+        overrides: { typo: 'value' } as unknown as TraitAxesOverrides,
+      }),
+    ).rejects.toThrow(ConfigError);
+
+    expect(readFileSync(path, 'utf-8')).toBe(beforeContent);
+  });
+
+  it('G4 — setUserProfile with invalid expertise enum throws; on-disk unchanged', async () => {
+    const { path, manager } = freshConfig();
+    const beforeContent = readFileSync(path, 'utf-8');
+
+    await expect(
+      manager.setUserProfile({
+        expertise: 'expert' as UserProfile['expertise'],
+      }),
+    ).rejects.toThrow(ConfigError);
+
+    expect(readFileSync(path, 'utf-8')).toBe(beforeContent);
+  });
+});

--- a/self/autonomic/config/src/__tests__/agent-block.test.ts
+++ b/self/autonomic/config/src/__tests__/agent-block.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Schema-shape baseline tests for the SP 1.3 `agent` block
+ * (Goals C1-C5; SDS § 6.1 Block H).
+ *
+ * Block H asserts that the SystemConfigSchema extension is shaped correctly,
+ * the missing-block contract holds, the profile schema is typed-and-strict,
+ * and the personality structural mirror is consistent (delegated to
+ * `personality-mirror-compat.test.ts`).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  AgentBlockSchema,
+  PersonalityConfigSchema,
+  SystemConfigSchema,
+  UserProfileSchema,
+} from '../schema.js';
+import { DEFAULT_SYSTEM_CONFIG } from '../defaults.js';
+
+describe('SP 1.3 agent block — schema shape (Block H)', () => {
+  // H1
+  it('SystemConfigSchema has an optional top-level `agent` field', () => {
+    expect(SystemConfigSchema.shape.agent).toBeDefined();
+    // The optional() wrapper exposes the inner schema via .unwrap() in zod.
+    // We assert by attempting to parse a config with the agent field absent.
+    const candidate = { ...DEFAULT_SYSTEM_CONFIG };
+    const result = SystemConfigSchema.safeParse(candidate);
+    expect(result.success).toBe(true);
+  });
+
+  // H2
+  it('a baseline config without an `agent` key parses successfully', () => {
+    const baseline = { ...DEFAULT_SYSTEM_CONFIG };
+    expect(() => SystemConfigSchema.parse(baseline)).not.toThrow();
+  });
+
+  // H3
+  it('DEFAULT_SYSTEM_CONFIG does NOT contain an `agent` entry', () => {
+    expect((DEFAULT_SYSTEM_CONFIG as { agent?: unknown }).agent).toBeUndefined();
+    expect('agent' in DEFAULT_SYSTEM_CONFIG).toBe(false);
+  });
+
+  // H4
+  it('UserProfileSchema is .strict() — unknown keys are rejected', () => {
+    // Zod .strict() rejects unknown keys. This is the binding behaviour for
+    // catching wizard typos at write time (Decision 7 § Profile Schema
+    // Constraints, F6 mitigation).
+    const result = UserProfileSchema.safeParse({
+      displayName: 'Andrew',
+      // unknown key — strict() should reject
+      displayname: 'should-fail',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('UserProfileSchema accepts the V1 roster fields, all optional', () => {
+    expect(() => UserProfileSchema.parse({})).not.toThrow();
+    expect(() => UserProfileSchema.parse({ displayName: 'Andrew' })).not.toThrow();
+    expect(() => UserProfileSchema.parse({
+      displayName: 'Andrew',
+      role: 'Software Engineer',
+      primaryUseCase: 'Building Nous',
+      expertise: 'advanced',
+    })).not.toThrow();
+  });
+
+  it('AgentBlockSchema accepts partial blocks (every nested field optional)', () => {
+    expect(() => AgentBlockSchema.parse({})).not.toThrow();
+    expect(() => AgentBlockSchema.parse({ name: 'Nia' })).not.toThrow();
+    expect(() => AgentBlockSchema.parse({
+      personality: { preset: 'professional' },
+    })).not.toThrow();
+    expect(() => AgentBlockSchema.parse({
+      welcomeMessageSent: true,
+    })).not.toThrow();
+    expect(() => AgentBlockSchema.parse({
+      profile: { displayName: 'Andrew' },
+    })).not.toThrow();
+  });
+
+  it('PersonalityConfigSchema requires a preset; overrides optional', () => {
+    expect(() => PersonalityConfigSchema.parse({ preset: 'balanced' })).not.toThrow();
+    expect(() => PersonalityConfigSchema.parse({
+      preset: 'professional',
+      overrides: { thoroughness: 'strict' },
+    })).not.toThrow();
+    // Missing preset
+    const missingPreset = PersonalityConfigSchema.safeParse({});
+    expect(missingPreset.success).toBe(false);
+    // Invalid preset
+    const invalidPreset = PersonalityConfigSchema.safeParse({ preset: 'invalid' });
+    expect(invalidPreset.success).toBe(false);
+  });
+
+  it('TraitAxesOverrides is .strict() — unknown trait keys rejected', () => {
+    const result = PersonalityConfigSchema.safeParse({
+      preset: 'balanced',
+      overrides: { typo: 'value' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('SystemConfigSchema accepts a config with a populated `agent` block', () => {
+    const candidate = {
+      ...DEFAULT_SYSTEM_CONFIG,
+      agent: {
+        name: 'Nia',
+        personality: { preset: 'professional' as const },
+        welcomeMessageSent: false,
+        profile: { displayName: 'Andrew' },
+      },
+    };
+    expect(() => SystemConfigSchema.parse(candidate)).not.toThrow();
+  });
+});

--- a/self/autonomic/config/src/__tests__/iconfig-profile-compat.test.ts
+++ b/self/autonomic/config/src/__tests__/iconfig-profile-compat.test.ts
@@ -1,0 +1,56 @@
+/**
+ * IConfig profile structural-mirror compatibility test
+ * (SP 1.3 / SDS § 6.2 / SDS I2 / F5).
+ *
+ * Asserts assignment compatibility in BOTH directions between the canonical
+ * `UserProfile` declared in `@nous/autonomic-config`'s schema (Zod-derived) and
+ * the `AgentUserProfile` structural mirror declared in `@nous/shared`'s
+ * `interfaces/autonomic.ts`. The mirror lives in `@nous/shared` because that
+ * is where `IConfig` lives; per ADR 018 the shared package must not import
+ * from `@nous/autonomic-config`, so a structural mirror is the path that
+ * keeps `IConfig.getUserProfile()` typeable without a layering violation.
+ *
+ * Compile-time pass is the assertion. Mirrors SP 1.2's
+ * `shared-interface-compatibility.test.ts` pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentUserProfile } from '@nous/shared';
+import type { UserProfile } from '../schema.js';
+
+function acceptsAutonomic(profile: UserProfile): UserProfile {
+  return profile;
+}
+
+function acceptsShared(profile: AgentUserProfile): AgentUserProfile {
+  return profile;
+}
+
+describe('UserProfile structural-mirror compatibility (SDS I2)', () => {
+  it('accepts an autonomic-config UserProfile where AgentUserProfile is expected', () => {
+    const autonomic: UserProfile = {
+      displayName: 'Andrew',
+      role: 'Software Engineer',
+    };
+    // Compile-time assertion: UserProfile is assignable to AgentUserProfile.
+    const shared: AgentUserProfile = autonomic;
+    expect(acceptsShared(shared)).toEqual(autonomic);
+  });
+
+  it('accepts an AgentUserProfile where UserProfile is expected', () => {
+    const shared: AgentUserProfile = {
+      displayName: 'Andrew',
+      primaryUseCase: 'Building a personal AI agent',
+      expertise: 'advanced',
+    };
+    // Compile-time assertion: AgentUserProfile is assignable to UserProfile.
+    const autonomic: UserProfile = shared;
+    expect(acceptsAutonomic(autonomic)).toEqual(shared);
+  });
+
+  it('round-trips an empty profile in both directions', () => {
+    const empty: AgentUserProfile = {};
+    const asAutonomic: UserProfile = empty;
+    const back: AgentUserProfile = asAutonomic;
+    expect(back).toEqual({});
+  });
+});

--- a/self/autonomic/config/src/__tests__/personality-mirror-compat.test.ts
+++ b/self/autonomic/config/src/__tests__/personality-mirror-compat.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Personality structural-mirror compatibility test (SP 1.3 / SDS § 6.1 H5).
+ *
+ * Mirrors SP 1.2's `shared-interface-compatibility.test.ts` precedent: assert
+ * assignment compatibility in BOTH directions between the canonical
+ * `PersonalityConfig` declared in `@nous/autonomic-config`'s schema (Zod-derived)
+ * and the structural mirror declared in `@nous/shared`'s `interfaces/agent-gateway.ts`
+ * (per ADR 018 layering invariant).
+ *
+ * Compile-time pass is the assertion. Runtime asserts that the two values
+ * survive a JSON round-trip with the same shape.
+ */
+import { describe, it, expect } from 'vitest';
+import type { PersonalityConfig as SharedPersonalityConfig } from '@nous/shared';
+import type { PersonalityConfig as AutonomicPersonalityConfig } from '../schema.js';
+
+function acceptsAutonomic(config: AutonomicPersonalityConfig): AutonomicPersonalityConfig {
+  return config;
+}
+
+function acceptsShared(config: SharedPersonalityConfig): SharedPersonalityConfig {
+  return config;
+}
+
+describe('PersonalityConfig structural-mirror compatibility (ADR 018 / SDS I1)', () => {
+  it('accepts an autonomic-config value where a shared value is expected', () => {
+    const autonomic: AutonomicPersonalityConfig = { preset: 'balanced' };
+    // Compile-time assertion: AutonomicPersonalityConfig is assignable to
+    // SharedPersonalityConfig.
+    const shared: SharedPersonalityConfig = autonomic;
+    expect(acceptsShared(shared)).toEqual(autonomic);
+  });
+
+  it('accepts a shared value where an autonomic-config value is expected', () => {
+    const shared: SharedPersonalityConfig = {
+      preset: 'professional',
+      overrides: { thoroughness: 'strict' },
+    };
+    // Compile-time assertion: SharedPersonalityConfig is assignable to
+    // AutonomicPersonalityConfig.
+    const autonomic: AutonomicPersonalityConfig = shared;
+    expect(acceptsAutonomic(autonomic)).toEqual(shared);
+  });
+
+  it('round-trips both shapes through JSON without drift', () => {
+    const fixture: SharedPersonalityConfig = {
+      preset: 'thorough',
+      overrides: {
+        candor: 'standard',
+        codeStyle: 'minimal',
+      },
+    };
+    const roundTripped = JSON.parse(JSON.stringify(fixture)) as AutonomicPersonalityConfig;
+    expect(roundTripped).toEqual(fixture);
+  });
+});

--- a/self/autonomic/config/src/config-manager.ts
+++ b/self/autonomic/config/src/config-manager.ts
@@ -9,6 +9,13 @@
  * to avoid circular dependencies between shared and autonomic/config.
  * This implementation uses the full Zod-inferred SystemConfig internally
  * and conforms to the interface's generic signatures through explicit typing.
+ *
+ * SP 1.3 — Decision 7 identity-persistence-schema-v1 readers/writers added.
+ * The four agent-block readers synthesize typed defaults at read time when
+ * the `agent` block is absent on disk; the four writers + clearAgentBlock
+ * persist via a sibling-level shallow spread (preserves untargeted fields
+ * inside `agent`) and validate the candidate config through the Zod schema
+ * before writing.
  */
 import { writeFileSync } from 'node:fs';
 import { ConfigError } from '@nous/shared';
@@ -16,8 +23,27 @@ import type {
   IConfig,
   SystemConfig as BaseSystemConfig,
 } from '@nous/shared';
-import { SystemConfigSchema, type SystemConfig } from './schema.js';
+import {
+  SystemConfigSchema,
+  type SystemConfig,
+  type AgentBlock,
+  type PersonalityConfig,
+  type UserProfile,
+} from './schema.js';
 import { loadConfig } from './loader.js';
+
+// SP 1.3 — module-level frozen defaults for the agent-block readers.
+//
+// Frozen so that callers that mutate the returned reference cannot
+// accidentally pollute the shared default. Module-level so that every call
+// returns the same reference (allows callers to compare against the sentinel
+// — used by tests A2/A3 in agent-block-readers-writers.test.ts).
+const DEFAULT_AGENT_NAME = 'Nous';
+const DEFAULT_PERSONALITY_CONFIG: PersonalityConfig = Object.freeze({
+  preset: 'balanced' as const,
+});
+const DEFAULT_USER_PROFILE: UserProfile = Object.freeze({});
+const DEFAULT_WELCOME_MESSAGE_SENT = false;
 
 export class ConfigManager implements IConfig {
   private config: SystemConfig;
@@ -99,5 +125,123 @@ export class ConfigManager implements IConfig {
     console.log(
       `[nous:config] Configuration reloaded from ${this.configPath}`,
     );
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  // SP 1.3 — Decision 7 identity-persistence-schema-v1 readers.
+  //
+  // O(1) in-memory accesses. Read from `this.config.agent?.<field>` and
+  // synthesize the module-level frozen sentinel when absent. NEVER write
+  // to disk during reads (asserted by reader-purity test B1).
+  // ───────────────────────────────────────────────────────────────────
+
+  getAgentName(): string {
+    return this.config.agent?.name ?? DEFAULT_AGENT_NAME;
+  }
+
+  getPersonalityConfig(): PersonalityConfig {
+    return this.config.agent?.personality ?? DEFAULT_PERSONALITY_CONFIG;
+  }
+
+  getUserProfile(): UserProfile {
+    return this.config.agent?.profile ?? DEFAULT_USER_PROFILE;
+  }
+
+  getWelcomeMessageSent(): boolean {
+    return this.config.agent?.welcomeMessageSent ?? DEFAULT_WELCOME_MESSAGE_SENT;
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  // SP 1.3 — Decision 7 writers.
+  //
+  // Writer pattern note (SP 1.3 — folds SDS-review Note 4):
+  //
+  // Each writer composes the next AgentBlock via a SIBLING-LEVEL SHALLOW
+  // SPREAD of the current `agent` block:
+  //
+  //     { ...this.config.agent, <field>: value }
+  //
+  // Spreading `undefined` is a no-op in object literals (per ECMAScript
+  // spec), so when `this.config.agent` is absent the writer creates a
+  // single-field block; when it is present, the writer preserves all
+  // sibling fields. This preserves SIBLING fields of the targeted field
+  // inside `agent` (e.g., setPersonalityConfig preserves `name`,
+  // `welcomeMessageSent`, `profile`). It is NOT a deep merge — the
+  // targeted field is REPLACED WHOLESALE (e.g., setPersonalityConfig({
+  // preset: 'professional' }) replaces the full PersonalityConfig
+  // including any prior `overrides`). This matches SDS § 3.4 and Goals
+  // C12-C14: writers take complete typed values, not partials.
+  //
+  // The existing `update()` shallow-merges at the SECTION level — that
+  // pattern is insufficient for `agent.*` field-level preservation, hence
+  // the dedicated `writeAgentBlock` helper below.
+  // ───────────────────────────────────────────────────────────────────
+
+  private async writeAgentBlock(next: AgentBlock | undefined): Promise<void> {
+    const candidate: SystemConfig = next === undefined
+      ? { ...this.config, agent: undefined }
+      : { ...this.config, agent: next };
+
+    const result = SystemConfigSchema.safeParse(candidate);
+    if (!result.success) {
+      const fieldErrors = result.error.issues.map((issue) => ({
+        path: issue.path.join('.'),
+        message: issue.message,
+      }));
+      throw new ConfigError(
+        `Agent block validation failed: ${fieldErrors.length} error(s)`,
+        { section: 'agent', errors: fieldErrors },
+      );
+    }
+
+    this.config = result.data;
+
+    if (this.configPath) {
+      // JSON.stringify drops top-level keys with `undefined` values per
+      // ECMAScript spec — so `clearAgentBlock` writes a config file with no
+      // `"agent"` key, not `"agent": null`.
+      writeFileSync(
+        this.configPath,
+        JSON.stringify(this.config, null, 2),
+        'utf-8',
+      );
+    }
+  }
+
+  async setAgentName(name: string): Promise<void> {
+    // Sibling-level shallow spread — see writer pattern note above.
+    // Spreading undefined `this.config.agent` is safe (no-op); oxlint
+    // unicorn/no-useless-fallback-in-spread flags `?? {}` as unnecessary.
+    const next: AgentBlock = { ...this.config.agent, name };
+    await this.writeAgentBlock(next);
+    console.log(`[nous:config] Section 'agent' updated (name)`);
+  }
+
+  async setPersonalityConfig(config: PersonalityConfig): Promise<void> {
+    const next: AgentBlock = { ...this.config.agent, personality: config };
+    await this.writeAgentBlock(next);
+    console.log(`[nous:config] Section 'agent' updated (personality)`);
+  }
+
+  async setUserProfile(profile: UserProfile): Promise<void> {
+    const next: AgentBlock = { ...this.config.agent, profile };
+    await this.writeAgentBlock(next);
+    console.log(`[nous:config] Section 'agent' updated (profile)`);
+  }
+
+  async setWelcomeMessageSent(value: boolean): Promise<void> {
+    const next: AgentBlock = { ...this.config.agent, welcomeMessageSent: value };
+    await this.writeAgentBlock(next);
+    console.log(`[nous:config] Section 'agent' updated (welcomeMessageSent)`);
+  }
+
+  async clearAgentBlock(): Promise<void> {
+    if (this.config.agent === undefined) {
+      // No-op when block already absent. Preserves I9 trivially and avoids
+      // an unnecessary disk write (mtime unchanged — Block F2 assertion).
+      return;
+    }
+    await this.writeAgentBlock(undefined);
+    console.log(`[nous:config] Section 'agent' cleared`);
   }
 }

--- a/self/autonomic/config/src/index.ts
+++ b/self/autonomic/config/src/index.ts
@@ -11,6 +11,12 @@ export {
   DefaultsConfigSchema,
   ProviderConfigEntrySchema,
   LoggingConfigSchema,
+  // SP 1.3 — Decision 7 identity-persistence-schema-v1
+  AgentBlockSchema,
+  PersonalityConfigSchema,
+  PersonalityPresetSchema,
+  TraitAxesOverridesSchema,
+  UserProfileSchema,
 } from './schema.js';
 export type {
   SystemConfig,
@@ -22,6 +28,12 @@ export type {
   DefaultsConfig,
   ProviderConfigEntry,
   LoggingConfig,
+  // SP 1.3 — Decision 7
+  AgentBlock,
+  PersonalityConfig,
+  PersonalityPreset,
+  TraitAxesOverrides,
+  UserProfile,
 } from './schema.js';
 
 export {

--- a/self/autonomic/config/src/schema.ts
+++ b/self/autonomic/config/src/schema.ts
@@ -146,6 +146,77 @@ export const LoggingConfigSchema = z.object({
 }).optional().default({});
 export type LoggingConfig = z.infer<typeof LoggingConfigSchema>;
 
+// --- Agent Block (SP 1.3 — Decision 7 identity-persistence-schema-v1) ---
+//
+// The `agent` block is the canonical persistence site for everything the
+// onboarding wizard authors about the agent: name, personality, welcome flag,
+// and a typed-and-optional user profile. Per Decision 7, defaults are
+// synthesized at read time by `ConfigManager`'s readers and are NEVER written
+// to disk until the user configures. The entire block is optional at the top
+// level; configs without it validate.
+//
+// Personality types are declared here as a structural mirror of SP 1.2's
+// canonical types in `self/cortex/core/src/gateway-runtime/personality/`. The
+// shapes are byte-equivalent (proven by `personality-mirror-compat.test.ts`).
+// Per ADR 018 the `@nous/shared` mirror is the boundary surface for the
+// `IConfig` interface — see SDS § 1.3 / I1.
+
+// Personality preset enum (mirrors SP 1.2's PersonalityPreset literal type).
+export const PersonalityPresetSchema = z.enum([
+  'balanced',
+  'professional',
+  'efficient',
+  'thorough',
+]);
+export type PersonalityPreset = z.infer<typeof PersonalityPresetSchema>;
+
+// Trait-axes overrides — Partial<TraitAxes> at the type layer. Each field is
+// optional; unknown keys rejected by `.strict()`. Enum values byte-match SP 1.2's
+// `TraitAxes`.
+export const TraitAxesOverridesSchema = z.object({
+  thoroughness: z.enum(['strict', 'standard']).optional(),
+  initiative: z.enum(['collaborative', 'compliant']).optional(),
+  candor: z.enum(['strict', 'standard']).optional(),
+  communicationStyle: z.enum(['detailed', 'concise']).optional(),
+  codeStyle: z.enum(['minimal', 'standard']).optional(),
+}).strict();
+export type TraitAxesOverrides = z.infer<typeof TraitAxesOverridesSchema>;
+
+// PersonalityConfig — preset + optional overrides.
+export const PersonalityConfigSchema = z.object({
+  preset: PersonalityPresetSchema,
+  overrides: TraitAxesOverridesSchema.optional(),
+}).strict();
+export type PersonalityConfig = z.infer<typeof PersonalityConfigSchema>;
+
+// UserProfile — Decision 7's typed-and-optional V1 roster (per Goals R9).
+// V1 fields map to SP 1.4's identity sub-stage UX:
+//   - displayName: user's preferred name for the agent to use
+//   - role: user's role/title
+//   - primaryUseCase: short free-text description of what the user is working on
+//   - expertise: the user's familiarity with their domain
+// Every field is optional; absent fields produce a `{}` shape from the reader.
+// Adding a field is an additive Zod schema change; renaming or removing
+// requires explicit migration (Decision 7 § Profile Schema Constraints).
+export const UserProfileSchema = z.object({
+  displayName: z.string().min(1).max(120).optional(),
+  role: z.string().min(1).max(120).optional(),
+  primaryUseCase: z.string().min(1).max(500).optional(),
+  expertise: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
+}).strict();
+export type UserProfile = z.infer<typeof UserProfileSchema>;
+
+// AgentBlock — the new top-level block. Every nested field is optional so
+// partial blocks (e.g., `{ name: "Nia" }` only) validate. Empty profile (`{}`)
+// is allowed and is the default the reader synthesizes (C8).
+export const AgentBlockSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  personality: PersonalityConfigSchema.optional(),
+  welcomeMessageSent: z.boolean().optional(),
+  profile: UserProfileSchema.optional(),
+}).strict();
+export type AgentBlock = z.infer<typeof AgentBlockSchema>;
+
 // --- Full System Configuration ---
 export const SystemConfigSchema = z.object({
   profile: ProfileSchema,
@@ -159,5 +230,10 @@ export const SystemConfigSchema = z.object({
     traceSensitiveData: false,
   }),
   logging: LoggingConfigSchema,
+  // SP 1.3 — Decision 7 identity-persistence-schema-v1.
+  // Optional at the top level. Defaults are synthesized at read time by
+  // ConfigManager's `getAgent*` readers; never written to disk until the user
+  // configures via the wizard.
+  agent: AgentBlockSchema.optional(),
 });
 export type SystemConfig = z.infer<typeof SystemConfigSchema>;

--- a/self/autonomic/logger/src/__bench__/logger.bench.ts
+++ b/self/autonomic/logger/src/__bench__/logger.bench.ts
@@ -22,6 +22,16 @@ describe('Logger performance', () => {
     getSection: () => undefined as any,
     update: async () => {},
     reload: async () => {},
+    // SP 1.3 — IConfig agent-block stubs (Decision 7).
+    getAgentName: () => 'Nous',
+    getPersonalityConfig: () => ({ preset: 'balanced' as const }),
+    getUserProfile: () => ({}),
+    getWelcomeMessageSent: () => false,
+    setAgentName: async () => {},
+    setPersonalityConfig: async () => {},
+    setUserProfile: async () => {},
+    setWelcomeMessageSent: async () => {},
+    clearAgentBlock: async () => {},
   });
   const disabledChannel = disabledLogger.channel('nous:bench-disabled');
 

--- a/self/autonomic/logger/src/__tests__/logger.test.ts
+++ b/self/autonomic/logger/src/__tests__/logger.test.ts
@@ -46,6 +46,17 @@ function createMockConfig(overrides?: {
     getSection: () => undefined as any,
     update: async () => {},
     reload: async () => {},
+    // SP 1.3 — IConfig agent-block stubs (Decision 7). Logger tests do not
+    // touch the agent block; defaults are sufficient.
+    getAgentName: () => 'Nous',
+    getPersonalityConfig: () => ({ preset: 'balanced' as const }),
+    getUserProfile: () => ({}),
+    getWelcomeMessageSent: () => false,
+    setAgentName: async () => {},
+    setPersonalityConfig: async () => {},
+    setUserProfile: async () => {},
+    setWelcomeMessageSent: async () => {},
+    clearAgentBlock: async () => {},
   };
 }
 
@@ -219,6 +230,16 @@ describe('NousLogger', () => {
         getSection: () => undefined as any,
         update: async () => {},
         reload: async () => {},
+        // SP 1.3 — IConfig agent-block stubs (Decision 7).
+        getAgentName: () => 'Nous',
+        getPersonalityConfig: () => ({ preset: 'balanced' as const }),
+        getUserProfile: () => ({}),
+        getWelcomeMessageSent: () => false,
+        setAgentName: async () => {},
+        setPersonalityConfig: async () => {},
+        setUserProfile: async () => {},
+        setWelcomeMessageSent: async () => {},
+        clearAgentBlock: async () => {},
       };
       expect(() => logger.bindConfig(config)).not.toThrow();
     });

--- a/self/cortex/core/src/__tests__/gateway-runtime/agent-profile.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/agent-profile.test.ts
@@ -257,3 +257,67 @@ describe('resolveAgentProfile — edge cases', () => {
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// SP 1.3 — WR-127 dimension isolation under cortex-runtime migration (C25)
+// ---------------------------------------------------------------------------
+//
+// SP 1.2 verified WR-127 dimension isolation at the resolver layer (Block C/D/E
+// above). SP 1.3 migrates the Principal/System runtime composition to route
+// PersonalityConfig through `resolveAgentProfile`. This describe block proves
+// the dimension-isolation invariant survives the call-site migration: for the
+// two migrated agent classes (Principal, System), every preset and a
+// representative overrides case produce an AgentProfile whose mechanical
+// dimensions, guardrails, and outputContract enum value are bit-equal to the
+// no-personality baseline.
+
+const MIGRATED_AGENT_CLASSES: AgentClass[] = ['Cortex::Principal', 'Cortex::System'];
+
+describe('WR-127 dimension isolation under cortex-runtime migration (C25)', () => {
+  for (const agentClass of MIGRATED_AGENT_CLASSES) {
+    describe(`${agentClass}`, () => {
+      const baseline = resolveAgentProfile(agentClass);
+
+      for (const config of CONFIGS_FOR_DIMENSION_ISOLATION) {
+        const label = config.overrides
+          ? `${config.preset} + overrides`
+          : config.preset;
+
+        it(`${label}: contextBudget unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.contextBudget).toEqual(baseline.contextBudget);
+        });
+
+        it(`${label}: compactionStrategy unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.compactionStrategy).toEqual(baseline.compactionStrategy);
+        });
+
+        it(`${label}: loopShape unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.loopShape).toBe(baseline.loopShape);
+        });
+
+        it(`${label}: toolConcurrency unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.toolConcurrency).toEqual(baseline.toolConcurrency);
+        });
+
+        it(`${label}: escalationRules unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.escalationRules).toEqual(baseline.escalationRules);
+        });
+
+        it(`${label}: guardrails unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.guardrails).toEqual(baseline.guardrails);
+        });
+
+        it(`${label}: outputContract enum value unchanged from baseline`, () => {
+          const actual = resolveAgentProfile(agentClass, undefined, config);
+          expect(actual.outputContract).toBe(baseline.outputContract);
+        });
+      }
+    });
+  }
+});

--- a/self/cortex/core/src/__tests__/gateway-runtime/prompt-routing-parity.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/prompt-routing-parity.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Prompt routing parity (C24 — Decision 4 fail-close).
+ *
+ * Mirrors the test-independence pattern used by SP 1.2's
+ * `integration-with-apply-personality.test.ts` (lines 30-45): capture the
+ * expected output via a path that does NOT route through the surface under
+ * test (`resolveAgentProfile` + personality pipeline), compare to actual
+ * output produced by the migrated path. Sharing `resolvePromptConfig` between
+ * sides is intentional — that function is unchanged by SP 1.3 (Decision 4
+ * § Untouched Surfaces, Goals C23).
+ *
+ * Binding scope (per SDS § 6.4): `'Cortex::Principal'` and `'Cortex::System'`
+ * are the C24 fail-close assertions; `'Orchestrator'` and `'Worker'` are
+ * forward-compatibility soft signals (their migration is out of scope per
+ * Decision 4 § Production Wiring). The systemTools-populated assertion is
+ * the SDS-review Should-Fix #3 future-proof.
+ */
+import { describe, expect, it } from 'vitest';
+import type { AgentClass, ToolDefinition } from '@nous/shared';
+import {
+  composeSystemPromptFromConfig,
+  resolveAgentProfile,
+  resolvePromptConfig,
+} from '../../gateway-runtime/prompt-strategy.js';
+
+const ALL_AGENT_CLASSES: AgentClass[] = [
+  'Cortex::Principal',
+  'Cortex::System',
+  'Orchestrator',
+  'Worker',
+];
+
+// SP 1.3 SDS-review Should-Fix #3: a synthetic systemTools fixture exercises
+// the production System call site shape with `tools` populated (not
+// undefined). The base `{ preset: 'balanced' }` byte-identity assertion still
+// holds (all fragments null), and this future-proofs against any signature
+// change that later introduces a tools-personality interaction.
+const SYSTEM_TOOLS_FIXTURE: ToolDefinition[] = [
+  {
+    name: 'echo',
+    version: '1.0.0',
+    description: 'Echo input back',
+    inputSchema: {},
+    outputSchema: {},
+    capabilities: [],
+    permissionScope: 'public',
+  },
+];
+
+describe("Prompt routing parity (C24 — Decision 4 fail-close)", () => {
+  for (const agentClass of ALL_AGENT_CLASSES) {
+    it(`${agentClass}: byte-identity at { preset: 'balanced' } (no tools)`, () => {
+      const expected = composeSystemPromptFromConfig(
+        resolvePromptConfig(agentClass),
+      );
+      const actual = composeSystemPromptFromConfig(
+        resolveAgentProfile(agentClass, undefined, { preset: 'balanced' }),
+      );
+      expect(actual).toBe(expected);
+    });
+  }
+
+  it("Cortex::System: byte-identity at { preset: 'balanced' } with populated systemTools (SDS-review Should-Fix #3)", () => {
+    const expected = composeSystemPromptFromConfig(
+      resolvePromptConfig('Cortex::System'),
+      SYSTEM_TOOLS_FIXTURE,
+    );
+    const actual = composeSystemPromptFromConfig(
+      resolveAgentProfile('Cortex::System', undefined, { preset: 'balanced' }),
+      SYSTEM_TOOLS_FIXTURE,
+    );
+    expect(actual).toBe(expected);
+  });
+});

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -300,6 +300,22 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     ];
     // WR-138 row #6: capture config before handing it to the factory so
     // attachProviders() can recompose in place.
+    //
+    // SP 1.3 — Decision 4 prompt-routing-decision-v1: production wiring of
+    // PersonalityConfig into the Principal baseSystemPrompt. The migrated
+    // composition is `composeSystemPromptFromConfig(resolveAgentProfile(...))`
+    // which routes through the personality pipeline. When `configReader` is
+    // not wired (test fixtures), the `?.` fallback supplies
+    // `{ preset: 'balanced' }`, which is byte-identical to the pre-migration
+    // path (SDS Invariant I5; F8). `providerId` is sourced from the
+    // existing `providerIdByClass` map per SDS § 1.5 / R6 — the call sites
+    // do not introduce a new provider-resolution path.
+    const principalProviderId = this.deps.providerIdByClass?.['Cortex::Principal'];
+    const principalProfile = resolveAgentProfile(
+      'Cortex::Principal',
+      principalProviderId,
+      this.deps.configReader?.getPersonalityConfig() ?? { preset: 'balanced' },
+    );
     this.principalGatewayConfig = this.createGatewayConfig({
       agentClass: 'Cortex::Principal',
       agentId: principalAgentId,
@@ -307,7 +323,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       lifecycleHooks: principalBase.lifecycleHooks,
       baseSystemPrompt:
         this.deps.principalBaseSystemPrompt
-          ?? composeSystemPromptFromConfig(resolvePromptConfig('Cortex::Principal')),
+          ?? composeSystemPromptFromConfig(principalProfile),
       outbox: new HealthTrackingOutboxSink('Cortex::Principal', this.healthSink, this.deps.eventBus),
     });
     this.principalGateway = this.gatewayFactory.create(this.principalGatewayConfig);
@@ -327,13 +343,21 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     this.systemTools = this.catalogDefinitions('Cortex::System');
     // WR-138 row #6: capture config before handing it to the factory so
     // attachProviders() can recompose in place.
+    //
+    // SP 1.3 — Decision 4 production wiring (mirrors Principal above).
+    const systemProviderId = this.deps.providerIdByClass?.['Cortex::System'];
+    const systemProfile = resolveAgentProfile(
+      'Cortex::System',
+      systemProviderId,
+      this.deps.configReader?.getPersonalityConfig() ?? { preset: 'balanced' },
+    );
     this.systemGatewayConfig = this.createGatewayConfig({
       agentClass: 'Cortex::System',
       agentId: systemAgentId,
       toolSurface: systemBundle.toolSurface,
       lifecycleHooks: systemBundle.lifecycleHooks,
       baseSystemPrompt: this.deps.systemBaseSystemPrompt
-        ?? composeSystemPromptFromConfig(resolvePromptConfig('Cortex::System'), this.systemTools),
+        ?? composeSystemPromptFromConfig(systemProfile, this.systemTools),
       outbox: new HealthTrackingOutboxSink('Cortex::System', this.healthSink, this.deps.eventBus),
     });
     this.systemGateway = this.gatewayFactory.create(this.systemGatewayConfig);

--- a/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/principal-system-runtime.ts
@@ -37,7 +37,7 @@ import { detectAndStripNarration, parseModelOutput } from '../output-parser.js';
 import { CARD_PROMPT_FRAGMENT } from './card-prompt-fragment.js';
 import { WORKFLOW_PROMPT_FRAGMENT } from './workflow-prompt-fragment.js';
 import { getOrchestratorPrompt } from '../prompts/index.js';
-import { resolvePromptConfig, composeSystemPromptFromConfig } from './prompt-strategy.js';
+import { resolvePromptConfig, composeSystemPromptFromConfig, resolveAgentProfile } from './prompt-strategy.js';
 import { RetryPolicyEvaluator } from '../recovery/retry-policy-evaluator.js';
 import { RollbackPolicyEvaluator } from '../recovery/rollback-policy-evaluator.js';
 import { WorkmodeAdmissionGuard } from '../workmode/admission-guard.js';
@@ -239,6 +239,16 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       ...this.catalogDefinitions('Cortex::Principal'),
       ...getPrincipalCommunicationToolDefinitions(),
     ];
+    // SP 1.3 — Decision 4 production wiring (mirrors cortex-runtime.ts).
+    // This is the legacy alias file kept consistent with the production
+    // runtime per SDS § 1.5 dual-file decision so any future direct caller
+    // sees the migrated pattern.
+    const legacyPrincipalProviderId = this.deps.providerIdByClass?.['Cortex::Principal'];
+    const legacyPrincipalProfile = resolveAgentProfile(
+      'Cortex::Principal',
+      legacyPrincipalProviderId,
+      this.deps.configReader?.getPersonalityConfig() ?? { preset: 'balanced' },
+    );
     this.principalGateway = this.gatewayFactory.create(
       this.createGatewayConfig({
         agentClass: 'Cortex::Principal',
@@ -247,7 +257,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         lifecycleHooks: principalBase.lifecycleHooks,
         baseSystemPrompt:
           this.deps.principalBaseSystemPrompt
-            ?? composeSystemPromptFromConfig(resolvePromptConfig('Cortex::Principal')),
+            ?? composeSystemPromptFromConfig(legacyPrincipalProfile),
         outbox: new HealthTrackingOutboxSink('Cortex::Principal', this.healthSink, this.deps.eventBus),
       }),
     );
@@ -265,6 +275,13 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
       deps: this.createInternalMcpDeps(),
     });
     this.systemTools = this.catalogDefinitions('Cortex::System');
+    // SP 1.3 — Decision 4 production wiring (mirrors cortex-runtime.ts).
+    const legacySystemProviderId = this.deps.providerIdByClass?.['Cortex::System'];
+    const legacySystemProfile = resolveAgentProfile(
+      'Cortex::System',
+      legacySystemProviderId,
+      this.deps.configReader?.getPersonalityConfig() ?? { preset: 'balanced' },
+    );
     this.systemGateway = this.gatewayFactory.create(
       this.createGatewayConfig({
         agentClass: 'Cortex::System',
@@ -272,7 +289,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         toolSurface: systemBundle.toolSurface,
         lifecycleHooks: systemBundle.lifecycleHooks,
         baseSystemPrompt: this.deps.systemBaseSystemPrompt
-          ?? composeSystemPromptFromConfig(resolvePromptConfig('Cortex::System'), this.systemTools),
+          ?? composeSystemPromptFromConfig(legacySystemProfile, this.systemTools),
         outbox: new HealthTrackingOutboxSink('Cortex::System', this.healthSink, this.deps.eventBus),
       }),
     );

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -3,6 +3,7 @@ import type {
   AgentClass,
   AppHealthSnapshot,
   AppRuntimeSession,
+  IConfig,
   IDocumentStore,
   IAgentGateway,
   IAgentGatewayFactory,
@@ -294,6 +295,22 @@ export interface PrincipalSystemGatewayRuntimeDeps {
   /** Structured logger (WR-157). When provided, the runtime creates
    *  channels for itself, the gateways, and the backlog queue. */
   logger?: ILogger;
+  /**
+   * SP 1.3 — Decision 4 prompt-routing-decision-v1.
+   *
+   * Source of the live `PersonalityConfig` for the Principal/System gateway
+   * runtime composition. When provided, the Principal and System
+   * `baseSystemPrompt` call sites in `cortex-runtime.ts` (and the legacy
+   * alias `principal-system-runtime.ts`) consume
+   * `configReader.getPersonalityConfig()` and feed it to
+   * `resolveAgentProfile`.
+   *
+   * Optional with a no-op fallback: when absent, the call sites use
+   * `{ preset: 'balanced' }`, which is byte-identical to the pre-migration
+   * path (SDS Invariant I5; F8). This preserves backward compatibility with
+   * test fixtures that do not wire a config reader.
+   */
+  configReader?: IConfig;
 }
 
 export interface LaneLeaseReleasedEvent {

--- a/self/cortex/pfc/src/__tests__/evaluator-adapter.test.ts
+++ b/self/cortex/pfc/src/__tests__/evaluator-adapter.test.ts
@@ -15,6 +15,16 @@ function mockConfig(): IConfig {
     getSection: () => ({}),
     update: async () => {},
     reload: async () => {},
+    // SP 1.3 — IConfig agent-block stubs (Decision 7).
+    getAgentName: () => 'Nous',
+    getPersonalityConfig: () => ({ preset: 'balanced' as const }),
+    getUserProfile: () => ({}),
+    getWelcomeMessageSent: () => false,
+    setAgentName: async () => {},
+    setPersonalityConfig: async () => {},
+    setUserProfile: async () => {},
+    setWelcomeMessageSent: async () => {},
+    clearAgentBlock: async () => {},
   };
 }
 

--- a/self/cortex/pfc/src/__tests__/pfc-engine.test.ts
+++ b/self/cortex/pfc/src/__tests__/pfc-engine.test.ts
@@ -12,6 +12,16 @@ function mockConfig(pfcTier: number): IConfig {
     getSection: () => ({}),
     update: async () => {},
     reload: async () => {},
+    // SP 1.3 — IConfig agent-block stubs (Decision 7).
+    getAgentName: () => 'Nous',
+    getPersonalityConfig: () => ({ preset: 'balanced' as const }),
+    getUserProfile: () => ({}),
+    getWelcomeMessageSent: () => false,
+    setAgentName: async () => {},
+    setPersonalityConfig: async () => {},
+    setUserProfile: async () => {},
+    setWelcomeMessageSent: async () => {},
+    clearAgentBlock: async () => {},
   };
 }
 

--- a/self/shared/src/__tests__/wizard-registry.test.ts
+++ b/self/shared/src/__tests__/wizard-registry.test.ts
@@ -43,6 +43,7 @@ describe('wizard-registry — factory defaults', () => {
         complete: false,
         steps: {
           ollama_check: { status: 'pending' },
+          agent_identity: { status: 'pending' },
           model_download: { status: 'pending' },
           provider_config: { status: 'pending' },
           role_assignment: { status: 'pending' },
@@ -68,14 +69,19 @@ describe('wizard-registry — factory defaults', () => {
 });
 
 describe('wizard-registry — manifest / schema', () => {
-  it('FIRST_RUN_STEP_VALUES is the canonical V1 tuple', () => {
+  it('FIRST_RUN_STEP_VALUES is the canonical SP 1.3 tuple (agent_identity included)', () => {
+    // SP 1.3 — SDS § 0 Note 2 Posture (i): `agent_identity` lives in the
+    // manifest tuple so the `firstRun.writeIdentity` tRPC procedure can call
+    // `markStepComplete(dataDir, 'agent_identity')` legally. The renderer
+    // registry row lands in SP 1.4.
     expect(FIRST_RUN_STEP_VALUES).toEqual([
       'ollama_check',
+      'agent_identity',
       'model_download',
       'provider_config',
       'role_assignment',
     ]);
-    expect(FIRST_RUN_STEP_VALUES).not.toContain('agent_identity');
+    expect(FIRST_RUN_STEP_VALUES).toContain('agent_identity');
   });
 
   it('buildFirstRunStateStepsSchema keys equal FIRST_RUN_STEP_VALUES', () => {
@@ -84,7 +90,7 @@ describe('wizard-registry — manifest / schema', () => {
     expect(keys).toEqual([...FIRST_RUN_STEP_VALUES]);
   });
 
-  it('FirstRunStateSchema.parse round-trips a canonical pre-migration fixture', () => {
+  it('FirstRunStateSchema.parse round-trips a canonical SP 1.3 fixture', () => {
     const fixture = {
       currentStep: 'model_download' as const,
       complete: false,
@@ -93,6 +99,7 @@ describe('wizard-registry — manifest / schema', () => {
           status: 'complete' as const,
           completedAt: '2026-03-22T00:04:00.000Z',
         },
+        agent_identity: { status: 'pending' as const },
         model_download: { status: 'pending' as const },
         provider_config: { status: 'pending' as const },
         role_assignment: { status: 'pending' as const },
@@ -129,7 +136,12 @@ function buildValidV1Registry() {
       label: 'Model',
       component: null,
       backendStep: 'model_download',
-      extraBackendSteps: ['provider_config', 'role_assignment'],
+      // SP 1.3 — `agent_identity` added to the V1 test fixture's
+      // extraBackendSteps so `assertRegistryMatchesManifest` keeps full
+      // coverage after the manifest gained `agent_identity`. SP 1.4 will land
+      // a dedicated `agent-identity` wizard step row owning the `agent_identity`
+      // backend step; this fixture remains a synthetic test-only registry.
+      extraBackendSteps: ['agent_identity', 'provider_config', 'role_assignment'],
       previous: 'ollama-setup',
       skippable: true,
     }),
@@ -337,6 +349,8 @@ describe('wizard-registry — assertRegistryMatchesManifest', () => {
         label: 'Model',
         component: null,
         backendStep: 'model_download',
+        // SP 1.3 — under-covers manifest: missing `agent_identity` AND
+        // `role_assignment` from extras (manifest now has 5 entries).
         extraBackendSteps: ['provider_config'],
         previous: 'ollama-setup',
         skippable: true,
@@ -392,6 +406,7 @@ describe('wizard-registry — assertRegistryMatchesManifest', () => {
         component: null,
         backendStep: 'model_download',
         extraBackendSteps: [
+          'agent_identity',
           'provider_config',
           'role_assignment',
           'role_assignment', // duplicate — forces count > manifest length
@@ -427,15 +442,18 @@ describe('wizard-registry — derivations', () => {
     expect(new Set(derived)).toEqual(new Set(FIRST_RUN_STEP_VALUES));
   });
 
-  it('deriveFirstRunStepValues preserves the manifest ordering for V1 registry', () => {
+  it('deriveFirstRunStepValues preserves the registry ordering for V1 registry', () => {
     const registry = buildValidV1Registry();
     const derived = deriveFirstRunStepValues(registry);
-    // V1 entries visit backend steps in manifest order:
+    // V1 entries visit backend steps in registry-traversal order:
     //   ollama-setup → ollama_check
-    //   model-download → model_download, provider_config, role_assignment
+    //   model-download → model_download, then extras
+    //                    [agent_identity, provider_config, role_assignment]
+    // SP 1.3 fixture extension — see buildValidV1Registry comment.
     expect(derived).toEqual([
       'ollama_check',
       'model_download',
+      'agent_identity',
       'provider_config',
       'role_assignment',
     ]);
@@ -446,6 +464,7 @@ describe('wizard-registry — derivations', () => {
     const map = deriveBackendStepToWizardStep(registry);
     expect(map).toEqual({
       ollama_check: 'ollama-setup',
+      agent_identity: 'model-download',
       model_download: 'model-download',
       provider_config: 'model-download',
       role_assignment: 'model-download',

--- a/self/shared/src/interfaces/autonomic.ts
+++ b/self/shared/src/interfaces/autonomic.ts
@@ -32,11 +32,37 @@ import type {
   SystemStatusSnapshot,
 } from '../types/index.js';
 
+import type { PersonalityConfig as SharedPersonalityConfig } from './agent-gateway.js';
+
 // SystemConfig is defined in @nous/autonomic-config, but the interface
 // references it. We define a minimal type here to avoid circular deps.
 // The actual schema lives in self/autonomic/config.
 export interface SystemConfig {
   [key: string]: unknown;
+}
+
+/**
+ * SP 1.3 — Decision 7 identity-persistence-schema-v1.
+ *
+ * Structural mirror of `UserProfile` declared canonically in
+ * `@nous/autonomic-config` (`self/autonomic/config/src/schema.ts`). The mirror
+ * lives here adjacent to `IConfig` so the boundary type for `IConfig`'s
+ * profile reader/writer does not require an `@nous/shared → @nous/autonomic-config`
+ * import (which would violate ADR 018's layering invariant — see SDS § 1.3 / I2).
+ *
+ * Every field is optional; absent fields produce a `{}` shape from
+ * `IConfig.getUserProfile()`. Adding a field is an additive Zod schema change
+ * in the canonical schema. Renaming or removing requires explicit migration
+ * (Decision 7 § Profile Schema Constraints).
+ *
+ * Drift from the canonical Zod-derived `UserProfile` is detected by
+ * `self/autonomic/config/src/__tests__/iconfig-profile-compat.test.ts`.
+ */
+export interface AgentUserProfile {
+  readonly displayName?: string;
+  readonly role?: string;
+  readonly primaryUseCase?: string;
+  readonly expertise?: 'beginner' | 'intermediate' | 'advanced';
 }
 
 export interface IDocumentStore {
@@ -156,6 +182,39 @@ export interface IConfig {
 
   /** Reload configuration from disk */
   reload(): Promise<void>;
+
+  // SP 1.3 — agent block readers (Decision 7 identity-persistence-schema-v1).
+  // Each reader synthesizes its typed default at read time when the `agent`
+  // block is absent on disk; defaults are NEVER written to disk by readers
+  // (see `ConfigManager.getAgent*`).
+  /** Get the agent's display name. Default: `"Nous"`. */
+  getAgentName(): string;
+  /** Get the agent's personality config. Default: `{ preset: 'balanced' }`. */
+  getPersonalityConfig(): SharedPersonalityConfig;
+  /** Get the user profile. Default: `{}`. */
+  getUserProfile(): AgentUserProfile;
+  /** Get the welcome-message-sent flag. Default: `false`. */
+  getWelcomeMessageSent(): boolean;
+
+  // SP 1.3 — agent block writers (Decision 7).
+  // Writers create the `agent` block on first write and preserve sibling
+  // fields on subsequent writes. Each writer validates the candidate config
+  // through Zod before persisting; invalid input throws ConfigError and
+  // leaves disk unchanged.
+  /** Persist the agent's display name. */
+  setAgentName(name: string): Promise<void>;
+  /** Persist the agent's personality config. */
+  setPersonalityConfig(config: SharedPersonalityConfig): Promise<void>;
+  /** Persist the user profile. */
+  setUserProfile(profile: AgentUserProfile): Promise<void>;
+  /** Persist the welcome-message-sent flag. */
+  setWelcomeMessageSent(value: boolean): Promise<void>;
+  /**
+   * Remove the entire `agent` block from disk. No-op when block already
+   * absent. Other top-level keys (`providers`, `modelRoleAssignments`, etc.)
+   * are preserved bit-for-bit.
+   */
+  clearAgentBlock(): Promise<void>;
 }
 
 export interface IHealthMonitor {

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -154,6 +154,7 @@ export type {
   ICredentialVaultService,
   ICredentialInjector,
   SystemConfig,
+  AgentUserProfile,
 } from './autonomic.js';
 export type {
   ILogChannel,

--- a/self/shared/src/wizard-registry.ts
+++ b/self/shared/src/wizard-registry.ts
@@ -20,8 +20,20 @@ import { z } from 'zod';
 // Backend step manifest — the single source of truth for state-machine shape.
 // ---------------------------------------------------------------------------
 
+// SP 1.3 — `agent_identity` added per SDS § 0 Note 2 Posture (i): the
+// backend-step constant lands with the SP 1.3 tooling sub-phase so the
+// `firstRun.writeIdentity` tRPC procedure's `markStepComplete(dataDir,
+// 'agent_identity')` call typechecks. The matching renderer-side
+// `WIZARD_STEP_REGISTRY` row (with `component: WizardStepIdentity`) lands in
+// SP 1.4 — until then the renderer's `assertRegistryMatchesManifest` will
+// throw at module load (SDS § 4 F4; SP 1.4 task #1 mitigation).
+//
+// Position rationale (SDS § 1.4): `agent_identity` is between `ollama_check`
+// (prerequisite check) and `model_download` (first user-configurable step) so
+// the user can customize the agent before committing to model assets.
 export const FIRST_RUN_STEP_VALUES = [
   'ollama_check',
+  'agent_identity',
   'model_download',
   'provider_config',
   'role_assignment',


### PR DESCRIPTION
## Summary

Phase 1.3 of the onboarding-agent-identity feature: persistence and prompt routing.

- Adds agent block schema, readers, writers, and `clearAgentBlock` helper to autonomic-config (Decision 7)
- Extends `IConfig` with SP 1.3 agent-block surface and adds `agent_identity` to `FIRST_RUN_STEP_VALUES` (Decision 7 / SDS § 0 Note 2)
- Wires `PersonalityConfig` into Principal/System gateway runtime composition (Decision 4)
- Adds `firstRun.writeIdentity` tRPC procedure and rewrites `resetWizard` (Decisions 3 + 7)
- Extends IConfig test stubs with SP 1.3 agent-block methods
- Documents the SP 1.3 agent block and firstRun identity procedures

## Review

- Synthesis review: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.3/review.mdx` — **Approved With Actions**
- ADRs: 019 (Reset Wizard Composition Pattern), 020 (Wizard Step Cross-Sub-Phase Landing)

## Test plan

- [x] Per WR-deferral, BT runs once at Phase 1 close on the integrated phase branch
- [x] Automated checks (typecheck, lint, test) executed at Code+Verify time