### PR TITLE
feat(onboarding): SP 1.8 wizard BT R2 fixes (RC-1 identity persistence, RC-2 model rec, RC-3 welcome)

### DIFF
--- a/self/apps/desktop/src/renderer/src/__tests__/desktop-chat-wrappers.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/desktop-chat-wrappers.test.tsx
@@ -1,10 +1,16 @@
 /**
- * SP 1.6 — DesktopChatPanel renderer wrapper Tier-1 contract tests
- * (T14-T19). Asserts mount-once mutation invocation, StrictMode resilience,
- * empty-deps `useEffect` (no re-fire on prop / activeProjectId change), and
- * non-blocking failure handling.
+ * SP 1.6 (T14-T19) + SP 1.8 — DesktopChatPanel + ConnectedChatSurface
+ * renderer wrapper tests, plus Tier-1 contract tests for the shared
+ * `useFireWelcomeOnMount` hook (Plan Task #16; Goals C13-C16).
+ *
+ * The wrapper-level T14-T19 tests continue to assert end-to-end
+ * mount-once + StrictMode + non-blocking failure semantics through the
+ * shared hook (which the wrappers now delegate to). The hook-level
+ * cases (a)-(e) below test the shared-hook behavior directly via
+ * `renderHook`. Case (e) is the BINDING negative regression for the
+ * BT R2 ref-set-before-await bug (Invariant A / SDS § 0 Note 2).
  */
-import { render } from '@testing-library/react'
+import { render, renderHook } from '@testing-library/react'
 import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -39,13 +45,14 @@ vi.mock('@nous/transport', () => ({
   },
 }))
 
-import { DesktopChatPanel } from '../desktop-chat-wrappers'
+import { ConnectedChatSurface, DesktopChatPanel } from '../desktop-chat-wrappers'
+import { useFireWelcomeOnMount } from '../desktop-welcome-trigger'
 
 function makeProps(): Parameters<typeof DesktopChatPanel>[0] {
   return {} as Parameters<typeof DesktopChatPanel>[0]
 }
 
-describe('DesktopChatPanel — welcome trigger (SP 1.6)', () => {
+describe('DesktopChatPanel — welcome trigger (SP 1.6 contracts via shared hook)', () => {
   beforeEach(() => {
     mutateAsyncMock.mockReset()
     mutateAsyncMock.mockResolvedValue({ welcomeFired: true, traceId: 'tr-1' })
@@ -58,31 +65,38 @@ describe('DesktopChatPanel — welcome trigger (SP 1.6)', () => {
   })
 
   // T14 — Mount-once: mutation invoked exactly once on first mount.
-  it('T14 fires the welcome mutation exactly once on first mount with the active projectId', () => {
+  it('T14 fires the welcome mutation exactly once on first mount with the active projectId', async () => {
     render(<DesktopChatPanel {...makeProps()} />)
+    await Promise.resolve()
+    await Promise.resolve()
 
     expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
     expect(mutateAsyncMock).toHaveBeenCalledWith({ projectId: PROJECT_A })
   })
 
   // T15 — StrictMode-resilient: double-invoke effect does not double-fire.
-  it('T15 StrictMode double-invokes the effect but the useRef guard prevents double-fire', () => {
+  it('T15 StrictMode double-invokes the effect but the useRef guard prevents double-fire', async () => {
     render(
       <StrictMode>
         <DesktopChatPanel {...makeProps()} />
       </StrictMode>,
     )
+    await Promise.resolve()
+    await Promise.resolve()
 
     expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   // T16 — Re-render does not re-fire.
-  it('T16 re-rendering with new props does not re-fire the mutation', () => {
+  it('T16 re-rendering with new props does not re-fire the mutation', async () => {
     const { rerender } = render(<DesktopChatPanel {...makeProps()} />)
+    await Promise.resolve()
+    await Promise.resolve()
     expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
 
     rerender(<DesktopChatPanel {...makeProps()} />)
     rerender(<DesktopChatPanel {...makeProps()} />)
+    await Promise.resolve()
 
     expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
   })
@@ -112,20 +126,160 @@ describe('DesktopChatPanel — welcome trigger (SP 1.6)', () => {
     await Promise.resolve()
   })
 
-  // T19 — `activeProjectId` change does not re-fire (empty-deps useEffect).
-  it('T19 activeProjectId change between renders does not re-trigger the mutation', () => {
+  // T19 — `activeProjectId` change does not re-fire after a successful first fire.
+  // Note: SP 1.8's shared hook now uses [activeProjectId] deps (not []),
+  // but the latched ref still prevents re-fire after a successful first
+  // call. This preserves the T19 contract.
+  it('T19 activeProjectId change between renders does not re-trigger the mutation after a successful first fire', async () => {
     useShellContextMock.mockReturnValue({ activeProjectId: PROJECT_A })
 
     const { rerender } = render(<DesktopChatPanel {...makeProps()} />)
+    await Promise.resolve()
+    await Promise.resolve()
     expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
     expect(mutateAsyncMock).toHaveBeenCalledWith({ projectId: PROJECT_A })
 
     useShellContextMock.mockReturnValue({ activeProjectId: PROJECT_B })
     rerender(<DesktopChatPanel {...makeProps()} />)
     rerender(<DesktopChatPanel {...makeProps()} />)
+    await Promise.resolve()
 
     expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
-    // Still the original projectId; the second render did not re-fire.
     expect(mutateAsyncMock).not.toHaveBeenCalledWith({ projectId: PROJECT_B })
+  })
+})
+
+// SP 1.8 Plan Task #16c — symmetric mount-once test for ConnectedChatSurface.
+describe('ConnectedChatSurface — SP 1.8 simple-mode welcome trigger', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockReset()
+    mutateAsyncMock.mockResolvedValue({ welcomeFired: true, traceId: 'tr-1' })
+    useShellContextMock.mockReturnValue({ activeProjectId: PROJECT_A })
+    useChatApiMock.mockReturnValue({})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('mounting ConnectedChatSurface fires the welcome mutation exactly once with the active projectId', async () => {
+    render(<ConnectedChatSurface />)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ projectId: PROJECT_A })
+  })
+})
+
+// SP 1.8 Plan Task #16b — Tier-1 contract tests for the shared
+// `useFireWelcomeOnMount` hook (Goals C13/C14/C15/C16). Cases (a)-(e).
+describe('useFireWelcomeOnMount — Tier-1 hook contract (SP 1.8)', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockReset()
+    mutateAsyncMock.mockResolvedValue({ welcomeFired: true, traceId: 'tr-1' })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // (a) — does NOT fire when activeProjectId === null.
+  it('(a) does not fire when activeProjectId === null', async () => {
+    renderHook(() => useFireWelcomeOnMount(null))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).not.toHaveBeenCalled()
+  })
+
+  // (b) — fires once when activeProjectId becomes non-null after initial null render.
+  it('(b) fires once when activeProjectId transitions from null to a real id', async () => {
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) => useFireWelcomeOnMount(id),
+      { initialProps: { id: null as string | null } },
+    )
+    await Promise.resolve()
+    expect(mutateAsyncMock).not.toHaveBeenCalled()
+
+    rerender({ id: 'p1' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ projectId: 'p1' })
+  })
+
+  // (c) — does NOT re-fire on activeProjectId change after a successful first fire.
+  it('(c) does not re-fire on activeProjectId change after a successful first fire', async () => {
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) => useFireWelcomeOnMount(id),
+      { initialProps: { id: 'p1' as string | null } },
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+
+    rerender({ id: 'p2' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  // (d) — StrictMode double-invocation fires exactly once.
+  it('(d) StrictMode double-invocation fires exactly once', async () => {
+    renderHook(() => useFireWelcomeOnMount('p1'), {
+      wrapper: ({ children }) => <StrictMode>{children}</StrictMode>,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  // (e) — BINDING per Invariant A / SDS § 0 Note 2 / Goals C13:
+  // a 'no_project_id' result MUST NOT latch the ref so the next render
+  // with a non-null activeProjectId re-fires.
+  it('(e) BINDING negative regression — "no_project_id" outcome leaves ref false; transition null→real id re-fires', async () => {
+    // First fire returns 'no_project_id' (the BT R2 latent dockview race).
+    mutateAsyncMock
+      .mockResolvedValueOnce({ welcomeFired: false, reason: 'no_project_id' })
+      .mockResolvedValueOnce({ welcomeFired: true, traceId: 'tr-1' })
+
+    // Initially null — does not call.
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) => useFireWelcomeOnMount(id),
+      { initialProps: { id: null as string | null } },
+    )
+    await Promise.resolve()
+    expect(mutateAsyncMock).not.toHaveBeenCalled()
+
+    // Transition to 'p1'. Effect calls; mock returns 'no_project_id'.
+    // After the await, the ref MUST remain false because reason === 'no_project_id'.
+    rerender({ id: 'p1' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+
+    // Transition to 'p2' → effect deps change → re-runs because ref is still false.
+    rerender({ id: 'p2' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(2)
+    expect(mutateAsyncMock).toHaveBeenLastCalledWith({ projectId: 'p2' })
+  })
+
+  it('non-no_project_id failure (e.g., "already_sent") latches the ref — no re-fire on subsequent activeProjectId change', async () => {
+    mutateAsyncMock.mockResolvedValueOnce({ welcomeFired: false, reason: 'already_sent' })
+
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) => useFireWelcomeOnMount(id),
+      { initialProps: { id: 'p1' as string | null } },
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+
+    rerender({ id: 'p2' })
+    await Promise.resolve()
+    await Promise.resolve()
+    // Still only one call — 'already_sent' latches the ref.
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/self/apps/desktop/src/renderer/src/__tests__/welcome-end-to-end.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/welcome-end-to-end.test.tsx
@@ -71,7 +71,7 @@ vi.mock('@nous/transport', () => ({
   },
 }))
 
-import { DesktopChatPanel } from '../desktop-chat-wrappers'
+import { ConnectedChatSurface, DesktopChatPanel } from '../desktop-chat-wrappers'
 
 function makeProps(): Parameters<typeof DesktopChatPanel>[0] {
   return {} as Parameters<typeof DesktopChatPanel>[0]
@@ -112,6 +112,20 @@ describe('SP 1.6 — wizard → workspace → chat init E2E', () => {
   // T23 — Welcome appears in chat history on next history fetch with the
   // standard agent-message shape (role: 'assistant'; no welcome badge or
   // bespoke metadata). Verifies Goals C9 / C10 at the renderer seam.
+  // SP 1.8 Plan Task #17 — End-to-end welcome-fires-in-simple-mode test
+  // (Goals C15 / Issue 3 closure). Mounts `ConnectedChatSurface` (the
+  // simple-mode shell's chat surface) under the post-wizard workspace
+  // harness with a non-null `activeProjectId`; asserts the welcome
+  // mutation fires exactly once via the shared `useFireWelcomeOnMount`
+  // hook. Symmetric to T22 for the dockview path.
+  it('T22b (SP 1.8) — mounting ConnectedChatSurface (simple-mode chat) fires the welcome mutation once', async () => {
+    render(<ConnectedChatSurface />)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mutateAsyncMock).toHaveBeenCalledTimes(1)
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ projectId: PROJECT_ID })
+  })
+
   it('T23 welcome surfaces in chat history with the standard assistant-row shape', async () => {
     const { getByTestId } = render(<DesktopChatPanel {...makeProps()} />)
 

--- a/self/apps/desktop/src/renderer/src/components/FirstRunWizard.tsx
+++ b/self/apps/desktop/src/renderer/src/components/FirstRunWizard.tsx
@@ -24,8 +24,10 @@ function deriveNextRegistryStepAfter(
 }
 import {
   getRecommendedModelSpec,
+  INITIAL_IDENTITY_DRAFT,
   type FirstRunPrerequisites,
   type FirstRunState,
+  type IdentityDraft,
   type OllamaStatus,
   type RoleAssignments,
 } from './wizard/types'
@@ -49,6 +51,13 @@ export function FirstRunWizard({
   const [ollamaStatus, setOllamaStatus] = useState<OllamaStatus | null>(null)
   const [selectedModelSpec, setSelectedModelSpec] = useState<string | null>(null)
   const [roleAssignments, setRoleAssignments] = useState<RoleAssignments>({})
+  // SP 1.8 Fix #3 — Identity draft slice lifted to the orchestrator so
+  // back-nav re-entry into the identity step retains entered values.
+  // `clearIdentityDraft` is invoked from `handleResetWizard` so a wizard
+  // reset wipes both the backend `agent` block (via `firstRun.resetWizard`)
+  // AND the renderer-side draft. Trace: SDS § 4.2 / Goals C3 / Plan Task #3 /
+  // Invariant C.
+  const [identityDraft, setIdentityDraft] = useState<IdentityDraft>(INITIAL_IDENTITY_DRAFT)
   const [roleAssignmentMode, setRoleAssignmentMode] =
     useState<RoleAssignmentMode>('default')
   const [actionInProgress, setActionInProgress] = useState(false)
@@ -196,6 +205,12 @@ export function FirstRunWizard({
       setCurrentStepOverride(null)
       setRoleAssignments({})
       setRoleAssignmentMode('default')
+      // SP 1.8 Fix #3c / Invariant C — clear the renderer-side identity draft
+      // alongside the backend `agent` block reset (parallel to
+      // `setRoleAssignments({})` above). Without this, the user-typed
+      // identity values would survive a reset and re-render on the next
+      // identity-step mount.
+      setIdentityDraft(INITIAL_IDENTITY_DRAFT)
       setSelectedModelSpec(getRecommendedModelSpec(prerequisites))
       await loadPrerequisites()
     } catch (error) {
@@ -257,8 +272,13 @@ export function FirstRunWizard({
           },
         }
       case 'agent_identity':
+        // SP 1.8 Fix #3b — thread the orchestrator-owned identity draft
+        // slice into the identity step's props per the
+        // WizardStepIdentityProps contract (SDS § 4.2 / Plan Task #3b).
         return {
           ...sharedProps,
+          identityDraft,
+          setIdentityDraft,
           onStepComplete: (nextState: FirstRunState) => {
             applyStepCompletion('agent_identity', nextState)
           },

--- a/self/apps/desktop/src/renderer/src/components/__tests__/FirstRunWizard.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/__tests__/FirstRunWizard.test.tsx
@@ -710,6 +710,125 @@ describe('FirstRunWizard — SP 1.7 regression coverage', () => {
     ).toBeInTheDocument()
   })
 
+  // ────────────────────────────────────────────────────────────────────
+  // SP 1.8 — Identity entered-values retention across back-nav (Goals C4)
+  // and reset-clears-draft semantic (Goals C5). Plan Tasks #5a + #5b.
+  // ────────────────────────────────────────────────────────────────────
+
+  it('SP 1.8 — entered identity values are retained across back-nav re-entry (Goals C4)', async () => {
+    installMock()
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    // Welcome → click Continue setup to reach identity sub-stage A.
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue setup' }))
+    await screen.findByTestId('identity-substage-a')
+
+    // Sub-stage A — type a name.
+    fireEvent.change(screen.getByTestId('identity-name-input'), {
+      target: { value: 'Iris' },
+    })
+    fireEvent.click(screen.getByTestId('identity-name-submit'))
+
+    // Sub-stage B — pick the 'professional' preset and toggle advanced open.
+    await screen.findByTestId('identity-substage-b')
+    const presetCard = screen
+      .getAllByTestId('preset-card')
+      .find((card) => card.getAttribute('data-preset-id') === 'professional')!
+    fireEvent.click(presetCard)
+    fireEvent.click(screen.getByTestId('identity-advanced-toggle'))
+
+    // Continue to sub-stage C — fill profile fields (do NOT submit).
+    fireEvent.click(screen.getByTestId('identity-personality-submit'))
+    await screen.findByTestId('identity-substage-c')
+
+    fireEvent.change(screen.getByLabelText(/Your name/i), {
+      target: { value: 'Iris' },
+    })
+
+    // Back-navigate to welcome (back chain: agent_identity → welcome).
+    fireEvent.click(screen.getByTestId('wizard-back-button'))
+    await screen.findByText('Set up your local runtime in a few guided steps.')
+
+    // Forward into identity again — assert the draft values are retained.
+    fireEvent.click(screen.getByRole('button', { name: 'Continue setup' }))
+    await screen.findByTestId('identity-substage-a')
+
+    // Name persisted on the lifted draft and re-rendered.
+    const reRenderedName = screen.getByTestId('identity-name-input') as HTMLInputElement
+    expect(reRenderedName.value).toBe('Iris')
+
+    // Advance through the sub-stages to confirm personality + advanced are
+    // also retained.
+    fireEvent.click(screen.getByTestId('identity-name-submit'))
+    await screen.findByTestId('identity-substage-b')
+
+    // Personality preset selection is preserved (the 'professional' card is selected).
+    const proCard = screen
+      .getAllByTestId('preset-card')
+      .find((card) => card.getAttribute('data-preset-id') === 'professional')!
+    expect(proCard.getAttribute('aria-checked')).toBe('true')
+
+    // Advanced section is open (toggle was previously expanded).
+    expect(screen.getByTestId('identity-trait-list')).toBeInTheDocument()
+  })
+
+  it('SP 1.8 — handleResetWizard clears the lifted identityDraft so next mount shows empty INITIAL_IDENTITY_DRAFT (Goals C5)', async () => {
+    installMock()
+
+    // Induce a prerequisites error so the alert toolbar (which exposes
+    // the Reset wizard CTA) renders. The toolbar only renders on error.
+    let prereqCallCount = 0
+    const freshState = createFirstRunState()
+    trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.checkPrerequisites') {
+        prereqCallCount++
+        if (prereqCallCount === 1) throw new Error('prereqs failed')
+        return DEFAULT_PREREQUISITES
+      }
+      return null
+    })
+    trpcFetchMock.trpcMutate.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.resetWizard') return freshState
+      return null
+    })
+
+    render(
+      <FirstRunWizard
+        initialState={createFirstRunState()}
+        onComplete={vi.fn()}
+      />,
+    )
+
+    // Wait for the prereq error toolbar to render.
+    expect(await screen.findByText('prereqs failed')).toBeInTheDocument()
+
+    // Walk the welcome step → identity → type a name.
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue setup' }))
+    await screen.findByTestId('identity-substage-a')
+    fireEvent.change(screen.getByTestId('identity-name-input'), {
+      target: { value: 'Iris' },
+    })
+
+    // Trigger the Reset CTA (still in the alert toolbar).
+    fireEvent.click(screen.getByRole('button', { name: 'Reset wizard' }))
+
+    // After reset, the wizard returns to the welcome step (fresh state).
+    await screen.findByText('Set up your local runtime in a few guided steps.')
+
+    // Walk forward into identity — the name must be EMPTY (draft cleared).
+    fireEvent.click(screen.getByRole('button', { name: 'Continue setup' }))
+    await screen.findByTestId('identity-substage-a')
+
+    const nameInput = screen.getByTestId('identity-name-input') as HTMLInputElement
+    expect(nameInput.value).toBe('')
+  })
+
   it('resume after identity completion does NOT re-render welcome (Fix #5)', async () => {
     // Setup: backend currentStep === 'ollama_check' (user already completed
     // identity); steps['agent_identity'].status === 'complete'.

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepIdentity.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepIdentity.tsx
@@ -16,6 +16,14 @@
  * payload. The `agent_identity` backend step transitions to `complete`
  * only after sub-stage C completes (submit or skip).
  *
+ * SP 1.8 — entered field values (`name`, `personality`, `profile`,
+ * `advancedOpen`) are lifted to the orchestrator (`FirstRunWizard`) via
+ * `props.identityDraft` + `props.setIdentityDraft` so back-nav re-entry
+ * into this step retains the values. `subStage` remains component-local
+ * (SP 1.4 Goals item 11 — sub-stage progress is ephemeral; on remount the
+ * component restarts at sub-stage A). Trace: SDS § 4.1 / Goals C1 / Plan
+ * Task #1 / Invariant B.
+ *
  * Animation: opacity fade between sub-stages, suppressed when
  * `prefers-reduced-motion: reduce` is set. The state machine is
  * decoupled from animation — forward navigation is synchronous on
@@ -30,34 +38,13 @@ import {
   type TraitAxes,
 } from '@nous/cortex-core/personality'
 import { trpcMutate } from './trpc-fetch'
-import type { FirstRunActionResult, WizardStepProps } from './types'
+import type {
+  FirstRunActionResult,
+  ProfileFormState,
+  WizardStepIdentityProps,
+} from './types'
 
 type SubStage = 'A' | 'B' | 'C'
-
-type ExpertiseLevel = 'beginner' | 'intermediate' | 'advanced'
-
-interface ProfileFormState {
-  displayName?: string
-  role?: string
-  primaryUseCase?: string
-  expertise?: ExpertiseLevel
-}
-
-interface IdentityFormState {
-  subStage: SubStage
-  name: string
-  personality: PersonalityConfig
-  profile: ProfileFormState
-  advancedOpen: boolean
-}
-
-const INITIAL_STATE: IdentityFormState = {
-  subStage: 'A',
-  name: '',
-  personality: { preset: 'balanced' },
-  profile: {},
-  advancedOpen: false,
-}
 
 function detectReducedMotion(): boolean {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -95,73 +82,80 @@ interface WriteIdentityPayload {
   profile: ProfileFormState
 }
 
-export function WizardStepIdentity(props: WizardStepProps): ReactElement {
-  const { actionInProgress, setActionInProgress, setActionError, onStepComplete } = props
+export function WizardStepIdentity(props: WizardStepIdentityProps): ReactElement {
+  const {
+    actionInProgress,
+    setActionInProgress,
+    setActionError,
+    onStepComplete,
+    identityDraft,
+    setIdentityDraft,
+  } = props
 
-  const [state, setState] = useState<IdentityFormState>(INITIAL_STATE)
+  const [subStage, setSubStage] = useState<SubStage>('A')
   const reducedMotion = useMemo(() => detectReducedMotion(), [])
   const nameInputRef = useRef<HTMLInputElement | null>(null)
 
+  // Read the lifted entered-values draft from props.
+  const { name, personality, profile, advancedOpen } = identityDraft
+
   // Focus management — name input on sub-stage A render.
   useEffect(() => {
-    if (state.subStage === 'A') {
+    if (subStage === 'A') {
       nameInputRef.current?.focus()
     }
-  }, [state.subStage])
+  }, [subStage])
 
   const advanceToB = () => {
     console.log('[nous:wizard:identity] Sub-stage A → B (name submitted)')
-    setState((prev) => ({ ...prev, subStage: 'B' }))
+    setSubStage('B')
   }
 
   const handleNameSubmit = (event: React.FormEvent) => {
     event.preventDefault()
-    if (state.name.trim() === '') return
+    if (name.trim() === '') return
     advanceToB()
   }
 
   const handlePresetSelect = (presetId: PersonalityPreset) => {
-    setState((prev) => ({
-      ...prev,
+    setIdentityDraft({
+      ...identityDraft,
       personality: {
         preset: presetId,
-        ...(prev.personality.overrides ? { overrides: prev.personality.overrides } : {}),
+        ...(personality.overrides ? { overrides: personality.overrides } : {}),
       },
-    }))
+    })
   }
 
   const handleOverrideSelect = (traitId: keyof TraitAxes, value: string) => {
-    setState((prev) => {
-      const nextOverrides: Partial<TraitAxes> = {
-        ...prev.personality.overrides,
-        [traitId]: value,
-      } as Partial<TraitAxes>
-      return {
-        ...prev,
-        personality: {
-          preset: prev.personality.preset,
-          overrides: nextOverrides,
-        },
-      }
+    const nextOverrides: Partial<TraitAxes> = {
+      ...personality.overrides,
+      [traitId]: value,
+    } as Partial<TraitAxes>
+    setIdentityDraft({
+      ...identityDraft,
+      personality: {
+        preset: personality.preset,
+        overrides: nextOverrides,
+      },
     })
   }
 
   const toggleAdvanced = () => {
-    setState((prev) => ({ ...prev, advancedOpen: !prev.advancedOpen }))
+    setIdentityDraft({ ...identityDraft, advancedOpen: !advancedOpen })
   }
 
   const handlePersonalityContinue = () => {
-    setState((prev) => {
-      const overrides = prev.personality.overrides
-      const hasOverrides = overrides && Object.keys(overrides).length > 0
-      const nextPersonality: PersonalityConfig = hasOverrides
-        ? { preset: prev.personality.preset, overrides }
-        : { preset: prev.personality.preset }
-      console.log(
-        `[nous:wizard:identity] Sub-stage B → C (preset: ${nextPersonality.preset}; overrides: ${hasOverrides ? 'yes' : 'no'}; via: submit)`,
-      )
-      return { ...prev, personality: nextPersonality, subStage: 'C' }
-    })
+    const overrides = personality.overrides
+    const hasOverrides = overrides && Object.keys(overrides).length > 0
+    const nextPersonality: PersonalityConfig = hasOverrides
+      ? { preset: personality.preset, overrides }
+      : { preset: personality.preset }
+    console.log(
+      `[nous:wizard:identity] Sub-stage B → C (preset: ${nextPersonality.preset}; overrides: ${hasOverrides ? 'yes' : 'no'}; via: submit)`,
+    )
+    setIdentityDraft({ ...identityDraft, personality: nextPersonality })
+    setSubStage('C')
   }
 
   const handlePersonalitySkip = () => {
@@ -169,11 +163,11 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
     // `{ preset: 'balanced', overrides: {} }`. Empty overrides leak through
     // serialization and are observable downstream.
     console.log('[nous:wizard:identity] Sub-stage B → C (preset: balanced; overrides: no; via: skip)')
-    setState((prev) => ({
-      ...prev,
+    setIdentityDraft({
+      ...identityDraft,
       personality: { preset: 'balanced' as const },
-      subStage: 'C',
-    }))
+    })
+    setSubStage('C')
   }
 
   const submitIdentity = async (
@@ -203,16 +197,16 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
 
   const handleProfileSubmit = (event: React.FormEvent) => {
     event.preventDefault()
-    const profilePayload = buildProfilePayload(state.profile)
+    const profilePayload = buildProfilePayload(profile)
     void submitIdentity(
-      { name: state.name, personality: state.personality, profile: profilePayload },
+      { name, personality, profile: profilePayload },
       'submit',
     )
   }
 
   const handleProfileSkip = () => {
     void submitIdentity(
-      { name: state.name, personality: state.personality, profile: {} },
+      { name, personality, profile: {} },
       'skip',
     )
   }
@@ -225,8 +219,8 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
   ].join(' ')
 
   return (
-    <div className={containerClassName} data-substage={state.subStage}>
-      {state.subStage === 'A' ? (
+    <div className={containerClassName} data-substage={subStage}>
+      {subStage === 'A' ? (
         <section
           className="nous-wizard__card"
           data-testid="identity-substage-a"
@@ -247,10 +241,10 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
               ref={nameInputRef}
               type="text"
               autoComplete="off"
-              value={state.name}
+              value={name}
               onChange={(event) => {
                 const next = event.target.value
-                setState((prev) => ({ ...prev, name: next }))
+                setIdentityDraft({ ...identityDraft, name: next })
               }}
               className="nous-wizard__input"
               data-testid="identity-name-input"
@@ -259,7 +253,7 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
               <button
                 type="submit"
                 className="nous-wizard__button nous-wizard__button--primary"
-                disabled={state.name.trim() === '' || actionInProgress}
+                disabled={name.trim() === '' || actionInProgress}
                 data-testid="identity-name-submit"
               >
                 Continue
@@ -269,7 +263,7 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
         </section>
       ) : null}
 
-      {state.subStage === 'B' ? (
+      {subStage === 'B' ? (
         <section
           className="nous-wizard__card"
           data-testid="identity-substage-b"
@@ -287,7 +281,7 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
             aria-label="Personality preset"
           >
             {(Object.keys(PRESETS) as PersonalityPreset[]).map((presetId) => {
-              const isSelected = state.personality.preset === presetId
+              const isSelected = personality.preset === presetId
               return (
                 <button
                   key={presetId}
@@ -318,18 +312,18 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
               className="nous-wizard__button nous-wizard__button--ghost"
               onClick={toggleAdvanced}
               data-testid="identity-advanced-toggle"
-              aria-expanded={state.advancedOpen}
+              aria-expanded={advancedOpen}
             >
-              {state.advancedOpen ? 'Hide advanced options' : 'Advanced options'}
+              {advancedOpen ? 'Hide advanced options' : 'Advanced options'}
             </button>
-            {state.advancedOpen ? (
+            {advancedOpen ? (
               <div className="nous-wizard__stack" data-testid="identity-trait-list">
                 {TRAIT_REGISTRY.map((trait) => {
-                  const overrides = state.personality.overrides
+                  const overrides = personality.overrides
                   const overrideValue = overrides
                     ? (overrides[trait.id as keyof TraitAxes] as string | undefined)
                     : undefined
-                  const presetTraits = PRESETS[state.personality.preset]
+                  const presetTraits = PRESETS[personality.preset]
                   const presetValue = presetTraits[trait.id as keyof TraitAxes]
                   const effectiveValue = overrideValue ?? presetValue
                   return (
@@ -399,7 +393,7 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
         </section>
       ) : null}
 
-      {state.subStage === 'C' ? (
+      {subStage === 'C' ? (
         <section
           className="nous-wizard__card"
           data-testid="identity-substage-c"
@@ -429,13 +423,13 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
               id="profile-display-name"
               type="text"
               autoComplete="given-name"
-              value={state.profile.displayName ?? ''}
+              value={profile.displayName ?? ''}
               onChange={(event) => {
                 const next = event.target.value
-                setState((prev) => ({
-                  ...prev,
-                  profile: { ...prev.profile, displayName: next },
-                }))
+                setIdentityDraft({
+                  ...identityDraft,
+                  profile: { ...profile, displayName: next },
+                })
               }}
               className="nous-wizard__input"
             />
@@ -447,13 +441,13 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
               id="profile-role"
               type="text"
               autoComplete="organization-title"
-              value={state.profile.role ?? ''}
+              value={profile.role ?? ''}
               onChange={(event) => {
                 const next = event.target.value
-                setState((prev) => ({
-                  ...prev,
-                  profile: { ...prev.profile, role: next },
-                }))
+                setIdentityDraft({
+                  ...identityDraft,
+                  profile: { ...profile, role: next },
+                })
               }}
               className="nous-wizard__input"
             />
@@ -464,13 +458,13 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
             <textarea
               id="profile-use-case"
               autoComplete="off"
-              value={state.profile.primaryUseCase ?? ''}
+              value={profile.primaryUseCase ?? ''}
               onChange={(event) => {
                 const next = event.target.value
-                setState((prev) => ({
-                  ...prev,
-                  profile: { ...prev.profile, primaryUseCase: next },
-                }))
+                setIdentityDraft({
+                  ...identityDraft,
+                  profile: { ...profile, primaryUseCase: next },
+                })
               }}
               className="nous-wizard__textarea"
               rows={3}
@@ -493,12 +487,12 @@ export function WizardStepIdentity(props: WizardStepProps): ReactElement {
                         type="radio"
                         name="profile-expertise"
                         value={level}
-                        checked={state.profile.expertise === level}
+                        checked={profile.expertise === level}
                         onChange={() => {
-                          setState((prev) => ({
-                            ...prev,
-                            profile: { ...prev.profile, expertise: level },
-                          }))
+                          setIdentityDraft({
+                            ...identityDraft,
+                            profile: { ...profile, expertise: level },
+                          })
                         }}
                       />
                       <span>{level.charAt(0).toUpperCase() + level.slice(1)}</span>

--- a/self/apps/desktop/src/renderer/src/components/wizard/WizardStepModelDownload.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/WizardStepModelDownload.tsx
@@ -251,17 +251,92 @@ export function WizardStepModelDownload({
     }
   }
 
+  // SP 1.8 Fix #11 — surface detected hardware + tier-to-recommendation
+  // mapping. Reads `prerequisites.hardware` and the new optional
+  // `prerequisites.recommendations.tier` / `.tierLabel` (added in Fix #10
+  // for the local-first branch; absent for remote-only). Renders an
+  // explanatory section between the hero and the recommendation list so
+  // the user can see the link from their hardware to the per-tier set.
+  // Trace: SDS § 4.7 / Goals C11 / Plan Task #11.
+  const hardware = prerequisites?.hardware
+  const tierLabel = prerequisites?.recommendations.tierLabel ?? null
+  const ramGB = hardware ? Math.max(1, Math.round(hardware.totalMemoryMB / 1024)) : null
+  const cpuCores = hardware?.cpuCores ?? null
+  const gpuDetected = hardware?.gpu.detected ?? false
+  const gpuName = hardware?.gpu.name ?? null
+  const tierRecommendationTitles: string[] = []
+  if (tierLabel && prerequisites?.recommendations) {
+    if (prerequisites.recommendations.singleModel) {
+      tierRecommendationTitles.push(prerequisites.recommendations.singleModel.displayName)
+    }
+    for (const entry of prerequisites.recommendations.multiModel) {
+      if (!tierRecommendationTitles.includes(entry.recommendation.displayName)) {
+        tierRecommendationTitles.push(entry.recommendation.displayName)
+      }
+    }
+  }
+
   return (
     <div className="nous-wizard__stack">
       <section className="nous-wizard__hero">
         <div className="nous-wizard__eyebrow">Model recommendation</div>
         <h1 className="nous-wizard__title">Download the local model that fits this machine.</h1>
         <p className="nous-wizard__subtitle">
-          The recommendation engine has already picked a starting point from your
-          hardware profile. You can keep the default, switch to a recommended
-          alternative, or type a custom Ollama model id.
+          Recommendations are tailored to your detected hardware. Adjust below if needed.
         </p>
       </section>
+
+      {hardware ? (
+        <section
+          className="nous-wizard__card nous-wizard__hardware-summary"
+          data-testid="wizard-hardware-summary"
+          aria-labelledby="wizard-hardware-summary-heading"
+        >
+          <h2
+            id="wizard-hardware-summary-heading"
+            className="nous-wizard__section-title"
+          >
+            Detected hardware
+          </h2>
+          <ul className="nous-wizard__meta-list" data-testid="wizard-hardware-meta">
+            {ramGB !== null ? (
+              <li data-testid="wizard-hardware-ram">
+                <strong>RAM:</strong> {ramGB} GB
+              </li>
+            ) : null}
+            {cpuCores !== null ? (
+              <li data-testid="wizard-hardware-cpu">
+                <strong>CPU cores:</strong> {cpuCores}
+              </li>
+            ) : null}
+            <li data-testid="wizard-hardware-gpu">
+              <strong>GPU:</strong>{' '}
+              {gpuDetected
+                ? gpuName
+                  ? `Detected (${gpuName})`
+                  : 'Detected'
+                : 'Not detected'}
+            </li>
+            {tierLabel ? (
+              <li data-testid="wizard-hardware-tier">
+                <strong>Tier:</strong> {tierLabel}
+              </li>
+            ) : null}
+          </ul>
+          {tierLabel ? (
+            <p
+              className="nous-wizard__section-copy"
+              data-testid="wizard-hardware-tier-link"
+            >
+              These specs map to the <strong>{tierLabel}</strong> tier, which
+              recommends:
+              {tierRecommendationTitles.length > 0
+                ? ` ${tierRecommendationTitles.join(', ')}.`
+                : null}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
 
       <div className="nous-wizard__grid">
         <section className="nous-wizard__card">

--- a/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardStepIdentity.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardStepIdentity.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PRESETS, TRAIT_REGISTRY, type PersonalityPreset } from '@nous/cortex-core/personality'
 import { identityStep } from '../steps/identity'
 import { WizardStepIdentity } from '../WizardStepIdentity'
+import { INITIAL_IDENTITY_DRAFT, type IdentityDraft } from '../types'
 import {
   createElectronAPIMock,
   createFirstRunActionResult,
@@ -28,33 +29,66 @@ function installMock() {
   return mock
 }
 
-function renderIdentity(overrides: Partial<Parameters<typeof WizardStepIdentity>[0]> = {}) {
+// SP 1.8 — orchestrator harness. The identity draft (`name`,
+// `personality`, `profile`, `advancedOpen`) now lives at the parent
+// (`FirstRunWizard`); the test harness simulates that parent by holding a
+// stateful draft and rerendering with the updated value when
+// `setIdentityDraft` is invoked. Sub-stage cursor remains internal.
+function renderIdentity(
+  overrides: Partial<Parameters<typeof WizardStepIdentity>[0]> = {},
+) {
   installMock()
   const onStepComplete = vi.fn()
   const setActionInProgress = vi.fn()
   const setActionError = vi.fn()
-  const view = render(
+
+  let draft: IdentityDraft = overrides.identityDraft ?? INITIAL_IDENTITY_DRAFT
+  const setIdentityDraft = vi.fn((next: IdentityDraft) => {
+    draft = next
+    rerender()
+  })
+
+  const baseProps = {
+    state: createFirstRunState({
+      currentStep: 'agent_identity',
+      steps: {
+        ollama_check: { status: 'complete', completedAt: '2026-04-19T00:00:00.000Z' },
+        agent_identity: { status: 'pending' },
+        model_download: { status: 'pending' },
+        provider_config: { status: 'pending' },
+        role_assignment: { status: 'pending' },
+      },
+    }),
+    prerequisites: createPrerequisites(),
+    actionInProgress: false,
+    actionError: null,
+    setActionInProgress,
+    setActionError,
+    onStepComplete,
+    ...overrides,
+  }
+
+  const buildElement = () => (
     <WizardStepIdentity
-      state={createFirstRunState({
-        currentStep: 'agent_identity',
-        steps: {
-          ollama_check: { status: 'complete', completedAt: '2026-04-19T00:00:00.000Z' },
-          agent_identity: { status: 'pending' },
-          model_download: { status: 'pending' },
-          provider_config: { status: 'pending' },
-          role_assignment: { status: 'pending' },
-        },
-      })}
-      prerequisites={createPrerequisites()}
-      actionInProgress={false}
-      actionError={null}
-      setActionInProgress={setActionInProgress}
-      setActionError={setActionError}
-      onStepComplete={onStepComplete}
-      {...overrides}
-    />,
+      {...baseProps}
+      identityDraft={draft}
+      setIdentityDraft={setIdentityDraft}
+    />
   )
-  return { view, onStepComplete, setActionInProgress, setActionError }
+
+  const view = render(buildElement())
+  function rerender() {
+    view.rerender(buildElement())
+  }
+
+  return {
+    view,
+    onStepComplete,
+    setActionInProgress,
+    setActionError,
+    setIdentityDraft,
+    getDraft: () => draft,
+  }
 }
 
 beforeEach(() => {
@@ -471,6 +505,66 @@ describe('WizardStepIdentity — Block E: Animation and accessibility', () => {
 // ──────────────────────────────────────────────────────────────────────────
 // Block F — defineWizardStep registry-row contract — Goals C2.
 // ──────────────────────────────────────────────────────────────────────────
+
+// ──────────────────────────────────────────────────────────────────────────
+// Block G — SP 1.8 lifted-state contract (Goals C1, C2, C4 partial; Plan Task #4).
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('WizardStepIdentity — Block G: SP 1.8 lifted identityDraft contract', () => {
+  it('G1 (Tier-1): renders entered values verbatim from props.identityDraft', () => {
+    renderIdentity({
+      identityDraft: {
+        name: 'Iris',
+        personality: { preset: 'professional' },
+        profile: {
+          displayName: 'Iris',
+          role: 'Designer',
+          primaryUseCase: 'Design systems',
+          expertise: 'advanced',
+        },
+        advancedOpen: true,
+      },
+    })
+    // Sub-stage A renders the name input from the lifted draft.
+    const input = screen.getByTestId('identity-name-input') as HTMLInputElement
+    expect(input.value).toBe('Iris')
+  })
+
+  it('G2 (Tier-1): typing into the name input invokes setIdentityDraft with the new name', () => {
+    const { setIdentityDraft, getDraft } = renderIdentity()
+    fireEvent.change(screen.getByTestId('identity-name-input'), {
+      target: { value: 'Iris' },
+    })
+    expect(setIdentityDraft).toHaveBeenCalledWith({
+      ...INITIAL_IDENTITY_DRAFT,
+      name: 'Iris',
+    })
+    expect(getDraft().name).toBe('Iris')
+  })
+
+  it('G3 (Tier-2): mount-unmount-remount with stable draft retains values; sub-stage cursor resets to A (Invariant B)', () => {
+    // First mount — type a name.
+    const first = renderIdentity()
+    fireEvent.change(screen.getByTestId('identity-name-input'), {
+      target: { value: 'Iris' },
+    })
+    fireEvent.click(screen.getByTestId('identity-name-submit'))
+    expect(screen.getByTestId('identity-substage-b')).toBeInTheDocument()
+    const draftAfter = first.getDraft()
+    expect(draftAfter.name).toBe('Iris')
+
+    // Unmount.
+    first.view.unmount()
+
+    // Remount with the carried draft. The component should display 'Iris'
+    // and start at sub-stage A (cursor is component-local per SP 1.4
+    // Goals item 11 / Invariant B).
+    renderIdentity({ identityDraft: draftAfter })
+    expect(screen.getByTestId('identity-substage-a')).toBeInTheDocument()
+    const input = screen.getByTestId('identity-name-input') as HTMLInputElement
+    expect(input.value).toBe('Iris')
+  })
+})
 
 describe('WizardStepIdentity — Block F: defineWizardStep registry-row', () => {
   it('F1: identityStep carries the SDS § 1.3 field shape with factory defaults', () => {

--- a/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardStepModelDownload.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/wizard/__tests__/WizardStepModelDownload.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * SP 1.8 Fix #13 — `WizardStepModelDownload` Tier-1 + Tier-2 tests.
+ *
+ * Tier-1: explanatory section renders detected RAM/CPU/GPU/tier label
+ * when `prerequisites.hardware` and `prerequisites.recommendations.tierLabel`
+ * are populated (Goals C11; new file per Plan Verification Sweep 5).
+ *
+ * Tier-2 (RC-2a regression): when `validation['ollama:qwen2.5:32b'] === 'validated'`,
+ * the corresponding card renders the `validated` indicator. Regresses
+ * the four-state validation vocabulary contract for the cross-axis
+ * derivation case.
+ */
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WizardStepModelDownload } from '../WizardStepModelDownload'
+import {
+  createElectronAPIMock,
+  createFirstRunState,
+  createPrerequisites,
+} from '../../../test-setup'
+
+const trpcFetchMock = vi.hoisted(() => ({
+  setBackendPort: vi.fn(),
+  trpcQuery: vi.fn(),
+  trpcMutate: vi.fn(),
+}))
+
+vi.mock('../trpc-fetch', () => trpcFetchMock)
+
+function installMock() {
+  const mock = createElectronAPIMock()
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    writable: true,
+    value: mock,
+  })
+  return mock
+}
+
+function renderStep(
+  prerequisitesOverrides: Parameters<typeof createPrerequisites>[0] = {},
+) {
+  installMock()
+  return render(
+    <WizardStepModelDownload
+      state={createFirstRunState()}
+      prerequisites={createPrerequisites(prerequisitesOverrides)}
+      selectedModelSpec={null}
+      setSelectedModelSpec={vi.fn()}
+      actionInProgress={false}
+      actionError={null}
+      setActionInProgress={vi.fn()}
+      setActionError={vi.fn()}
+      onStepComplete={vi.fn()}
+    />,
+  )
+}
+
+beforeEach(() => {
+  trpcFetchMock.trpcMutate.mockReset()
+  trpcFetchMock.trpcQuery.mockReset()
+})
+
+describe('WizardStepModelDownload — SP 1.8 explanatory section (Tier-1)', () => {
+  it('renders detected RAM, CPU cores, GPU presence + name, and tier label when populated', () => {
+    renderStep({
+      recommendations: {
+        ...createPrerequisites().recommendations,
+        tier: 'large',
+        tierLabel: 'High-spec (advanced reasoning)',
+      },
+    })
+
+    const ramRow = screen.getByTestId('wizard-hardware-ram')
+    const cpuRow = screen.getByTestId('wizard-hardware-cpu')
+    const gpuRow = screen.getByTestId('wizard-hardware-gpu')
+    const tierRow = screen.getByTestId('wizard-hardware-tier')
+
+    // 32768 MB → 32 GB.
+    expect(ramRow.textContent).toContain('32 GB')
+    expect(cpuRow.textContent).toContain('12')
+    expect(gpuRow.textContent).toContain('Detected')
+    expect(gpuRow.textContent).toContain('RTX 4080')
+    expect(tierRow.textContent).toContain('High-spec (advanced reasoning)')
+
+    const tierLink = screen.getByTestId('wizard-hardware-tier-link')
+    expect(tierLink.textContent).toContain('High-spec (advanced reasoning)')
+  })
+
+  it('omits the hardware summary when prerequisites are not yet loaded', () => {
+    installMock()
+    render(
+      <WizardStepModelDownload
+        state={createFirstRunState()}
+        prerequisites={null}
+        selectedModelSpec={null}
+        setSelectedModelSpec={vi.fn()}
+        actionInProgress={false}
+        actionError={null}
+        setActionInProgress={vi.fn()}
+        setActionError={vi.fn()}
+        onStepComplete={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('wizard-hardware-summary')).toBeNull()
+  })
+})
+
+describe('WizardStepModelDownload — RC-2a four-state vocabulary regression (Tier-2)', () => {
+  it('renders the "Available" indicator when validation map marks the spec as validated', () => {
+    renderStep({
+      validation: {
+        'ollama:qwen2.5:7b': 'validated',
+      },
+      recommendations: {
+        ...createPrerequisites().recommendations,
+        tier: 'medium',
+        tierLabel: 'Mid-spec (stronger reasoning)',
+      },
+    })
+
+    // The single-model recommendation in the default fixture is qwen2.5:7b.
+    // Its card should render the "Available" validation label.
+    const labels = screen.getAllByText('Available')
+    expect(labels.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/self/apps/desktop/src/renderer/src/components/wizard/types.ts
+++ b/self/apps/desktop/src/renderer/src/components/wizard/types.ts
@@ -10,6 +10,7 @@ import type {
   FirstRunPrerequisites,
   FirstRunStep,
 } from '@nous/shared-server'
+import type { PersonalityConfig } from '@nous/cortex-core/personality'
 
 export type FirstRunCurrentStep = FirstRunState['currentStep']
 
@@ -52,6 +53,41 @@ export interface WizardStepProps {
   setActionInProgress: (value: boolean) => void
   setActionError: (value: string | null) => void
   onStepComplete: (nextState: FirstRunState) => void
+}
+
+// SP 1.8 Fix #2 — Identity draft shape lifted to the orchestrator
+// (`FirstRunWizard`) so back-nav into the identity step retains entered
+// values. `subStage` is NOT included — the sub-stage cursor remains
+// component-local per SP 1.4 Goals item 11 (sub-stage progress is
+// ephemeral and not persisted; on remount the component restarts at
+// sub-stage A). The lifted slice carries only entered field values.
+//
+// Trace: SP 1.8 SDS § Data Model § Identity draft contract; Goals C1 / C2 / C4;
+// Implementation Plan Task #2; Invariant B.
+export interface ProfileFormState {
+  displayName?: string
+  role?: string
+  primaryUseCase?: string
+  expertise?: 'beginner' | 'intermediate' | 'advanced'
+}
+
+export interface IdentityDraft {
+  name: string
+  personality: PersonalityConfig
+  profile: ProfileFormState
+  advancedOpen: boolean
+}
+
+export const INITIAL_IDENTITY_DRAFT: IdentityDraft = {
+  name: '',
+  personality: { preset: 'balanced' },
+  profile: {},
+  advancedOpen: false,
+}
+
+export interface WizardStepIdentityProps extends WizardStepProps {
+  identityDraft: IdentityDraft
+  setIdentityDraft: (next: IdentityDraft) => void
 }
 
 export const MODEL_ROLES = ModelRoleSchema.options

--- a/self/apps/desktop/src/renderer/src/components/wizard/wizard.css
+++ b/self/apps/desktop/src/renderer/src/components/wizard/wizard.css
@@ -589,3 +589,45 @@
   color: var(--nous-fg);
   font-size: var(--nous-font-size-sm);
 }
+
+/* SP 1.8 Fix #12 — additive rules for the hardware-summary explanatory
+   section in WizardStepModelDownload (Goals C11 / C12, Plan Task #12).
+   No existing rule altered. `prefers-reduced-motion: reduce` is honored
+   on the subtle background transition. */
+
+.nous-wizard__hardware-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nous-space-sm);
+  background: color-mix(in srgb, var(--nous-card-bg) 96%, transparent);
+  transition: background 200ms ease;
+}
+
+.nous-wizard__meta-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--nous-space-xs) var(--nous-space-md);
+  color: var(--nous-fg);
+  font-size: var(--nous-font-size-sm);
+}
+
+.nous-wizard__meta-list > li {
+  display: flex;
+  flex-direction: row;
+  gap: var(--nous-space-xs);
+  align-items: baseline;
+}
+
+.nous-wizard__meta-list > li > strong {
+  color: var(--nous-fg-muted);
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nous-wizard__hardware-summary {
+    transition: none;
+  }
+}

--- a/self/apps/desktop/src/renderer/src/desktop-chat-wrappers.tsx
+++ b/self/apps/desktop/src/renderer/src/desktop-chat-wrappers.tsx
@@ -1,48 +1,51 @@
-import { useEffect, useRef } from 'react'
 import type { IDockviewPanelProps } from 'dockview-react'
 import { ChatPanel } from '@nous/ui/panels'
 import { ChatSurface, useShellContext, type ChatStage } from '@nous/ui/components'
-import { useChatApi, trpc } from '@nous/transport'
+import { useChatApi } from '@nous/transport'
+import { useFireWelcomeOnMount } from './desktop-welcome-trigger'
 
 /** Wrapper that wires ChatPanel to tRPC via useChatApi (dockview).
  *
- * SP 1.6 — also fires the one-shot welcome message trigger on first mount.
- * The trigger is gated by a renderer-side ref (mount-once, guards against
- * React StrictMode double-invocation in development) plus the backend's
- * persisted `welcomeMessageSent` flag (cross-mount idempotency). See SDS
- * § 1.2 (the dockview principal chat panel is the chat-init delegate per
- * Decision 6 § Mechanism step 1; `useChatApi`, `ChatPanel`, and
- * `ConnectedChatSurface` are deliberately NOT modified per SDS § 0 Note 1
- * and Note 4).
+ * SP 1.6 — fires the one-shot welcome message trigger on first mount.
+ *
+ * SP 1.8 (ADR 023) revisit — both `DesktopChatPanel` (dockview) and
+ * `ConnectedChatSurface` (simple mode) now share the `useFireWelcomeOnMount`
+ * hook so the welcome turn fires once on first-run completion regardless
+ * of which shell mode the user is in. The persisted `welcomeMessageSent`
+ * flag (set in the welcome-coordinator after STM append) remains the
+ * cross-mount idempotency gate. The shared hook also gates on
+ * `activeProjectId !== null` so the latent dockview-mode RC-3b race (where
+ * `activeProjectId` is null at first render and resolves on a subsequent
+ * render) is hardened.
+ *
+ * The SP 1.6 SDS § 0 Note 1 single-site choice (which excluded
+ * `ConnectedChatSurface` from being a trigger site) is narrowly
+ * superseded by ADR 023 for the welcome-trigger concern only. The SP 1.6
+ * SDS § 0 Note 4 binding constraint that the trigger MUST NOT live inside
+ * `useChatApi` (which has multiple consumers) is PRESERVED — the shared
+ * hook lives in the two delegate wrappers, NOT inside `useChatApi`.
+ * `ChatPanel`, `useChatApi`, the chat-API surface, and
+ * `web-chat-wrappers.tsx` remain unmodified.
  */
 export function DesktopChatPanel(props: IDockviewPanelProps) {
   const { activeProjectId } = useShellContext()
   const chatApi = useChatApi({ projectId: activeProjectId ?? undefined })
 
-  const welcomeFiredRef = useRef(false)
-  const fireWelcome = trpc.chat.fireWelcomeIfUnsent.useMutation()
-
-  useEffect(() => {
-    if (welcomeFiredRef.current) return
-    welcomeFiredRef.current = true
-    fireWelcome
-      .mutateAsync({ projectId: activeProjectId ?? undefined })
-      .catch(() => {
-        // Defensive only — the coordinator never throws (failure modes are
-        // returned as `welcomeFired: false`). A throw at this surface is a
-        // transport-layer error (network, serialization). Log via console;
-        // do not propagate (must not block ChatPanel render).
-        console.warn('[nous:welcome] fireWelcomeIfUnsent transport error')
-      })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // mount-once; activeProjectId changes do not re-trigger (the backend flag handles cross-project re-mount).
+  useFireWelcomeOnMount(activeProjectId)
 
   return <ChatPanel {...props} params={{ chatApi }} />
 }
 
-/** Wrapper that wires ChatSurface to tRPC via useChatApi (simple mode). */
+/** Wrapper that wires ChatSurface to tRPC via useChatApi (simple mode).
+ *
+ * SP 1.8 (ADR 023) — invokes the shared `useFireWelcomeOnMount` hook so
+ * first-run users in default `simple` shell mode receive the welcome
+ * turn (Issue 3 closure). See the `DesktopChatPanel` docstring above for
+ * the full rationale and ADR cross-reference.
+ */
 export function ConnectedChatSurface({ stage, onStageChange, onSendStart, isPinned, onTogglePin, onInputFocus, onUnreadMessage, onMessagesRead }: { stage?: ChatStage; onStageChange?: (stage: ChatStage) => void; onSendStart?: () => void; isPinned?: boolean; onTogglePin?: () => void; onInputFocus?: () => void; onUnreadMessage?: () => void; onMessagesRead?: () => void } = {}) {
   const { activeProjectId } = useShellContext()
   const chatApi = useChatApi({ projectId: activeProjectId ?? undefined })
+  useFireWelcomeOnMount(activeProjectId)
   return <ChatSurface chatApi={chatApi} stage={stage} onStageChange={onStageChange} onSendStart={onSendStart} isPinned={isPinned} onTogglePin={onTogglePin} onInputFocus={onInputFocus} onUnreadMessage={onUnreadMessage} onMessagesRead={onMessagesRead} />
 }

--- a/self/apps/desktop/src/renderer/src/desktop-welcome-trigger.ts
+++ b/self/apps/desktop/src/renderer/src/desktop-welcome-trigger.ts
@@ -1,0 +1,92 @@
+/**
+ * SP 1.8 Fix #14 — Shared welcome-trigger hook.
+ *
+ * `useFireWelcomeOnMount(activeProjectId)` centralizes the one-shot
+ * welcome-emission firing concern that previously lived inline inside
+ * `DesktopChatPanel`. Both `DesktopChatPanel` (dockview) and
+ * `ConnectedChatSurface` (simple mode) now invoke this hook so the
+ * welcome turn fires once on first-run completion regardless of which
+ * shell mode the user lands in. The persisted `welcomeMessageSent` flag
+ * (set inside the welcome-coordinator after STM append) remains the
+ * cross-mount idempotency gate.
+ *
+ * Trace: SP 1.8 SDS § 4.8 / Goals C13 / C14 / C15 / C16; Plan Task #14;
+ * ADR 023; Invariant A (set-after-await).
+ *
+ * --- BINDING IMPLEMENTATION INVARIANT (SDS § 0 Note 2 / I10 / Goals C13) ---
+ *
+ * `welcomeFiredRef.current = true` MUST be set AFTER the await, conditional
+ * on the result. Setting it before the await reproduces the BT R2 bug
+ * (Issue 3) — when `activeProjectId === null` at first render the
+ * coordinator returns `{ welcomeFired: false, reason: 'no_project_id' }`
+ * but the latch then prevents the next render's retry, so the welcome
+ * never fires.
+ *
+ * The latch rule:
+ *
+ *   if (
+ *     result.welcomeFired === true ||
+ *     (result.welcomeFired === false && result.reason !== 'no_project_id')
+ *   ) {
+ *     welcomeFiredRef.current = true
+ *   }
+ *
+ * `'no_project_id'` outcomes leave the ref `false` so the next render
+ * with a non-null `activeProjectId` re-fires (the dockview RC-3b retry
+ * path). All other `welcomeFired: false` reasons (`already_sent`,
+ * `composition_error`, `empty_response`, `stm_append_error`) latch the
+ * ref because the coordinator already evaluated the persisted flag and
+ * either succeeded (already_sent) or hit a non-retryable failure.
+ */
+import { useEffect, useRef } from 'react'
+import { trpc } from '@nous/transport'
+
+export function useFireWelcomeOnMount(activeProjectId: string | null): void {
+  // `welcomeFiredRef` is the BINDING latch (Invariant A): set to `true`
+  // ONLY after the await, conditional on the result. `'no_project_id'`
+  // outcomes leave it `false` so the next render with a non-null
+  // `activeProjectId` re-fires.
+  const welcomeFiredRef = useRef(false)
+  // `inFlightRef` is a synchronous concurrency guard for StrictMode
+  // double-invocation in development (per Goals C15 / SP 1.6 T15
+  // contract). It latches synchronously to coalesce StrictMode's
+  // back-to-back effect invocations, and is reset in `finally` so a
+  // legitimate retry (e.g., after `'no_project_id'`) is not blocked.
+  // This guard does NOT replace the BINDING `welcomeFiredRef` post-await
+  // contract — it only prevents the same render's effect from racing
+  // itself.
+  const inFlightRef = useRef(false)
+  const fireWelcome = trpc.chat.fireWelcomeIfUnsent.useMutation()
+
+  useEffect(() => {
+    if (welcomeFiredRef.current) return
+    if (activeProjectId === null) return
+    if (inFlightRef.current) return
+
+    inFlightRef.current = true
+    const projectId = activeProjectId
+    void (async () => {
+      try {
+        const result = await fireWelcome.mutateAsync({ projectId })
+        // BINDING — set-after-await, conditional. See doc-comment above.
+        if (
+          result.welcomeFired === true ||
+          (result.welcomeFired === false && result.reason !== 'no_project_id')
+        ) {
+          welcomeFiredRef.current = true
+        }
+        // else: leave `welcomeFiredRef` `false` so the next render with a
+        // non-null `activeProjectId` re-fires (dockview RC-3b retry path).
+      } catch {
+        // Defensive only — the coordinator never throws (failure modes
+        // are returned as `welcomeFired: false`). A throw at this surface
+        // is a transport-layer error (network, serialization). Log via
+        // console; do not propagate (must not block the host render).
+        console.warn('[nous:welcome] fireWelcomeIfUnsent transport error')
+      } finally {
+        inFlightRef.current = false
+      }
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProjectId])
+}

--- a/self/apps/shared-server/__tests__/first-run-wizard.test.ts
+++ b/self/apps/shared-server/__tests__/first-run-wizard.test.ts
@@ -453,3 +453,72 @@ describe('first-run wizard router', () => {
     expect(firstRunMock.resetFirstRunState).toHaveBeenCalledWith(ctx.dataDir);
   });
 });
+
+// SP 1.8 Fix #9 — Cross-axis derivation tests for `buildValidationMap`.
+// Validates the local-axis short-circuit (Goals C7 / C9) and the
+// `(local)` log-line annotation (Goals C8). Trace: SDS § 4.5 / Plan Task #9.
+describe('buildValidationMap — cross-axis derivation (RC-2a + RC-2b)', () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    // Clear the per-spec cache between tests (the local-axis short-circuit
+    // does NOT write the cache, but the registry path does).
+    const { __resetRegistryAvailabilityCacheForTesting } = await vi.importActual<
+      typeof import('../src/ollama-detection')
+    >('../src/ollama-detection');
+    __resetRegistryAvailabilityCacheForTesting();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function loadBuildValidationMap() {
+    return (await import('../src/trpc/routers/first-run')).buildValidationMap;
+  }
+
+  it('locally-installed spec short-circuits to "validated" without invoking the registry HEAD probe (BT R2 spec-mismatch case)', async () => {
+    const buildValidationMap = await loadBuildValidationMap();
+    const result = await buildValidationMap(
+      ['ollama:qwen2.5:32b'],
+      ['qwen2.5:32b'],
+    );
+    expect(result).toEqual({ 'ollama:qwen2.5:32b': 'validated' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      '[nous:first-run] validation: ollama:qwen2.5:32b -> validated (local)',
+    );
+  });
+
+  it('falls through to the registry HEAD probe when the spec is NOT locally installed', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+    const buildValidationMap = await loadBuildValidationMap();
+    const result = await buildValidationMap(['ollama:qwen2.5:32b'], []);
+    expect(result['ollama:qwen2.5:32b']).toBe('validated');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mixed list: locally-installed short-circuits; registry-only falls through', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+    } as Response);
+    const buildValidationMap = await loadBuildValidationMap();
+    const result = await buildValidationMap(
+      ['ollama:qwen2.5:32b', 'ollama:llama3.2:3b'],
+      ['qwen2.5:32b'],
+    );
+    expect(result['ollama:qwen2.5:32b']).toBe('validated');
+    expect(result['ollama:llama3.2:3b']).toBe('unavailable');
+    // Only the non-local spec hit the network.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/self/apps/shared-server/__tests__/ollama-detection-availability.test.ts
+++ b/self/apps/shared-server/__tests__/ollama-detection-availability.test.ts
@@ -11,6 +11,7 @@ import {
   REGISTRY_AVAILABILITY_CACHE_TTL_MS,
   __resetRegistryAvailabilityCacheForTesting,
   checkRegistryAvailability,
+  normalizeSpecForLocalLookup,
 } from '../src/ollama-detection';
 
 const fetchMock = vi.fn();
@@ -221,5 +222,26 @@ describe('checkRegistryAvailability — Tier 3 edge cases', () => {
     const state = await checkRegistryAvailability(undefined as unknown as string);
     expect(state).toBe('unavailable');
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// SP 1.8 Fix #8 — Unit tests for the `normalizeSpecForLocalLookup`
+// helper. Verifies first-occurrence-only `'ollama:'` strip semantics
+// (Goals C6 / Plan Task #8).
+describe('normalizeSpecForLocalLookup — SP 1.8', () => {
+  it('strips a leading "ollama:" prefix', () => {
+    expect(normalizeSpecForLocalLookup('ollama:qwen2.5:32b')).toBe('qwen2.5:32b');
+  });
+
+  it('passes through a non-prefixed spec unchanged', () => {
+    expect(normalizeSpecForLocalLookup('qwen2.5:32b')).toBe('qwen2.5:32b');
+  });
+
+  it('passes through an empty string unchanged', () => {
+    expect(normalizeSpecForLocalLookup('')).toBe('');
+  });
+
+  it('passes through a non-"ollama:" prefixed spec unchanged', () => {
+    expect(normalizeSpecForLocalLookup('something-else:foo')).toBe('something-else:foo');
   });
 });

--- a/self/apps/shared-server/src/hardware-detection.ts
+++ b/self/apps/shared-server/src/hardware-detection.ts
@@ -68,12 +68,29 @@ export const RoleModelRecommendationSchema = z.object({
 
 export type RoleModelRecommendation = z.infer<typeof RoleModelRecommendationSchema>;
 
+// SP 1.8 Fix #10 — `tier` and `tierLabel` are optional fields populated by
+// `buildLocalRecommendations` (the local-first hardware-tier branch) and
+// left unset by `buildRemoteRecommendations` and the no-providers branch.
+// They surface in the wizard's `WizardStepModelDownload` explanatory
+// section so the user can see how their detected hardware maps to the
+// per-tier recommendation set. Additive optional schema fields per
+// Invariant I12 (JSON-serializable; no migration). Trace: SDS § 4.6 /
+// Goals C10 / Plan Task #10.
+export const RecommendationTierSchema = z.enum([
+  'tiny',
+  'small',
+  'medium',
+  'large',
+]);
+
 export const RecommendationResultSchema = z.object({
   singleModel: ModelRecommendationSchema.nullable(),
   multiModel: z.array(RoleModelRecommendationSchema),
   hardwareSpec: HardwareSpecSchema,
   profileName: z.string(),
   advisory: z.string(),
+  tier: RecommendationTierSchema.optional(),
+  tierLabel: z.string().optional(),
 });
 
 export type RecommendationResult = z.infer<typeof RecommendationResultSchema>;
@@ -84,7 +101,17 @@ export type RecommendationProfilePolicy = {
   allowRemoteProviders?: boolean;
 };
 
-type RecommendationTier = 'tiny' | 'small' | 'medium' | 'large';
+type RecommendationTier = z.infer<typeof RecommendationTierSchema>;
+
+// SP 1.8 Fix #10 — per-tier human-readable label vocabulary. Surfaced by
+// `WizardStepModelDownload`'s explanatory section so the user sees the
+// link from their detected hardware to the recommendation set.
+const TIER_LABELS: Record<RecommendationTier, string> = {
+  tiny: 'Compact (low-memory)',
+  small: 'Balanced (entry-to-mid desktop)',
+  medium: 'Mid-spec (stronger reasoning)',
+  large: 'High-spec (advanced reasoning)',
+};
 
 /**
  * Curated Ollama-library catalog used by `recommendModels` to seed the
@@ -393,6 +420,11 @@ function buildLocalRecommendations(
     hardwareSpec: spec,
     profileName: 'local-first',
     advisory,
+    // SP 1.8 Fix #10 — populate `tier` + `tierLabel` so the wizard's
+    // explanatory section can surface the hardware-to-recommendation
+    // mapping (Goals C11 / Plan Task #10b).
+    tier,
+    tierLabel: TIER_LABELS[tier],
   });
 }
 

--- a/self/apps/shared-server/src/index.ts
+++ b/self/apps/shared-server/src/index.ts
@@ -59,6 +59,7 @@ export {
   detectOllama,
   getOllamaVersion,
   meetsMinimumVersion,
+  normalizeSpecForLocalLookup,
   pullOllamaModel,
   resolveOllamaBinary,
 } from './ollama-detection';

--- a/self/apps/shared-server/src/ollama-detection.ts
+++ b/self/apps/shared-server/src/ollama-detection.ts
@@ -599,6 +599,28 @@ function parseOllamaModelSpec(
   return modelId;
 }
 
+/**
+ * SP 1.8 Fix #6 — strip a leading `'ollama:'` provider prefix from a
+ * recommendation/catalog spec so the bare model id can be cross-referenced
+ * against the locally-installed ids returned by `OllamaStatus.models`
+ * (which do NOT carry the `'ollama:'` prefix). Returns input unchanged
+ * for non-prefixed specs (passthrough).
+ *
+ * First-occurrence-only strip semantics: only the leading `'ollama:'`
+ * prefix is stripped; any further `':'` segments (e.g., model + tag like
+ * `'qwen2.5:32b'`) are preserved.
+ *
+ * Pure function; no side effects. Trace: SP 1.8 SDS § Data Model § Spec
+ * normalization; Goals C6; Implementation Plan Task #6.
+ */
+export function normalizeSpecForLocalLookup(spec: string): string {
+  if (typeof spec !== 'string') return spec
+  if (spec.startsWith('ollama:')) {
+    return spec.slice('ollama:'.length)
+  }
+  return spec
+}
+
 function isAbortError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) {
     return false;

--- a/self/apps/shared-server/src/trpc/routers/first-run.ts
+++ b/self/apps/shared-server/src/trpc/routers/first-run.ts
@@ -17,6 +17,7 @@ import {
 import {
   checkRegistryAvailability,
   detectOllama,
+  normalizeSpecForLocalLookup,
   pullOllamaModel,
 } from '../../ollama-detection';
 
@@ -31,19 +32,46 @@ export const ValidationMapSchema = z.record(z.string(), ValidationStateSchema);
 export type ValidationMap = z.infer<typeof ValidationMapSchema>;
 
 /**
- * Build the validation map for a set of recommended Ollama specs by
- * fan-out HEAD-probing the Ollama library page for each spec in parallel.
+ * Build the validation map for a set of recommended Ollama specs.
+ *
+ * SP 1.8 Fix #7 — cross-axis derivation. For each unique spec:
+ *   1. Local axis (preferred — durable signal). Strip the `'ollama:'`
+ *      prefix via `normalizeSpecForLocalLookup` and check whether the bare
+ *      id is in `locallyInstalledIds` (the `OllamaStatus.models` list).
+ *      If yes, short-circuit to `'validated'` WITHOUT invoking
+ *      `checkRegistryAvailability` and WITHOUT writing the 30-min session
+ *      cache — the local presence is durable signal that registry
+ *      unreachability cannot contradict (SP 1.5 Decision 5 graceful
+ *      degradation extended).
+ *   2. Otherwise fall through to the existing registry-axis HEAD probe.
  *
  * The fan-out is bounded by the recommendation set size (typically 2-4
  * unique specs after dedup); the per-spec session cache inside
  * `checkRegistryAvailability` deduplicates within the TTL window.
+ *
+ * Trace: SP 1.8 SDS § 4.5 / Goals C7 / C8 / Plan Task #7 / Invariant D
+ * (the standalone `validateModelAvailability` procedure remains
+ * registry-only and is NOT modified).
  */
-async function buildValidationMap(
+export async function buildValidationMap(
   recommendedSpecs: readonly string[],
+  locallyInstalledIds: readonly string[],
 ): Promise<ValidationMap> {
   const uniqueSpecs = Array.from(new Set(recommendedSpecs));
+  const localSet = new Set(locallyInstalledIds);
   const states = await Promise.all(
     uniqueSpecs.map(async (spec) => {
+      const localId = normalizeSpecForLocalLookup(spec);
+      if (localSet.has(localId)) {
+        // Local-axis short-circuit — durable signal beats registry.
+        // Note: deliberately skips the per-spec registry session cache
+        // (`setCachedAvailability`) so a future registry-axis call for
+        // the same spec is not pre-poisoned by this local derivation.
+        console.info(
+          `[nous:first-run] validation: ${spec} -> validated (local)`,
+        );
+        return [spec, 'validated' as const] as const;
+      }
       const state = await checkRegistryAvailability(spec);
       return [spec, state] as const;
     }),
@@ -179,7 +207,10 @@ export const firstRunRouter = router({
     for (const entry of recommendations.multiModel) {
       recommendedSpecs.push(entry.recommendation.modelSpec);
     }
-    const validation = await buildValidationMap(recommendedSpecs);
+    // SP 1.8 Fix #7b — pass the locally-installed model id list (from
+    // `OllamaStatus.models`) so `buildValidationMap` can derive
+    // `'validated'` from local presence without a registry HEAD probe.
+    const validation = await buildValidationMap(recommendedSpecs, ollama.models);
 
     let validatedCount = 0;
     let unavailableCount = 0;


### PR DESCRIPTION
## Summary

Sub-phase 1.8 closures for BT Round 2 issues on the onboarding-agent-identity feature integration branch. Three coupled root-cause fixes:

- **RC-1 (Identity persistence):** Lift `name`/`personality`/`profile`/`advancedOpen` from `WizardStepIdentity` local state to `FirstRunWizard`-owned `identityDraft` so identity edits survive step navigation; reset on wizard reset alongside role assignments.
- **RC-2 (Model recommendation cross-axis):** `buildValidationMap` widened to `(recommendedSpecs, locallyInstalledIds)` with O(1) Set lookup; emits `[nous:first-run] validation: <spec> -> validated (local)` and short-circuits `checkRegistryAvailability` when locally present. Adds `tier`/`tierLabel` to `RecommendationResultSchema` and a transparency surface in `WizardStepModelDownload` showing detected RAM/CPU/GPU + tier mapping.
- **RC-3 (Welcome trigger — simple mode + dockview RC-3b race):** New shared `useFireWelcomeOnMount` hook in `desktop-welcome-trigger.ts` with conditional set-after-await latch (Invariant A); both `DesktopChatPanel` (dockview) and `ConnectedChatSurface` (simple mode) invoke it. `useChatApi`, `ChatPanel`, `ChatSurface`, and `web-chat-wrappers.tsx` remain unmodified. Codified in ADR 023 (narrow supersession of SP 1.6 SDS § 0 Note 1; preservation of Note 4).

## Artifacts

- Goals: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/goals.mdx`
- SDS: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/sds.mdx`
- Implementation Plan: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/implementation-plan.mdx`
- Completion Report: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/completion-report.mdx`
- Completion Report Review (Approved With Actions): `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/reviews/completion-report.mdx`
- Root Cause Manifest: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/discovery/root-cause-manifest.mdx`
- Ratified Decision: `.worklog/sprints/feat/onboarding-agent-identity/phase-1/sp-1.8/decisions/wizard-bt-r2-fix-v1.mdx`
- ADR 023: `.worklog/adr/023-welcome-trigger-shared-hook-and-simple-mode-coverage.mdx`

References WR-161. BT Round 3 (per-phase aggregate) to follow on the integrated `feat/onboarding-agent-identity` branch.

## Test plan

- [x] `pnpm typecheck` clean (re-verified during CR review)
- [x] `pnpm lint` 149/0 — matches SP 1.7 baseline, no upward drift
- [x] New SP 1.8 unit + integration tests pass (identity retention, cross-axis validation, shared welcome hook including `'no_project_id'` non-latch negative regression, simple-mode E2E T22b)
- [ ] BT Round 3 on the feature integration branch (post-merge)