### PR TITLE
Phase 1.16 — BT R8 fixes: RC-α native thinking + RC-β.1/β.2/β.3 narrate-without-dispatch + timeout + fallback (WR-159)

### DIFF
--- a/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/adapters/ollama-adapter.test.ts
@@ -712,3 +712,29 @@ describe('Ollama adapter regression — text-listed fallback', () => {
     expect(result.toolCalls).toEqual([]);
   });
 });
+
+describe('createOllamaAdapter — formatRequest sets result.think (SP 1.16 RC-α / α7)', () => {
+  it('sets result.think === true when extendedThinking capability is true (tool-bearing turn)', () => {
+    const adapter = createOllamaAdapter('llama3.2:3b');
+    expect(adapter.capabilities.extendedThinking).toBe(true);
+    const result = adapter.formatRequest({
+      systemPrompt: 'sys',
+      context: [makeFrame('user', 'hi')],
+      toolDefinitions: [SAMPLE_TOOL],
+    });
+    expect((result.input as Record<string, unknown>).think).toBe(true);
+  });
+
+  it('sets result.think === true on non-tool-bearing turns too (placement OUTSIDE tool block)', () => {
+    const adapter = createOllamaAdapter('llama3.2:3b');
+    const result = adapter.formatRequest({
+      systemPrompt: 'sys',
+      context: [makeFrame('user', 'hi')],
+      toolDefinitions: [],
+    });
+    // Load-bearing: the activation must NOT be gated on tool presence.
+    expect((result.input as Record<string, unknown>).think).toBe(true);
+    // And tools key must not be present when no tools were supplied.
+    expect((result.input as Record<string, unknown>).tools).toBeUndefined();
+  });
+});

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-thinking-stream.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-thinking-stream.test.ts
@@ -344,3 +344,98 @@ describe('AgentGateway SP 1.13 RC-2 thinking-stream dispatch', () => {
     expect(recorded.some((r) => r.channel === 'chat:thinking-chunk')).toBe(true);
   });
 });
+
+// ── SP 1.16 Tier 3 — production wrap chain end-to-end ──
+
+describe('AgentGateway SP 1.16 RC-α end-to-end native-thinking activation', () => {
+  it('Scenario A — adapter-prepared input passed to invokeWithThinkingStream carries think: true', async () => {
+    let capturedRequest: ModelRequest | undefined;
+    const itsSpy = vi.fn().mockImplementation(async (req: ModelRequest, _bus: IEventBus, traceId) => {
+      capturedRequest = req;
+      return {
+        output: makeMessageOutput('task_complete'),
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId,
+      } satisfies ModelResponse;
+    });
+    const provider = makeProvider({ invokeWithThinkingStream: itsSpy });
+    const eventBus = recordingEventBus();
+
+    const { gateway } = createGateway({ provider, eventBus });
+    await gateway.run(createBaseInput());
+
+    expect(itsSpy).toHaveBeenCalled();
+    // The Ollama adapter sets result.think = true unconditionally per SP 1.16 RC-α.
+    const input = (capturedRequest?.input ?? {}) as Record<string, unknown>;
+    expect(input.think).toBe(true);
+    // SP 1.15 invariant — tool-bearing turn forces stream: false (preserved).
+    expect(input.stream).toBe(false);
+  });
+});
+
+describe('AgentGateway SP 1.16 RC-β.1 + RC-β.3 end-to-end narrate-without-dispatch', () => {
+  it('Scenario B-primary — primary-path detector adjudication produces NARRATE_WITHOUT_DISPATCH_MARKER', async () => {
+    // Ollama-shaped non-empty content, zero tool calls — detector adjudicates.
+    const provider = makeProvider({
+      invoke: vi.fn().mockResolvedValue({
+        output: { role: 'assistant', content: 'I created the workflow you requested.' },
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId: TRACE_ID,
+      } satisfies ModelResponse),
+    });
+
+    // Use a tool surface whose tool name yields a token (`workflow`) the
+    // detector matches against.
+    const toolSurface = {
+      listTools: vi.fn().mockResolvedValue([
+        {
+          name: 'workflow_create',
+          version: '1.0.0',
+          description: 'create',
+          inputSchema: {},
+          outputSchema: {},
+          capabilities: ['write'],
+          permissionScope: 'project',
+        } as ToolDefinition,
+      ]),
+      executeTool: vi.fn(),
+    };
+
+    const { gateway } = createGateway({ provider, toolSurface });
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBe('narrate_without_dispatch');
+    // Lazy import of marker constant via re-export from @nous/shared
+    expect(output.response).toContain('I described an action without actually performing it');
+  });
+
+  it('Scenario B-fallback — invokeWithThinkingStream throws → fromFallback → case (b) fires UNCONDITIONALLY', async () => {
+    // Detector-negative content; case (b) must still fire because fromFallback === true.
+    const provider = makeProvider({
+      invokeWithThinkingStream: vi.fn().mockRejectedValue(new Error('thinking-stream simulated failure')),
+      invoke: vi.fn().mockResolvedValue({
+        output: { role: 'assistant', content: 'Sure, here is some helpful information.' },
+        providerId: PROVIDER_ID,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        traceId: TRACE_ID,
+      } satisfies ModelResponse),
+    });
+    const eventBus = recordingEventBus();
+    // Tools present so canStreamContent is false (the cycle-1 SP 1.9 RC-2
+    // invariant) and canStreamThinking is true → invokeWithThinkingStream
+    // path engages → fallback fires when it throws.
+    const { gateway } = createGateway({ provider, eventBus });
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBe('narrate_without_dispatch');
+    expect(output.response).toContain('I described an action without actually performing it');
+  });
+});

--- a/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-turn-loop.test.ts
+++ b/self/cortex/core/src/__tests__/agent-gateway/agent-gateway-turn-loop.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
-import { EMPTY_RESPONSE_MARKER } from '@nous/shared';
-import type { IModelProvider } from '@nous/shared';
+import { EMPTY_RESPONSE_MARKER, NARRATE_WITHOUT_DISPATCH_MARKER } from '@nous/shared';
+import type { IEventBus, IModelProvider, ToolDefinition } from '@nous/shared';
+import { AgentGateway } from '../../agent-gateway/agent-gateway.js';
+import { InMemoryGatewayOutboxSink } from '../../agent-gateway/outbox.js';
 import {
+  AGENT_ID,
   createBaseInput,
   createGatewayHarness,
   createInjectedFrame,
   createStampedPacket,
   createToolSurface,
+  NOW,
   PROVIDER_ID,
   TRACE_ID,
 } from './helpers.js';
@@ -162,5 +166,223 @@ describe('AgentGateway empty-loop guard (SP 1.15 RC-1)', () => {
     expect(data.response).toBe('');
     // And the user-facing output still carries the marker
     expect((result.output as { response: string }).response).toBe(EMPTY_RESPONSE_MARKER);
+  });
+});
+
+// ── SP 1.16 RC-β.1 + RC-β.3 — narrate-without-dispatch detector + fromFallback ──
+
+/**
+ * Helper: build a tools array whose names produce the requested tokens of
+ * length ≥ 4. Default tools include `lookup_status` (tokens `lookup`, `status`).
+ */
+function buildToolsWithTokens(names: string[]): ToolDefinition[] {
+  return names.map((name) => ({
+    name,
+    version: '1.0.0',
+    description: `${name} tool`,
+    inputSchema: {},
+    outputSchema: {},
+    capabilities: ['read'],
+    permissionScope: 'project',
+  }));
+}
+
+describe('AgentGateway narrate-without-dispatch detector (SP 1.16 RC-β.1 / case c)', () => {
+  it('classifies past-tense action narration referencing a tool token within proximity window', async () => {
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        // Past-tense action verb (`created`) within ±120 chars of `workflow` token.
+        { content: 'I created the workflow you requested.' },
+      ]),
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['workflow_create'])),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBe('narrate_without_dispatch');
+    expect(output.response).toBe(NARRATE_WITHOUT_DISPATCH_MARKER);
+  });
+
+  it('does NOT classify present-tense statements (negative case)', async () => {
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        { content: 'The workflow handles routing for incoming events.' },
+      ]),
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['workflow_create'])),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBeUndefined();
+    expect(output.response).toBe('The workflow handles routing for incoming events.');
+  });
+
+  it('does NOT classify questions (negative case)', async () => {
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        { content: 'What workflow should I create for you?' },
+      ]),
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['workflow_create'])),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBeUndefined();
+  });
+
+  it('does NOT classify a past-tense action when no tool token is in proximity (defensive)', async () => {
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        // Past-tense verb but no tool token within ±120 chars.
+        { content: 'I added the requested item to the list.' },
+      ]),
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['unrelated_tool'])),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBeUndefined();
+  });
+
+  it('does NOT classify when toolDefinitions is empty (short-circuit)', async () => {
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        { content: 'I created the workflow you requested.' },
+      ]),
+      toolSurface: createToolSurface(undefined, []),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBeUndefined();
+  });
+
+  it('does NOT classify when tool tokens are all length < 4 (short-circuit)', async () => {
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        { content: 'I created the workflow you requested.' },
+      ]),
+      // Each token after splitting on `_` is length < 4 → toolTokens empty.
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['ab_cd_ef'])),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBeUndefined();
+  });
+
+  it('SP 1.15 RC-1 case (a) precedence preserved — empty response yields SP 1.15 marker, NOT SP 1.16 marker', async () => {
+    // Even when fromFallback would otherwise apply, an empty trimmed response
+    // routes to case (a) per the conversational-exit branch's if/else order.
+    const { gateway } = createGatewayHarness({
+      modelProvider: createOllamaShapedProvider([
+        { content: '' },
+      ]),
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['workflow_create'])),
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    expect(output.empty_response_kind).toBe('no_output_at_all');
+    expect(output.response).toBe(EMPTY_RESPONSE_MARKER);
+    expect(output.response).not.toBe(NARRATE_WITHOUT_DISPATCH_MARKER);
+  });
+});
+
+// ── SP 1.16 RC-β.3 — fromFallback observability case (b) ──
+
+function recordingBus(): IEventBus & { recorded: Array<{ channel: string; payload: unknown }> } {
+  const recorded: Array<{ channel: string; payload: unknown }> = [];
+  return {
+    publish: vi.fn().mockImplementation((channel: string, payload: unknown) => {
+      recorded.push({ channel, payload });
+    }),
+    subscribe: vi.fn().mockReturnValue('sub'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+    recorded,
+  } as unknown as IEventBus & { recorded: Array<{ channel: string; payload: unknown }> };
+}
+
+/**
+ * Provider that supports `invokeWithThinkingStream` but always throws so the
+ * fallback path engages, then `invoke()` returns a non-empty response with no
+ * tool calls.
+ */
+function createFallbackThrowingProvider(content: string): IModelProvider {
+  return {
+    invoke: vi.fn().mockResolvedValue({
+      output: { role: 'assistant', content },
+      providerId: PROVIDER_ID,
+      usage: { inputTokens: 5, outputTokens: 5 },
+      traceId: TRACE_ID,
+    }),
+    stream: vi.fn(),
+    invokeWithThinkingStream: vi.fn().mockRejectedValue(new Error('thinking-stream simulated failure')),
+    getConfig: vi.fn().mockReturnValue({
+      id: PROVIDER_ID,
+      name: 'ollama-test',
+      type: 'ollama',
+      vendor: 'ollama',
+      modelId: 'gemma3:4b',
+      isLocal: true,
+      capabilities: ['reasoning'],
+    }),
+  };
+}
+
+describe('AgentGateway fromFallback observability (SP 1.16 RC-β.3 / case b)', () => {
+  it('non-empty fallback response with zero tool calls is classified narrate_without_dispatch UNCONDITIONALLY', async () => {
+    // Build a harness with eventBus so canStreamThinking gate fires; provider
+    // throws on invokeWithThinkingStream; fallback invoke returns a benign
+    // response that the detector would NOT match — case (b) must still fire.
+    const harness = createGatewayHarness({
+      modelProvider: createFallbackThrowingProvider('Sure, here is some helpful information.'),
+      toolSurface: createToolSurface(undefined, buildToolsWithTokens(['workflow_create'])),
+    });
+    // Inject eventBus into the gateway config via a fresh AgentGateway built
+    // around the same harness inputs but with eventBus set.
+    const eventBus = recordingBus();
+    const gateway = new AgentGateway({
+      agentClass: 'Worker',
+      agentId: AGENT_ID,
+      toolSurface: harness.toolSurface,
+      modelProvider: harness.modelProvider,
+      outbox: new InMemoryGatewayOutboxSink(),
+      eventBus,
+      now: () => NOW,
+      nowMs: () => Date.parse(NOW),
+      idFactory: () => AGENT_ID,
+    });
+
+    const result = await gateway.run(createBaseInput({ budget: { maxTurns: 1, maxTokens: 200, timeoutMs: 1000 } }));
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const output = result.output as { response: string; empty_response_kind?: string };
+    // Detector would NOT match this content; case (b) fires regardless.
+    expect(output.empty_response_kind).toBe('narrate_without_dispatch');
+    expect(output.response).toBe(NARRATE_WITHOUT_DISPATCH_MARKER);
   });
 });

--- a/self/cortex/core/src/__tests__/gateway-runtime/principal-chat-integration.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/principal-chat-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { EMPTY_RESPONSE_MARKER } from '@nous/shared';
+import { EMPTY_RESPONSE_MARKER, NARRATE_WITHOUT_DISPATCH_MARKER } from '@nous/shared';
 import type { IModelProvider } from '@nous/shared';
 import { createPrincipalSystemGatewayRuntime } from '../../gateway-runtime/index.js';
 import {
@@ -407,5 +407,78 @@ describe('PrincipalSystemGatewayRuntime — empty_response_kind round-trip (SP 1
 
     expect((result as { empty_response_kind?: string }).empty_response_kind).toBeUndefined();
     expect(result.response).toBe('Normal reply.');
+  });
+});
+
+describe('PrincipalSystemGatewayRuntime — narrate_without_dispatch round-trip (SP 1.16 RC-β.1)', () => {
+  it('SKIPs STM entries tagged with empty_response_kind = narrate_without_dispatch on next turn', async () => {
+    const stmStore = {
+      getContext: vi.fn().mockResolvedValue({
+        entries: [
+          {
+            role: 'assistant',
+            content: NARRATE_WITHOUT_DISPATCH_MARKER,
+            timestamp: '2026-04-18T00:00:00Z',
+            metadata: { empty_response_kind: 'narrate_without_dispatch' },
+          },
+          {
+            role: 'user',
+            content: 'previous user message',
+            timestamp: '2026-04-18T00:00:01Z',
+          },
+        ],
+        summary: undefined,
+        tokenCount: 0,
+      }),
+      append: vi.fn().mockResolvedValue(undefined),
+      compact: vi.fn(),
+      clear: vi.fn(),
+    };
+
+    const principalProvider = createModelProvider([
+      JSON.stringify({
+        response: 'ok',
+        toolCalls: [
+          {
+            name: 'task_complete',
+            params: { output: { response: 'ok' }, summary: 's' },
+          },
+        ],
+      }),
+    ]);
+
+    const runtime = createPrincipalSystemGatewayRuntime({
+      documentStore: createDocumentStore(),
+      modelProviderByClass: {
+        'Cortex::Principal': principalProvider,
+        'Cortex::System': createModelProvider(['{"response":"idle","toolCalls":[]}']),
+        Orchestrator: createModelProvider(['{"response":"idle","toolCalls":[]}']),
+        Worker: createModelProvider(['{"response":"idle","toolCalls":[]}']),
+      },
+      getProjectApi: () => createProjectApi(),
+      pfc: createPfcEngine(),
+      outputSchemaValidator: { validate: vi.fn().mockResolvedValue({ success: true }) },
+      stmStore,
+      idFactory: (() => {
+        let counter = 0;
+        return () => {
+          const suffix = String(counter).padStart(12, '0');
+          counter += 1;
+          return `00000000-0000-4000-8000-${suffix}`;
+        };
+      })(),
+    });
+
+    await runtime.handleChatTurn({
+      message: 'Follow up',
+      projectId: '00000000-0000-4000-8000-000000000001',
+      traceId: '00000000-0000-4000-8000-000000000099',
+    });
+
+    const invokeArgs = (principalProvider.invoke as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const contextFrames = (invokeArgs.input.context ?? []) as Array<{ role: string; content: string }>;
+    expect(contextFrames.some((f) => f.content === 'previous user message')).toBe(true);
+    // SP 1.15 SKIP policy applies to the new discriminator too — Invariant I-13 preserved.
+    expect(contextFrames.some((f) => f.content === NARRATE_WITHOUT_DISPATCH_MARKER)).toBe(false);
   });
 });

--- a/self/cortex/core/src/__tests__/gateway-runtime/workflow-prompt-fragment.test.ts
+++ b/self/cortex/core/src/__tests__/gateway-runtime/workflow-prompt-fragment.test.ts
@@ -45,4 +45,18 @@ describe('WORKFLOW_PROMPT_FRAGMENT — content contract', () => {
   it('SP 1.15 RC-4 — contains the load-bearing semantic ("Treat this as the answer to your call")', () => {
     expect(WORKFLOW_PROMPT_FRAGMENT).toContain('Treat this as the answer to your call');
   });
+
+  // ── SP 1.16 RC-β.1 — action-discipline anchor ──
+  it('SP 1.16 RC-β.1 — contains the **Action discipline:** anchor', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('**Action discipline:**');
+  });
+
+  it('SP 1.16 RC-β.1 — contains the load-bearing semantic ("Do NOT describe an action as completed")', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('Do NOT describe an action as completed');
+  });
+
+  // ── SP 1.13 RC-1 anti-namespacing anchor (regression preservation) ──
+  it('SP 1.13 RC-1 — preserves the do-not-prefix-tool-name guidance', () => {
+    expect(WORKFLOW_PROMPT_FRAGMENT).toContain('Do not prefix or suffix the name');
+  });
 });

--- a/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
+++ b/self/cortex/core/src/agent-gateway/adapters/ollama-adapter.ts
@@ -325,6 +325,18 @@ export function createOllamaAdapter(modelId?: string, log?: ILogChannel): Provid
         result.stream = false;
       }
 
+      // SP 1.16 RC-α — Activate native-thinking output on the wire when the
+      // adapter declares `extendedThinking: true`. Required by Ollama's /api/chat
+      // for thinking-capable models per Ollama API v0.4.0+. The adapter declares
+      // `extendedThinking: true` unconditionally at line 234, so this activation
+      // is unconditional today. Future model-aware tightening (Goals Decision D
+      // note; α5 — out of SP 1.16 scope) would gate this on a model-capability
+      // check. Mirrors the SP 1.15 RC-2 wire-mode-honoring precedent at the
+      // `result.stream = false` setter above.
+      if (capabilities.extendedThinking) {
+        result.think = true;
+      }
+
       // Pass model requirements metadata
       if (input.modelRequirements) {
         result.model_profile = input.modelRequirements.profile;

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -4,6 +4,7 @@ import {
   AgentResultSchema,
   EMPTY_RESPONSE_MARKER,
   GatewayContextFrameSchema,
+  NARRATE_WITHOUT_DISPATCH_MARKER,
   NousError,
   ValidationError,
   type AgentClass,
@@ -84,6 +85,29 @@ function deriveDefaultModelRole(agentClass: AgentClass | undefined): ModelRole {
   if (!agentClass) return 'cortex-chat'; // I5 first-run fallback
   return DEFAULT_MODEL_ROLE_BY_CLASS[agentClass];
 }
+
+/**
+ * SP 1.16 RC-β.1 — single source of truth for the empty/narrate-exit marker
+ * text given a discriminator. Used by the gateway's `buildSingleTurnResult`
+ * AND by `cortex-runtime.finalizeChatStmTurn` (STM write) so the marker
+ * substitution logic exists in exactly one place. Exported for cross-module
+ * (same-package) reuse — `default: never` exhaustiveness check fails the
+ * typechecker if a future cycle adds a new `EmptyResponseKind` value without
+ * updating this switch.
+ */
+export const markerForKind = (kind: EmptyResponseKind): string => {
+  switch (kind) {
+    case 'thinking_only_no_finalizer':
+    case 'no_output_at_all':
+      return EMPTY_RESPONSE_MARKER;
+    case 'narrate_without_dispatch':
+      return NARRATE_WITHOUT_DISPATCH_MARKER;
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+};
 
 const DEFAULT_MODEL_REQUIREMENTS = {
   profile: 'review-standard',
@@ -278,11 +302,27 @@ export class AgentGateway implements IAgentGateway {
           && adapter.capabilities.extendedThinking
           && typeof provider.invokeWithThinkingStream === 'function';
 
+        // SP 1.16 RC-β.3 — per-turn observability flag. Lifetime is exactly one
+        // turn; declared inside the turn-loop iteration scope so each turn starts
+        // fresh. The dispatch ternary's `invokeWithThinkingStreamFallback` arm
+        // (defined below) sets this to true via the `observability.onFallback`
+        // callback when the catch path executes `provider.invoke(request)` as the
+        // fallback. Consumed only by the conversational-exit branch in the same
+        // scope. Generalizes to `let fallbackTier: number = 0;` if multi-tier
+        // fallback is added later.
+        let fromFallback = false;
+        // SP 1.16 RC-β.1 — stable local-scope capture of the in-scope tools
+        // identifier (the post-`formatRequest` ToolDefinition[] used to build
+        // `formatted`) so the conversational-exit branch reads from a stable
+        // name regardless of upstream identifier renames. Per SDS Note 2.
+        const toolDefinitionsForDetector: ToolDefinition[] = tools ?? [];
+
         const modelResponse = canStreamContent
           ? await this.invokeWithStreaming(provider, adapter, formatted, traceId, projectId, correlation)
           : canStreamThinking
             ? await this.invokeWithThinkingStreamFallback(
                 provider, formatted, traceId, projectId, correlation,
+                { onFallback: () => { fromFallback = true; } },
               )
             : await provider.invoke({
                 role: this.config.modelRole ?? deriveDefaultModelRole(this.config.agentClass),
@@ -373,14 +413,41 @@ export class AgentGateway implements IAgentGateway {
         if (parsedOutput.toolCalls.length === 0) {
           let emptyResponseKind: EmptyResponseKind | undefined;
           if (!parsedOutput.response.trim()) {
-            // SP 1.15 RC-1 — derive the empty-exit discriminator so the
-            // user-facing surface gets EMPTY_RESPONSE_MARKER + a typed
-            // signal instead of a silent assistant bubble.
+            // SP 1.15 RC-1 — case (a) — derive the empty-exit discriminator so
+            // the user-facing surface gets EMPTY_RESPONSE_MARKER + a typed
+            // signal instead of a silent assistant bubble. This branch takes
+            // precedence over the SP 1.16 fallback / detector branches below
+            // (a fallback-derived empty response is still empty).
             emptyResponseKind = parsedOutput.thinkingContent && parsedOutput.thinkingContent.trim().length > 0
               ? 'thinking_only_no_finalizer'
               : 'no_output_at_all';
             this.log.warn('empty model response with no tool calls — exiting loop', { agentClass: this.agentClass, emptyResponseKind });
+          } else if (fromFallback) {
+            // SP 1.16 RC-β.3 — case (b) — fail-closed: any non-empty response
+            // produced via the `invokeWithThinkingStreamFallback` catch path
+            // is classified as narrate-without-dispatch UNCONDITIONALLY,
+            // because the fallback path is the load-bearing observability
+            // signal that the primary streaming path failed and the model
+            // surfaced text without exercising the tool-emission contract.
+            emptyResponseKind = 'narrate_without_dispatch';
+            this.log.warn('fallback-derived non-empty response — classifying as narrate_without_dispatch', {
+              agentClass: this.agentClass,
+              responseLength: parsedOutput.response.length,
+            });
+          } else if (this.detectNarrateWithoutDispatch(parsedOutput.response, toolDefinitionsForDetector)) {
+            // SP 1.16 RC-β.1 — case (c) — primary-path detector adjudication:
+            // the model emitted a non-empty conversational response, no tool
+            // calls, primary path (not fallback). The `detectNarrateWithoutDispatch`
+            // heuristic classifies as narrate-without-dispatch only when a
+            // bounded past-tense action verb co-occurs with a tool-name token
+            // within a tight proximity window AND the agent has tools available.
+            emptyResponseKind = 'narrate_without_dispatch';
+            this.log.warn('detector fired — classifying as narrate_without_dispatch', {
+              agentClass: this.agentClass,
+              responseLength: parsedOutput.response.length,
+            });
           } else {
+            // case (d) — default no-op: normal conversational exit.
             this.log.debug('conversational exit (no tool calls)', { agentClass: this.agentClass });
           }
           budgetTracker.recordTurn();
@@ -626,6 +693,7 @@ export class AgentGateway implements IAgentGateway {
     traceId: string,
     projectId: string | undefined,
     correlation: { runId: string; parentId?: string; sequence: number },
+    observability: { onFallback: () => void },
   ): Promise<import('@nous/shared').ModelResponse> {
     const eventBus = this.config.eventBus!;
     const request = {
@@ -644,6 +712,14 @@ export class AgentGateway implements IAgentGateway {
       return await provider.invokeWithThinkingStream!(request, eventBus, traceId as TraceId);
     } catch (err) {
       this.log.warn('invokeWithThinkingStream failed, falling back to invoke()', { error: String(err) });
+      // SP 1.16 RC-β.3 — fire the per-turn observability callback BEFORE
+      // returning provider.invoke(). The callback flips the caller's
+      // `fromFallback` flag so the conversational-exit branch can fail-closed
+      // on the fallback path. Firing before invoke() means the flag is set
+      // even if invoke() itself throws (in which case the error propagates
+      // and the conversational-exit branch is not reached for that turn —
+      // correctness for the returned-without-throwing path is preserved).
+      observability.onFallback();
       return provider.invoke(request);
     }
   }
@@ -1481,6 +1557,68 @@ export class AgentGateway implements IAgentGateway {
     });
   }
 
+  /**
+   * SP 1.16 RC-β.1 — high-precision-low-recall heuristic that classifies a
+   * non-empty primary-path conversational response as narrate-without-dispatch
+   * when the model emits a past-tense action verb that co-occurs with a
+   * tool-name token within a tight character-window AND the agent actually
+   * has tools available.
+   *
+   * Defensive guards:
+   *  - `toolDefinitions.length === 0` → returns false unconditionally (the
+   *    agent has no tools so "narrating without dispatching" is not a
+   *    meaningful classification).
+   *  - tool-token derivation produces zero tokens of length ≥ 4 → returns
+   *    false (no usable signal to anchor a proximity check).
+   *
+   * Heuristic shape (intentionally narrow to avoid false positives on
+   * questions, present-tense statements, or tool-result paraphrasing):
+   *  1. Match a bounded set of past-tense action verbs (`PAST_TENSE_ACTIONS`).
+   *  2. Derive tool tokens by splitting tool names on `_`, stripping
+   *     namespace-prefix-like prefixes, keeping tokens of length ≥ 4.
+   *  3. For each matched action verb, scan a ±120 char window for any
+   *     tool-token literal (case-insensitive).
+   *  4. Returns true on the first window match; false otherwise.
+   */
+  private detectNarrateWithoutDispatch(
+    response: string,
+    toolDefinitions: ToolDefinition[],
+  ): boolean {
+    if (toolDefinitions.length === 0) return false;
+
+    const PAST_TENSE_ACTIONS = /\b(?:added|created|deleted|removed|updated|installed|saved|ran|executed|dispatched|sent|registered|configured|started|stopped|wrote|fetched|loaded)\b/gi;
+
+    // Derive tool tokens: split each tool name on `_`, drop short tokens, drop
+    // common namespace-prefix-like leading segments by keeping length ≥ 4.
+    const toolTokens = new Set<string>();
+    for (const def of toolDefinitions) {
+      const parts = def.name.split('_');
+      for (const part of parts) {
+        if (part.length >= 4) {
+          toolTokens.add(part.toLowerCase());
+        }
+      }
+    }
+    if (toolTokens.size === 0) return false;
+
+    const lower = response.toLowerCase();
+    PAST_TENSE_ACTIONS.lastIndex = 0;
+    let actionMatch: RegExpExecArray | null;
+    while ((actionMatch = PAST_TENSE_ACTIONS.exec(response)) !== null) {
+      const actionIndex = actionMatch.index;
+      const windowStart = Math.max(0, actionIndex - 120);
+      const windowEnd = Math.min(response.length, actionIndex + actionMatch[0].length + 120);
+      const window = lower.slice(windowStart, windowEnd);
+      for (const token of toolTokens) {
+        if (window.includes(token)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
   private buildSingleTurnResult(
     parsedOutput: ParsedModelOutput,
     sequencer: CorrelationSequencer,
@@ -1494,13 +1632,15 @@ export class AgentGateway implements IAgentGateway {
     const now = this.now();
     const nowMs = this.nowMs();
     const correlation = sequencer.snapshot();
-    // SP 1.15 RC-1 — when the empty-loop guard fires, the user-visible output
-    // carries EMPTY_RESPONSE_MARKER + the discriminator. The witness packet
-    // (v3Packet.payload.data.response) keeps the raw model output so the
-    // witness's view of "what the model actually emitted" is unchanged.
+    // SP 1.15 RC-1 + SP 1.16 RC-β.1 — when the empty-loop or narrate-without-
+    // dispatch guard fires, the user-visible output carries the appropriate
+    // marker (selected via `markerForKind` exhaustive switch) + the
+    // discriminator. The witness packet (v3Packet.payload.data.response below)
+    // keeps the raw model output so the witness's view of "what the model
+    // actually emitted" is unchanged.
     const baseOutput: ChatAgentOutput = emptyResponseKind
       ? {
-          response: EMPTY_RESPONSE_MARKER,
+          response: markerForKind(emptyResponseKind),
           contentType: parsedOutput.contentType,
           thinkingContent: parsedOutput.thinkingContent,
           empty_response_kind: emptyResponseKind,

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -39,7 +39,8 @@ import type {
   PromptFormatterInput,
   ProviderVendor,
 } from '@nous/shared';
-import { EMPTY_RESPONSE_MARKER, GatewayContextFrameSchema, type EmptyResponseKind } from '@nous/shared';
+import { GatewayContextFrameSchema, type EmptyResponseKind } from '@nous/shared';
+import { markerForKind } from '../agent-gateway/agent-gateway.js';
 import { AgentGatewayFactory, createInboxFrame } from '../agent-gateway/index.js';
 import {
   createInternalMcpSurfaceBundle,
@@ -986,11 +987,13 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         timestamp,
         ...(Object.keys(userMetadata).length > 0 ? { metadata: userMetadata } : {}),
       });
-      // SP 1.15 RC-1 — when the empty-loop guard fired upstream, the STM
-      // entry stores EMPTY_RESPONSE_MARKER as content and tags the metadata
-      // so buildChatContextFrames can SKIP it on the next turn (avoids
-      // marker-text bleeding into model context).
-      const assistantContent = emptyResponseKind ? EMPTY_RESPONSE_MARKER : assistantResponse;
+      // SP 1.15 RC-1 + SP 1.16 RC-β.1 — when the empty-loop or narrate-without-
+      // dispatch guard fired upstream, the STM entry stores the appropriate
+      // marker (selected via shared `markerForKind` exhaustive switch) as
+      // content and tags the metadata so buildChatContextFrames can SKIP it
+      // on the next turn (avoids marker-text bleeding into model context;
+      // SP 1.15 SKIP policy continuity per Invariant I-13).
+      const assistantContent = emptyResponseKind ? markerForKind(emptyResponseKind) : assistantResponse;
       const assistantMetadata: Record<string, unknown> = {};
       if (contentType && contentType !== 'text') assistantMetadata.contentType = contentType;
       if (thinkingContent) assistantMetadata.thinkingContent = thinkingContent;

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -205,11 +205,11 @@ export const ChatTurnResultSchema = z.object({
     type: z.string(),
     props: z.record(z.string(), z.unknown()),
   })).optional(),
-  // SP 1.15 RC-1 — propagated from AgentResult.output.empty_response_kind
+  // SP 1.15 RC-1 + SP 1.16 RC-β.1 — propagated from AgentResult.output.empty_response_kind
   // so the UI can render <details open> on the thinking disclosure. Mirrors
   // EmptyResponseKindSchema in @nous/shared (single source of truth at the
   // gateway boundary; this duplication is the same pattern ChatMessage uses).
-  empty_response_kind: z.enum(['thinking_only_no_finalizer', 'no_output_at_all']).optional(),
+  empty_response_kind: z.enum(['thinking_only_no_finalizer', 'no_output_at_all', 'narrate_without_dispatch']).optional(),
 }).strict();
 export type ChatTurnResult = z.infer<typeof ChatTurnResultSchema>;
 

--- a/self/cortex/core/src/gateway-runtime/workflow-prompt-fragment.ts
+++ b/self/cortex/core/src/gateway-runtime/workflow-prompt-fragment.ts
@@ -15,6 +15,8 @@ You have access to workflow tools. Here is how to use them.
 
 **Tool results:** When a tool you dispatched returns its result, the conversation will contain a \`tool\` message with the structured output. Treat this as the answer to your call and use it to compose your reply to the user. Do not ignore it or claim you have not received the information.
 
+**Action discipline:** When you intend to dispatch a tool, emit the tool call. Do NOT describe an action as completed when you have not actually emitted the corresponding tool call. If you cannot dispatch the tool the user's request requires, say so directly and ask the user how to proceed.
+
 - **workflow_list**: List installed workflow definitions and active runs for the current project. Use when the user asks "what workflows do I have?", "show my workflows", or similar.
 - **workflow_inspect**: Get detailed information about a specific workflow definition. Use when the user asks about a particular workflow's structure or configuration.
 - **workflow_status**: Check the status of a running workflow. Use when the user asks "how is my workflow going?", "is it done?", or similar.

--- a/self/shared/src/__tests__/types/agent-gateway.test.ts
+++ b/self/shared/src/__tests__/types/agent-gateway.test.ts
@@ -8,6 +8,7 @@ import {
   DispatchWorkerRequestSchema,
   EMPTY_RESPONSE_MARKER,
   EmptyResponseKindSchema,
+  NARRATE_WITHOUT_DISPATCH_MARKER,
   GatewayInboxMessageSchema,
   GatewayOutboxEventSchema,
   GatewayStampedPacketSchema,
@@ -562,18 +563,54 @@ describe('EMPTY_RESPONSE_MARKER (SP 1.15 RC-1)', () => {
   });
 });
 
-describe('EmptyResponseKindSchema (SP 1.15 RC-1)', () => {
-  it('accepts both discriminator branches', () => {
+describe('EmptyResponseKindSchema (SP 1.15 RC-1 + SP 1.16 RC-β.1)', () => {
+  it('accepts all three discriminator branches', () => {
     expect(EmptyResponseKindSchema.safeParse('thinking_only_no_finalizer').success).toBe(true);
     expect(EmptyResponseKindSchema.safeParse('no_output_at_all').success).toBe(true);
+    expect(EmptyResponseKindSchema.safeParse('narrate_without_dispatch').success).toBe(true);
   });
 
   it('rejects any other string', () => {
     expect(EmptyResponseKindSchema.safeParse('').success).toBe(false);
     expect(EmptyResponseKindSchema.safeParse('thinking_only').success).toBe(false);
     expect(EmptyResponseKindSchema.safeParse('partial_finalizer').success).toBe(false);
+    expect(EmptyResponseKindSchema.safeParse('arbitrary_value').success).toBe(false);
     expect(EmptyResponseKindSchema.safeParse(null).success).toBe(false);
     expect(EmptyResponseKindSchema.safeParse(undefined).success).toBe(false);
+  });
+});
+
+describe('NARRATE_WITHOUT_DISPATCH_MARKER (SP 1.16 RC-β.1)', () => {
+  it('pins the literal marker text — drift-detector for the user-visible string', () => {
+    expect(NARRATE_WITHOUT_DISPATCH_MARKER).toBe(
+      '[I described an action without actually performing it. The tool I should have called was not dispatched. Please rephrase your request or try again.]',
+    );
+  });
+});
+
+describe('Cross-package UI literal-union consistency (SP 1.16 RC-β.1)', () => {
+  // The UI layer (self/ui/src/panels/chat/types.ts) duplicates the
+  // EmptyResponseKindSchema literal-union per the existing chat-types
+  // convention (no @nous/shared import in UI types). This test pins the
+  // expected UI shape against the shared schema so future drift fails fast.
+  const UI_LITERAL_UNION_VALUES = [
+    'thinking_only_no_finalizer',
+    'no_output_at_all',
+    'narrate_without_dispatch',
+  ] as const;
+
+  it('every shared EmptyResponseKindSchema value appears in the UI literal-union', () => {
+    const sharedValues = EmptyResponseKindSchema.options;
+    for (const value of sharedValues) {
+      expect(UI_LITERAL_UNION_VALUES).toContain(value);
+    }
+  });
+
+  it('UI literal-union has no extra values beyond the shared schema', () => {
+    const sharedValues = EmptyResponseKindSchema.options as readonly string[];
+    for (const uiValue of UI_LITERAL_UNION_VALUES) {
+      expect(sharedValues).toContain(uiValue);
+    }
   });
 });
 

--- a/self/shared/src/types/agent-gateway.ts
+++ b/self/shared/src/types/agent-gateway.ts
@@ -411,16 +411,38 @@ export const EMPTY_RESPONSE_MARKER =
   '[I produced reasoning but did not finalize a response. Click Thinking to view what I was working on, or rephrase your request.]';
 
 /**
- * Discriminator written alongside `EMPTY_RESPONSE_MARKER` so callers can tell
- * the two empty-exit shapes apart:
+ * Marker text written to `AgentResult.output.response` (and to STM) when the
+ * Principal gateway's narrate-without-dispatch guard fires — that is, when
+ * the model produced a non-empty conversational response that describes an
+ * action as completed (e.g., "I added the workflow") without emitting the
+ * corresponding tool call AND either (a) the response was produced via the
+ * fallback path of `invokeWithThinkingStreamFallback` (fail-closed) OR (b)
+ * the gateway's `detectNarrateWithoutDispatch` heuristic fired on the
+ * primary-path response (adjudicated).
+ *
+ * SP 1.16 RC-β.1 + RC-β.3 — Bug Chain β. Lives in `@nous/shared` so every
+ * consumer (gateway, runtime, UI) imports a single source of truth; future
+ * copy-edits must update this constant, never the importers.
+ */
+export const NARRATE_WITHOUT_DISPATCH_MARKER =
+  '[I described an action without actually performing it. The tool I should have called was not dispatched. Please rephrase your request or try again.]';
+
+/**
+ * Discriminator written alongside the appropriate empty-exit / narrate-exit
+ * marker so callers can tell the empty-exit and narrate-exit shapes apart:
  *
  * - `thinking_only_no_finalizer` — model emitted thinking content but no
  *   user-facing response and no tool calls.
  * - `no_output_at_all` — model emitted neither thinking nor response.
+ * - `narrate_without_dispatch` — model emitted a non-empty conversational
+ *   response describing an action as completed without emitting the
+ *   corresponding tool call (fail-closed on fallback OR detector-adjudicated
+ *   on primary path). SP 1.16 RC-β.1 + RC-β.3.
  */
 export const EmptyResponseKindSchema = z.enum([
   'thinking_only_no_finalizer',
   'no_output_at_all',
+  'narrate_without_dispatch',
 ]);
 export type EmptyResponseKind = z.infer<typeof EmptyResponseKindSchema>;
 

--- a/self/subcortex/providers/src/__tests__/anthropic-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/anthropic-provider.test.ts
@@ -359,3 +359,50 @@ describe('AnthropicProvider', () => {
     ).rejects.toMatchObject({ code: 'ABORTED' });
   });
 });
+
+describe('AnthropicProvider — fetchWithTimeout classification (SP 1.16 RC-β.2 / β6)', () => {
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+  });
+
+  it('timeout abort is classified as Anthropic request timed out (NOT endpoint unreachable)', async () => {
+    const provider = new AnthropicProvider(MOCK_CONFIG, { timeoutMs: 50 });
+    let capturedReason: unknown;
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const sig = (init as RequestInit).signal;
+        sig?.addEventListener('abort', () => {
+          capturedReason = (sig as AbortSignal).reason;
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const promise = provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    });
+    let caught: NousError | undefined;
+    const settled = promise.catch((e) => { caught = e as NousError; });
+
+    await vi.advanceTimersByTimeAsync(60);
+    await settled;
+    expect(caught).toBeInstanceOf(NousError);
+    expect(caught?.message).toContain('Anthropic request timed out after');
+    expect(caught?.message).not.toContain('Anthropic endpoint unreachable');
+    expect(capturedReason).toBeInstanceOf(DOMException);
+    expect((capturedReason as DOMException).name).toBe('AbortError');
+  });
+});

--- a/self/subcortex/providers/src/__tests__/ollama-provider-thinking-stream.test.ts
+++ b/self/subcortex/providers/src/__tests__/ollama-provider-thinking-stream.test.ts
@@ -368,3 +368,81 @@ describe('OllamaProvider.invokeWithThinkingStream', () => {
     expect(concatenated).toBe('foobar');
   });
 });
+
+describe('OllamaProvider — wire-body think propagation (SP 1.16 RC-α / α6)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('wire body has think:true when input.think === true', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    let capturedBody: Record<string, unknown> | undefined;
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      capturedBody = JSON.parse((init as RequestInit).body as string);
+      return {
+        ok: true,
+        json: async () => ({ message: { role: 'assistant', content: 'ok' }, done: true }),
+      } as Response;
+    });
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { messages: [{ role: 'user', content: 'hi' }], stream: false, think: true },
+      traceId: TRACE_ID,
+    });
+
+    expect(capturedBody?.think).toBe(true);
+  });
+
+  it('wire body omits think key when input.think is unset (backwards-compat)', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    let capturedBody: Record<string, unknown> | undefined;
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      capturedBody = JSON.parse((init as RequestInit).body as string);
+      return {
+        ok: true,
+        json: async () => ({ message: { role: 'assistant', content: 'ok' }, done: true }),
+      } as Response;
+    });
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { messages: [{ role: 'user', content: 'hi' }], stream: false },
+      traceId: TRACE_ID,
+    });
+
+    expect(capturedBody).toBeDefined();
+    expect('think' in (capturedBody ?? {})).toBe(false);
+  });
+
+  it('non-streaming branch publishes a chat:thinking-chunk with the full thinking text', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG);
+    const bus = recordingBus();
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          role: 'assistant',
+          content: 'final answer',
+          thinking: 'full reasoning trace',
+        },
+        done: true,
+      }),
+    } as Response);
+
+    await provider.invokeWithThinkingStream!(
+      {
+        role: 'cortex-chat',
+        input: { messages: [{ role: 'user', content: 'hi' }], stream: false, think: true },
+        traceId: TRACE_ID,
+      },
+      bus,
+      TRACE_ID,
+    );
+
+    const recorded = (bus as unknown as { recorded: Array<{ channel: string; payload: { content: string } }> }).recorded;
+    const thinkingEvents = recorded.filter((r) => r.channel === 'chat:thinking-chunk');
+    expect(thinkingEvents.length).toBe(1);
+    expect(thinkingEvents[0].payload.content).toBe('full reasoning trace');
+  });
+});

--- a/self/subcortex/providers/src/__tests__/ollama-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/ollama-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ProviderId } from '@nous/shared';
 import { NousError, ValidationError } from '@nous/shared';
 import { OllamaProvider } from '../ollama-provider.js';
@@ -246,5 +246,52 @@ describe('OllamaProvider', () => {
       expect(chunks[0].content).toBe('hello<thi');
       expect(chunks[0].thinking).toBeUndefined();
     });
+  });
+});
+
+describe('OllamaProvider — fetchWithTimeout classification (SP 1.16 RC-β.2 / β6)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('timeout abort is classified as Ollama request timed out (NOT endpoint unreachable)', async () => {
+    const provider = new OllamaProvider(MOCK_CONFIG, { timeoutMs: 50 });
+    let capturedReason: unknown;
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const sig = (init as RequestInit).signal;
+        sig?.addEventListener('abort', () => {
+          capturedReason = (sig as AbortSignal).reason;
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const promise = provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: '00000000-0000-0000-0000-000000000002' as any,
+    });
+    // Attach an immediate handler so any sync rejection from the underlying
+    // fetch promise does not surface as an unhandled rejection in vitest.
+    let caught: NousError | undefined;
+    const settled = promise.catch((e) => { caught = e as NousError; });
+
+    // Advance the fake timers past the configured 50ms timeout.
+    await vi.advanceTimersByTimeAsync(60);
+    await settled;
+    expect(caught).toBeInstanceOf(NousError);
+    expect(caught?.message).toContain('Ollama request timed out after');
+    expect(caught?.message).not.toContain('Ollama not available at');
+    // SP 1.16 RC-β.2 / β1 — abort reason is now a DOMException.
+    expect(capturedReason).toBeInstanceOf(DOMException);
+    expect((capturedReason as DOMException).name).toBe('AbortError');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 });

--- a/self/subcortex/providers/src/__tests__/openai-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/openai-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ProviderId } from '@nous/shared';
 import { NousError, ValidationError } from '@nous/shared';
 import { OpenAiCompatibleProvider } from '../openai-provider.js';
@@ -136,5 +136,54 @@ describe('OpenAiCompatibleProvider', () => {
         abortSignal: controller.signal,
       }),
     ).rejects.toMatchObject({ code: 'ABORTED' });
+  });
+});
+
+describe('OpenAiCompatibleProvider — fetchWithTimeout classification (SP 1.16 RC-β.2 / β6)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('process', {
+      ...process,
+      env: { ...process.env, OPENAI_API_KEY: 'test-key' },
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('timeout abort is classified as OpenAI request timed out (NOT endpoint unreachable)', async () => {
+    const provider = new OpenAiCompatibleProvider(
+      MOCK_CONFIG,
+      { apiKey: 'test-key', timeoutMs: 50 },
+    );
+    let capturedReason: unknown;
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const sig = (init as RequestInit).signal;
+        sig?.addEventListener('abort', () => {
+          capturedReason = (sig as AbortSignal).reason;
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const promise = provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: '00000000-0000-0000-0000-000000000002' as any,
+    });
+    let caught: NousError | undefined;
+    const settled = promise.catch((e) => { caught = e as NousError; });
+
+    await vi.advanceTimersByTimeAsync(60);
+    await settled;
+    expect(caught).toBeInstanceOf(NousError);
+    expect(caught?.message).toContain('OpenAI request timed out after');
+    expect(caught?.message).not.toContain('OpenAI endpoint unreachable');
+    expect(capturedReason).toBeInstanceOf(DOMException);
+    expect((capturedReason as DOMException).name).toBe('AbortError');
   });
 });

--- a/self/subcortex/providers/src/anthropic-provider.ts
+++ b/self/subcortex/providers/src/anthropic-provider.ts
@@ -356,8 +356,12 @@ export class AnthropicProvider implements IModelProvider {
     init: RequestInit,
   ): Promise<Response> {
     const timeoutController = new AbortController();
+    // SP 1.16 RC-β.2 / β3 — symmetric to Ollama β1: abort with a DOMException
+    // (name: 'AbortError') so the catch block classifies timeout aborts via
+    // either the hoisted signal check OR the name check, never falling
+    // through to the generic "endpoint unreachable" branch.
     const timeout = setTimeout(
-      () => timeoutController.abort('provider_timeout'),
+      () => timeoutController.abort(new DOMException('provider_timeout', 'AbortError')),
       this.timeoutMs,
     );
     const signal = init.signal
@@ -370,15 +374,15 @@ export class AnthropicProvider implements IModelProvider {
         signal,
       });
     } catch (error) {
+      // SP 1.16 RC-β.2 / β3 — hoist signal-aborted check above name check.
+      if (timeoutController.signal.aborted) {
+        throw new NousError(
+          `Anthropic request timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        );
+      }
       if ((error as Error).name === 'AbortError') {
-        if (timeoutController.signal.aborted) {
-          throw new NousError(
-            `Anthropic request timed out after ${this.timeoutMs}ms`,
-            'PROVIDER_UNAVAILABLE',
-            { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
-          );
-        }
-
         throw new NousError('Anthropic request aborted.', 'ABORTED');
       }
 

--- a/self/subcortex/providers/src/ollama-provider.ts
+++ b/self/subcortex/providers/src/ollama-provider.ts
@@ -485,8 +485,14 @@ export class OllamaProvider implements IModelProvider {
     init: RequestInit,
   ): Promise<Response> {
     const timeoutController = new AbortController();
+    // SP 1.16 RC-β.2 / β1 — abort with a DOMException(name: 'AbortError') so
+    // the catch block's `(e as Error).name === 'AbortError'` branch fires for
+    // timeout aborts (the prior string-reason form `'provider_timeout'` was
+    // surfaced as the rejection's `.message`/`.cause`, NOT as a name change,
+    // so the timeout path silently fell through to the generic
+    // "Ollama not available at ${endpoint}: undefined" branch).
     const timeout = setTimeout(
-      () => timeoutController.abort('provider_timeout'),
+      () => timeoutController.abort(new DOMException('provider_timeout', 'AbortError')),
       this.timeoutMs,
     );
     const signal = init.signal
@@ -500,14 +506,20 @@ export class OllamaProvider implements IModelProvider {
       });
       return response;
     } catch (e) {
+      // SP 1.16 RC-β.2 / β2 — hoist the timeout-controller signal check above
+      // the AbortError name check so a timeout-driven abort is classified as
+      // a timeout regardless of which class of exception the runtime surfaces
+      // (DOMException vs Error). Belt-and-suspenders against runtime drift.
+      if (timeoutController.signal.aborted) {
+        throw new NousError(
+          `Ollama request timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        );
+      }
+      // After SP 1.16 RC-β.2 hoist, this branch reaches user-initiated aborts
+      // only (the timeout-driven abort has already been classified above).
       if ((e as Error).name === 'AbortError') {
-        if (timeoutController.signal.aborted) {
-          throw new NousError(
-            `Ollama request timed out after ${this.timeoutMs}ms`,
-            'PROVIDER_UNAVAILABLE',
-            { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
-          );
-        }
         throw new NousError('Ollama request aborted.', 'ABORTED');
       }
       throw new NousError(

--- a/self/subcortex/providers/src/ollama-provider.ts
+++ b/self/subcortex/providers/src/ollama-provider.ts
@@ -402,6 +402,7 @@ export class OllamaProvider implements IModelProvider {
     messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }>;
     tools?: Array<Record<string, unknown>>;
     stream?: boolean;
+    think?: boolean;
   } {
     const result = TextModelInputSchema.safeParse(input);
     if (!result.success) {
@@ -416,6 +417,7 @@ export class OllamaProvider implements IModelProvider {
       messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }>;
       tools?: Array<Record<string, unknown>>;
       stream?: boolean;
+      think?: boolean;
     };
   }
 
@@ -425,6 +427,7 @@ export class OllamaProvider implements IModelProvider {
       messages?: Array<{ role: string; content: string | unknown[]; tool_call_id?: string; tool_calls?: unknown[] }>;
       tools?: Array<Record<string, unknown>>;
       stream?: boolean;
+      think?: boolean;
     },
   ): Record<string, unknown> {
     const base: Record<string, unknown> = { model: this.config.modelId };
@@ -457,6 +460,15 @@ export class OllamaProvider implements IModelProvider {
     // contract requirement.
     if (typeof input.stream === 'boolean') {
       body.stream = input.stream;
+    }
+
+    // SP 1.16 RC-α — propagate `think` from the validated input so the Ollama
+    // adapter's `result.think = true` setter (created at SP 1.16 RC-α / α4) is
+    // honored end-to-end on the wire body. Pattern mirrors the SP 1.15 Tier 5
+    // deviation #1 `stream` propagation above. Ollama API v0.4.0+ accepts
+    // `think: true` on /api/chat; non-thinking models silently ignore the field.
+    if (typeof input.think === 'boolean') {
+      body.think = input.think;
     }
 
     return body;

--- a/self/subcortex/providers/src/openai-provider.ts
+++ b/self/subcortex/providers/src/openai-provider.ts
@@ -233,8 +233,9 @@ export class OpenAiCompatibleProvider implements IModelProvider {
     init: RequestInit,
   ): Promise<Response> {
     const timeoutController = new AbortController();
+    // SP 1.16 RC-β.2 / β4 — symmetric to Ollama β1 + Anthropic β3.
     const timeout = setTimeout(
-      () => timeoutController.abort('provider_timeout'),
+      () => timeoutController.abort(new DOMException('provider_timeout', 'AbortError')),
       this.timeoutMs,
     );
     const signal = init.signal
@@ -247,14 +248,15 @@ export class OpenAiCompatibleProvider implements IModelProvider {
         signal,
       });
     } catch (e) {
+      // SP 1.16 RC-β.2 / β4 — hoist signal-aborted check above name check.
+      if (timeoutController.signal.aborted) {
+        throw new NousError(
+          `OpenAI request timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        );
+      }
       if ((e as Error).name === 'AbortError') {
-        if (timeoutController.signal.aborted) {
-          throw new NousError(
-            `OpenAI request timed out after ${this.timeoutMs}ms`,
-            'PROVIDER_UNAVAILABLE',
-            { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
-          );
-        }
         throw new NousError('OpenAI request aborted.', 'ABORTED');
       }
       throw new NousError(

--- a/self/subcortex/providers/src/schemas.ts
+++ b/self/subcortex/providers/src/schemas.ts
@@ -58,6 +58,7 @@ export const TextModelInputSchema = z.union([
     system: z.union([z.string(), z.array(z.unknown())]).optional(),
     systemSegments: z.array(z.string()).optional(),
     stream: z.boolean().optional(),
+    think: z.boolean().optional(),
   }),
 ]);
 export type TextModelInput = z.infer<typeof TextModelInputSchema>;

--- a/self/ui/src/panels/chat/types.ts
+++ b/self/ui/src/panels/chat/types.ts
@@ -15,13 +15,15 @@ export interface ChatMessage {
   }
   cards?: Array<{ type: string; props: Record<string, unknown> }>
   queued?: boolean
-  // SP 1.15 RC-1 — populated when the gateway's empty-loop guard fires.
-  // ChatMessageList renders <details open> on the thinking disclosure
-  // when this is set, so the user can see what the model was working on.
-  // Literal union duplicated (not imported from @nous/shared) per the
-  // existing chat-types convention; runtime validation lives at
-  // ChatTurnResultSchema in cortex-core.
-  empty_response_kind?: 'thinking_only_no_finalizer' | 'no_output_at_all'
+  // SP 1.15 RC-1 + SP 1.16 RC-β.1 — populated when the gateway's empty-loop
+  // guard or narrate-without-dispatch guard fires. ChatMessageList renders
+  // <details open> on the thinking disclosure when this is set, so the user
+  // can see what the model was working on (or failed to do). Literal union
+  // duplicated (not imported from @nous/shared) per the existing chat-types
+  // convention; runtime validation lives at ChatTurnResultSchema in
+  // cortex-core. Cross-package consistency check lives at
+  // self/shared/src/__tests__/types/agent-gateway.test.ts.
+  empty_response_kind?: 'thinking_only_no_finalizer' | 'no_output_at_all' | 'narrate_without_dispatch'
 }
 
 export interface ActionResult {
@@ -32,7 +34,7 @@ export interface ActionResult {
 }
 
 export interface ChatAPI {
-  send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui'; thinkingContent?: string; cards?: Array<{ type: string; props: Record<string, unknown> }>; empty_response_kind?: 'thinking_only_no_finalizer' | 'no_output_at_all' }>
+  send: (message: string) => Promise<{ response: string; traceId: string; contentType?: 'text' | 'openui'; thinkingContent?: string; cards?: Array<{ type: string; props: Record<string, unknown> }>; empty_response_kind?: 'thinking_only_no_finalizer' | 'no_output_at_all' | 'narrate_without_dispatch' }>
   getHistory: () => Promise<ChatMessage[]>
   sendAction?: (action: CardAction) => Promise<ActionResult>
 }


### PR DESCRIPTION
## Summary

Phase 1.16 closes the BT R8 fix cycle for WR-159. Six commits across Tiers 0-7:

- **Tier 0** — `NARRATE_WITHOUT_DISPATCH_MARKER` + 3-value `EmptyResponseKindSchema`.
- **Tier 1+2 (RC-α)** — Ollama native thinking activation (`think: true` end-to-end through schemas + provider + adapter).
- **Tier 3 (RC-β.2)** — Symmetric `DOMException('AbortError')` + signal-aborted hoist across Ollama / Anthropic / OpenAI `fetchWithTimeout` (timeout misclassification fix).
- **Tier 4 (RC-β.1+β.3)** — Per-turn `fromFallback` flag, observability `onFallback` 6th param, `detectNarrateWithoutDispatch` heuristic, four-case conversational-exit branch, exhaustive `markerForKind` switch.
- **Tier 5+6** — STM marker switch via `markerForKind`, UI literal-union extension, `WORKFLOW_PROMPT_FRAGMENT` "Action discipline" anchor.
- **Tier 7** — 23 new assertions across 10 test files (regression + integration).

## Verification

- `pnpm typecheck` — Pass (workspace).
- `pnpm lint` — 0 errors / 151 warnings (pre-existing baseline; no NEW oxlint errors).
- `pnpm test --run` — 5541 / 5541 pass (582 files).
- Builds: `@nous/shared`, `@nous/subcortex-providers`, `@nous/cortex-core`, `@nous/desktop` all green.
- `@nous/web` deferred per WR-171 precedent.

## CR + Review

- Completion Report (Approved): `.worklog/sprints/feat/chat-experience-quality/phase-1/phase-1.16/completion-report.md`
- CR Review (Approved): `.worklog/sprints/feat/chat-experience-quality/phase-1/phase-1.16/reviews/completion-report.mdx`

BT R9 will run on the integrated `feat/chat-experience-quality` branch per `bt_cadence: per-sub-phase`.