### PR TITLE
feat(wr-162 sp-5): supervisor enforcement + resume-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1127,6 +1127,9 @@ importers:
         specifier: workspace:*
         version: link:../../shared
     devDependencies:
+      '@nous/subcortex-opctl':
+        specifier: workspace:*
+        version: link:../opctl
       '@nous/subcortex-witnessd':
         specifier: workspace:*
         version: link:../witnessd

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -106,11 +106,14 @@ import {
   InMemoryStartLockStore,
   InMemoryScopeLockStore,
   InMemoryProjectControlStateStore,
+  issueSupervisorProof,
 } from '@nous/subcortex-opctl';
 import { MaoProjectionService, InferenceProjectionAdapter } from '@nous/subcortex-mao';
 import {
   SupervisorService,
   SupervisorOutboxSink,
+  enforce as enforceSupervisor,
+  type EnforcementDeps,
 } from '@nous/subcortex-supervisor';
 import { registerCodingAgentNodeTypes } from '@nous/subcortex-coding-agents';
 import { GtmGateCalculator } from '@nous/subcortex-gtm';
@@ -922,12 +925,28 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
   const supervisorEnabled: boolean =
     (resolvedConfig as { supervisor?: { enabled?: boolean } }).supervisor
       ?.enabled ?? true;
-  // WR-162 SP 4 — thread `witnessService` + `eventBus` into the supervisor
-  // so `runClassifier` can write detection witness events (EVID-SUP-001)
-  // and publish `supervisor:violation-detected`. `gatewayRunSnapshotRegistry`
-  // is supplied to the outbox sink factory below (SUPV-SP4-003 populator).
-  // `onEnforcementDispatch` is left at the default debug-log stub per
-  // SUPV-SP4-009; SP 5 threads the real `OpctlService.submitCommand` caller.
+  // WR-162 SP 5 — construct the production enforcement deps and thread
+  // them into `new SupervisorService(...)` via the additive `enforcement`
+  // slot. The SUPV-SP5-005 slot replaces the SP 4 `onEnforcementDispatch`
+  // log stub with the real `enforce(...)` pipeline: supervisor → opctl
+  // submit → witness + EventBus. The proof issuer chooses path (b)
+  // (`issueSupervisorProof`) per SUPV-SP5-004; SP 7 swaps in
+  // `issueSystemProof` with a one-line rename.
+  const supervisorEnforcementDeps: EnforcementDeps = {
+    opctlService: {
+      submitCommand: (envelope, proof) =>
+        opctlService.submitCommand(envelope, proof),
+    },
+    witnessService,
+    eventBus,
+    proofIssuer: (args) => issueSupervisorProof(args.action, args.scope),
+    actorId: '00000000-0000-0000-0000-000000000001',
+    actorSessionId: '00000000-0000-0000-0000-000000000002',
+    nextActorSeq: (() => {
+      let seq = 0;
+      return () => ++seq;
+    })(),
+  };
   const supervisorService = new SupervisorService({
     config: {
       enabled: supervisorEnabled,
@@ -935,6 +954,10 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     },
     witnessService,
     eventBus,
+    enforcement: {
+      enforce: (violation, deps) => enforceSupervisor(violation, deps),
+      deps: supervisorEnforcementDeps,
+    },
   });
 
   const maoProjectionService = new MaoProjectionService({

--- a/self/shared/src/__tests__/types/evidence-supervisor-actor.test.ts
+++ b/self/shared/src/__tests__/types/evidence-supervisor-actor.test.ts
@@ -1,0 +1,40 @@
+/**
+ * WR-162 SP 5 — UT-SH1 — `WitnessActorSchema` widening (SUPV-SP5-007).
+ *
+ * Asserts the additive `'supervisor'` literal parses successfully and
+ * every pre-existing literal still parses (regression floor for the
+ * widening). Extends (does not replace) the SP 4 evidence tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { WitnessActorSchema } from '../../types/evidence.js';
+
+describe('WitnessActorSchema — SP 5 widening (UT-SH1)', () => {
+  it('accepts the new "supervisor" literal', () => {
+    const parsed = WitnessActorSchema.safeParse('supervisor');
+    expect(parsed.success).toBe(true);
+  });
+
+  it('still accepts every pre-existing literal post-widening (regression floor)', () => {
+    const preExisting = [
+      'core',
+      'pfc',
+      'subcortex',
+      'app',
+      'principal',
+      'system',
+      'orchestration_agent',
+      'worker_agent',
+    ] as const;
+    for (const literal of preExisting) {
+      const parsed = WitnessActorSchema.safeParse(literal);
+      expect(parsed.success, `expected ${literal} to parse post-widening`).toBe(
+        true,
+      );
+    }
+  });
+
+  it('rejects an invalid literal (closed-enum invariant preserved)', () => {
+    const parsed = WitnessActorSchema.safeParse('sup');
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/self/shared/src/types/evidence.ts
+++ b/self/shared/src/types/evidence.ts
@@ -90,6 +90,10 @@ export const WitnessActorSchema = z.enum([
   'system',
   'orchestration_agent',
   'worker_agent',
+  // WR-162 SP 5 — widens for supervisor witness emission (SUPV-SP5-007/008).
+  // Flipped in `self/subcortex/supervisor/src/witness-emission.ts` from
+  // `actor: 'system'` + `detail.supervisorActor: 'supervisor'` breadcrumb.
+  'supervisor',
 ]);
 export type WitnessActor = z.infer<typeof WitnessActorSchema>;
 

--- a/self/subcortex/opctl/src/__tests__/confirmation-supervisor-proof.test.ts
+++ b/self/subcortex/opctl/src/__tests__/confirmation-supervisor-proof.test.ts
@@ -1,0 +1,90 @@
+/**
+ * WR-162 SP 5 — UT-OP2 — `issueSupervisorProof` helper (SUPV-SP5-004 path (b)).
+ *
+ * Asserts the proof round-trips at `validateConfirmationProof` with a
+ * scope-bound + action-bound envelope, and fails on cross-scope,
+ * cross-action, and TTL-expired mismatches. Confirms the "converge at
+ * runtime on the existing gate" invariant named in the SDS.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type { ControlCommandEnvelope, ProjectId } from '@nous/shared';
+import {
+  issueSupervisorProof,
+  validateConfirmationProof,
+} from '../confirmation.js';
+
+const PROJECT_ID = randomUUID() as ProjectId;
+const PROJECT_ID_OTHER = randomUUID() as ProjectId;
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+function envelope(
+  overrides: Partial<ControlCommandEnvelope> = {},
+): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: 'supervisor',
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 1,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: {
+      class: 'project_run_scope',
+      kind: 'project_run',
+      target_ids: [],
+      project_id: PROJECT_ID,
+    },
+    payload_hash: HASH,
+    command_signature: 'stub-sig',
+    action: 'hard_stop',
+    ...overrides,
+  };
+}
+
+describe('issueSupervisorProof (UT-OP2)', () => {
+  it('round-trips: proof validates against a scope-bound + action-bound envelope', () => {
+    const env = envelope({ action: 'hard_stop' });
+    const proof = issueSupervisorProof('hard_stop', env.scope);
+    expect(validateConfirmationProof(proof, env)).toBe(true);
+  });
+
+  it('rejects cross-scope — proof bound to project A; envelope on project B', () => {
+    const envA = envelope({ action: 'hard_stop' });
+    const proof = issueSupervisorProof('hard_stop', envA.scope);
+    const envB = envelope({
+      action: 'hard_stop',
+      scope: {
+        class: 'project_run_scope',
+        kind: 'project_run',
+        target_ids: [],
+        project_id: PROJECT_ID_OTHER,
+      },
+    });
+    expect(validateConfirmationProof(proof, envB)).toBe(false);
+  });
+
+  it('rejects cross-action — proof bound to hard_stop; envelope action is pause', () => {
+    const env = envelope({ action: 'hard_stop' });
+    const proof = issueSupervisorProof('hard_stop', env.scope);
+    const envPause = envelope({ action: 'pause' });
+    // envPause has a different nonce/command_id; scope is identical by
+    // construction (default PROJECT_ID). Proof fails action-binding.
+    expect(validateConfirmationProof(proof, envPause)).toBe(false);
+  });
+
+  it('rejects TTL-expired proof (> 5 min old)', () => {
+    vi.useFakeTimers();
+    const start = new Date('2026-04-22T12:00:00.000Z');
+    vi.setSystemTime(start);
+    const env = envelope({ action: 'hard_stop', issued_at: start.toISOString() });
+    const proof = issueSupervisorProof('hard_stop', env.scope);
+    // Advance beyond the 5-minute PROOF_TTL_MS.
+    vi.setSystemTime(new Date(start.getTime() + 6 * 60 * 1000));
+    expect(validateConfirmationProof(proof, env)).toBe(false);
+    vi.useRealTimers();
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/project-control-state-supervisor-lock.test.ts
+++ b/self/subcortex/opctl/src/__tests__/project-control-state-supervisor-lock.test.ts
@@ -1,0 +1,116 @@
+/**
+ * WR-162 SP 5 — UT-OP1 — `InMemoryProjectControlStateStore` supervisor-lock
+ * extension (SUPV-SP5-009/010).
+ *
+ * Asserts the three new methods (`getSupervisorLock` /
+ * `setSupervisorLock` / `clearSupervisorLock`) operate exclusively on the
+ * lock-field half of the record and do not disturb the SP 3 `state` half.
+ * Cross-project isolation is also covered.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { ProjectId } from '@nous/shared';
+import { InMemoryProjectControlStateStore } from '../project-control-state.js';
+
+describe('InMemoryProjectControlStateStore — supervisor lock (UT-OP1)', () => {
+  it('returns default unlocked snapshot for an unknown project', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pid = randomUUID() as ProjectId;
+    const snap = await store.getSupervisorLock(pid);
+    expect(snap).toEqual({
+      locked: false,
+      sup_code: null,
+      severity: null,
+      set_at: null,
+    });
+  });
+
+  it('setSupervisorLock persists provenance → getSupervisorLock reads back', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pid = randomUUID() as ProjectId;
+    await store.setSupervisorLock(pid, {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      set_at: '2026-04-22T12:00:00.000Z',
+    });
+    const snap = await store.getSupervisorLock(pid);
+    expect(snap.locked).toBe(true);
+    expect(snap.sup_code).toBe('SUP-001');
+    expect(snap.severity).toBe('S0');
+    expect(snap.set_at).toBe('2026-04-22T12:00:00.000Z');
+  });
+
+  it('clearSupervisorLock resets to default snapshot', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pid = randomUUID() as ProjectId;
+    await store.setSupervisorLock(pid, {
+      sup_code: 'SUP-003',
+      severity: 'S1',
+      set_at: '2026-04-22T12:00:00.000Z',
+    });
+    await store.clearSupervisorLock(pid);
+    const snap = await store.getSupervisorLock(pid);
+    expect(snap).toEqual({
+      locked: false,
+      sup_code: null,
+      severity: null,
+      set_at: null,
+    });
+  });
+
+  it('SP 3 set("paused_review") does NOT touch lock fields (non-interference)', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pid = randomUUID() as ProjectId;
+    await store.setSupervisorLock(pid, {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      set_at: '2026-04-22T12:00:00.000Z',
+    });
+    await store.set(pid, 'paused_review');
+    const snap = await store.getSupervisorLock(pid);
+    expect(snap.locked).toBe(true);
+    expect(snap.sup_code).toBe('SUP-001');
+    expect(await store.get(pid)).toBe('paused_review');
+  });
+
+  it('SP 3 clear() does NOT touch lock fields (non-interference)', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pid = randomUUID() as ProjectId;
+    await store.setSupervisorLock(pid, {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      set_at: '2026-04-22T12:00:00.000Z',
+    });
+    await store.set(pid, 'paused_review');
+    await store.clear(pid);
+    expect(await store.get(pid)).toBeNull();
+    const snap = await store.getSupervisorLock(pid);
+    expect(snap.locked).toBe(true);
+    expect(snap.sup_code).toBe('SUP-001');
+  });
+
+  it('setSupervisorLock does NOT touch state half (non-interference)', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pid = randomUUID() as ProjectId;
+    await store.set(pid, 'paused_review');
+    await store.setSupervisorLock(pid, {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      set_at: '2026-04-22T12:00:00.000Z',
+    });
+    expect(await store.get(pid)).toBe('paused_review');
+  });
+
+  it('cross-project isolation — locking project A does not affect project B', async () => {
+    const store = new InMemoryProjectControlStateStore();
+    const pidA = randomUUID() as ProjectId;
+    const pidB = randomUUID() as ProjectId;
+    await store.setSupervisorLock(pidA, {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      set_at: '2026-04-22T12:00:00.000Z',
+    });
+    const snapB = await store.getSupervisorLock(pidB);
+    expect(snapB.locked).toBe(false);
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/supervisor-actor-authorization.test.ts
+++ b/self/subcortex/opctl/src/__tests__/supervisor-actor-authorization.test.ts
@@ -1,0 +1,128 @@
+/**
+ * WR-162 SP 5 — UT-OP3 — supervisor-actor authorization allowlist
+ * (SUPV-SP5-011).
+ *
+ * Negative coverage (8 rows): each forbidden action returns
+ * `status: 'rejected'`, `reason_code: 'supervisor_actor_forbidden_action'`.
+ * Positive coverage (3 rows): allowlisted actions proceed past the
+ * authorization gate (assertion = the rejection path does NOT fire).
+ * For the positive rows we construct a scope/tier proof and assert we
+ * reach a non-`supervisor_actor_forbidden_action` outcome — the actual
+ * downstream result can be any of `applied` / `blocked` / `rejected`
+ * depending on the action's own tier requirements; the assertion we
+ * pin is solely "the gate let us through".
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlAction,
+  ControlCommandEnvelope,
+  ProjectId,
+} from '@nous/shared';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryStartLockStore,
+  InMemoryScopeLockStore,
+  InMemoryProjectControlStateStore,
+  issueSupervisorProof,
+} from '../index.js';
+import type { WitnessEvent } from '@nous/shared';
+
+function mockWitnessService(): import('@nous/shared').IWitnessService {
+  return {
+    appendAuthorization: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    appendCompletion: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 2 } as WitnessEvent),
+    appendInvariant: async () => ({} as WitnessEvent),
+    createCheckpoint: async () => ({} as import('@nous/shared').WitnessCheckpoint),
+    rotateKeyEpoch: async () => 1,
+    verify: async () => ({} as import('@nous/shared').VerificationReport),
+    getReport: async () => null,
+    listReports: async () => [],
+    getLatestCheckpoint: async () => null,
+  };
+}
+
+const HASH = createHash('sha256').update('payload').digest('hex');
+const PROJECT_ID = randomUUID() as ProjectId;
+
+function envelope(
+  action: ControlAction,
+  overrides: Partial<ControlCommandEnvelope> = {},
+): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: 'supervisor',
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 1,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: {
+      class: 'project_run_scope',
+      kind: 'project_run',
+      target_ids: [],
+      project_id: PROJECT_ID,
+    },
+    payload_hash: HASH,
+    command_signature: 'stub-sig',
+    action,
+    payload: { sup_code: 'SUP-001', severity: 'S0' },
+    ...overrides,
+  };
+}
+
+function makeService(): OpctlService {
+  return new OpctlService({
+    replayStore: new InMemoryReplayStore(),
+    startLockStore: new InMemoryStartLockStore(),
+    scopeLockStore: new InMemoryScopeLockStore(),
+    projectControlStateStore: new InMemoryProjectControlStateStore(),
+    witnessService: mockWitnessService(),
+  });
+}
+
+describe('OpctlService — supervisor-actor authorization (UT-OP3)', () => {
+  const FORBIDDEN: ControlAction[] = [
+    'resume',
+    'cancel',
+    'retry',
+    'retry_step',
+    'revert',
+    'revert_to_previous_state',
+    'edit',
+    'edit_submitted_prompt',
+  ];
+
+  for (const action of FORBIDDEN) {
+    it(`rejects supervisor-actor ${action} with supervisor_actor_forbidden_action`, async () => {
+      const svc = makeService();
+      const env = envelope(action);
+      // Provide a proof so the tier gate does not fire first. The
+      // authorization gate must reject BEFORE the tier gate.
+      const proof = issueSupervisorProof(action, env.scope);
+      const result = await svc.submitCommand(env, proof);
+      expect(result.status).toBe('rejected');
+      expect(result.reason_code).toBe('supervisor_actor_forbidden_action');
+    });
+  }
+
+  const ALLOWED: ControlAction[] = ['hard_stop', 'pause', 'stop_response'];
+
+  for (const action of ALLOWED) {
+    it(`allows supervisor-actor ${action} past the authorization gate`, async () => {
+      const svc = makeService();
+      const env = envelope(action);
+      const proof = issueSupervisorProof(action, env.scope);
+      const result = await svc.submitCommand(env, proof);
+      // Regardless of downstream outcome, the authorization gate must
+      // not be what rejects this command.
+      expect(result.reason_code).not.toBe('supervisor_actor_forbidden_action');
+    });
+  }
+});

--- a/self/subcortex/opctl/src/__tests__/supervisor-actor-lock-write.test.ts
+++ b/self/subcortex/opctl/src/__tests__/supervisor-actor-lock-write.test.ts
@@ -1,0 +1,120 @@
+/**
+ * WR-162 SP 5 — UT-OP5 — supervisor-actor lock-write branch (SUPV-SP5-009).
+ *
+ * Asserts that when an allowlisted supervisor-actor command applies
+ * (`hard_stop`, `pause`), the supervisor enforcement lock is written
+ * atomically inside the state-apply try/block with the provenance the
+ * enforcement layer supplied via `envelope.payload`.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlAction,
+  ControlCommandEnvelope,
+  ProjectId,
+  WitnessEvent,
+} from '@nous/shared';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryStartLockStore,
+  InMemoryScopeLockStore,
+  InMemoryProjectControlStateStore,
+  issueSupervisorProof,
+} from '../index.js';
+
+function mockWitnessService(): import('@nous/shared').IWitnessService {
+  return {
+    appendAuthorization: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    appendCompletion: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 2 } as WitnessEvent),
+    appendInvariant: async () => ({} as WitnessEvent),
+    createCheckpoint: async () => ({} as import('@nous/shared').WitnessCheckpoint),
+    rotateKeyEpoch: async () => 1,
+    verify: async () => ({} as import('@nous/shared').VerificationReport),
+    getReport: async () => null,
+    listReports: async () => [],
+    getLatestCheckpoint: async () => null,
+  };
+}
+
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+function supervisorEnvelope(
+  action: ControlAction,
+  projectId: ProjectId,
+): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: 'supervisor',
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 1,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: {
+      class: 'project_run_scope',
+      kind: 'project_run',
+      target_ids: [],
+      project_id: projectId,
+    },
+    payload_hash: HASH,
+    command_signature: 'stub-sig',
+    action,
+    payload: {
+      sup_code: action === 'hard_stop' ? 'SUP-001' : 'SUP-003',
+      severity: action === 'hard_stop' ? 'S0' : 'S1',
+      lock_set_at: '2026-04-22T12:00:00.000Z',
+    },
+  };
+}
+
+function makeService(): {
+  svc: OpctlService;
+  store: InMemoryProjectControlStateStore;
+} {
+  const store = new InMemoryProjectControlStateStore();
+  const svc = new OpctlService({
+    replayStore: new InMemoryReplayStore(),
+    startLockStore: new InMemoryStartLockStore(),
+    scopeLockStore: new InMemoryScopeLockStore(),
+    projectControlStateStore: store,
+    witnessService: mockWitnessService(),
+  });
+  return { svc, store };
+}
+
+describe('Supervisor-actor lock write (UT-OP5)', () => {
+  it('supervisor hard_stop applies → supervisor lock written with provenance', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const { svc, store } = makeService();
+    const env = supervisorEnvelope('hard_stop', projectId);
+    const proof = issueSupervisorProof('hard_stop', env.scope);
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('applied');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(true);
+    expect(lock.sup_code).toBe('SUP-001');
+    expect(lock.severity).toBe('S0');
+    expect(lock.set_at).toBe('2026-04-22T12:00:00.000Z');
+  });
+
+  it('supervisor pause applies → supervisor lock written with provenance', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const { svc, store } = makeService();
+    const env = supervisorEnvelope('pause', projectId);
+    const proof = issueSupervisorProof('pause', env.scope);
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('applied');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(true);
+    expect(lock.sup_code).toBe('SUP-003');
+    expect(lock.severity).toBe('S1');
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/supervisor-actor-s2-consumer-path.test.ts
+++ b/self/subcortex/opctl/src/__tests__/supervisor-actor-s2-consumer-path.test.ts
@@ -1,0 +1,98 @@
+/**
+ * WR-162 SP 5 — UT-OP6 — supervisor-actor S2 consumer-path (SUPV-SP5-009 + N1).
+ *
+ * The S2 branch ships the lock-write boundary (opctl owns lock state)
+ * while the EventBus emit is enforce(...)'s responsibility (the supervisor
+ * module's witness/event layer). This test asserts the opctl side:
+ *   - `stop_response` applies (no state-apply branch is required — the
+ *     action is consumer-path only at opctl; state remains whatever it
+ *     was before).
+ *   - Supervisor lock is written post-apply.
+ *
+ * The "no supervisor:enforcement-action EventBus emit on the opctl side"
+ * invariant is inherent — `OpctlService` has no EventBus dependency and
+ * does not publish any supervisor channel. The paired UT-EN6 on the
+ * supervisor side locks the V1 skip-in-consumer behavior.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlCommandEnvelope,
+  ProjectId,
+  WitnessEvent,
+} from '@nous/shared';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryStartLockStore,
+  InMemoryScopeLockStore,
+  InMemoryProjectControlStateStore,
+  issueSupervisorProof,
+} from '../index.js';
+
+function mockWitnessService(): import('@nous/shared').IWitnessService {
+  return {
+    appendAuthorization: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    appendCompletion: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 2 } as WitnessEvent),
+    appendInvariant: async () => ({} as WitnessEvent),
+    createCheckpoint: async () => ({} as import('@nous/shared').WitnessCheckpoint),
+    rotateKeyEpoch: async () => 1,
+    verify: async () => ({} as import('@nous/shared').VerificationReport),
+    getReport: async () => null,
+    listReports: async () => [],
+    getLatestCheckpoint: async () => null,
+  };
+}
+
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+describe('Supervisor-actor stop_response (S2) consumer-path (UT-OP6)', () => {
+  it('stop_response applies → lock written; opctl does not emit any EventBus event (no bus dep)', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const store = new InMemoryProjectControlStateStore();
+    const svc = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore: new InMemoryScopeLockStore(),
+      projectControlStateStore: store,
+      witnessService: mockWitnessService(),
+    });
+
+    const now = new Date().toISOString();
+    const later = new Date(Date.now() + 60000).toISOString();
+    const env: ControlCommandEnvelope = {
+      control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+      actor_type: 'supervisor',
+      actor_id: randomUUID(),
+      actor_session_id: randomUUID(),
+      actor_seq: 1,
+      nonce: randomUUID(),
+      issued_at: now,
+      expires_at: later,
+      scope: {
+        class: 'project_run_scope',
+        kind: 'project_run',
+        target_ids: [],
+        project_id: projectId,
+      },
+      payload_hash: HASH,
+      command_signature: 'stub-sig',
+      action: 'stop_response',
+      payload: {
+        sup_code: 'SUP-009',
+        severity: 'S2',
+        lock_set_at: '2026-04-22T12:00:00.000Z',
+      },
+    };
+    const proof = issueSupervisorProof('stop_response', env.scope);
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('applied');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(true);
+    expect(lock.sup_code).toBe('SUP-009');
+    expect(lock.severity).toBe('S2');
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/supervisor-arbitration.test.ts
+++ b/self/subcortex/opctl/src/__tests__/supervisor-arbitration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * WR-162 SP 5 — UT-OP7 — supervisor arbitration (SUPV-SP5-012).
+ *
+ * The `PRECEDENCE_ORDER` invariant is preserved verbatim: supervisor
+ * commands use the same action-level precedence as every other actor.
+ *   - Supervisor `pause` colliding with an in-flight operator `hard_stop`
+ *     → `blocked + opctl_conflict_resolved + holderAction: 'hard_stop'`
+ *     (pause has lower precedence rank than hard_stop).
+ *   - Supervisor `pause` first, then operator `hard_stop` after the
+ *     supervisor pause releases → operator applies (the supervisor has
+ *     already released the scope lock; no precedence race).
+ *
+ * The in-flight collision is simulated by seeding the ScopeLockStore
+ * with a pre-existing holder (the in-flight command), then submitting
+ * the supervisor command against that held scope. This is the same
+ * pattern the existing OPCTL-005 arbitration tests use.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlAction,
+  ControlActorType,
+  ControlCommandEnvelope,
+  ProjectId,
+  WitnessEvent,
+} from '@nous/shared';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryStartLockStore,
+  InMemoryScopeLockStore,
+  InMemoryProjectControlStateStore,
+  issueSupervisorProof,
+  issueConfirmationProof,
+} from '../index.js';
+import { resolveScope } from '../scope.js';
+
+function mockWitnessService(): import('@nous/shared').IWitnessService {
+  return {
+    appendAuthorization: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    appendCompletion: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 2 } as WitnessEvent),
+    appendInvariant: async () => ({} as WitnessEvent),
+    createCheckpoint: async () => ({} as import('@nous/shared').WitnessCheckpoint),
+    rotateKeyEpoch: async () => 1,
+    verify: async () => ({} as import('@nous/shared').VerificationReport),
+    getReport: async () => null,
+    listReports: async () => [],
+    getLatestCheckpoint: async () => null,
+  };
+}
+
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+function envelope(
+  params: {
+    actor: ControlActorType;
+    action: ControlAction;
+    projectId: ProjectId;
+  },
+): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: params.actor,
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 1,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: {
+      class: 'project_run_scope',
+      kind: 'project_run',
+      target_ids: [],
+      project_id: params.projectId,
+    },
+    payload_hash: HASH,
+    command_signature: 'stub-sig',
+    action: params.action,
+    payload: { sup_code: 'SUP-003', severity: 'S1' },
+  };
+}
+
+describe('Supervisor arbitration (UT-OP7)', () => {
+  it('supervisor pause during in-flight operator hard_stop → blocked + opctl_conflict_resolved', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const scopeLockStore = new InMemoryScopeLockStore();
+    const svc = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore,
+      projectControlStateStore: new InMemoryProjectControlStateStore(),
+      witnessService: mockWitnessService(),
+    });
+
+    // Pre-seed the scope-lock with an in-flight hard_stop holder.
+    const env = envelope({
+      actor: 'supervisor',
+      action: 'pause',
+      projectId,
+    });
+    const snapshot = resolveScope(env.scope);
+    const scopeKey = snapshot.target_ids_hash;
+    const acquireHolder = await scopeLockStore.acquire(
+      scopeKey,
+      'hard_stop',
+      randomUUID(),
+    );
+    expect(acquireHolder.acquired).toBe(true);
+
+    const proof = issueSupervisorProof('pause', env.scope);
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('blocked');
+    expect(result.reason_code).toBe('opctl_conflict_resolved');
+  });
+
+  it('supervisor pause first (releases lock) → operator hard_stop applies', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const svc = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore: new InMemoryScopeLockStore(),
+      projectControlStateStore: new InMemoryProjectControlStateStore(),
+      witnessService: mockWitnessService(),
+    });
+
+    const pauseEnv = envelope({ actor: 'supervisor', action: 'pause', projectId });
+    const pauseProof = issueSupervisorProof('pause', pauseEnv.scope);
+    const pauseResult = await svc.submitCommand(pauseEnv, pauseProof);
+    expect(pauseResult.status).toBe('applied');
+
+    const hardStopEnv = envelope({
+      actor: 'orchestration_agent',
+      action: 'hard_stop',
+      projectId,
+    });
+    const hardStopProof = issueConfirmationProof({
+      action: 'hard_stop',
+      scope: hardStopEnv.scope,
+      tier: 'T3',
+    });
+    const hardStopResult = await svc.submitCommand(hardStopEnv, hardStopProof);
+    expect(hardStopResult.status).toBe('applied');
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/supervisor-enforcement-lock-resume.test.ts
+++ b/self/subcortex/opctl/src/__tests__/supervisor-enforcement-lock-resume.test.ts
@@ -1,0 +1,208 @@
+/**
+ * WR-162 SP 5 — UT-OP4 — ESC-001 resume-lock matrix (SUPV-SP5-010).
+ *
+ * Four-row matrix per Goals SC 4 + SDS § Failure Modes:
+ *   - Supervisor self-resume on locked scope → rejected by SUPV-SP5-011
+ *     allowlist (supervisor_actor_forbidden_action). Lock stays set.
+ *   - Operator-actor resume on locked scope → rejected by SUPV-SP5-010
+ *     resume-lock gate (supervisor_enforcement_lock). Lock stays set.
+ *   - Principal resume with invalid T3 proof → rejected by the existing
+ *     OPCTL-003 gate (precedes the resume-lock gate). Lock stays set.
+ *   - Principal resume with valid T3 proof → applied; state transitions
+ *     to 'resuming'; supervisor lock cleared atomically.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlActorType,
+  ControlAction,
+  ControlCommandEnvelope,
+  ProjectId,
+  WitnessEvent,
+} from '@nous/shared';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryStartLockStore,
+  InMemoryScopeLockStore,
+  InMemoryProjectControlStateStore,
+  issueConfirmationProof,
+  issueSupervisorProof,
+} from '../index.js';
+
+function mockWitnessService(): import('@nous/shared').IWitnessService {
+  return {
+    appendAuthorization: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    appendCompletion: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 2 } as WitnessEvent),
+    appendInvariant: async () => ({} as WitnessEvent),
+    createCheckpoint: async () => ({} as import('@nous/shared').WitnessCheckpoint),
+    rotateKeyEpoch: async () => 1,
+    verify: async () => ({} as import('@nous/shared').VerificationReport),
+    getReport: async () => null,
+    listReports: async () => [],
+    getLatestCheckpoint: async () => null,
+  };
+}
+
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+function envelope(
+  params: {
+    actor: ControlActorType;
+    action: ControlAction;
+    projectId: ProjectId;
+    payload?: Record<string, unknown>;
+  },
+): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: params.actor,
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 1,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: {
+      class: 'project_run_scope',
+      kind: 'project_run',
+      target_ids: [],
+      project_id: params.projectId,
+    },
+    payload_hash: HASH,
+    command_signature: 'stub-sig',
+    action: params.action,
+    payload: params.payload ?? { sup_code: 'SUP-001', severity: 'S0' },
+  };
+}
+
+function makeService(store?: InMemoryProjectControlStateStore): {
+  svc: OpctlService;
+  store: InMemoryProjectControlStateStore;
+} {
+  const s = store ?? new InMemoryProjectControlStateStore();
+  const svc = new OpctlService({
+    replayStore: new InMemoryReplayStore(),
+    startLockStore: new InMemoryStartLockStore(),
+    scopeLockStore: new InMemoryScopeLockStore(),
+    projectControlStateStore: s,
+    witnessService: mockWitnessService(),
+  });
+  return { svc, store: s };
+}
+
+async function seedLockViaSupervisorHardStop(
+  svc: OpctlService,
+  projectId: ProjectId,
+): Promise<void> {
+  const env = envelope({
+    actor: 'supervisor',
+    action: 'hard_stop',
+    projectId,
+    payload: {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      lock_set_at: '2026-04-22T12:00:00.000Z',
+    },
+  });
+  const proof = issueSupervisorProof('hard_stop', env.scope);
+  const result = await svc.submitCommand(env, proof);
+  if (result.status !== 'applied') {
+    throw new Error(`seed failed: ${result.status} ${result.reason_code}`);
+  }
+}
+
+describe('ESC-001 resume-lock matrix (UT-OP4)', () => {
+  it('supervisor self-resume on locked scope → rejected (forbidden_action); lock stays set', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const { svc, store } = makeService();
+    await seedLockViaSupervisorHardStop(svc, projectId);
+
+    const env = envelope({ actor: 'supervisor', action: 'resume', projectId });
+    const proof = issueSupervisorProof('resume', env.scope);
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('rejected');
+    // Supervisor self-resume is forbidden by the allowlist gate; it
+    // never reaches the resume-lock gate. Either reason_code is a
+    // pass per the ESC-001 matrix — the spec pins both. We assert
+    // the allowlist path here to document the ordering.
+    expect(result.reason_code).toBe('supervisor_actor_forbidden_action');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(true);
+  });
+
+  it('operator-actor resume on locked scope → rejected (supervisor_enforcement_lock); lock stays set', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const { svc, store } = makeService();
+    await seedLockViaSupervisorHardStop(svc, projectId);
+
+    const env = envelope({
+      actor: 'orchestration_agent',
+      action: 'resume',
+      projectId,
+    });
+    const proof = issueConfirmationProof({
+      action: 'resume',
+      scope: env.scope,
+      tier: 'T3',
+    });
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('rejected');
+    expect(result.reason_code).toBe('supervisor_enforcement_lock');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(true);
+  });
+
+  it('principal resume + invalid T3 proof → rejected (OPCTL-003); lock stays set', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const otherProjectId = randomUUID() as ProjectId;
+    const { svc, store } = makeService();
+    await seedLockViaSupervisorHardStop(svc, projectId);
+
+    const env = envelope({ actor: 'principal', action: 'resume', projectId });
+    // Scope-mismatched proof: binds to a DIFFERENT project_id, so
+    // validateConfirmationProof fails with OPCTL-003 BEFORE the
+    // resume-lock gate fires.
+    const badProof = issueConfirmationProof({
+      action: 'resume',
+      scope: {
+        class: 'project_run_scope',
+        kind: 'project_run',
+        target_ids: [],
+        project_id: otherProjectId,
+      },
+      tier: 'T3',
+    });
+    const result = await svc.submitCommand(env, badProof);
+    expect(result.status).toBe('blocked');
+    expect(result.reason_code).toBe('OPCTL-003');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(true);
+  });
+
+  it('principal resume + valid T3 proof → applied; state → resuming; lock cleared atomically', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const { svc, store } = makeService();
+    await seedLockViaSupervisorHardStop(svc, projectId);
+
+    const env = envelope({ actor: 'principal', action: 'resume', projectId });
+    const proof = issueConfirmationProof({
+      action: 'resume',
+      scope: env.scope,
+      tier: 'T3',
+    });
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('applied');
+    expect(await store.get(projectId)).toBe('resuming');
+
+    const lock = await store.getSupervisorLock(projectId);
+    expect(lock.locked).toBe(false);
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/supervisor-submit-result-branches.test.ts
+++ b/self/subcortex/opctl/src/__tests__/supervisor-submit-result-branches.test.ts
@@ -1,0 +1,137 @@
+/**
+ * WR-162 SP 5 — UT-OP8 — `OpctlSubmitResult` branch coverage (SUPV-SP5-013).
+ *
+ * Pins the three ratified `OpctlSubmitResult.status` values at the
+ * envelope-level boundary for supervisor actor:
+ *   - `applied`          — happy path with valid proof + resumable state.
+ *   - `blocked`          — arbitration preemption (uses the same seed as
+ *     UT-OP7 but asserts at the `OpctlSubmitResult` shape).
+ *   - `rejected`         — OPCTL-003 reject on invalid / missing proof.
+ *
+ * UT-EN7 in the supervisor package locks the unknown-status throw
+ * behavior; at the opctl boundary these three branches are the only
+ * legal outcomes.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlCommandEnvelope,
+  ProjectId,
+  WitnessEvent,
+} from '@nous/shared';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryStartLockStore,
+  InMemoryScopeLockStore,
+  InMemoryProjectControlStateStore,
+  issueSupervisorProof,
+} from '../index.js';
+import { resolveScope } from '../scope.js';
+
+function mockWitnessService(): import('@nous/shared').IWitnessService {
+  return {
+    appendAuthorization: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    appendCompletion: async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 2 } as WitnessEvent),
+    appendInvariant: async () => ({} as WitnessEvent),
+    createCheckpoint: async () => ({} as import('@nous/shared').WitnessCheckpoint),
+    rotateKeyEpoch: async () => 1,
+    verify: async () => ({} as import('@nous/shared').VerificationReport),
+    getReport: async () => null,
+    listReports: async () => [],
+    getLatestCheckpoint: async () => null,
+  };
+}
+
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+function envelope(projectId: ProjectId): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: 'supervisor',
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 1,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: {
+      class: 'project_run_scope',
+      kind: 'project_run',
+      target_ids: [],
+      project_id: projectId,
+    },
+    payload_hash: HASH,
+    command_signature: 'stub-sig',
+    action: 'hard_stop',
+    payload: {
+      sup_code: 'SUP-001',
+      severity: 'S0',
+      lock_set_at: '2026-04-22T12:00:00.000Z',
+    },
+  };
+}
+
+describe('Supervisor OpctlSubmitResult branches (UT-OP8)', () => {
+  it('applied — happy path with valid proof', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const svc = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore: new InMemoryScopeLockStore(),
+      projectControlStateStore: new InMemoryProjectControlStateStore(),
+      witnessService: mockWitnessService(),
+    });
+    const env = envelope(projectId);
+    const proof = issueSupervisorProof('hard_stop', env.scope);
+    const result = await svc.submitCommand(env, proof);
+    expect(result.status).toBe('applied');
+    expect(result.control_command_id).toBe(env.control_command_id);
+  });
+
+  it('blocked — opctl_conflict_resolved via scope-lock preempt', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const scopeLockStore = new InMemoryScopeLockStore();
+    const svc = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore,
+      projectControlStateStore: new InMemoryProjectControlStateStore(),
+      witnessService: mockWitnessService(),
+    });
+    const env = envelope(projectId);
+    // Make it a lower-precedence action so the pre-seeded hard_stop
+    // holder preempts it.
+    const pauseEnv: ControlCommandEnvelope = { ...env, action: 'pause' };
+    const snapshot = resolveScope(pauseEnv.scope);
+    await scopeLockStore.acquire(
+      snapshot.target_ids_hash,
+      'hard_stop',
+      randomUUID(),
+    );
+    const proof = issueSupervisorProof('pause', pauseEnv.scope);
+    const result = await svc.submitCommand(pauseEnv, proof);
+    expect(result.status).toBe('blocked');
+    expect(result.reason_code).toBe('opctl_conflict_resolved');
+  });
+
+  it('blocked — OPCTL-003 on missing proof for T3 action', async () => {
+    const projectId = randomUUID() as ProjectId;
+    const svc = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore: new InMemoryScopeLockStore(),
+      projectControlStateStore: new InMemoryProjectControlStateStore(),
+      witnessService: mockWitnessService(),
+    });
+    const env = envelope(projectId);
+    // No proof supplied → tier gate rejects with OPCTL-003 blocked.
+    const result = await svc.submitCommand(env);
+    expect(result.status).toBe('blocked');
+    expect(result.reason_code).toBe('OPCTL-003');
+  });
+});

--- a/self/subcortex/opctl/src/confirmation.ts
+++ b/self/subcortex/opctl/src/confirmation.ts
@@ -6,6 +6,7 @@ import { randomUUID, createHash } from 'node:crypto';
 import type {
   ControlCommandEnvelope,
   ControlAction,
+  ControlScope,
   ConfirmationProof,
   ConfirmationProofRequest,
   ConfirmationTier,
@@ -75,6 +76,35 @@ export function getRequiredTier(action: ControlAction): ConfirmationTier {
   if (action === 'cancel' || action === 'revert_to_previous_state' || action === 'edit_submitted_prompt') return 'T2';
   if (action === 'pause' || action === 'stop_response' || action === 'retry_step') return 'T1';
   return 'T0';
+}
+
+/**
+ * WR-162 SP 5 — supervisor-tier proof-issuance helper (SUPV-SP5-004 path (b)).
+ *
+ * Thin wrapper over `issueConfirmationProof({ action, scope, tier })` that
+ * uses the same `getRequiredTier(action)` tier lookup every principal-
+ * authored proof flows through. This is the **first production caller**
+ * path for supervisor enforcement: `enforce(...)` in
+ * `@nous/subcortex-supervisor` imports this helper via the `ProofIssuer`
+ * DI seam wired at bootstrap.
+ *
+ * Policy citation: `supervisor-escalation-policy-v1.md § Special Notes`
+ * — supervisor commands carry a `ConfirmationProof` that converges at
+ * runtime on the same `validateConfirmationProof` gate every actor goes
+ * through. Path (a) would reuse `issueSystemProof`; SP 5 picks path (b)
+ * because `issueSystemProof` does not exist yet (SP 7 lands it). When
+ * SP 7 ships, the `bootstrap.ts` wiring swaps the closure in one line;
+ * this helper may be migrated or kept alongside `issueSystemProof`.
+ */
+export function issueSupervisorProof(
+  action: ControlAction,
+  scope: ControlScope,
+): ConfirmationProof {
+  return issueConfirmationProof({
+    action,
+    scope,
+    tier: getRequiredTier(action),
+  });
 }
 
 // --- WR-162 SP 2 additions — failure-recovery-ux-patterns-v1.md § 9c ---

--- a/self/subcortex/opctl/src/index.ts
+++ b/self/subcortex/opctl/src/index.ts
@@ -15,10 +15,21 @@ export { InMemoryScopeLockStore } from './scope-lock.js';
 export { InMemoryStartLockStore } from './start-lock.js';
 export { OpctlService } from './opctl-service.js';
 
-export { T3_COOLDOWN_MS, getTierDisplay } from './confirmation.js';
+export {
+  T3_COOLDOWN_MS,
+  getTierDisplay,
+  issueConfirmationProof,
+  validateConfirmationProof,
+  getRequiredTier,
+  issueSupervisorProof,
+} from './confirmation.js';
 
 export type { ConfirmationTierDisplay } from './confirmation.js';
-export type { ProjectControlStateStore } from './project-control-state.js';
+export type {
+  ProjectControlStateStore,
+  SupervisorEnforcementLockFields,
+  SupervisorEnforcementLockSnapshot,
+} from './project-control-state.js';
 export type { ReplayStore } from './replay-store.js';
 export type { ScopeLockStore } from './scope-lock.js';
 export type { StartLockStore } from './start-lock.js';

--- a/self/subcortex/opctl/src/opctl-service.ts
+++ b/self/subcortex/opctl/src/opctl-service.ts
@@ -30,7 +30,46 @@ function mapActorToWitness(actor: ControlActorType): WitnessActor {
   if (actor === 'principal') return 'principal';
   if (actor === 'orchestration_agent') return 'orchestration_agent';
   if (actor === 'system_agent') return 'subcortex';
+  if (actor === 'supervisor') return 'supervisor';
   return 'worker_agent';
+}
+
+/**
+ * WR-162 SP 5 — SUPV-SP5-011 supervisor-actor authorization allowlist.
+ *
+ * Supervisor-actor commands are restricted to the enforcement action set
+ * named in `supervisor-escalation-policy-v1.md § Enforcement Actions`:
+ * `hard_stop`, `pause`, `stop_response`. Every other action is rejected
+ * with `reason_code: 'supervisor_actor_forbidden_action'`. UX aliases
+ * (`retry_step`, `revert_to_previous_state`, `edit_submitted_prompt`)
+ * fall into the forbidden set because they are user-surface aliases
+ * that have no supervisor policy semantics.
+ */
+const SUPERVISOR_ACTOR_ALLOWED_ACTIONS: ReadonlySet<string> = new Set([
+  'hard_stop',
+  'pause',
+  'stop_response',
+]);
+
+function validateSupervisorActorAuthorization(
+  envelope: ControlCommandEnvelope,
+): { ok: true } | { ok: false; reasonCode: 'supervisor_actor_forbidden_action' } {
+  if (envelope.actor_type !== 'supervisor') return { ok: true };
+  if (SUPERVISOR_ACTOR_ALLOWED_ACTIONS.has(envelope.action)) return { ok: true };
+  return { ok: false, reasonCode: 'supervisor_actor_forbidden_action' };
+}
+
+/**
+ * WR-162 SP 5 — payload shape expected on supervisor-actor envelopes for
+ * the lock-write branch (SUPV-SP5-009). The enforcement layer populates
+ * these fields; opctl reads them verbatim. Missing / malformed payload
+ * causes the write to fall back to best-effort defaults (the supervisor
+ * layer guarantees shape via its own envelope construction).
+ */
+interface SupervisorActorLockPayload {
+  sup_code?: string;
+  severity?: string;
+  lock_set_at?: string;
 }
 
 export interface OpctlServiceDeps {
@@ -58,6 +97,21 @@ export class OpctlService {
       });
     }
     const { envelope: validEnvelope } = validation as { envelope: ControlCommandEnvelope };
+
+    // WR-162 SP 5 — SUPV-SP5-011. Supervisor-actor allowlist check runs
+    // AFTER envelope validation and BEFORE arbitration: forbidden actions
+    // (supervisor trying `resume` / `cancel` / `retry` / aliases / …) fail
+    // fast with `supervisor_actor_forbidden_action` and never consume a
+    // scope-lock slot.
+    const supervisorActorCheck = validateSupervisorActorAuthorization(validEnvelope);
+    if (supervisorActorCheck.ok === false) {
+      return OpctlSubmitResultSchema.parse({
+        status: 'rejected',
+        control_command_id: validEnvelope.control_command_id,
+        reason: `Supervisor actor cannot issue '${validEnvelope.action}' commands`,
+        reason_code: supervisorActorCheck.reasonCode,
+      });
+    }
 
     const requiredTier = getRequiredTier(validEnvelope.action);
     if (requiredTier !== 'T0') {
@@ -153,14 +207,56 @@ export class OpctlService {
       const projectId = validEnvelope.scope.project_id;
       if (projectId && this.deps.projectControlStateStore) {
         const store = this.deps.projectControlStateStore;
+        // WR-162 SP 5 — SUPV-SP5-010. ESC-001 resume-lock gate. Runs at
+        // the top of the project-run scope state-apply branch, before
+        // the `resume` handler. Only a principal-authored resume (with
+        // a valid T3 proof — already validated above at line ~72) may
+        // clear the supervisor enforcement lock. Supervisor self-resume
+        // is blocked by SUPV-SP5-011 allowlist earlier; this gate blocks
+        // operator / orchestrator / worker / system-agent resume on a
+        // scope that a supervisor has locked.
+        if (validEnvelope.action === 'resume') {
+          const lockState = await store.getSupervisorLock(projectId);
+          if (lockState.locked && validEnvelope.actor_type !== 'principal') {
+            return OpctlSubmitResultSchema.parse({
+              status: 'rejected',
+              control_command_id: validEnvelope.control_command_id,
+              reason: 'Supervisor enforcement lock active; principal T3 resume required',
+              reason_code: 'supervisor_enforcement_lock',
+            });
+          }
+        }
         if (validEnvelope.action === 'pause') {
           await store.set(projectId, 'paused_review');
         } else if (validEnvelope.action === 'resume') {
           await this.deps.startLockStore.setStartLock(projectId, false);
           await store.set(projectId, 'resuming');
+          // WR-162 SP 5 — SUPV-SP5-010. Atomic clear on principal-
+          // authorized resume apply. The resume-lock gate above
+          // guarantees we reach this branch only when the actor is
+          // `principal` AND the T3 proof validated AND any supervisor
+          // lock (if present) must be cleared alongside the state
+          // transition. When no lock was set, the clear is a no-op.
+          await store.clearSupervisorLock(projectId);
         } else if (validEnvelope.action === 'hard_stop') {
           await this.deps.startLockStore.setStartLock(projectId, true);
           await store.clear(projectId);
+        }
+        // WR-162 SP 5 — SUPV-SP5-009. Supervisor-actor lock write.
+        // Runs AFTER the state-apply branches so the lock captures the
+        // enforcement action that just succeeded. `pause` → state is
+        // `paused_review` + lock set. `hard_stop` → startLock + lock
+        // set (state is cleared by the hard_stop branch, which is
+        // expected: hard_stopped is derived from startLockStore).
+        // `stop_response` has no state-apply branch (it is consumer-
+        // path only), but we still set the lock so ESC-001 applies.
+        if (validEnvelope.actor_type === 'supervisor') {
+          const payload = (validEnvelope.payload ?? {}) as SupervisorActorLockPayload;
+          await store.setSupervisorLock(projectId, {
+            sup_code: payload.sup_code ?? '',
+            severity: payload.severity ?? '',
+            set_at: payload.lock_set_at ?? new Date().toISOString(),
+          });
         }
       } else if (
         projectId &&

--- a/self/subcortex/opctl/src/project-control-state.ts
+++ b/self/subcortex/opctl/src/project-control-state.ts
@@ -2,33 +2,138 @@
  * Project control state — tracks pause/resume per project.
  * Phase 2.6 — MAO-007: getProjectControlState for dispatch gating.
  * hard_stopped comes from StartLockStore; paused_review/resuming from this store.
+ *
+ * WR-162 SP 5 — SUPV-SP5-009/010: adds `supervisor_enforcement_lock` state on
+ * the same in-memory record. Three new methods operate exclusively on the
+ * lock fields; the existing `get`/`set`/`clear` methods remain unchanged
+ * and continue to read/write only the `state` field.
+ *
+ * The internal `StoredProjectControlState` shape is NOT exported across
+ * packages — keep the widening surgical (Goals SC 16/17 / SUPV-SP5-006).
  */
 import type { ProjectId, ProjectControlState } from '@nous/shared';
+
+/**
+ * Supervisor enforcement lock provenance — written by `setSupervisorLock`
+ * when a supervisor-actor command applies; cleared atomically on
+ * principal-authorized resume. See `supervisor-escalation-policy-v1.md
+ * § ESC-001`.
+ */
+export interface SupervisorEnforcementLockFields {
+  readonly sup_code: string;
+  readonly severity: string;
+  readonly set_at: string;
+}
+
+export interface SupervisorEnforcementLockSnapshot {
+  readonly locked: boolean;
+  readonly sup_code: string | null;
+  readonly severity: string | null;
+  readonly set_at: string | null;
+}
+
+/**
+ * Internal stored shape — the in-memory record carries the SP 3 `state`
+ * field AND the SP 5 `supervisor_enforcement_lock` fields side-by-side
+ * on the same record. The two halves are operated on by disjoint method
+ * sets so writes to one cannot touch the other (SUPV-SP5-006).
+ */
+interface StoredProjectControlState {
+  state: ProjectControlState | null;
+  lock: SupervisorEnforcementLockFields | null;
+}
 
 export interface ProjectControlStateStore {
   get(projectId: ProjectId): Promise<ProjectControlState | null>;
   set(projectId: ProjectId, state: ProjectControlState): Promise<void>;
   clear(projectId: ProjectId): Promise<void>;
+  /** WR-162 SP 5 — SUPV-SP5-010. Default (unset) returns `{ locked: false }`. */
+  getSupervisorLock(
+    projectId: ProjectId,
+  ): Promise<SupervisorEnforcementLockSnapshot>;
+  /** WR-162 SP 5 — SUPV-SP5-009. Persists provenance fields verbatim. */
+  setSupervisorLock(
+    projectId: ProjectId,
+    fields: SupervisorEnforcementLockFields,
+  ): Promise<void>;
+  /** WR-162 SP 5 — SUPV-SP5-010. Atomic clear (runs inside opctl's resume try/block). */
+  clearSupervisorLock(projectId: ProjectId): Promise<void>;
 }
 
 /**
  * In-memory implementation for Phase 2.6 baseline.
  * Tracks pause/resuming state per project. hard_stopped is from StartLockStore.
+ *
+ * WR-162 SP 5 — adds `supervisor_enforcement_lock` fields on the same
+ * internal record. Unset projects return a default-lock snapshot
+ * (`{ locked: false, sup_code: null, severity: null, set_at: null }`).
  */
 export class InMemoryProjectControlStateStore
   implements ProjectControlStateStore
 {
-  private stateByProject = new Map<string, ProjectControlState>();
+  private records = new Map<string, StoredProjectControlState>();
+
+  private ensureRecord(projectId: string): StoredProjectControlState {
+    let rec = this.records.get(projectId);
+    if (rec === undefined) {
+      rec = { state: null, lock: null };
+      this.records.set(projectId, rec);
+    }
+    return rec;
+  }
 
   async get(projectId: ProjectId): Promise<ProjectControlState | null> {
-    return this.stateByProject.get(projectId) ?? null;
+    return this.records.get(projectId)?.state ?? null;
   }
 
   async set(projectId: ProjectId, state: ProjectControlState): Promise<void> {
-    this.stateByProject.set(projectId, state);
+    const rec = this.ensureRecord(projectId);
+    rec.state = state;
   }
 
   async clear(projectId: ProjectId): Promise<void> {
-    this.stateByProject.delete(projectId);
+    const rec = this.records.get(projectId);
+    if (rec === undefined) return;
+    rec.state = null;
+    if (rec.lock === null) {
+      // Drop the record entirely when both halves are empty.
+      this.records.delete(projectId);
+    }
+  }
+
+  async getSupervisorLock(
+    projectId: ProjectId,
+  ): Promise<SupervisorEnforcementLockSnapshot> {
+    const lock = this.records.get(projectId)?.lock ?? null;
+    if (lock === null) {
+      return { locked: false, sup_code: null, severity: null, set_at: null };
+    }
+    return {
+      locked: true,
+      sup_code: lock.sup_code,
+      severity: lock.severity,
+      set_at: lock.set_at,
+    };
+  }
+
+  async setSupervisorLock(
+    projectId: ProjectId,
+    fields: SupervisorEnforcementLockFields,
+  ): Promise<void> {
+    const rec = this.ensureRecord(projectId);
+    rec.lock = {
+      sup_code: fields.sup_code,
+      severity: fields.severity,
+      set_at: fields.set_at,
+    };
+  }
+
+  async clearSupervisorLock(projectId: ProjectId): Promise<void> {
+    const rec = this.records.get(projectId);
+    if (rec === undefined) return;
+    rec.lock = null;
+    if (rec.state === null) {
+      this.records.delete(projectId);
+    }
   }
 }

--- a/self/subcortex/supervisor/package.json
+++ b/self/subcortex/supervisor/package.json
@@ -22,6 +22,7 @@
     "@nous/shared": "workspace:*"
   },
   "devDependencies": {
+    "@nous/subcortex-opctl": "workspace:*",
     "@nous/subcortex-witnessd": "workspace:*",
     "vitest": "^2.1.0"
   }

--- a/self/subcortex/supervisor/src/__tests__/enforcement-integration.test.ts
+++ b/self/subcortex/supervisor/src/__tests__/enforcement-integration.test.ts
@@ -1,0 +1,420 @@
+/**
+ * WR-162 SP 5 — IT-SP5-1 — end-to-end S0 enforcement flow (DoD 2/3/5/6).
+ *
+ * Wires real components at the hermetic boundary:
+ *   - Real `WitnessService` over in-memory document store.
+ *   - Real `OpctlService` with in-memory replay/start/scope/control-state stores.
+ *   - Real `SupervisorService` with a real `enforcement` slot.
+ *   - Real `issueSupervisorProof` proof issuer.
+ *   - Real `AgentClassToolSurfaceRegistry` subset tuned for SUP-001.
+ *   - Stub `GatewayRunSnapshotRegistry` returning a Worker-class snapshot
+ *     (same pattern as SP 4 IT-1).
+ *
+ * Seed: SUP-001 fixture (Worker dispatch_agent tool call).
+ * Assertions: 11 per SDS § Integration Tests
+ *   1. violationBuffer has one SUP-001 entry.
+ *   2. supervisor:violation-detected emitted once.
+ *   3. opctlService.submitCommand called once (supervisor / hard_stop).
+ *   4. OpctlSubmitResult.applied; hard_stopped state; supervisor lock set.
+ *   5. supervisor:enforcement-action emitted once with full payload.
+ *   6. emitEnforcementWitness called once; verify() chain intact.
+ *   7. Subsequent supervisor resume → supervisor_enforcement_lock (or
+ *      forbidden_action — spec allows either).
+ *   8. Subsequent operator resume → supervisor_enforcement_lock.
+ *   9. Principal resume + valid T3 proof → applied; lock cleared.
+ *   10. Principal resume + invalid T3 proof → OPCTL-003; lock stays.
+ *   11. Replay with `enabled: false` → zero side effects.
+ *
+ * T3 proof stand-in (prompt § Integration test item 9): we use
+ * `issueConfirmationProof({ action: 'resume', scope, tier: 'T3' })` as
+ * the principal-T3 proof construction path — the same code path every
+ * principal-actor resume uses in production. Full T3 UI / dialog
+ * integration is SP 14.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type {
+  EventChannelMap,
+  GatewayAgentId,
+  GatewayRunId,
+  GatewayRunSnapshot,
+  IEventBus,
+  SupervisorEnforcementActionPayload,
+  SupervisorViolationDetectedPayload,
+} from '@nous/shared';
+import { WitnessService } from '@nous/subcortex-witnessd';
+import {
+  OpctlService,
+  InMemoryReplayStore,
+  InMemoryScopeLockStore,
+  InMemoryStartLockStore,
+  InMemoryProjectControlStateStore,
+  issueSupervisorProof,
+  issueConfirmationProof,
+} from '@nous/subcortex-opctl';
+import { createMemoryDocumentStore } from './in-memory-document-store.js';
+import { SupervisorService } from '../supervisor-service.js';
+import { SupervisorOutboxSink } from '../supervisor-outbox-sink.js';
+import { enforce, type EnforcementDeps } from '../enforcement.js';
+import type { GatewayRunSnapshotRegistry } from '../gateway-run-registry.js';
+
+const ISO = '2026-04-22T00:00:00.000Z';
+const PROJECT_ID = '550e8400-e29b-41d4-a716-446655440000';
+const RUN_ID = '550e8400-e29b-41d4-a716-446655440001';
+const AGENT_ID = '550e8400-e29b-41d4-a716-446655440002';
+const GATEWAY_ID = '550e8400-e29b-41d4-a716-446655440003';
+const EVENT_ID = '550e8400-e29b-41d4-a716-446655440004';
+
+function createTestEventBus(): IEventBus {
+  type AnyHandler = (payload: unknown) => void;
+  const subs = new Map<keyof EventChannelMap, Set<AnyHandler>>();
+  return {
+    publish(channel, payload) {
+      subs.get(channel)?.forEach((h) => h(payload as never));
+    },
+    subscribe(channel, handler) {
+      if (!subs.has(channel)) subs.set(channel, new Set());
+      subs.get(channel)!.add(handler as AnyHandler);
+      return `sub-${channel.toString()}-${Math.random()}`;
+    },
+    unsubscribe() {
+      /* noop */
+    },
+    dispose() {
+      subs.clear();
+    },
+  };
+}
+
+function stubRegistry(): GatewayRunSnapshotRegistry {
+  const snapshot: GatewayRunSnapshot = {
+    agentId: AGENT_ID as GatewayAgentId,
+    agentClass: 'Worker',
+    correlation: {
+      runId: RUN_ID as GatewayRunId,
+      parentId: GATEWAY_ID as GatewayAgentId,
+      sequence: 1,
+    },
+    budget: { maxTurns: 10, maxTokens: 1000, timeoutMs: 60000 },
+    usage: { turnsUsed: 1, tokensUsed: 10, elapsedMs: 20, spawnUnitsUsed: 0 },
+    startedAt: ISO,
+    lastUpdatedAt: ISO,
+    contextFrameCount: 0,
+    execution: {
+      projectId: PROJECT_ID as never,
+    },
+  };
+  return {
+    get: (runId) => (runId === (RUN_ID as GatewayRunId) ? snapshot : null),
+  };
+}
+
+function mkEnforcementDeps(
+  opctlService: OpctlService,
+  witnessService: WitnessService,
+  eventBus: IEventBus,
+): EnforcementDeps {
+  return {
+    opctlService: {
+      submitCommand: (envelope, proof) =>
+        opctlService.submitCommand(envelope, proof),
+    },
+    witnessService,
+    eventBus,
+    proofIssuer: (args) => issueSupervisorProof(args.action, args.scope),
+    actorId: '550e8400-e29b-41d4-a716-446655440abc',
+    actorSessionId: '550e8400-e29b-41d4-a716-446655440def',
+    nextActorSeq: (() => {
+      let n = 0;
+      return () => ++n;
+    })(),
+  };
+}
+
+describe('IT-SP5-1 — end-to-end S0 enforcement flow', () => {
+  it('assertions 1–6: happy path S0 detection → enforcement → witness + EventBus', async () => {
+    const documentStore = createMemoryDocumentStore();
+    const witnessService = new WitnessService(documentStore);
+    const bus = createTestEventBus();
+    const detected: SupervisorViolationDetectedPayload[] = [];
+    const enforced: SupervisorEnforcementActionPayload[] = [];
+    bus.subscribe('supervisor:violation-detected', (p) => detected.push(p));
+    bus.subscribe('supervisor:enforcement-action', (p) => enforced.push(p));
+
+    const controlStateStore = new InMemoryProjectControlStateStore();
+    const startLockStore = new InMemoryStartLockStore();
+    const opctlService = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore,
+      scopeLockStore: new InMemoryScopeLockStore(),
+      projectControlStateStore: controlStateStore,
+      witnessService,
+    });
+    const submitSpy = vi.spyOn(opctlService, 'submitCommand');
+    const enforcementDeps = mkEnforcementDeps(opctlService, witnessService, bus);
+    const supervisor = new SupervisorService({
+      config: { enabled: true, maxObservationQueueDepth: 64 },
+      witnessService,
+      eventBus: bus,
+      enforcement: {
+        enforce: (v, d) => enforce(v, d),
+        deps: enforcementDeps,
+      },
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    const sink = new SupervisorOutboxSink({
+      service: supervisor,
+      gatewayRunSnapshotRegistry: stubRegistry(),
+    });
+    await sink.emit({
+      type: 'observation',
+      eventId: EVENT_ID as never,
+      observation: {
+        observationType: 'tool_call',
+        content: 'dispatch',
+        detail: { name: 'dispatch_agent', params: {} },
+      },
+      correlation: {
+        runId: RUN_ID as GatewayRunId,
+        parentId: GATEWAY_ID as GatewayAgentId,
+        sequence: 1,
+      },
+      usage: { turnsUsed: 1, tokensUsed: 10, elapsedMs: 20, spawnUnitsUsed: 0 },
+      emittedAt: ISO,
+    });
+    // Allow fire-and-forget classify + fire-and-await enforcement to
+    // settle. The `await enforce(...)` is inside a microtask chain
+    // kicked off by `runClassifier`; a short wait drains both.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // (1) violation buffer has one SUP-001 entry.
+    const snapshot = supervisor.getViolationBufferSnapshot();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0]?.supCode).toBe('SUP-001');
+    expect(snapshot[0]?.severity).toBe('S0');
+
+    // (2) supervisor:violation-detected emitted once.
+    expect(detected).toHaveLength(1);
+
+    // (3) opctlService.submitCommand called once; supervisor / hard_stop.
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    const submittedEnvelope = submitSpy.mock.calls[0]?.[0];
+    expect(submittedEnvelope?.actor_type).toBe('supervisor');
+    expect(submittedEnvelope?.action).toBe('hard_stop');
+
+    // (4) OpctlSubmitResult.applied; startLock → true (hard_stopped);
+    //     supervisor lock set.
+    const hasStartLock = await startLockStore.hasStartLock(
+      PROJECT_ID as import('@nous/shared').ProjectId,
+    );
+    expect(hasStartLock).toBe(true);
+    const lockSnap = await controlStateStore.getSupervisorLock(
+      PROJECT_ID as import('@nous/shared').ProjectId,
+    );
+    expect(lockSnap.locked).toBe(true);
+    expect(lockSnap.sup_code).toBe('SUP-001');
+    expect(lockSnap.severity).toBe('S0');
+
+    // (5) supervisor:enforcement-action emitted once.
+    expect(enforced).toHaveLength(1);
+    expect(enforced[0]?.sup_code).toBe('SUP-001');
+    expect(enforced[0]?.action).toBe('hard_stop');
+
+    // (6) witness ledger has >= 2 events (detection + enforcement);
+    //     verify() chain-integrity booleans are true.
+    const report = await witnessService.verify();
+    expect(report.ledger.eventCount).toBeGreaterThanOrEqual(2);
+    expect(report.ledger.hashChainValid).toBe(true);
+    expect(report.ledger.sequenceContiguous).toBe(true);
+    expect(report.checkpoints.checkpointChainValid).toBe(true);
+    expect(report.checkpoints.signaturesValid).toBe(true);
+
+    // (7) supervisor self-resume → rejected.
+    const supResumeEnv: import('@nous/shared').ControlCommandEnvelope = {
+      control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+      actor_type: 'supervisor',
+      actor_id: randomUUID(),
+      actor_session_id: randomUUID(),
+      actor_seq: 1,
+      nonce: randomUUID(),
+      issued_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      scope: {
+        class: 'project_run_scope',
+        kind: 'project_run',
+        target_ids: [],
+        project_id: PROJECT_ID as import('@nous/shared').ProjectId,
+      },
+      payload_hash: 'a'.repeat(64),
+      command_signature: 'stub-sig',
+      action: 'resume',
+    };
+    const supResumeProof = issueSupervisorProof('resume', supResumeEnv.scope);
+    const supResumeResult = await opctlService.submitCommand(
+      supResumeEnv,
+      supResumeProof,
+    );
+    expect(supResumeResult.status).toBe('rejected');
+    expect(
+      supResumeResult.reason_code === 'supervisor_actor_forbidden_action' ||
+        supResumeResult.reason_code === 'supervisor_enforcement_lock',
+    ).toBe(true);
+    expect(
+      (
+        await controlStateStore.getSupervisorLock(
+          PROJECT_ID as import('@nous/shared').ProjectId,
+        )
+      ).locked,
+    ).toBe(true);
+
+    // (8) operator resume → supervisor_enforcement_lock. Use a fresh
+    // actor_session_id so actor_seq sequencing starts clean per actor.
+    const opResumeEnv: import('@nous/shared').ControlCommandEnvelope = {
+      ...supResumeEnv,
+      control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+      actor_type: 'orchestration_agent',
+      nonce: randomUUID(),
+      actor_session_id: randomUUID(),
+      actor_seq: 1,
+    };
+    const opResumeProof = issueConfirmationProof({
+      action: 'resume',
+      scope: opResumeEnv.scope,
+      tier: 'T3',
+    });
+    const opResumeResult = await opctlService.submitCommand(
+      opResumeEnv,
+      opResumeProof,
+    );
+    expect(opResumeResult.status).toBe('rejected');
+    expect(opResumeResult.reason_code).toBe('supervisor_enforcement_lock');
+    expect(
+      (
+        await controlStateStore.getSupervisorLock(
+          PROJECT_ID as import('@nous/shared').ProjectId,
+        )
+      ).locked,
+    ).toBe(true);
+
+    // (10) principal + invalid T3 proof → OPCTL-003; lock stays.
+    const pInvalidEnv: import('@nous/shared').ControlCommandEnvelope = {
+      ...supResumeEnv,
+      control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+      actor_type: 'principal',
+      nonce: randomUUID(),
+      actor_session_id: randomUUID(),
+      actor_seq: 1,
+    };
+    const pInvalidProof = issueConfirmationProof({
+      action: 'resume',
+      scope: {
+        ...pInvalidEnv.scope,
+        project_id: randomUUID() as import('@nous/shared').ProjectId,
+      },
+      tier: 'T3',
+    });
+    const pInvalidResult = await opctlService.submitCommand(
+      pInvalidEnv,
+      pInvalidProof,
+    );
+    expect(pInvalidResult.status).toBe('blocked');
+    expect(pInvalidResult.reason_code).toBe('OPCTL-003');
+    expect(
+      (
+        await controlStateStore.getSupervisorLock(
+          PROJECT_ID as import('@nous/shared').ProjectId,
+        )
+      ).locked,
+    ).toBe(true);
+
+    // (9) principal + valid T3 proof → applied; lock cleared.
+    const pValidEnv: import('@nous/shared').ControlCommandEnvelope = {
+      ...supResumeEnv,
+      control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+      actor_type: 'principal',
+      nonce: randomUUID(),
+      actor_session_id: randomUUID(),
+      actor_seq: 1,
+    };
+    const pValidProof = issueConfirmationProof({
+      action: 'resume',
+      scope: pValidEnv.scope,
+      tier: 'T3',
+    });
+    const pValidResult = await opctlService.submitCommand(
+      pValidEnv,
+      pValidProof,
+    );
+    expect(pValidResult.status).toBe('applied');
+    expect(
+      (
+        await controlStateStore.getSupervisorLock(
+          PROJECT_ID as import('@nous/shared').ProjectId,
+        )
+      ).locked,
+    ).toBe(false);
+  });
+
+  it('assertion 11: enabled: false → zero side effects', async () => {
+    const documentStore = createMemoryDocumentStore();
+    const witnessService = new WitnessService(documentStore);
+    const bus = createTestEventBus();
+    const detected: SupervisorViolationDetectedPayload[] = [];
+    const enforced: SupervisorEnforcementActionPayload[] = [];
+    bus.subscribe('supervisor:violation-detected', (p) => detected.push(p));
+    bus.subscribe('supervisor:enforcement-action', (p) => enforced.push(p));
+    const controlStateStore = new InMemoryProjectControlStateStore();
+    const opctlService = new OpctlService({
+      replayStore: new InMemoryReplayStore(),
+      startLockStore: new InMemoryStartLockStore(),
+      scopeLockStore: new InMemoryScopeLockStore(),
+      projectControlStateStore: controlStateStore,
+      witnessService,
+    });
+    const submitSpy = vi.spyOn(opctlService, 'submitCommand');
+    const enforcementDeps = mkEnforcementDeps(opctlService, witnessService, bus);
+    const supervisor = new SupervisorService({
+      config: { enabled: false, maxObservationQueueDepth: 64 },
+      witnessService,
+      eventBus: bus,
+      enforcement: { enforce: (v, d) => enforce(v, d), deps: enforcementDeps },
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    const sink = new SupervisorOutboxSink({
+      service: supervisor,
+      gatewayRunSnapshotRegistry: stubRegistry(),
+    });
+    await sink.emit({
+      type: 'observation',
+      eventId: EVENT_ID as never,
+      observation: {
+        observationType: 'tool_call',
+        content: 'dispatch',
+        detail: { name: 'dispatch_agent', params: {} },
+      },
+      correlation: {
+        runId: RUN_ID as GatewayRunId,
+        parentId: GATEWAY_ID as GatewayAgentId,
+        sequence: 1,
+      },
+      usage: { turnsUsed: 1, tokensUsed: 10, elapsedMs: 20, spawnUnitsUsed: 0 },
+      emittedAt: ISO,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(supervisor.getViolationBufferSnapshot()).toHaveLength(0);
+    expect(detected).toHaveLength(0);
+    expect(enforced).toHaveLength(0);
+    expect(submitSpy).not.toHaveBeenCalled();
+    const lockSnap = await controlStateStore.getSupervisorLock(
+      PROJECT_ID as import('@nous/shared').ProjectId,
+    );
+    expect(lockSnap.locked).toBe(false);
+  });
+});

--- a/self/subcortex/supervisor/src/__tests__/enforcement.test.ts
+++ b/self/subcortex/supervisor/src/__tests__/enforcement.test.ts
@@ -1,0 +1,407 @@
+/**
+ * WR-162 SP 5 — UT-EN1..UT-EN10 — enforcement module contract tests.
+ *
+ * Covers the 8-step `enforce(...)` body per SDS § Invariants:
+ *   - UT-EN1 severity → action matrix (S0/S1/S2/S3)
+ *   - UT-EN2 S3 short-circuit (SUPV-SP5-003)
+ *   - UT-EN3 applied branch
+ *   - UT-EN4 conflict_resolved branch
+ *   - UT-EN5 rejected branch
+ *   - UT-EN6 S2 consumer-path EventBus skip (review N1)
+ *   - UT-EN7 no-heuristic-bandaid (SUPV-SP5-013) — unknown status throws
+ *   - UT-EN8 submitCommand throws → propagates; no witness; no EventBus
+ *   - UT-EN9 emitEnforcementWitness throws → metric; result preserved
+ *   - UT-EN10 eventBus.publish throws → metric; result preserved
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type {
+  ControlAction,
+  ConfirmationProof,
+  ControlCommandEnvelope,
+  ControlScope,
+  IEventBus,
+  IWitnessService,
+  OpctlSubmitResult,
+  SupervisorViolationRecord,
+  WitnessEvent,
+} from '@nous/shared';
+import {
+  enforce,
+  EnforcementContractDefectError,
+  type EnforcementDeps,
+  type EnforcementOpctlService,
+} from '../enforcement.js';
+
+const ISO = '2026-04-22T00:00:00.000Z';
+const PROJECT_ID = '550e8400-e29b-41d4-a716-446655440000';
+const RUN_ID = '550e8400-e29b-41d4-a716-446655440001';
+const AGENT_ID = '550e8400-e29b-41d4-a716-446655440002';
+
+function mkViolation(
+  overrides: Partial<SupervisorViolationRecord> = {},
+): SupervisorViolationRecord {
+  return {
+    supCode: 'SUP-001',
+    severity: 'S0',
+    agentId: AGENT_ID,
+    agentClass: 'Worker',
+    runId: RUN_ID,
+    projectId: PROJECT_ID,
+    evidenceRefs: ['evt-1'],
+    detectedAt: ISO,
+    enforcement: null,
+    ...overrides,
+  };
+}
+
+function mkWitnessService(): IWitnessService {
+  return {
+    appendInvariant: vi.fn(async () =>
+      ({ id: randomUUID() as import('@nous/shared').WitnessEventId, sequence: 1 } as WitnessEvent),
+    ),
+    appendAuthorization: vi.fn(),
+    appendCompletion: vi.fn(),
+    createCheckpoint: vi.fn(),
+    rotateKeyEpoch: vi.fn(),
+    verify: vi.fn(),
+    getReport: vi.fn(),
+    listReports: vi.fn(),
+    getLatestCheckpoint: vi.fn(),
+  } as unknown as IWitnessService;
+}
+
+function mkEventBus(): IEventBus {
+  return {
+    publish: vi.fn(),
+    subscribe: vi.fn(() => 'sub-id'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function mkOpctlService(
+  result: OpctlSubmitResult,
+): {
+  svc: EnforcementOpctlService;
+  submit: ReturnType<typeof vi.fn>;
+} {
+  const submit = vi.fn(async () => result);
+  return {
+    svc: { submitCommand: submit as unknown as EnforcementOpctlService['submitCommand'] },
+    submit,
+  };
+}
+
+function mkProofIssuer(): {
+  issuer: EnforcementDeps['proofIssuer'];
+  calls: Array<{ action: ControlAction; scope: ControlScope }>;
+} {
+  const calls: Array<{ action: ControlAction; scope: ControlScope }> = [];
+  const issuer: EnforcementDeps['proofIssuer'] = (args) => {
+    calls.push(args);
+    return {
+      proof_id: randomUUID(),
+      issued_at: ISO,
+      expires_at: '2026-04-22T00:05:00.000Z',
+      scope_hash: 'a'.repeat(64),
+      action: args.action,
+      tier: 'T3',
+      signature: 'stub-sig',
+    } as ConfirmationProof;
+  };
+  return { issuer, calls };
+}
+
+function mkDeps(overrides: Partial<EnforcementDeps> = {}): {
+  deps: EnforcementDeps;
+  witnessService: IWitnessService;
+  eventBus: IEventBus;
+  metric: ReturnType<typeof vi.fn>;
+} {
+  const witnessService = overrides.witnessService ?? mkWitnessService();
+  const eventBus = overrides.eventBus ?? mkEventBus();
+  const metric = vi.fn();
+  const { issuer } = mkProofIssuer();
+  const deps: EnforcementDeps = {
+    opctlService: overrides.opctlService ?? {
+      submitCommand: vi.fn(async () => ({
+        status: 'applied',
+        control_command_id: randomUUID(),
+      } as unknown as OpctlSubmitResult)),
+    },
+    witnessService,
+    eventBus,
+    proofIssuer: overrides.proofIssuer ?? issuer,
+    metric: (overrides.metric as EnforcementDeps['metric']) ?? (metric as EnforcementDeps['metric']),
+    now: () => new Date(ISO),
+    actorId: 'supervisor-actor',
+    actorSessionId: 'supervisor-session',
+    nextActorSeq: (() => {
+      let n = 0;
+      return () => ++n;
+    })(),
+    ...overrides,
+  };
+  return { deps, witnessService, eventBus, metric };
+}
+
+describe('enforce — severity → action matrix (UT-EN1)', () => {
+  it('S0 SUP-001 → opctl envelope carries action hard_stop', async () => {
+    const { svc, submit } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const { deps } = mkDeps({ opctlService: svc });
+    await enforce(mkViolation({ supCode: 'SUP-001', severity: 'S0' }), deps);
+    expect(submit).toHaveBeenCalledTimes(1);
+    const envelope = submit.mock.calls[0]?.[0] as ControlCommandEnvelope;
+    expect(envelope.action).toBe('hard_stop');
+    expect(envelope.actor_type).toBe('supervisor');
+  });
+
+  it('S1 SUP-003 → opctl envelope carries action pause', async () => {
+    const { svc, submit } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const { deps } = mkDeps({ opctlService: svc });
+    await enforce(mkViolation({ supCode: 'SUP-003', severity: 'S1' }), deps);
+    const envelope = submit.mock.calls[0]?.[0] as ControlCommandEnvelope;
+    expect(envelope.action).toBe('pause');
+  });
+
+  it('S2 synthetic → opctl envelope carries action stop_response', async () => {
+    const { svc, submit } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const { deps } = mkDeps({ opctlService: svc });
+    await enforce(mkViolation({ supCode: 'SUP-001', severity: 'S2' }), deps);
+    const envelope = submit.mock.calls[0]?.[0] as ControlCommandEnvelope;
+    expect(envelope.action).toBe('stop_response');
+  });
+
+  it('S3 → warn_only short-circuit (no submit call)', async () => {
+    const { svc, submit } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const { deps } = mkDeps({ opctlService: svc });
+    const result = await enforce(
+      mkViolation({ supCode: 'SUP-009', severity: 'S3' }),
+      deps,
+    );
+    expect(result.status).toBe('warn_only');
+    expect(submit).not.toHaveBeenCalled();
+  });
+});
+
+describe('enforce — UT-EN2 S3 short-circuit spy (SUPV-SP5-003)', () => {
+  it('zero translator / opctl / witness / eventbus calls for S3', async () => {
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const opctlSubmit = vi.fn();
+    const { deps } = mkDeps({
+      opctlService: { submitCommand: opctlSubmit as unknown as EnforcementOpctlService['submitCommand'] },
+      witnessService,
+      eventBus,
+    });
+    await enforce(mkViolation({ severity: 'S3', supCode: 'SUP-009' }), deps);
+    expect(opctlSubmit).not.toHaveBeenCalled();
+    expect(witnessService.appendInvariant).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('enforce — UT-EN3 applied branch', () => {
+  it('enforce returns applied; witness + EventBus emit happen', async () => {
+    const commandId = randomUUID();
+    const { svc } = mkOpctlService({
+      status: 'applied',
+      control_command_id: commandId,
+    } as unknown as OpctlSubmitResult);
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const { deps } = mkDeps({
+      opctlService: svc,
+      witnessService,
+      eventBus,
+    });
+    const result = await enforce(mkViolation(), deps);
+    expect(result.status).toBe('applied');
+    expect(witnessService.appendInvariant).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect((eventBus.publish as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(
+      'supervisor:enforcement-action',
+    );
+  });
+});
+
+describe('enforce — UT-EN4 conflict_resolved branch', () => {
+  it('blocked + opctl_conflict_resolved → EnforcementResult conflict_resolved', async () => {
+    const { svc } = mkOpctlService({
+      status: 'blocked',
+      control_command_id: randomUUID(),
+      reason: 'conflict',
+      reason_code: 'opctl_conflict_resolved',
+    } as unknown as OpctlSubmitResult);
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const { deps } = mkDeps({ opctlService: svc, witnessService, eventBus });
+    const result = await enforce(mkViolation(), deps);
+    expect(result.status).toBe('conflict_resolved');
+    if (result.status === 'conflict_resolved') {
+      expect(result.reasonCode).toBe('opctl_conflict_resolved');
+    }
+    expect(witnessService.appendInvariant).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('enforce — UT-EN5 rejected branch', () => {
+  it('rejected + OPCTL-003 → EnforcementResult rejected', async () => {
+    const { svc } = mkOpctlService({
+      status: 'rejected',
+      control_command_id: randomUUID(),
+      reason: 'invalid proof',
+      reason_code: 'OPCTL-003',
+    } as unknown as OpctlSubmitResult);
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const { deps } = mkDeps({ opctlService: svc, witnessService, eventBus });
+    const result = await enforce(mkViolation(), deps);
+    expect(result.status).toBe('rejected');
+    if (result.status === 'rejected') {
+      expect(result.reasonCode).toBe('OPCTL-003');
+    }
+    expect(witnessService.appendInvariant).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('enforce — UT-EN6 S2 consumer-path EventBus skip (review N1)', () => {
+  it('S2 + applied → zero supervisor:enforcement-action emits; metric incremented; witness still written', async () => {
+    const { svc } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const metric = vi.fn();
+    const { deps } = mkDeps({
+      opctlService: svc,
+      witnessService,
+      eventBus,
+      metric: metric as EnforcementDeps['metric'],
+    });
+    await enforce(mkViolation({ severity: 'S2' }), deps);
+    expect(eventBus.publish).not.toHaveBeenCalled();
+    expect(witnessService.appendInvariant).toHaveBeenCalledTimes(1);
+    const names = metric.mock.calls.map((c) => c[0]);
+    expect(names).toContain('supervisor_enforcement_s2_emit_skipped_total');
+  });
+});
+
+describe('enforce — UT-EN7 no-heuristic-bandaid (SUPV-SP5-013)', () => {
+  it('unknown OpctlSubmitResult.status throws EnforcementContractDefectError; no witness; no EventBus', async () => {
+    const svc: EnforcementOpctlService = {
+      submitCommand: async () =>
+        ({
+          status: 'unexpected_value',
+          control_command_id: randomUUID(),
+        } as unknown as OpctlSubmitResult),
+    };
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const { deps } = mkDeps({ opctlService: svc, witnessService, eventBus });
+    await expect(enforce(mkViolation(), deps)).rejects.toBeInstanceOf(
+      EnforcementContractDefectError,
+    );
+    expect(witnessService.appendInvariant).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('enforce — UT-EN8 submitCommand throws', () => {
+  it('propagates; no witness row; no EventBus emit', async () => {
+    const svc: EnforcementOpctlService = {
+      submitCommand: async () => {
+        throw new Error('witness service down');
+      },
+    };
+    const witnessService = mkWitnessService();
+    const eventBus = mkEventBus();
+    const { deps } = mkDeps({ opctlService: svc, witnessService, eventBus });
+    await expect(enforce(mkViolation(), deps)).rejects.toThrow(
+      /witness service down/,
+    );
+    expect(witnessService.appendInvariant).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('enforce — UT-EN9 emitEnforcementWitness throws', () => {
+  it('witness throws → metric; EnforcementResult.status stays applied; EventBus still attempted', async () => {
+    const { svc } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const witnessService: IWitnessService = {
+      appendInvariant: vi.fn(async () => {
+        throw new Error('witness down');
+      }),
+      appendAuthorization: vi.fn(),
+      appendCompletion: vi.fn(),
+      createCheckpoint: vi.fn(),
+      rotateKeyEpoch: vi.fn(),
+      verify: vi.fn(),
+      getReport: vi.fn(),
+      listReports: vi.fn(),
+      getLatestCheckpoint: vi.fn(),
+    } as unknown as IWitnessService;
+    const eventBus = mkEventBus();
+    const metric = vi.fn();
+    const { deps } = mkDeps({
+      opctlService: svc,
+      witnessService,
+      eventBus,
+      metric: metric as EnforcementDeps['metric'],
+    });
+    const result = await enforce(mkViolation(), deps);
+    expect(result.status).toBe('applied');
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const names = metric.mock.calls.map((c) => c[0]);
+    expect(names).toContain('supervisor_enforcement_witness_failed_total');
+  });
+});
+
+describe('enforce — UT-EN10 eventBus.publish throws', () => {
+  it('EventBus throws → metric; EnforcementResult.status stays applied; witness row written', async () => {
+    const { svc } = mkOpctlService({
+      status: 'applied',
+      control_command_id: randomUUID(),
+    } as unknown as OpctlSubmitResult);
+    const witnessService = mkWitnessService();
+    const eventBus: IEventBus = {
+      publish: vi.fn(() => {
+        throw new Error('bus down');
+      }),
+      subscribe: vi.fn(() => 'sub-id'),
+      unsubscribe: vi.fn(),
+      dispose: vi.fn(),
+    };
+    const metric = vi.fn();
+    const { deps } = mkDeps({
+      opctlService: svc,
+      witnessService,
+      eventBus,
+      metric: metric as EnforcementDeps['metric'],
+    });
+    const result = await enforce(mkViolation(), deps);
+    expect(result.status).toBe('applied');
+    expect(witnessService.appendInvariant).toHaveBeenCalledTimes(1);
+    const names = metric.mock.calls.map((c) => c[0]);
+    expect(names).toContain('supervisor_enforcement_eventbus_failed_total');
+  });
+});

--- a/self/subcortex/supervisor/src/__tests__/supervisor-service-enforcement.test.ts
+++ b/self/subcortex/supervisor/src/__tests__/supervisor-service-enforcement.test.ts
@@ -1,0 +1,295 @@
+/**
+ * WR-162 SP 5 — UT-SV1..UT-SV4 — `SupervisorService` production enforcement
+ * routing (SUPV-SP5-005).
+ *
+ *   - UT-SV1: production-path fire-and-await.
+ *   - UT-SV2: log-stub fallback (SP 4 UT-R1 baseline preserved).
+ *   - UT-SV3: SUPV-SP3-002 gate end-to-end with enforcement wired.
+ *   - UT-SV4: enforcement throws → error contained; classifier continues.
+ *
+ * Kept in a separate file from `supervisor-service.test.ts` and
+ * `run-classifier.test.ts` so the SP 3 / SP 4 baselines stay untouched
+ * and the SP 5 additions live in a discoverable file.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  IEventBus,
+  IWitnessService,
+  SupervisorObservationSchema,
+  SupervisorViolationRecord,
+  WitnessEvent,
+} from '@nous/shared';
+import { z } from 'zod';
+import { SupervisorService } from '../supervisor-service.js';
+import type {
+  EnforcementDeps,
+  EnforcementResult,
+  SupervisorEnforcementSlot,
+} from '../index.js';
+
+const ISO = '2026-04-22T00:00:00.000Z';
+const PROJECT_ID = '550e8400-e29b-41d4-a716-446655440000';
+const RUN_ID = '550e8400-e29b-41d4-a716-446655440001';
+const AGENT_ID = '550e8400-e29b-41d4-a716-446655440002';
+const EVENT_ID = '550e8400-e29b-41d4-a716-446655440099';
+
+type ObservationInput = z.input<typeof SupervisorObservationSchema>;
+
+function mkObservation(
+  overrides: Partial<ObservationInput> = {},
+): ObservationInput {
+  return {
+    observedAt: ISO,
+    source: 'gateway_outbox',
+    payload: null,
+    agentId: AGENT_ID,
+    agentClass: 'Worker',
+    runId: RUN_ID,
+    projectId: PROJECT_ID,
+    traceId: null,
+    toolCall: { name: 'dispatch_agent', params: {} },
+    routingTarget: null,
+    lifecycleTransition: null,
+    actionClaim: null,
+    ...overrides,
+  };
+}
+
+function mkWitnessService(): {
+  service: IWitnessService;
+  appendInvariant: ReturnType<typeof vi.fn>;
+} {
+  const appendInvariant = vi.fn(async () =>
+    ({ id: EVENT_ID, sequence: 1 } as unknown as WitnessEvent),
+  );
+  const service = {
+    appendInvariant,
+    appendAuthorization: vi.fn(),
+    appendCompletion: vi.fn(),
+    createCheckpoint: vi.fn(),
+    rotateKeyEpoch: vi.fn(),
+    verify: vi.fn(),
+    getReport: vi.fn(),
+    listReports: vi.fn(),
+    getLatestCheckpoint: vi.fn(),
+  } as unknown as IWitnessService;
+  return { service, appendInvariant };
+}
+
+function mkEventBus(): IEventBus {
+  return {
+    publish: vi.fn(),
+    subscribe: vi.fn(() => 'sub-id'),
+    unsubscribe: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function mkDeps(): EnforcementDeps {
+  return {
+    opctlService: {
+      submitCommand: vi.fn(async () => ({
+        status: 'applied',
+        control_command_id: 'cmd-1',
+      })) as unknown as EnforcementDeps['opctlService']['submitCommand'],
+    },
+    witnessService: mkWitnessService().service,
+    eventBus: mkEventBus(),
+    proofIssuer: vi.fn(() => ({
+      proof_id: 'proof-1',
+      issued_at: ISO,
+      expires_at: '2026-04-22T00:05:00.000Z',
+      scope_hash: 'a'.repeat(64),
+      action: 'pause',
+      tier: 'T1',
+      signature: 'stub-sig',
+    })) as unknown as EnforcementDeps['proofIssuer'],
+    actorId: 'supervisor-actor',
+    actorSessionId: 'supervisor-session',
+    nextActorSeq: (() => {
+      let n = 0;
+      return () => ++n;
+    })(),
+  };
+}
+
+describe('UT-SV1 — production-path fire-and-await', () => {
+  it('enforcement slot wired → enforce called once; onEnforcementDispatch NOT called', async () => {
+    const { service: witnessService, appendInvariant } = mkWitnessService();
+    const eventBus = mkEventBus();
+    const onEnforcementDispatch = vi.fn();
+    const enforceSpy = vi.fn(async (): Promise<EnforcementResult> => ({
+      status: 'applied',
+      commandId: 'cmd-1',
+      action: 'pause',
+    }));
+    const enforcement: SupervisorEnforcementSlot = {
+      enforce: enforceSpy,
+      deps: mkDeps(),
+    };
+    const supervisor = new SupervisorService({
+      config: { enabled: true, maxObservationQueueDepth: 16 },
+      witnessService,
+      eventBus,
+      onEnforcementDispatch,
+      enforcement,
+      // Tool surface tuned for SUP-003 (Worker + dispatch_agent tripping
+      // the scope-boundary detector); identity-gate satisfied by default
+      // mkObservation fields.
+      // SUP-001 is tripped by a Worker class with dispatch_agent tool call
+      // against a registry that INCLUDES dispatch_agent (SUP-003 would
+      // need read_file allowed + dispatch_agent called forbidden). We
+      // allow both read_file + dispatch_agent → only SUP-001 trips.
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    supervisor.recordObservation(mkObservation());
+    await new Promise((r) => setTimeout(r, 30));
+    expect(appendInvariant).toHaveBeenCalled();
+    expect(enforceSpy).toHaveBeenCalledTimes(1);
+    expect(onEnforcementDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('UT-SV2 — log-stub fallback (SP 4 baseline preserved)', () => {
+  it('no enforcement slot → onEnforcementDispatch called; enforce not reached', async () => {
+    const { service: witnessService } = mkWitnessService();
+    const eventBus = mkEventBus();
+    const onEnforcementDispatch = vi.fn();
+    const supervisor = new SupervisorService({
+      config: { enabled: true, maxObservationQueueDepth: 16 },
+      witnessService,
+      eventBus,
+      onEnforcementDispatch,
+      // SUP-001 is tripped by a Worker class with dispatch_agent tool call
+      // against a registry that INCLUDES dispatch_agent (SUP-003 would
+      // need read_file allowed + dispatch_agent called forbidden). We
+      // allow both read_file + dispatch_agent → only SUP-001 trips.
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    supervisor.recordObservation(mkObservation());
+    await new Promise((r) => setTimeout(r, 30));
+    expect(onEnforcementDispatch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('UT-SV3 — SUPV-SP3-002 gate end-to-end (SUPV-SP5-001 preserved)', () => {
+  it('enabled: false + enforcement slot wired → zero enforce + zero onEnforcementDispatch + zero witness', async () => {
+    const { service: witnessService, appendInvariant } = mkWitnessService();
+    const eventBus = mkEventBus();
+    const onEnforcementDispatch = vi.fn();
+    const enforceSpy = vi.fn(async (): Promise<EnforcementResult> => ({
+      status: 'applied',
+      commandId: 'cmd-1',
+      action: 'pause',
+    }));
+    const enforcement: SupervisorEnforcementSlot = {
+      enforce: enforceSpy,
+      deps: mkDeps(),
+    };
+    const supervisor = new SupervisorService({
+      config: { enabled: false, maxObservationQueueDepth: 16 },
+      witnessService,
+      eventBus,
+      onEnforcementDispatch,
+      enforcement,
+      // SUP-001 is tripped by a Worker class with dispatch_agent tool call
+      // against a registry that INCLUDES dispatch_agent (SUP-003 would
+      // need read_file allowed + dispatch_agent called forbidden). We
+      // allow both read_file + dispatch_agent → only SUP-001 trips.
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    supervisor.recordObservation(mkObservation());
+    await new Promise((r) => setTimeout(r, 30));
+    expect(enforceSpy).not.toHaveBeenCalled();
+    expect(onEnforcementDispatch).not.toHaveBeenCalled();
+    expect(appendInvariant).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('UT-SV4 — enforcement throws → error containment (SUPV-SP5-005)', () => {
+  it('enforce throws → metric + error log; outer loop continues', async () => {
+    const { service: witnessService } = mkWitnessService();
+    const eventBus = mkEventBus();
+    const metric = vi.fn();
+    const errorLog = vi.fn();
+    const enforcement: SupervisorEnforcementSlot = {
+      enforce: vi.fn(async () => {
+        throw new Error('enforce-boom');
+      }) as unknown as SupervisorEnforcementSlot['enforce'],
+      deps: mkDeps(),
+    };
+    const supervisor = new SupervisorService({
+      config: { enabled: true, maxObservationQueueDepth: 16 },
+      witnessService,
+      eventBus,
+      enforcement,
+      metric: metric as unknown as import('../supervisor-service.js').SupervisorMetricCounter,
+      log: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: errorLog,
+        isEnabled: () => true,
+      },
+      // SUP-001 is tripped by a Worker class with dispatch_agent tool call
+      // against a registry that INCLUDES dispatch_agent (SUP-003 would
+      // need read_file allowed + dispatch_agent called forbidden). We
+      // allow both read_file + dispatch_agent → only SUP-001 trips.
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    supervisor.recordObservation(mkObservation());
+    await new Promise((r) => setTimeout(r, 30));
+    const metricNames = metric.mock.calls.map((c: unknown[]) => c[0]);
+    expect(metricNames).toContain('supervisor_enforcement_threw_total');
+    expect(errorLog).toHaveBeenCalled();
+    const logCalls = errorLog.mock.calls.map((c: unknown[]) => c[0]);
+    expect(logCalls).toContain('supervisor.enforcement_threw');
+    // Emit a second observation and assert loop is still alive.
+    supervisor.recordObservation(mkObservation({ agentId: '550e8400-e29b-41d4-a716-44665544aaaa' }));
+    await new Promise((r) => setTimeout(r, 30));
+    // metric log registered more than once isn't critical; the
+    // key assertion is "classifier kept running".
+  });
+});
+
+describe('Integration smoke: enforcement routed on SUP-001 observation', () => {
+  it('records a SUP-001 violation through the full routing surface', async () => {
+    const { service: witnessService } = mkWitnessService();
+    const eventBus = mkEventBus();
+    const enforceSpy = vi.fn(async (record: SupervisorViolationRecord): Promise<EnforcementResult> => ({
+      status: 'applied',
+      commandId: 'cmd-1',
+      action: record.severity === 'S0' ? 'hard_stop' : 'pause',
+    }));
+    const supervisor = new SupervisorService({
+      config: { enabled: true, maxObservationQueueDepth: 16 },
+      witnessService,
+      eventBus,
+      enforcement: { enforce: enforceSpy, deps: mkDeps() },
+      // Allow dispatch_agent to scope-wise avoid SUP-003; SUP-001
+      // (Worker dispatches any agent) still fires regardless.
+      toolSurfaceRegistry: {
+        getAllowedToolsForClass: (agentClass) =>
+          agentClass === 'Worker' ? ['read_file', 'dispatch_agent'] : ['*'],
+      },
+    });
+    supervisor.recordObservation(mkObservation());
+    await new Promise((r) => setTimeout(r, 30));
+    expect(enforceSpy).toHaveBeenCalledTimes(1);
+    const firstCallArg = enforceSpy.mock.calls[0]?.[0] as SupervisorViolationRecord;
+    expect(firstCallArg.supCode).toBe('SUP-001');
+  });
+});

--- a/self/subcortex/supervisor/src/__tests__/witness-emission.test.ts
+++ b/self/subcortex/supervisor/src/__tests__/witness-emission.test.ts
@@ -73,7 +73,10 @@ describe('emitDetectionWitness (UT-W1, UT-W3)', () => {
     expect(calls[0]?.actionCategory).toBe('supervisor-detection');
     expect(calls[0]?.actionRef).toBe(`SUP-001-${RUN_ID}`);
     expect(calls[0]?.detail.severity).toBe('S0');
-    expect(calls[0]?.detail.supervisorActor).toBe('supervisor');
+    // WR-162 SP 5 — SUPV-SP5-008 flip: actor is now 'supervisor'
+    // (was 'system' in SP 4); the `supervisorActor` breadcrumb is gone.
+    expect(calls[0]?.actor).toBe('supervisor');
+    expect('supervisorActor' in (calls[0]?.detail ?? {})).toBe(false);
     expect(calls[0]?.code).toBe('SUP-001');
   });
 });
@@ -101,5 +104,8 @@ describe('emitEnforcementWitness (UT-W2)', () => {
     expect(calls[0]?.detail.commandId).toBe('cmd-42');
     expect(calls[0]?.detail.action).toBe('hard_stop');
     expect(calls[0]?.detail.evidenceRefs).toEqual(['evt-1', 'evt-2']);
+    // WR-162 SP 5 — SUPV-SP5-008 flip assertion.
+    expect(calls[0]?.actor).toBe('supervisor');
+    expect('supervisorActor' in (calls[0]?.detail ?? {})).toBe(false);
   });
 });

--- a/self/subcortex/supervisor/src/enforcement.ts
+++ b/self/subcortex/supervisor/src/enforcement.ts
@@ -1,0 +1,433 @@
+/**
+ * WR-162 SP 5 — supervisor enforcement module (SUPV-SP5-002 .. SUPV-SP5-013).
+ *
+ * The production enforcement path: converts a finalized violation into a
+ * supervisor-actor control command, issues a supervisor-tier proof, submits
+ * it to `OpctlService.submitCommand`, inspects the three ratified
+ * `OpctlSubmitResult.status` branches exhaustively, and emits the paired
+ * witness row + EventBus payload. This module is the **first production
+ * caller** of `emitEnforcementWitness` (SUPV-SP4-010 resolution).
+ *
+ * Policy citations (authoritative):
+ *   - `supervisor-escalation-policy-v1.md § Enforcement Delegation Pattern` —
+ *     the 8-step enforcement body implemented below.
+ *   - `supervisor-evidence-contract-v1.md § EventBus Channel Contract` —
+ *     payload shape for `supervisor:enforcement-action`.
+ *   - `supervisor-scope-boundary-v1.md` — scope derivation from violation
+ *     identity.
+ *
+ * Invariants (authoritative in SDS § Invariants):
+ *   - SUPV-SP5-001 (no second gate) — this module performs NO
+ *     `config.enabled` check. The single gate sits at
+ *     `SupervisorService.runClassifier` (SUPV-SP3-002 / SP 4 invariant).
+ *     Grep evidence recorded in CR.
+ *   - SUPV-SP5-002 (translator reuse) — severity → action mapping reads
+ *     `SUPERVISOR_INVARIANT_SEVERITY_MAP` directly; kebab-case conversion
+ *     goes through the SP 4 `toWitnessdEnforcement` translator
+ *     (single-site enum bridge). No inline duplication.
+ *   - SUPV-SP5-003 (S3 short-circuit) — S3 violations return
+ *     `{ status: 'warn_only' }` WITHOUT calling the translator, opctl,
+ *     witness, or EventBus.
+ *   - SUPV-SP5-004 — proof-issuance is DI-seamed via `ProofIssuer`;
+ *     bootstrap wires `issueSupervisorProof` (path (b)). Swap to
+ *     `issueSystemProof` at SP 7 is a one-line bootstrap rename.
+ *   - SUPV-SP5-013 (no heuristic bandaids) — the switch over
+ *     `OpctlSubmitResult.status` is EXHAUSTIVE on the ratified three-
+ *     branch enum (`'applied' | 'blocked' | 'rejected'`). Unknown
+ *     values throw `EnforcementContractDefectError`; the caller's
+ *     `processRecord` try/catch surfaces the defect via metric + log
+ *     per `feedback_no_heuristic_bandaids.md` — fix the source, not
+ *     the symptom.
+ *
+ * S2 / V1 consumer-path (review N1):
+ *   `SupervisorEnforcementActionPayloadSchema` in `self/shared/src/event-bus/
+ *   types.ts` currently constrains `severity: z.enum(['S0','S1'])` and
+ *   `action: z.enum(['hard_stop','auto_pause'])`. S2 severity (with action
+ *   `'stop_response'`) would fail `.parse(...)` at the EventBus layer. SP 5
+ *   skips the EventBus emit on S2 and records the skip via metric; SP 6
+ *   widens the schema. Witness emission still happens for S2 (step 8).
+ */
+import { randomUUID, createHash } from 'node:crypto';
+import {
+  SUPERVISOR_INVARIANT_SEVERITY_MAP,
+  type ConfirmationProof,
+  type ControlAction,
+  type ControlCommandEnvelope,
+  type ControlScope,
+  type IEventBus,
+  type ILogChannel,
+  type IWitnessService,
+  type OpctlSubmitResult,
+  type SupervisorEnforcementActionPayload,
+  type SupervisorInvariantCode,
+  type SupervisorViolationRecord,
+} from '@nous/shared';
+import { emitEnforcementWitness } from './witness-emission.js';
+import { toWitnessdEnforcement } from './enforcement-action-translator.js';
+import type { SupervisorEnforcementActionSP4 } from './enforcement-action-translator.js';
+
+/**
+ * Minimal opctl-service shape the enforcement module depends on. Kept
+ * structural (not a class import) so test harnesses and bootstrap can
+ * both satisfy it.
+ */
+export interface EnforcementOpctlService {
+  submitCommand(
+    envelope: ControlCommandEnvelope,
+    proof?: ConfirmationProof,
+  ): Promise<OpctlSubmitResult>;
+}
+
+/**
+ * SUPV-SP5-004 — proof-issuance DI seam. `enforce(...)` never imports
+ * `issueSupervisorProof` directly; bootstrap wires the closure so
+ * migration to `issueSystemProof` at SP 7 is a one-line edit.
+ */
+export type ProofIssuer = (args: {
+  action: ControlAction;
+  scope: ControlScope;
+}) => ConfirmationProof;
+
+export type EnforcementMetric = (
+  name: string,
+  labels: Readonly<Record<string, string>>,
+) => void;
+
+export interface EnforcementDeps {
+  readonly opctlService: EnforcementOpctlService;
+  readonly witnessService: IWitnessService;
+  readonly eventBus: IEventBus;
+  readonly logger?: ILogChannel;
+  readonly proofIssuer: ProofIssuer;
+  readonly metric?: EnforcementMetric;
+  readonly now?: () => Date;
+  readonly newCommandId?: () => string;
+  readonly newNonce?: () => string;
+  readonly actorId: string;
+  readonly actorSessionId: string;
+  readonly nextActorSeq: () => number;
+}
+
+/**
+ * Discriminated union for `enforce(...)` return values.
+ *
+ * `applied` / `conflict_resolved` / `rejected` match the three ratified
+ * `OpctlSubmitResult.status` branches; `warn_only` is the S3 short-
+ * circuit carry-forward; `preflight_rejected` is reserved for future
+ * opctl preflight checks (not triggered in SP 5).
+ */
+export type EnforcementResult =
+  | {
+      readonly status: 'applied';
+      readonly commandId: string;
+      readonly action: ControlAction;
+    }
+  | {
+      readonly status: 'conflict_resolved';
+      readonly commandId: string;
+      readonly action: ControlAction;
+      readonly reasonCode: string;
+      readonly holderAction?: string;
+    }
+  | {
+      readonly status: 'rejected';
+      readonly commandId: string;
+      readonly action: ControlAction;
+      readonly reasonCode: string;
+    }
+  | {
+      readonly status: 'warn_only';
+      readonly supCode: string;
+      readonly reason: 'S3_sentinel_deferred_to_SP6';
+    }
+  | {
+      readonly status: 'preflight_rejected';
+      readonly supCode: string;
+      readonly reasonCode: string;
+    };
+
+/**
+ * Thrown by `enforce(...)` when `OpctlSubmitResult.status` is outside the
+ * ratified three-branch enum. The caller (`SupervisorService.processRecord`)
+ * catches this via its top-level try/catch (SUPV-SP5-005) and emits a
+ * metric + log — no silent `default: no-op`, no heuristic fallback.
+ * The contract defect is surfaced as `execution_blocked` with
+ * `blocker_type: design` per `feedback_no_heuristic_bandaids.md`.
+ */
+export class EnforcementContractDefectError extends Error {
+  public readonly kind = 'contract_defect' as const;
+  public readonly detail: { reason: string; status: unknown };
+  constructor(detail: { reason: string; status: unknown }) {
+    super(
+      `EnforcementContractDefectError: ${detail.reason} (status=${String(
+        detail.status,
+      )})`,
+    );
+    this.detail = detail;
+    this.name = 'EnforcementContractDefectError';
+  }
+}
+
+/**
+ * SUPV-SP5-002 — supervisor snake_case → opctl `ControlAction` rename map.
+ * Feeds through the SP 4 `toWitnessdEnforcement` translator first so the
+ * kebab-case bridge stays the single reconciliation site; this map then
+ * lands the result in opctl's domain (supervisor's `auto_pause` becomes
+ * opctl's `pause`; `hard_stop` stays `hard_stop`).
+ */
+const WITNESSD_TO_OPCTL_ACTION: Record<string, ControlAction> = {
+  'hard-stop': 'hard_stop',
+  'auto-pause': 'pause',
+  // SP 6 widens to include 'stop-response' → 'stop_response'. Until then
+  // we handle S2 through a direct lookup below (supervisor 'stop_response'
+  // is opctl 'stop_response' — no kebab trip). `review` not produced by
+  // SP 4/SP 5 classifier paths.
+};
+
+function severityToOpctlAction(
+  violation: SupervisorViolationRecord,
+): ControlAction {
+  // S2 branch: the SUPERVISOR_INVARIANT_SEVERITY_MAP table does not yet
+  // register any SUP code at S2 severity (SP 6 lands SUP-009 +
+  // `'require_review' → stop_response` widening). A synthetic S2
+  // violation (for testing / future SP 6 preview) maps directly to
+  // opctl `stop_response`; we do not route through the SP 4 translator
+  // because the witnessd kebab mapping for S2 is not widened yet.
+  if (violation.severity === 'S2') {
+    return 'stop_response';
+  }
+  // S0/S1 path: read the ratified policy table (single source of
+  // truth). Supervisor snake_case → witnessd kebab-case → opctl
+  // ControlAction. The translator throws on 'warn' — which cannot
+  // happen here because S3/warn is short-circuited upstream.
+  const policy =
+    SUPERVISOR_INVARIANT_SEVERITY_MAP[
+      violation.supCode as SupervisorInvariantCode
+    ];
+  if (policy === undefined) {
+    throw new EnforcementContractDefectError({
+      reason: 'unknown_sup_code',
+      status: violation.supCode,
+    });
+  }
+  const supervisorAction = policy.enforcement;
+  const kebab = toWitnessdEnforcement(
+    supervisorAction as SupervisorEnforcementActionSP4,
+  );
+  const opctl = WITNESSD_TO_OPCTL_ACTION[kebab];
+  if (opctl === undefined) {
+    throw new EnforcementContractDefectError({
+      reason: 'no_opctl_action_for_kebab',
+      status: kebab,
+    });
+  }
+  return opctl;
+}
+
+function buildEnvelope(
+  violation: SupervisorViolationRecord,
+  action: ControlAction,
+  deps: EnforcementDeps,
+  enforcedAt: string,
+): ControlCommandEnvelope {
+  const now = deps.now?.() ?? new Date();
+  const expires = new Date(now.getTime() + 5 * 60 * 1000); // 5 min TTL
+  const payloadHash = createHash('sha256')
+    .update(
+      JSON.stringify({
+        sup_code: violation.supCode,
+        severity: violation.severity,
+        run_id: violation.runId,
+        agent_id: violation.agentId,
+      }),
+    )
+    .digest('hex');
+  const scope: ControlScope = {
+    class: 'project_run_scope',
+    kind: 'project_run',
+    target_ids: [],
+    project_id: violation.projectId as import('@nous/shared').ProjectId,
+  };
+  return {
+    control_command_id: (deps.newCommandId?.() ??
+      randomUUID()) as import('@nous/shared').ControlCommandId,
+    actor_type: 'supervisor',
+    actor_id: deps.actorId,
+    actor_session_id: deps.actorSessionId,
+    actor_seq: deps.nextActorSeq(),
+    nonce: deps.newNonce?.() ?? randomUUID(),
+    issued_at: now.toISOString(),
+    expires_at: expires.toISOString(),
+    scope,
+    payload_hash: payloadHash,
+    command_signature: 'stub-sig',
+    action,
+    payload: {
+      sup_code: violation.supCode,
+      severity: violation.severity,
+      lock_set_at: enforcedAt,
+    },
+  };
+}
+
+/**
+ * WR-162 SP 5 — production enforcement path. See module doc-comment for
+ * the authoritative 8-step body; each step below is labeled with its
+ * invariant binding.
+ */
+export async function enforce(
+  violation: SupervisorViolationRecord,
+  deps: EnforcementDeps,
+): Promise<EnforcementResult> {
+  // Step 1 — SUPV-SP5-003: S3 short-circuit.
+  if (violation.severity === 'S3') {
+    return {
+      status: 'warn_only',
+      supCode: violation.supCode,
+      reason: 'S3_sentinel_deferred_to_SP6',
+    };
+  }
+
+  const enforcedAt = (deps.now?.() ?? new Date()).toISOString();
+
+  // Step 2 — SUPV-SP5-002: severity → action via translator + rename map.
+  const action = severityToOpctlAction(violation);
+
+  // Step 3: envelope construction (Identity-Completeness Gate upstream
+  // guarantees non-null identity fields on the violation record).
+  const envelope = buildEnvelope(violation, action, deps, enforcedAt);
+
+  // Step 4 — SUPV-SP5-004: issue proof via DI seam.
+  const proof = deps.proofIssuer({ action, scope: envelope.scope });
+
+  // Step 5: submit.
+  const result = await deps.opctlService.submitCommand(envelope, proof);
+
+  // Step 6 — SUPV-SP5-013: exhaustive switch on ratified enum.
+  let enforcementResult: EnforcementResult;
+  let reasonCodeForTrails: string | undefined;
+  switch (result.status) {
+    case 'applied': {
+      enforcementResult = {
+        status: 'applied',
+        commandId: envelope.control_command_id,
+        action,
+      };
+      reasonCodeForTrails = undefined;
+      break;
+    }
+    case 'blocked': {
+      const reasonCode = result.reason_code ?? 'unknown_blocked_reason';
+      if (reasonCode === 'opctl_conflict_resolved') {
+        enforcementResult = {
+          status: 'conflict_resolved',
+          commandId: envelope.control_command_id,
+          action,
+          reasonCode,
+          // holderAction is not carried on OpctlSubmitResult; surfaced
+          // via the reason message. SP 6 may promote it to a field.
+        };
+      } else {
+        enforcementResult = {
+          status: 'rejected',
+          commandId: envelope.control_command_id,
+          action,
+          reasonCode,
+        };
+      }
+      reasonCodeForTrails = reasonCode;
+      break;
+    }
+    case 'rejected': {
+      const reasonCode = result.reason_code ?? 'unknown_rejected_reason';
+      enforcementResult = {
+        status: 'rejected',
+        commandId: envelope.control_command_id,
+        action,
+        reasonCode,
+      };
+      reasonCodeForTrails = reasonCode;
+      break;
+    }
+    default: {
+      throw new EnforcementContractDefectError({
+        reason: 'unknown_opctl_submit_status',
+        status: (result as { status: unknown }).status,
+      });
+    }
+  }
+
+  // Step 7 — SUPV-SP5-002 + review N1 — EventBus emit (S2 skip in V1).
+  const isS0orS1 = violation.severity === 'S0' || violation.severity === 'S1';
+  if (isS0orS1) {
+    const publishPayload: SupervisorEnforcementActionPayload = {
+      sup_code: violation.supCode,
+      severity: violation.severity as 'S0' | 'S1',
+      action: action === 'hard_stop' ? 'hard_stop' : 'auto_pause',
+      scope: JSON.stringify(envelope.scope),
+      command_id: envelope.control_command_id,
+      agent_id: violation.agentId,
+      run_id: violation.runId,
+      project_id: violation.projectId,
+      evidence_refs: [...violation.evidenceRefs],
+      enforced_at: enforcedAt,
+    };
+    try {
+      deps.eventBus.publish('supervisor:enforcement-action', publishPayload);
+    } catch (err) {
+      deps.logger?.warn?.('supervisor.enforcement_eventbus_failed', {
+        sup_code: violation.supCode,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      deps.metric?.('supervisor_enforcement_eventbus_failed_total', {
+        sup_code: violation.supCode,
+      });
+    }
+  } else if (violation.severity === 'S2') {
+    deps.logger?.debug?.('supervisor.enforcement_s2_emit_skipped_pending_sp6', {
+      sup_code: violation.supCode,
+      action,
+    });
+    deps.metric?.('supervisor_enforcement_s2_emit_skipped_total', {
+      sup_code: violation.supCode,
+    });
+  }
+
+  // Step 8: witness emission. Runs AFTER submit so a throw in submit
+  // produces no enforcement witness row. SUPV-SP5-005 / review N2: the
+  // pre-submit `enforcement_attempt` witness row is a future ADR
+  // candidate; SP 5 ships without it.
+  if (
+    enforcementResult.status === 'applied' ||
+    enforcementResult.status === 'conflict_resolved' ||
+    enforcementResult.status === 'rejected'
+  ) {
+    try {
+      const witnessAction =
+        action === 'hard_stop' ? 'hard_stop' : 'auto_pause';
+      await emitEnforcementWitness({
+        supCode: violation.supCode,
+        severity: violation.severity,
+        action: witnessAction,
+        commandId: envelope.control_command_id,
+        agentId: violation.agentId,
+        agentClass: violation.agentClass,
+        runId: violation.runId,
+        projectId: violation.projectId,
+        evidenceRefs: [...violation.evidenceRefs, ...(reasonCodeForTrails ? [reasonCodeForTrails] : [])],
+        enforcedAt,
+        witnessService: deps.witnessService,
+      });
+    } catch (err) {
+      deps.logger?.warn?.('supervisor.enforcement_witness_failed', {
+        sup_code: violation.supCode,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      deps.metric?.('supervisor_enforcement_witness_failed_total', {
+        sup_code: violation.supCode,
+      });
+    }
+  }
+
+  return enforcementResult;
+}

--- a/self/subcortex/supervisor/src/index.ts
+++ b/self/subcortex/supervisor/src/index.ts
@@ -16,7 +16,16 @@ export {
   SupervisorService,
   createSupervisorService,
   type SupervisorServiceDeps,
+  type SupervisorEnforcementSlot,
 } from './supervisor-service.js';
+export {
+  enforce,
+  EnforcementContractDefectError,
+  type EnforcementDeps,
+  type EnforcementResult,
+  type EnforcementOpctlService,
+  type ProofIssuer,
+} from './enforcement.js';
 export {
   SupervisorOutboxSink,
   type SupervisorOutboxSinkDeps,

--- a/self/subcortex/supervisor/src/supervisor-service.ts
+++ b/self/subcortex/supervisor/src/supervisor-service.ts
@@ -53,6 +53,21 @@ import {
 import type { AgentClassToolSurfaceRegistry } from './agent-class-tool-surface.js';
 import type { BudgetReadonlyView } from './detection/types.js';
 import { emitDetectionWitness } from './witness-emission.js';
+import type { EnforcementDeps, EnforcementResult } from './enforcement.js';
+
+/**
+ * WR-162 SP 5 — `SupervisorServiceDeps.enforcement` slot shape.
+ * Additive and optional; SP 4 baseline tests construct `SupervisorService`
+ * without this slot and continue to hit the `onEnforcementDispatch`
+ * log-stub fallback. SP 5 production (bootstrap) supplies both.
+ */
+export interface SupervisorEnforcementSlot {
+  readonly enforce: (
+    violation: SupervisorViolationRecord,
+    deps: EnforcementDeps,
+  ) => Promise<EnforcementResult>;
+  readonly deps: EnforcementDeps;
+}
 
 /** Default ring-buffer capacity when `config.maxObservationQueueDepth` is absent. */
 const DEFAULT_MAX_DEPTH = 1024;
@@ -101,6 +116,20 @@ export interface SupervisorServiceDeps {
   readEventsForAuthorization?: DetectorContextFactoryDeps['readEventsForAuthorization'];
   /** Metric counter hook — default is a no-op. */
   metric?: SupervisorMetricCounter;
+  /**
+   * WR-162 SP 5 — production enforcement slot (SUPV-SP5-005).
+   *
+   * When provided, `processRecord` routes via
+   * `await deps.enforcement.enforce(finalized, deps.enforcement.deps)`
+   * instead of the SP 4 log-stub `onEnforcementDispatch`. Errors thrown
+   * by `enforce` are caught in `processRecord` and surfaced via metric
+   * + log (`supervisor_enforcement_threw_total`) without propagating
+   * to the outer classify loop.
+   *
+   * When absent (SP 4 baseline), `onEnforcementDispatch` remains the
+   * enforcement path so pre-existing tests continue to pass.
+   */
+  enforcement?: SupervisorEnforcementSlot;
 }
 
 type IdentityNullReason =
@@ -136,6 +165,9 @@ export class SupervisorService implements ISupervisorService {
   private readonly detectorContextFactory: DetectorContextFactory | null;
   private readonly metric: SupervisorMetricCounter;
   private readonly sup006DedupSeen = new Set<string>();
+  // WR-162 SP 5 — production enforcement slot (SUPV-SP5-005). Null when
+  // unset; `processRecord` falls back to `onEnforcementDispatch`.
+  private readonly enforcement: SupervisorEnforcementSlot | null;
 
   constructor(private readonly deps: SupervisorServiceDeps = {}) {
     this.now = deps.now ?? (() => new Date().toISOString());
@@ -159,6 +191,7 @@ export class SupervisorService implements ISupervisorService {
         });
       });
     this.metric = deps.metric ?? ((): void => undefined);
+    this.enforcement = deps.enforcement ?? null;
     // Build the default detector context factory when overrides aren't
     // provided AND witnessService is available. When neither is available,
     // runClassifier is disabled regardless of `supervisorEnabled` (the
@@ -392,7 +425,26 @@ export class SupervisorService implements ISupervisorService {
       SUPERVISOR_INVARIANT_SEVERITY_MAP[
         parsed.data.supCode as keyof typeof SUPERVISOR_INVARIANT_SEVERITY_MAP
       ]?.enforcement;
-    if (supervisorAction !== undefined) {
+    // WR-162 SP 5 — SUPV-SP5-005 production routing. When the
+    // enforcement slot is wired (bootstrap path), dispatch to the
+    // real `enforce(...)` function fire-and-await. Errors are caught
+    // here so the outer classify loop continues processing subsequent
+    // records (no propagation). When the slot is absent (SP 4 baseline
+    // test path), fall back to the log-stub `onEnforcementDispatch`.
+    if (this.enforcement !== null) {
+      try {
+        await this.enforcement.enforce(parsed.data, this.enforcement.deps);
+      } catch (err) {
+        this.log?.error?.('supervisor.enforcement_threw', {
+          sup_code: parsed.data.supCode,
+          severity: parsed.data.severity,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        this.metric('supervisor_enforcement_threw_total', {
+          sup_code: parsed.data.supCode,
+        });
+      }
+    } else if (supervisorAction !== undefined) {
       this.onEnforcementDispatch(parsed.data, supervisorAction);
     }
   }

--- a/self/subcortex/supervisor/src/witness-emission.ts
+++ b/self/subcortex/supervisor/src/witness-emission.ts
@@ -36,16 +36,17 @@ export async function emitDetectionWitness(
     code: violation.supCode as InvariantCode,
     actionCategory: 'supervisor-detection',
     actionRef: `${violation.supCode}-${violation.runId}`,
-    actor: 'system',
+    // WR-162 SP 5 — SUPV-SP5-008. Flipped from 'system' to 'supervisor'
+    // post-`WitnessActorSchema` widening (SUPV-SP5-007). The SP 4
+    // `supervisorActor` breadcrumb is dropped — the actor field is now
+    // the authoritative carrier.
+    actor: 'supervisor',
     detail: {
       severity: violation.severity,
       agentId: violation.agentId,
       agentClass: violation.agentClass,
       runId: violation.runId,
       projectId: violation.projectId,
-      // SUPV-SP4-008 forward-compat breadcrumb. SP 5 widens
-      // `WitnessActorSchema` to include 'supervisor' and flips `actor`.
-      supervisorActor: 'supervisor',
       reason: args.reason ?? '',
       evidenceFromDetector: args.evidenceFromDetector ?? {},
     },
@@ -81,7 +82,8 @@ export async function emitEnforcementWitness(
     code: args.supCode as InvariantCode,
     actionCategory: 'supervisor-enforcement',
     actionRef: `${args.supCode}-${args.commandId}`,
-    actor: 'system',
+    // WR-162 SP 5 — SUPV-SP5-008 flip (see `emitDetectionWitness`).
+    actor: 'supervisor',
     detail: {
       severity: args.severity,
       action: args.action,
@@ -90,7 +92,6 @@ export async function emitEnforcementWitness(
       agentClass: args.agentClass,
       runId: args.runId,
       projectId: args.projectId,
-      supervisorActor: 'supervisor',
       evidenceRefs: [...args.evidenceRefs],
     },
     occurredAt: args.enforcedAt,


### PR DESCRIPTION
## Summary

- Lands the SP 5 enforcement path closing detection → enforcement for S0/S1 SupervisorViolationRecords.
- `WitnessActorSchema` widens with `'supervisor'` literal; witness-emission flips `actor: 'system'` → `actor: 'supervisor'` and drops the SP 4 `supervisorActor` breadcrumb (SUPV-SP4-008 closure).
- New `@nous/subcortex-supervisor/enforcement.ts` module — first production caller of `emitEnforcementWitness` (SUPV-SP4-010 resolution). Exhaustive switch on ratified `OpctlSubmitResult.status` with `EnforcementContractDefectError` throw on unknown (no heuristic bandaid).
- `@nous/subcortex-opctl` extends `ProjectControlStateStore` with `supervisor_enforcement_lock` boolean + provenance, authorization-region allowlist for supervisor actor, ESC-001 resume-lock gate, and `issueSupervisorProof` helper (SUPV-SP5-004 path (b) — SP 7 swaps to `issueSystemProof`).
- `@nous/apps-shared-server` bootstrap threads production `EnforcementDeps` into `SupervisorService`. Additive wire-through.
- BT deferred per sprint's `index.md § Behavioral Testing Cadence` — unbroken SP 1 → SP 5 deferral chain.

## Test plan

- [x] `pnpm typecheck` — 0 errors workspace-wide.
- [x] `pnpm lint` — 0 errors, 150 warnings (delta −2 vs SP 4 baseline 152).
- [x] `pnpm build` — workspace graph clean.
- [x] `@nous/shared` — 1146 tests / 94 files green (UT-SH1 locks widening regression floor).
- [x] `@nous/subcortex-opctl` — 54 tests / 11 files green (UT-OP1..UT-OP8).
- [x] `@nous/subcortex-supervisor` — 128 tests / 23 files green (UT-EN1..UT-EN10 + UT-SV1..UT-SV4 + IT-SP5-1 + UT-W1/UT-W3 post-flip).
- [x] `@nous/subcortex-witnessd` — 31 tests / 4 files green (regression floor post-widening; zero SP 5 code edits).
- [x] IT-SP5-1 end-to-end assertions: SUP-001 seed → `applied` + lock set + EventBus emit + witness row + ESC-001 matrix (supervisor/operator reject, principal+validT3 apply + clear, principal+invalidT3 reject with lock stays) + SUPV-SP3-002 disabled-replay (zero side effects).
- [ ] Installer verification — deferred per WR-162 § Deferred Scope Matrix (re-runs at phase close).
- [ ] Behavioral testing — deferred to Phase 1 close per `index.md § Behavioral Testing Cadence`.