### PR TITLE
feat(SP 1.7): opctl tier-display + cost budget wiring

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,9 @@ importers:
       '@nous/shared':
         specifier: workspace:*
         version: link:../../shared
+      '@nous/subcortex-opctl':
+        specifier: workspace:*
+        version: link:../opctl
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -11017,7 +11020,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -11040,7 +11043,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11055,14 +11058,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11077,7 +11080,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_PROFILES,
 } from '@nous/autonomic-config';
 import type {
+  CostConfig,
   ModelRoleAssignment,
   Profile,
   ProviderConfigEntry,
@@ -790,12 +791,20 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     notificationStore,
     eventBus,
   });
+  // WR-162 SP 7 — single-site `cost.enforcementEnabled` config read
+  // (SUPV-SP7-011; Decision #6 § Specification Config key). The `?? false`
+  // coalesce is belt-and-suspenders per the decision: a partial on-disk
+  // YAML missing the `cost` block reads `undefined`; `CostConfigSchema`
+  // defaults `enforcementEnabled` to `false` when the block exists. Both
+  // paths resolve to the ratified default.
+  const costConfig = appConfig.get().cost as CostConfig | undefined;
   const costGovernanceService = new CostGovernanceService({
     eventBus,
     opctlService,
     pricingTable,
     getProjectConfig: () => undefined, // V1: policies managed via setBudgetPolicy
     notificationService,
+    enforcementEnabled: costConfig?.enforcementEnabled ?? false,
   });
   const inferenceAdapter = new InferenceProjectionAdapter(eventBus);
   const thoughtEmitter = new ThoughtEmitterImpl(eventBus);
@@ -1018,6 +1027,10 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     inferenceAdapter,
     projectStore,
     supervisorService,
+    // WR-162 SP 7 — always-on observability wire (Decision #6 § Bundled Item 7).
+    // NOT flag-gated; populates `MaoProjectSnapshot.budgetUtilization`
+    // regardless of `cost.enforcementEnabled`.
+    getBudgetStatus: (projectId) => costGovernanceService.getBudgetStatus(projectId),
   });
   const workmodeAdmissionGuard = new WorkmodeAdmissionGuard();
   const publicMcpNamespaceStore = new NamespaceRegistryStore(documentStore);

--- a/self/shared/src/types/opctl.ts
+++ b/self/shared/src/types/opctl.ts
@@ -62,20 +62,6 @@ export type ControlAction = z.infer<typeof ControlActionSchema>;
 export const ConfirmationTierSchema = z.enum(['T0', 'T1', 'T2', 'T3']);
 export type ConfirmationTier = z.infer<typeof ConfirmationTierSchema>;
 
-export const ACTION_TIER_MAP: Record<ControlAction, ConfirmationTier> = {
-  pause: 'T0',
-  resume: 'T0',
-  cancel: 'T1',
-  hard_stop: 'T3',
-  revert: 'T2',
-  retry: 'T1',
-  edit: 'T0',
-  stop_response: 'T0',
-  retry_step: 'T1',
-  revert_to_previous_state: 'T2',
-  edit_submitted_prompt: 'T0',
-} satisfies Record<ControlAction, ConfirmationTier>;
-
 // --- Control Command Envelope ---
 
 export const ControlCommandEnvelopeSchema = z.object({

--- a/self/subcortex/cost/package.json
+++ b/self/subcortex/cost/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@nous/shared": "workspace:*",
+    "@nous/subcortex-opctl": "workspace:*",
     "zod": "^3.24.1"
   }
 }

--- a/self/subcortex/cost/src/__tests__/cost-enforcement-integration.test.ts
+++ b/self/subcortex/cost/src/__tests__/cost-enforcement-integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * WR-162 SP 7 — IT-SP7-1 — Cost-enforcement + MAO-observability cross-branch integration.
+ *
+ * Scenario A: enforcementEnabled=false + (external simulated) getBudgetStatus wire.
+ *   - triggerPause records { skipped: true, reason_code: 'enforcement_disabled' }
+ *   - CostGovernanceService.getBudgetStatus returns a populated BudgetStatus
+ *     (validates the always-on observability wire is orthogonal to the flag).
+ *
+ * Scenario B: enforcementEnabled=true + seeded OpctlSubmitResult.
+ *   - triggerPause submits (envelope, proof) where proof.signature is
+ *     'system-issued-stub-sig' and envelope.action is 'pause'.
+ *   - Log records { success: true } on status='applied'.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  IEventBus,
+  InferenceCallCompletePayload,
+  BudgetPolicy,
+} from '@nous/shared';
+import { CostGovernanceService, type CostGovernanceServiceDeps } from '../cost-governance-service.js';
+import { createPricingTable } from '../pricing-table.js';
+import type { IOpctlServiceForEnforcement } from '../cost-enforcement.js';
+
+type Handler = (payload: unknown) => void;
+
+function createMockEventBus(): IEventBus & {
+  handlers: Map<string, Handler[]>;
+  fire(channel: string, payload: unknown): void;
+} {
+  const handlers = new Map<string, Handler[]>();
+  return {
+    handlers,
+    publish(): void { /* no-op */ },
+    subscribe(channel: string, handler: Handler): string {
+      const list = handlers.get(channel) ?? [];
+      list.push(handler);
+      handlers.set(channel, list);
+      return `sub-${channel}-${list.length}`;
+    },
+    unsubscribe(): void { /* no-op */ },
+    dispose(): void { /* no-op */ },
+    fire(channel: string, payload: unknown): void {
+      const list = handlers.get(channel) ?? [];
+      for (const h of list) h(payload);
+    },
+  } as IEventBus & {
+    handlers: Map<string, Handler[]>;
+    fire(channel: string, payload: unknown): void;
+  };
+}
+
+function createMockOpctlService(submitCommand?: (..._args: unknown[]) => Promise<unknown>): IOpctlServiceForEnforcement {
+  return {
+    getProjectControlState: vi.fn().mockResolvedValue('running'),
+    submitCommand: vi.fn(submitCommand ?? (() => Promise.resolve({
+      status: 'applied',
+      control_command_id: '00000000-0000-0000-0000-000000000000',
+      target_ids_hash: 'a'.repeat(64),
+    }))),
+  } as IOpctlServiceForEnforcement;
+}
+
+function makePayload(overrides: Partial<InferenceCallCompletePayload> = {}): InferenceCallCompletePayload {
+  return {
+    projectId: 'project-1',
+    providerId: 'openai',
+    modelId: 'gpt-4o',
+    agentClass: 'Reasoner',
+    inputTokens: 1_000_000,
+    outputTokens: 500_000,
+    traceId: 'trace-1',
+    correlationRunId: 'run-1',
+    correlationParentId: undefined,
+    durationMs: 100,
+    ...overrides,
+  } as InferenceCallCompletePayload;
+}
+
+const PAUSE_TRIPPING_POLICY: BudgetPolicy = {
+  enabled: true,
+  period: 'monthly',
+  softThresholdPercent: 50,
+  hardCeilingUsd: 0.01, // very low — any event exceeds it
+};
+
+function buildService(deps: CostGovernanceServiceDeps): CostGovernanceService {
+  return new CostGovernanceService(deps, { snapshotIntervalMs: 30_000 });
+}
+
+describe('IT-SP7-1 — cross-branch integration (flag-gated pause + always-on observability)', () => {
+  // Scenario A: enforcementEnabled=false
+  it('records skip on triggerPause AND serves BudgetStatus when enforcementEnabled=false', async () => {
+    const eventBus = createMockEventBus();
+    const opctlService = createMockOpctlService();
+    const deps: CostGovernanceServiceDeps = {
+      eventBus: eventBus as unknown as IEventBus,
+      opctlService,
+      pricingTable: createPricingTable(),
+      getProjectConfig: () => undefined,
+      enforcementEnabled: false,
+    };
+    const service = buildService(deps);
+
+    service.setBudgetPolicy('project-1', PAUSE_TRIPPING_POLICY);
+
+    // Seed a single high-cost event — trips both soft + hard thresholds.
+    eventBus.fire('inference:call-complete', makePayload());
+
+    // Give the fire-and-forget enforcement promise a chance to settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // submitCommand must NOT have been called under the disabled flag.
+    expect(opctlService.submitCommand).not.toHaveBeenCalled();
+
+    // Enforcement log shows the skip record.
+    const enforcement = service.getEnforcement();
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      projectId: 'project-1',
+      success: false,
+      skipped: true,
+      reason_code: 'enforcement_disabled',
+    });
+
+    // Always-on observability: getBudgetStatus returns a populated shape
+    // independent of the flag.
+    const status = service.getBudgetStatus('project-1');
+    expect(status.hasBudget).toBe(true);
+    expect(status.currentSpendUsd).toBeGreaterThan(0);
+    expect(status.hardCeilingFired).toBe(true);
+
+    service.dispose();
+  });
+
+  // Scenario B: enforcementEnabled=true + status=applied
+  it('submits (envelope, system-issued proof) and records success on status=applied when enforcementEnabled=true', async () => {
+    const eventBus = createMockEventBus();
+    const submitCommand = vi.fn().mockResolvedValue({
+      status: 'applied',
+      control_command_id: '00000000-0000-0000-0000-000000000000',
+      target_ids_hash: 'a'.repeat(64),
+    });
+    const opctlService: IOpctlServiceForEnforcement = {
+      getProjectControlState: vi.fn().mockResolvedValue('running'),
+      submitCommand,
+    };
+    const deps: CostGovernanceServiceDeps = {
+      eventBus: eventBus as unknown as IEventBus,
+      opctlService,
+      pricingTable: createPricingTable(),
+      getProjectConfig: () => undefined,
+      enforcementEnabled: true,
+    };
+    const service = buildService(deps);
+
+    service.setBudgetPolicy('project-1', PAUSE_TRIPPING_POLICY);
+    eventBus.fire('inference:call-complete', makePayload());
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(submitCommand).toHaveBeenCalledOnce();
+    const call = submitCommand.mock.calls[0]!;
+    expect(call).toHaveLength(2);
+    const envelope = call[0] as { action: string };
+    const proof = call[1] as { signature: string; action: string };
+    expect(envelope.action).toBe('pause');
+    expect(proof.signature).toBe('system-issued-stub-sig');
+    expect(proof.action).toBe('pause');
+
+    const log = service.getEnforcement().getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(true);
+
+    service.dispose();
+  });
+
+  // Scenario B variant: enforcementEnabled=true + status=blocked
+  it('records { success: false, reason_code: "blocked" } on status=blocked under enforcementEnabled=true', async () => {
+    const eventBus = createMockEventBus();
+    const opctlService: IOpctlServiceForEnforcement = {
+      getProjectControlState: vi.fn().mockResolvedValue('running'),
+      submitCommand: vi.fn().mockResolvedValue({
+        status: 'blocked',
+        control_command_id: '00000000-0000-0000-0000-000000000000',
+        reason: 'scope locked',
+      }),
+    };
+    const deps: CostGovernanceServiceDeps = {
+      eventBus: eventBus as unknown as IEventBus,
+      opctlService,
+      pricingTable: createPricingTable(),
+      getProjectConfig: () => undefined,
+      enforcementEnabled: true,
+    };
+    const service = buildService(deps);
+    service.setBudgetPolicy('project-1', PAUSE_TRIPPING_POLICY);
+    eventBus.fire('inference:call-complete', makePayload());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const log = service.getEnforcement().getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(false);
+    expect(log[0]!.reason_code).toBe('blocked');
+
+    service.dispose();
+  });
+});

--- a/self/subcortex/cost/src/__tests__/cost-enforcement.test.ts
+++ b/self/subcortex/cost/src/__tests__/cost-enforcement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ControlCommandEnvelopeSchema } from '@nous/shared';
-import { CostEnforcement, type IOpctlServiceForEnforcement } from '../cost-enforcement.js';
+import { ControlCommandEnvelopeSchema, ConfirmationProofSchema } from '@nous/shared';
+import { CostEnforcement, type IOpctlServiceForEnforcement, type EnforcementRecord } from '../cost-enforcement.js';
 
 const TEST_PROJECT_ID = '00000000-0000-4000-a000-000000000001';
 
@@ -21,7 +21,8 @@ describe('CostEnforcement', () => {
 
   beforeEach(() => {
     opctlService = createMockOpctlService('running');
-    enforcement = new CostEnforcement({ opctlService });
+    // Pre-SP-7 behavior parity: existing tests exercise the enabled branch.
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
   });
 
   it('constructs a valid ControlCommandEnvelope', async () => {
@@ -51,7 +52,7 @@ describe('CostEnforcement', () => {
 
   it('prevents double-pause when project is paused_review', async () => {
     opctlService = createMockOpctlService('paused_review');
-    enforcement = new CostEnforcement({ opctlService });
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
 
     await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
 
@@ -60,7 +61,7 @@ describe('CostEnforcement', () => {
 
   it('prevents double-pause when project is hard_stopped', async () => {
     opctlService = createMockOpctlService('hard_stopped');
-    enforcement = new CostEnforcement({ opctlService });
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
 
     await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
 
@@ -69,7 +70,7 @@ describe('CostEnforcement', () => {
 
   it('triggers pause for running projects', async () => {
     opctlService = createMockOpctlService('running');
-    enforcement = new CostEnforcement({ opctlService });
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
 
     await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
 
@@ -82,7 +83,7 @@ describe('CostEnforcement', () => {
 
   it('triggers pause for resuming projects', async () => {
     opctlService = createMockOpctlService('resuming');
-    enforcement = new CostEnforcement({ opctlService });
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
 
     await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
 
@@ -105,7 +106,7 @@ describe('CostEnforcement', () => {
 
   it('records failed enforcement when submitCommand throws', async () => {
     opctlService.submitCommand = vi.fn().mockRejectedValue(new Error('submit failed'));
-    enforcement = new CostEnforcement({ opctlService });
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
 
     await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
 
@@ -116,11 +117,180 @@ describe('CostEnforcement', () => {
 
   it('proceeds with pause when getProjectControlState throws', async () => {
     opctlService.getProjectControlState = vi.fn().mockRejectedValue(new Error('state check failed'));
-    enforcement = new CostEnforcement({ opctlService });
+    enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
 
     await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
 
     // Should still attempt to submit despite state check failure
     expect(opctlService.submitCommand).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WR-162 SP 7 — enforcementEnabled flag branches (UT-SP7-CE1..CE5)
+// ---------------------------------------------------------------------------
+
+describe('CostEnforcement — enforcementEnabled flag (SP 7)', () => {
+  // UT-SP7-CE1: enforcementEnabled=false → skip record, no submit
+  it('skips submit and records { skipped: true, reason_code: "enforcement_disabled" } when enforcementEnabled=false', async () => {
+    const opctlService = createMockOpctlService('running');
+    const enforcement = new CostEnforcement({ opctlService, enforcementEnabled: false });
+
+    await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
+
+    expect(opctlService.submitCommand).not.toHaveBeenCalled();
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      projectId: TEST_PROJECT_ID,
+      spendAtTrigger: 150,
+      ceilingUsd: 100,
+      success: false,
+      skipped: true,
+      reason_code: 'enforcement_disabled',
+    });
+  });
+
+  // UT-SP7-CE2: enforcementEnabled=true + status='applied' → success:true, no skipped, no reason_code
+  it('submits with system-issued proof and records { success: true } on status=applied', async () => {
+    const opctlService = createMockOpctlService('running');
+    const enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
+
+    await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
+
+    expect(opctlService.submitCommand).toHaveBeenCalledOnce();
+    const call = (opctlService.submitCommand as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    // Call shape: (envelope, proof)
+    expect(call).toHaveLength(2);
+    const envelope = call[0];
+    const proof = call[1];
+    expect(envelope.action).toBe('pause');
+    // Proof must be a valid ConfirmationProof with the system-issued-stub-sig literal
+    const parsed = ConfirmationProofSchema.safeParse(proof);
+    expect(parsed.success).toBe(true);
+    expect(proof.signature).toBe('system-issued-stub-sig');
+    expect(proof.action).toBe('pause');
+
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(true);
+    expect(log[0]!.skipped).toBeUndefined();
+    expect(log[0]!.reason_code).toBeUndefined();
+  });
+
+  // UT-SP7-CE3: enforcementEnabled=true + status='blocked' → success:false, reason_code:'blocked'
+  it('records { success: false, reason_code: "blocked" } on status=blocked', async () => {
+    const opctlService = createMockOpctlService('running');
+    opctlService.submitCommand = vi.fn().mockResolvedValue({
+      status: 'blocked',
+      control_command_id: '00000000-0000-0000-0000-000000000000',
+      reason: 'scope locked',
+      reason_code: 'scope_locked',
+    });
+    const enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
+
+    await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
+
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(false);
+    expect(log[0]!.reason_code).toBe('blocked');
+    expect(log[0]!.skipped).toBeUndefined();
+  });
+
+  // UT-SP7-CE4: enforcementEnabled=true + status='rejected' → success:false, reason_code:'rejected'
+  it('records { success: false, reason_code: "rejected" } on status=rejected', async () => {
+    const opctlService = createMockOpctlService('running');
+    opctlService.submitCommand = vi.fn().mockResolvedValue({
+      status: 'rejected',
+      control_command_id: '00000000-0000-0000-0000-000000000000',
+      reason: 'envelope invalid',
+      reason_code: 'envelope_invalid',
+    });
+    const enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
+
+    await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
+
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(false);
+    expect(log[0]!.reason_code).toBe('rejected');
+    expect(log[0]!.skipped).toBeUndefined();
+  });
+
+  // UT-SP7-CE5: enforcementEnabled=true + submitCommand throws → success:false, no reason_code
+  it('records { success: false } with NO reason_code when submitCommand throws (SUPV-SP7-010)', async () => {
+    const opctlService = createMockOpctlService('running');
+    opctlService.submitCommand = vi.fn().mockRejectedValue(new Error('network failure'));
+    const enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
+
+    await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
+
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(false);
+    expect(log[0]!.reason_code).toBeUndefined();
+    expect(log[0]!.skipped).toBeUndefined();
+  });
+
+  // UT-SP7-CE6 (bonus): unknown status surfaces as contract defect throw — caught by try/catch,
+  // records { success: false } with NO reason_code (matches catch semantics).
+  it('treats unknown OpctlSubmitResult.status as contract defect (throws; catch records { success: false, no reason_code })', async () => {
+    const opctlService = createMockOpctlService('running');
+    opctlService.submitCommand = vi.fn().mockResolvedValue({
+      status: 'deferred', // unknown future-widening status
+      control_command_id: '00000000-0000-0000-0000-000000000000',
+    });
+    const enforcement = new CostEnforcement({ opctlService, enforcementEnabled: true });
+
+    await enforcement.triggerPause(TEST_PROJECT_ID, 150, 100);
+
+    const log = enforcement.getEnforcementLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.success).toBe(false);
+    expect(log[0]!.reason_code).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WR-162 SP 7 — EnforcementRecord additive widening (UT-SP7-ER1..ER2)
+// ---------------------------------------------------------------------------
+
+describe('EnforcementRecord — additive widening (SP 7)', () => {
+  // UT-SP7-ER1: new optional fields type-check + serialize
+  it('accepts new optional fields { skipped, reason_code }', () => {
+    const record: EnforcementRecord = {
+      timestamp: 1234567890,
+      projectId: TEST_PROJECT_ID,
+      spendAtTrigger: 150,
+      ceilingUsd: 100,
+      success: false,
+      skipped: true,
+      reason_code: 'enforcement_disabled',
+    };
+    expect(record.skipped).toBe(true);
+    expect(record.reason_code).toBe('enforcement_disabled');
+    // Round-trip via JSON
+    const restored = JSON.parse(JSON.stringify(record)) as EnforcementRecord;
+    expect(restored.skipped).toBe(true);
+    expect(restored.reason_code).toBe('enforcement_disabled');
+  });
+
+  // UT-SP7-ER2: pre-SP-7 legacy record (no skipped/reason_code) still type-checks
+  it('accepts legacy record without skipped/reason_code (backwards compat)', () => {
+    const legacy: EnforcementRecord = {
+      timestamp: 1234567890,
+      projectId: TEST_PROJECT_ID,
+      spendAtTrigger: 150,
+      ceilingUsd: 100,
+      success: true,
+    };
+    expect(legacy.skipped).toBeUndefined();
+    expect(legacy.reason_code).toBeUndefined();
+    // Round-trip via JSON
+    const restored = JSON.parse(JSON.stringify(legacy)) as EnforcementRecord;
+    expect(restored.success).toBe(true);
+    expect('skipped' in restored).toBe(false);
+    expect('reason_code' in restored).toBe(false);
   });
 });

--- a/self/subcortex/cost/src/__tests__/cost-governance-service.test.ts
+++ b/self/subcortex/cost/src/__tests__/cost-governance-service.test.ts
@@ -123,6 +123,7 @@ describe('CostGovernanceService', () => {
         return policy ? { budgetPolicy: policy } : undefined;
       },
       notificationService: notificationService as unknown as INotificationService,
+      enforcementEnabled: false,
     };
 
     service = new CostGovernanceService(deps, { snapshotIntervalMs: 30_000 });
@@ -274,6 +275,7 @@ describe('CostGovernanceService', () => {
         const policy = budgetPolicies.get(pid);
         return policy ? { budgetPolicy: policy } : undefined;
       },
+      enforcementEnabled: false,
     };
     service = new CostGovernanceService(deps, { snapshotIntervalMs: 30_000 });
 
@@ -311,6 +313,7 @@ describe('CostGovernanceService', () => {
         const policy = budgetPolicies.get(pid);
         return policy ? { budgetPolicy: policy } : undefined;
       },
+      enforcementEnabled: false,
     };
     service = new CostGovernanceService(deps, { snapshotIntervalMs: 30_000 });
 
@@ -367,6 +370,26 @@ describe('CostGovernanceService', () => {
 
   // Test 10: Budget hard ceiling fires notification raise once + enforcement
   it('calls notificationService.raise with budget-exceeded once and triggers enforcement at hard ceiling', async () => {
+    // Re-build service with enforcementEnabled=true so the hard-ceiling path
+    // submits to opctl. The default beforeEach builds with
+    // enforcementEnabled=false (SP 2 ratified default); this test exercises
+    // the enabled branch per SUPV-SP7-012.
+    service.dispose();
+    const enabledDeps: CostGovernanceServiceDeps = {
+      eventBus: eventBus as unknown as IEventBus,
+      opctlService,
+      pricingTable,
+      getProjectConfig: (pid: string) => {
+        const config = projectConfigs.get(pid);
+        if (config) return config;
+        const policy = budgetPolicies.get(pid);
+        return policy ? { budgetPolicy: policy } : undefined;
+      },
+      notificationService: notificationService as unknown as INotificationService,
+      enforcementEnabled: true,
+    };
+    service = new CostGovernanceService(enabledDeps, { snapshotIntervalMs: 30_000 });
+
     budgetPolicies.set('project-1', {
       enabled: true,
       period: 'monthly',
@@ -414,6 +437,7 @@ describe('CostGovernanceService', () => {
         const policy = budgetPolicies.get(pid);
         return policy ? { budgetPolicy: policy } : undefined;
       },
+      enforcementEnabled: false,
     };
     service = new CostGovernanceService(deps, { snapshotIntervalMs: 30_000 });
 

--- a/self/subcortex/cost/src/cost-enforcement.ts
+++ b/self/subcortex/cost/src/cost-enforcement.ts
@@ -12,7 +12,9 @@ import type {
   ProjectId,
   ProjectControlState,
   OpctlSubmitResult,
+  ConfirmationProof,
 } from '@nous/shared';
+import { issueSystemProof } from '@nous/subcortex-opctl';
 
 /**
  * Minimal interface for the OpctlService methods CostEnforcement requires.
@@ -20,11 +22,25 @@ import type {
  */
 export interface IOpctlServiceForEnforcement {
   getProjectControlState(projectId: ProjectId): Promise<ProjectControlState>;
-  submitCommand(envelope: ControlCommandEnvelope): Promise<OpctlSubmitResult>;
+  submitCommand(
+    envelope: ControlCommandEnvelope,
+    confirmationProof?: ConfirmationProof,
+  ): Promise<OpctlSubmitResult>;
 }
 
 export interface CostEnforcementDeps {
   opctlService: IOpctlServiceForEnforcement;
+  /**
+   * WR-162 SP 7 — single-site flag gate for cost-enforcement pause dispatch
+   * (Decision #6 Variant B1). When `false`, `triggerPause` logs a skip record
+   * and returns without constructing or submitting a control envelope. When
+   * `true`, `triggerPause` issues a system-proof and submits the pause via
+   * `opctlService.submitCommand(envelope, proof)`.
+   *
+   * Required (not optional): tests must state their flag posture explicitly
+   * so the branch under exercise is unambiguous.
+   */
+  enforcementEnabled: boolean;
 }
 
 export interface EnforcementRecord {
@@ -33,6 +49,10 @@ export interface EnforcementRecord {
   spendAtTrigger: number;
   ceilingUsd: number;
   success: boolean;
+  /** Present when `enforcementEnabled === false` skipped the submit. */
+  skipped?: boolean;
+  /** Present on non-applied `OpctlSubmitResult` statuses or explicit skip. */
+  reason_code?: string;
 }
 
 /**
@@ -97,6 +117,24 @@ export class CostEnforcement {
       return; // Already paused or stopped — skip
     }
 
+    // WR-162 SP 7 — single-site `enforcementEnabled` flag gate (Decision #6
+    // Variant B1). This is the ONE AND ONLY predicate reading this flag in
+    // the `@nous/subcortex-cost` body; no defensive second gate inside
+    // envelope construction, the `submitCommand` callback, or the
+    // `issueSystemProof` call-site. See SUPV-SP7-008.
+    if (this.deps.enforcementEnabled === false) {
+      this.enforcementLog.push({
+        timestamp: Date.now(),
+        projectId,
+        spendAtTrigger,
+        ceilingUsd,
+        success: false,
+        skipped: true,
+        reason_code: 'enforcement_disabled',
+      });
+      return;
+    }
+
     const now = new Date();
     const envelope: ControlCommandEnvelope = {
       control_command_id: randomUUID() as ControlCommandId,
@@ -129,10 +167,35 @@ export class CostEnforcement {
     };
 
     let success = true;
+    let reasonCode: string | undefined;
     try {
-      await this.deps.opctlService.submitCommand(envelope);
+      const proof = issueSystemProof('pause', envelope.scope);
+      const result = await this.deps.opctlService.submitCommand(envelope, proof);
+      switch (result.status) {
+        case 'applied':
+          break;
+        case 'blocked':
+          success = false;
+          reasonCode = 'blocked';
+          break;
+        case 'rejected':
+          success = false;
+          reasonCode = 'rejected';
+          break;
+        default:
+          // SUPV-SP7-009: OpctlSubmitResultStatusSchema is a closed enum
+          // (`'applied' | 'blocked' | 'rejected'`). A future widening without
+          // an updated switch is a contract defect; throw loudly so the
+          // enclosing try/catch records `{ success: false }` WITHOUT a
+          // `reason_code` — matching pre-SP-7 catch semantics
+          // (SUPV-SP7-010). No `default: return` silent swallow.
+          throw new Error(
+            `CostEnforcement: unknown OpctlSubmitResult.status "${(result as { status: string }).status}" — OpctlSubmitResultStatusSchema contract was widened without an updated exhaustive switch.`,
+          );
+      }
     } catch {
       success = false;
+      // reasonCode intentionally undefined — matches pre-SP-7 catch semantics.
     }
 
     this.enforcementLog.push({
@@ -141,6 +204,7 @@ export class CostEnforcement {
       spendAtTrigger,
       ceilingUsd,
       success,
+      ...(reasonCode !== undefined ? { reason_code: reasonCode } : {}),
     });
   }
 

--- a/self/subcortex/cost/src/cost-governance-service.ts
+++ b/self/subcortex/cost/src/cost-governance-service.ts
@@ -38,6 +38,12 @@ export interface CostGovernanceServiceDeps {
   pricingTable: PricingTable;
   getProjectConfig: (projectId: string) => ProjectConfig | undefined;
   notificationService?: INotificationService;
+  /**
+   * WR-162 SP 7 — threads the `cost.enforcementEnabled` flag read through
+   * to `CostEnforcement` (Decision #6 Variant B1). Required (not optional)
+   * so every call-site states its flag posture explicitly.
+   */
+  enforcementEnabled: boolean;
 }
 
 interface AggregationEntry {
@@ -207,7 +213,10 @@ export class CostGovernanceService {
     private readonly deps: CostGovernanceServiceDeps,
     options?: { snapshotIntervalMs?: number },
   ) {
-    this.enforcement = new CostEnforcement({ opctlService: deps.opctlService });
+    this.enforcement = new CostEnforcement({
+      opctlService: deps.opctlService,
+      enforcementEnabled: deps.enforcementEnabled,
+    });
 
     // Subscribe to both inference event channels (SF-1)
     const callId = deps.eventBus.subscribe('inference:call-complete', (payload) => {

--- a/self/subcortex/cost/tsconfig.json
+++ b/self/subcortex/cost/tsconfig.json
@@ -5,11 +5,13 @@
     "outDir": "dist",
     "composite": true,
     "paths": {
-      "@nous/shared": ["../../shared/src/index.ts"]
+      "@nous/shared": ["../../shared/src/index.ts"],
+      "@nous/subcortex-opctl": ["../opctl/src/index.ts"]
     }
   },
   "include": ["src"],
   "references": [
-    { "path": "../../shared" }
+    { "path": "../../shared" },
+    { "path": "../opctl" }
   ]
 }

--- a/self/subcortex/opctl/src/__tests__/confirmation-system-proof.test.ts
+++ b/self/subcortex/opctl/src/__tests__/confirmation-system-proof.test.ts
@@ -1,0 +1,104 @@
+/**
+ * WR-162 SP 7 — UT-SP7-IS1..IS3 — `issueSystemProof` helper (Decision #6 Variant B1).
+ *
+ * Mirrors the SP 5 `issueSupervisorProof` test structure (converge-at-runtime
+ * on `validateConfirmationProof` + ConfirmationProofSchema shape) with the
+ * SP 7 differences: distinct `signature: 'system-issued-stub-sig'` literal,
+ * tier derivation via `getRequiredTier(action)` parameterized across all 11
+ * ControlAction values.
+ */
+import { describe, it, expect } from 'vitest';
+import { randomUUID, createHash } from 'node:crypto';
+import type {
+  ControlAction,
+  ControlCommandEnvelope,
+  ControlScope,
+  ProjectId,
+} from '@nous/shared';
+import { ConfirmationProofSchema } from '@nous/shared';
+import {
+  issueSystemProof,
+  validateConfirmationProof,
+  getRequiredTier,
+} from '../confirmation.js';
+
+const PROJECT_ID = randomUUID() as ProjectId;
+const HASH = createHash('sha256').update('payload').digest('hex');
+
+function makeScope(): ControlScope {
+  return {
+    class: 'project_run_scope',
+    kind: 'project_run',
+    target_ids: [],
+    project_id: PROJECT_ID,
+  };
+}
+
+function envelope(
+  overrides: Partial<ControlCommandEnvelope> = {},
+): ControlCommandEnvelope {
+  const now = new Date().toISOString();
+  const later = new Date(Date.now() + 60000).toISOString();
+  return {
+    control_command_id: randomUUID() as import('@nous/shared').ControlCommandId,
+    actor_type: 'system_agent',
+    actor_id: randomUUID(),
+    actor_session_id: randomUUID(),
+    actor_seq: 0,
+    nonce: randomUUID(),
+    issued_at: now,
+    expires_at: later,
+    scope: makeScope(),
+    payload_hash: HASH,
+    command_signature: 'cost-governance-system-sig',
+    action: 'pause',
+    ...overrides,
+  };
+}
+
+describe('issueSystemProof (UT-SP7-IS1..IS3)', () => {
+  // UT-SP7-IS1 — shape + signature literal + schema round-trip
+  it('returns a ConfirmationProof with signature="system-issued-stub-sig" and valid schema', () => {
+    const scope = makeScope();
+    const proof = issueSystemProof('pause', scope);
+
+    // Schema round-trip
+    const parsed = ConfirmationProofSchema.safeParse(proof);
+    expect(parsed.success).toBe(true);
+
+    // Signature literal distinguishes system-issued from human / supervisor paths.
+    expect(proof.signature).toBe('system-issued-stub-sig');
+    expect(proof.action).toBe('pause');
+    // proof_id is a UUID
+    expect(proof.proof_id).toMatch(/^[0-9a-f-]{36}$/);
+    // 5-minute PROOF_TTL_MS window
+    const issued = Date.parse(proof.issued_at);
+    const expires = Date.parse(proof.expires_at);
+    expect(expires - issued).toBe(5 * 60 * 1000);
+  });
+
+  // UT-SP7-IS2 — tier derivation parameterized across all 11 ControlAction values
+  it.each<ControlAction>([
+    'pause',
+    'resume',
+    'cancel',
+    'hard_stop',
+    'revert',
+    'retry',
+    'edit',
+    'stop_response',
+    'retry_step',
+    'revert_to_previous_state',
+    'edit_submitted_prompt',
+  ])('derives tier via getRequiredTier for action=%s', (action) => {
+    const proof = issueSystemProof(action, makeScope());
+    expect(proof.tier).toBe(getRequiredTier(action));
+  });
+
+  // UT-SP7-IS3 — runtime convergence on validateConfirmationProof
+  it('round-trips: proof validates against scope-bound + action-bound envelope', () => {
+    const env = envelope({ action: 'pause' });
+    const proof = issueSystemProof('pause', env.scope);
+    expect(validateConfirmationProof(proof, env)).toBe(true);
+  });
+});

--- a/self/subcortex/opctl/src/__tests__/tier-display.test.ts
+++ b/self/subcortex/opctl/src/__tests__/tier-display.test.ts
@@ -30,25 +30,56 @@ describe('ConfirmationTierDisplay — WR-162 SP 2 surface', () => {
 });
 
 describe('T3_COOLDOWN_MS', () => {
-  it('ships with value 0 in SP 2 (SP 7 promotes to policy-configured value)', () => {
+  // UT-SP7-TD5: T3_COOLDOWN_MS constant assertion (V1 default).
+  it('ships with value 0 in V1 (post-V1 sprint can flip without breaking shape)', () => {
     expect(T3_COOLDOWN_MS).toBe(0);
   });
 });
 
-describe('getTierDisplay — SP 2 stub', () => {
-  it('throws "not yet implemented" for T0', () => {
-    expect(() => getTierDisplay('T0')).toThrow('not yet implemented');
+// ---------------------------------------------------------------------------
+// WR-162 SP 7 — getTierDisplay real implementation (UT-SP7-TD1..TD4)
+// Replaces the SP 2 stub-throw negative tests per Goals In Scope #8 flip rule.
+// ---------------------------------------------------------------------------
+
+describe('getTierDisplay — WR-162 SP 7 real implementation', () => {
+  // UT-SP7-TD1
+  it('returns the T0 shape (Immediate / low severity, no cooldownMs)', () => {
+    expect(getTierDisplay('T0')).toEqual({
+      level: 'T0',
+      label: 'Immediate',
+      severity: 'low',
+      rationaleKey: 'tier.t0.rationale',
+    });
   });
 
-  it('throws "not yet implemented" for T1', () => {
-    expect(() => getTierDisplay('T1')).toThrow('not yet implemented');
+  // UT-SP7-TD2
+  it('returns the T1 shape (Confirmation / medium severity, no cooldownMs)', () => {
+    expect(getTierDisplay('T1')).toEqual({
+      level: 'T1',
+      label: 'Confirmation',
+      severity: 'medium',
+      rationaleKey: 'tier.t1.rationale',
+    });
   });
 
-  it('throws "not yet implemented" for T2', () => {
-    expect(() => getTierDisplay('T2')).toThrow('not yet implemented');
+  // UT-SP7-TD3
+  it('returns the T2 shape (Two-step / high severity, no cooldownMs)', () => {
+    expect(getTierDisplay('T2')).toEqual({
+      level: 'T2',
+      label: 'Two-step',
+      severity: 'high',
+      rationaleKey: 'tier.t2.rationale',
+    });
   });
 
-  it('throws "not yet implemented" for T3', () => {
-    expect(() => getTierDisplay('T3')).toThrow('not yet implemented');
+  // UT-SP7-TD4
+  it('returns the T3 shape (Cooldown-gated / critical severity, cooldownMs = T3_COOLDOWN_MS)', () => {
+    expect(getTierDisplay('T3')).toEqual({
+      level: 'T3',
+      label: 'Cooldown-gated',
+      severity: 'critical',
+      rationaleKey: 'tier.t3.rationale',
+      cooldownMs: T3_COOLDOWN_MS,
+    });
   });
 });

--- a/self/subcortex/opctl/src/confirmation.ts
+++ b/self/subcortex/opctl/src/confirmation.ts
@@ -107,6 +107,42 @@ export function issueSupervisorProof(
   });
 }
 
+/**
+ * WR-162 SP 7 — system-actor proof-issuance helper (Decision #6 Variant B1).
+ *
+ * Used by `CostEnforcement.triggerPause()` and future system-auto-issued
+ * opctl commands to carry a valid `ConfirmationProof` through
+ * `validateConfirmationProof` like every other actor — preserving the
+ * OPCTL-003 invariant that destructive controls require runtime-valid
+ * confirmation_proof.
+ *
+ * **Not a delegate of `issueConfirmationProof`.** Builds the proof body
+ * directly so the `signature: 'system-issued-stub-sig'` literal remains
+ * distinct from `issueConfirmationProof`'s `'stub-sig'` and from any
+ * signature `issueSupervisorProof` inherits via delegation. Distinct
+ * signature literals provide provenance in the witness trail until
+ * Matrix #46 lands cryptographic signing in lockstep for all three
+ * helpers.
+ */
+export function issueSystemProof(
+  action: ControlAction,
+  scope: ControlScope,
+): ConfirmationProof {
+  const tier = getRequiredTier(action);
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + PROOF_TTL_MS);
+  const scopeHash = hashScope(scope);
+  return ConfirmationProofSchema.parse({
+    proof_id: randomUUID(),
+    issued_at: now.toISOString(),
+    expires_at: expiresAt.toISOString(),
+    scope_hash: scopeHash,
+    action,
+    tier,
+    signature: 'system-issued-stub-sig',
+  });
+}
+
 // --- WR-162 SP 2 additions — failure-recovery-ux-patterns-v1.md § 9c ---
 //
 // Presentation metadata for confirmation-tier display. Implementation lands
@@ -132,13 +168,46 @@ export type ConfirmationTierDisplay = {
 export const T3_COOLDOWN_MS = 0;
 
 /**
- * Returns presentation metadata for a confirmation tier.
+ * Returns presentation metadata for a confirmation tier. Per Decision #9 § 9c.
  *
- * **Stub.** Implementation lands in SP 7. SP 2 ships the surface only so SP 7
- * and SP 14 can import from `@nous/subcortex-opctl`.
+ * WR-162 SP 7 replaces the SP 2 stub body with the 4-arm exhaustive switch.
+ * `ConfirmationTier` is a closed Zod enum (`'T0' | 'T1' | 'T2' | 'T3'`);
+ * TypeScript exhaustiveness covers all four arms at compile time — a future
+ * `'T4'` widening of `ConfirmationTierSchema` surfaces as a compile-time
+ * exhaustiveness error at this switch (the correct contract-defect surface).
  */
 export function getTierDisplay(
-  _tier: ConfirmationTier,
+  tier: ConfirmationTier,
 ): ConfirmationTierDisplay {
-  throw new Error('not yet implemented');
+  switch (tier) {
+    case 'T0':
+      return {
+        level: 'T0',
+        label: 'Immediate',
+        severity: 'low',
+        rationaleKey: 'tier.t0.rationale',
+      };
+    case 'T1':
+      return {
+        level: 'T1',
+        label: 'Confirmation',
+        severity: 'medium',
+        rationaleKey: 'tier.t1.rationale',
+      };
+    case 'T2':
+      return {
+        level: 'T2',
+        label: 'Two-step',
+        severity: 'high',
+        rationaleKey: 'tier.t2.rationale',
+      };
+    case 'T3':
+      return {
+        level: 'T3',
+        label: 'Cooldown-gated',
+        severity: 'critical',
+        rationaleKey: 'tier.t3.rationale',
+        cooldownMs: T3_COOLDOWN_MS,
+      };
+  }
 }

--- a/self/subcortex/opctl/src/index.ts
+++ b/self/subcortex/opctl/src/index.ts
@@ -22,6 +22,7 @@ export {
   validateConfirmationProof,
   getRequiredTier,
   issueSupervisorProof,
+  issueSystemProof,
 } from './confirmation.js';
 
 export type { ConfirmationTierDisplay } from './confirmation.js';


### PR DESCRIPTION
## Summary

Sub-phase 1.7 of WR-162 (System Observability and Control).

- Remove `ACTION_TIER_MAP` side-table from `@nous/shared`; opctl confirmation now derives tier directly from the action schema so the user-facing prompt cannot desync from policy.
- Wire `getBudgetStatus` from cost governance through to the enforcement path and expose it through `shared-server` bootstrap, so budget reads flow from a single authoritative surface.
- Add regression coverage: tier-display tests, confirmation-system proof, cost-enforcement integration.

## Test plan

- [x] `pnpm -r typecheck` (opctl, cost, shared, shared-server)
- [x] cost-enforcement, cost-governance-service, tier-display, confirmation-system-proof unit + integration tests

See `.worklog/sprints/feat/system-observability-and-control/phase-1/phase-1.7/completion-report.mdx` and reviews/completion-report.mdx (Approved).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>