### PR TITLE
WR-162 SP 11 — Observe panel keep-mounted tabs + ShellContext runtime + status-bar tRPC aggregator

### DIFF
--- a/self/apps/shared-server/__tests__/health-router.test.ts
+++ b/self/apps/shared-server/__tests__/health-router.test.ts
@@ -4,7 +4,11 @@ import type {
   SystemStatusSnapshot,
   ProviderHealthSnapshot,
   AgentStatusSnapshot,
+  SupervisorStatusSnapshot,
+  BudgetStatus,
+  MaoSystemSnapshot,
 } from '@nous/shared';
+import { StatusBarSnapshotSchema } from '@nous/shared';
 
 /**
  * Mock all router dependencies so we can isolate the health router.
@@ -127,7 +131,16 @@ function createMockHealthAggregator(): IHealthAggregator {
   };
 }
 
-function createMockContext(healthAggregator: IHealthAggregator) {
+interface MockContextOverrides {
+  supervisorService?: { getStatusSnapshot: () => Promise<SupervisorStatusSnapshot> };
+  costGovernanceService?: { getBudgetStatus: (projectId: string) => BudgetStatus };
+  maoProjectionService?: { getSystemSnapshot: (input: { densityMode: 'D1' | 'D2' | 'D3' }) => Promise<MaoSystemSnapshot> };
+}
+
+function createMockContext(
+  healthAggregator: IHealthAggregator,
+  overrides: MockContextOverrides = {},
+) {
   return {
     healthAggregator,
     documentStore: {
@@ -149,7 +162,7 @@ function createMockContext(healthAggregator: IHealthAggregator) {
     getProvider: () => null,
     witnessService: {},
     opctlService: {},
-    maoProjectionService: {},
+    maoProjectionService: overrides.maoProjectionService ?? {},
     gtmGateCalculator: {},
     knowledgeIndex: {},
     workflowEngine: {},
@@ -174,7 +187,91 @@ function createMockContext(healthAggregator: IHealthAggregator) {
     agentSessions: new Map(),
     eventBus: { subscribe: vi.fn(), unsubscribe: vi.fn(), publish: vi.fn() },
     healthMonitor: { check: vi.fn(), getMetrics: vi.fn() },
+    supervisorService: overrides.supervisorService ?? {},
+    costGovernanceService: overrides.costGovernanceService ?? {},
+    notificationService: {},
+    tokenAccumulator: {},
   } as any;
+}
+
+// ---------------------------------------------------------------------------
+// WR-162 SP 11 — getStatusBarSnapshot fixtures.
+// ---------------------------------------------------------------------------
+
+const SP11_NOW = '2026-04-25T12:00:00.000Z';
+
+function createMockSystemStatusForSP11(
+  overrides: Partial<SystemStatusSnapshot['backlogAnalytics']> = {},
+): SystemStatusSnapshot {
+  return {
+    bootStatus: 'ready',
+    completedBootSteps: ['subcortex_initialized', 'principal_booted'],
+    issueCodes: [],
+    inboxReady: true,
+    pendingSystemRuns: 0,
+    backlogAnalytics: {
+      queuedCount: 5,
+      activeCount: 0,
+      suspendedCount: 0,
+      completedInWindow: 0,
+      failedInWindow: 0,
+      pressureTrend: 'stable',
+      ...overrides,
+    },
+    collectedAt: SP11_NOW,
+  };
+}
+
+function createMockSupervisorSnapshot(
+  overrides: Partial<SupervisorStatusSnapshot> = {},
+): SupervisorStatusSnapshot {
+  return {
+    active: true,
+    agentsMonitored: 3,
+    activeViolationCounts: { s0: 0, s1: 0, s2: 0, s3: 0 },
+    lifetime: {
+      violationsDetected: 0,
+      anomaliesClassified: 0,
+      enforcementsApplied: 0,
+    },
+    witnessIntegrity: {
+      lastVerificationAt: SP11_NOW,
+      tipDigest: 'tip',
+      length: 0,
+      verified: true,
+    },
+    riskSummary: {},
+    reportedAt: SP11_NOW,
+    ...overrides,
+  };
+}
+
+function createMockBudgetStatus(overrides: Partial<BudgetStatus> = {}): BudgetStatus {
+  return {
+    hasBudget: true,
+    currentSpendUsd: 14.7,
+    budgetCeilingUsd: 20.0,
+    utilizationPercent: 73.5,
+    softAlertFired: false,
+    hardCeilingFired: false,
+    periodStart: '2026-04-01T00:00:00.000Z',
+    periodEnd: '2026-04-30T23:59:59.000Z',
+    projectControlState: 'running',
+    ...overrides,
+  };
+}
+
+function createMockMaoSnapshot(agentCount: number): MaoSystemSnapshot {
+  // Only the `.agents.length` is read by `safeActiveAgents`; the array
+  // contents are opaque for SP 11 purposes. Cast through `unknown` to
+  // bypass the rich `MaoAgentProjection` shape (owned by SP 1 / SP 8).
+  return {
+    agents: Array.from({ length: agentCount }, () => ({}) as unknown) as MaoSystemSnapshot['agents'],
+    leaseRoots: [],
+    projectControls: {},
+    densityMode: 'D2',
+    generatedAt: SP11_NOW,
+  };
 }
 
 describe('health tRPC router', () => {
@@ -309,6 +406,502 @@ describe('health tRPC router', () => {
       expect(aggregator.getSystemStatus).not.toHaveBeenCalled();
       expect(aggregator.getProviderHealth).not.toHaveBeenCalled();
       expect(aggregator.getAgentStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // WR-162 SP 11 — getStatusBarSnapshot procedure + four `safe*` helpers.
+  //
+  // SUPV-SP11-012 — `safeBackpressure` closed-form try/catch + threshold ladder.
+  // SUPV-SP11-013 — `safeCognitiveProfile` unconditional null (Decision #7 D.2).
+  // SUPV-SP11-014 — `safeBudget` closed-form try/catch + threshold ladder.
+  // SUPV-SP11-015 — `safeActiveAgents` closed-form try/catch.
+  // SUPV-SP11-016 — only-if-all-four-fail four-clause AND throw threshold.
+  // =========================================================================
+
+  describe('health.getStatusBarSnapshot', () => {
+    function makeAggregatorWithSystemStatus(status: SystemStatusSnapshot): IHealthAggregator {
+      return {
+        getSystemStatus: vi.fn().mockReturnValue(status),
+        getProviderHealth: vi.fn().mockReturnValue(createMockProviderHealth()),
+        getAgentStatus: vi.fn().mockReturnValue(createMockAgentStatus()),
+        dispose: vi.fn(),
+      };
+    }
+
+    it('UT-SP11-SAFE-BACKPRESSURE-HAPPY — returns nominal state with queueDepth + activeAgents', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11({ queuedCount: 5 })),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi
+              .fn()
+              .mockResolvedValue(createMockSupervisorSnapshot({ agentsMonitored: 3 })),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(2)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({});
+      expect(result.backpressure).toEqual({ state: 'nominal', queueDepth: 5, activeAgents: 3 });
+    });
+
+    it('UT-SP11-SAFE-BACKPRESSURE-THROW — healthAggregator throw → backpressure null; other slots unaffected', async () => {
+      const aggregator: IHealthAggregator = {
+        getSystemStatus: vi.fn().mockImplementation(() => {
+          throw new Error('boom');
+        }),
+        getProviderHealth: vi.fn().mockReturnValue(createMockProviderHealth()),
+        getAgentStatus: vi.fn().mockReturnValue(createMockAgentStatus()),
+        dispose: vi.fn(),
+      };
+      const ctx = createMockContext(aggregator, {
+        supervisorService: {
+          getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+        },
+        maoProjectionService: {
+          getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(1)),
+        },
+      });
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({});
+      expect(result.backpressure).toBeNull();
+      // Other slots are unaffected — activeAgents non-null because mao didn't throw.
+      expect(result.activeAgents).not.toBeNull();
+    });
+
+    it('UT-SP11-SAFE-BACKPRESSURE-CRITICAL — s0 violation → state=critical', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(
+              createMockSupervisorSnapshot({
+                activeViolationCounts: { s0: 1, s1: 0, s2: 0, s3: 0 },
+              }),
+            ),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({});
+      expect(result.backpressure?.state).toBe('critical');
+    });
+
+    it('UT-SP11-SAFE-BACKPRESSURE-ELEVATED — s1 violation OR rising-equivalent → state=elevated', async () => {
+      // s1 violation
+      const ctx1 = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(
+              createMockSupervisorSnapshot({
+                activeViolationCounts: { s0: 0, s1: 1, s2: 0, s3: 0 },
+              }),
+            ),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller1 = await getCaller(ctx1);
+      const result1 = await caller1.health.getStatusBarSnapshot({});
+      expect(result1.backpressure?.state).toBe('elevated');
+
+      // pressureTrend === 'increasing' (the verified field-name; SDS used
+      // 'rising' which doesn't exist on the schema)
+      const ctx2 = createMockContext(
+        makeAggregatorWithSystemStatus(
+          createMockSystemStatusForSP11({ pressureTrend: 'increasing' }),
+        ),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller2 = await getCaller(ctx2);
+      const result2 = await caller2.health.getStatusBarSnapshot({});
+      expect(result2.backpressure?.state).toBe('elevated');
+    });
+
+    it('UT-SP11-SAFE-COGNITIVE-NULL — cognitiveProfile is null and ctx is never accessed for that slot', async () => {
+      // Build a Proxy that throws on every property read; pass it via the
+      // wider ctx. `safeCognitiveProfile`'s body must NOT touch ctx (Decision
+      // #7 Option D.2). The whole-procedure can still construct because
+      // safeCognitiveProfile uses `_ctx`/`_projectId` and never reads them.
+      let cognitiveCtxAccessed = false;
+      const realCtx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(1)),
+          },
+        },
+      );
+      // Wrap the ctx in a Proxy that flags any access path that mentions
+      // 'cognitive' or 'profile'. (The `safe*` helpers do NOT route through
+      // such a path; the assertion is that no such handle is read.)
+      const trapped = new Proxy(realCtx, {
+        get(target, prop) {
+          if (typeof prop === 'string' && /cognitive|profile/i.test(prop)) {
+            cognitiveCtxAccessed = true;
+          }
+          return Reflect.get(target, prop);
+        },
+      });
+      const caller = await getCaller(trapped);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.cognitiveProfile).toBeNull();
+      expect(cognitiveCtxAccessed).toBe(false);
+    });
+
+    it('UT-SP11-SAFE-BUDGET-HAPPY — nominal: ratio < 75%, no alerts → state=nominal', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi.fn().mockReturnValue(createMockBudgetStatus({ utilizationPercent: 73.5 })),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.budget).toEqual({
+        state: 'nominal',
+        spent: 14.7,
+        ceiling: 20,
+        period: '2026-04-01T00:00:00.000Z',
+      });
+    });
+
+    it('UT-SP11-SAFE-BUDGET-THRESHOLDS — exceeded / caution / warning ladder', async () => {
+      // exceeded
+      const ctx1 = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi
+              .fn()
+              .mockReturnValue(createMockBudgetStatus({ hardCeilingFired: true })),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller1 = await getCaller(ctx1);
+      expect((await caller1.health.getStatusBarSnapshot({ projectId: 'p' })).budget?.state).toBe(
+        'exceeded',
+      );
+
+      // caution
+      const ctx2 = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi
+              .fn()
+              .mockReturnValue(createMockBudgetStatus({ softAlertFired: true })),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller2 = await getCaller(ctx2);
+      expect((await caller2.health.getStatusBarSnapshot({ projectId: 'p' })).budget?.state).toBe(
+        'caution',
+      );
+
+      // warning (>= 75%)
+      const ctx3 = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi
+              .fn()
+              .mockReturnValue(createMockBudgetStatus({ utilizationPercent: 80 })),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller3 = await getCaller(ctx3);
+      expect((await caller3.health.getStatusBarSnapshot({ projectId: 'p' })).budget?.state).toBe(
+        'warning',
+      );
+    });
+
+    it('UT-SP11-SAFE-BUDGET-NO-PROJECT — projectId undefined → budget null and getBudgetStatus is not called', async () => {
+      const getBudgetStatus = vi.fn();
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: { getBudgetStatus },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(1)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({});
+      expect(result.budget).toBeNull();
+      expect(getBudgetStatus).not.toHaveBeenCalled();
+    });
+
+    it('UT-SP11-SAFE-AGENTS-HAPPY — count > 0 → status=active; count = 0 → status=idle', async () => {
+      // active (3 agents)
+      const ctx1 = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(3)),
+          },
+        },
+      );
+      const caller1 = await getCaller(ctx1);
+      const result1 = await caller1.health.getStatusBarSnapshot({});
+      expect(result1.activeAgents).toEqual({ count: 3, status: 'active' });
+
+      // idle (0 agents)
+      const ctx2 = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller2 = await getCaller(ctx2);
+      const result2 = await caller2.health.getStatusBarSnapshot({});
+      expect(result2.activeAgents).toEqual({ count: 0, status: 'idle' });
+    });
+
+    it('UT-SP11-SAFE-BUDGET-NO-HASBUDGET — hasBudget=false → budget null even with valid projectId', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi
+              .fn()
+              .mockReturnValue(createMockBudgetStatus({ hasBudget: false })),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(0)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.budget).toBeNull();
+    });
+
+    it('UT-SP11-SAFE-BUDGET-THROW — costGovernanceService throw → budget null', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi.fn().mockImplementation(() => {
+              throw new Error('budget boom');
+            }),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(1)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.budget).toBeNull();
+    });
+
+    it('UT-SP11-SAFE-AGENTS-THROW — maoProjectionService throw → activeAgents null', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockRejectedValue(new Error('mao boom')),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({});
+      expect(result.activeAgents).toBeNull();
+    });
+
+    // ---- IT-SP11-SNAPSHOT-* integration tests ----
+
+    it('IT-SP11-SNAPSHOT-FULL — all four sources happy → aggregate parses through StatusBarSnapshotSchema (cognitiveProfile structurally null)', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi.fn().mockReturnValue(createMockBudgetStatus()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(2)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      // Parses through the schema (the procedure already uses .output(...))
+      expect(StatusBarSnapshotSchema.safeParse(result).success).toBe(true);
+      // Three of four are non-null; cognitiveProfile is structurally null per
+      // SUPV-SP11-013 (Decision #7 Option D.2).
+      expect(result.backpressure).not.toBeNull();
+      expect(result.budget).not.toBeNull();
+      expect(result.activeAgents).not.toBeNull();
+      expect(result.cognitiveProfile).toBeNull();
+    });
+
+    it('IT-SP11-SNAPSHOT-PARTIAL-BACKPRESSURE-NULL — only backpressure source throws → backpressure null; others unaffected; no throw', async () => {
+      const aggregator: IHealthAggregator = {
+        getSystemStatus: vi.fn().mockImplementation(() => {
+          throw new Error('boom');
+        }),
+        getProviderHealth: vi.fn().mockReturnValue(createMockProviderHealth()),
+        getAgentStatus: vi.fn().mockReturnValue(createMockAgentStatus()),
+        dispose: vi.fn(),
+      };
+      const ctx = createMockContext(aggregator, {
+        supervisorService: {
+          getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+        },
+        costGovernanceService: {
+          getBudgetStatus: vi.fn().mockReturnValue(createMockBudgetStatus()),
+        },
+        maoProjectionService: {
+          getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(1)),
+        },
+      });
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.backpressure).toBeNull();
+      expect(result.budget).not.toBeNull();
+      expect(result.activeAgents).not.toBeNull();
+    });
+
+    it('IT-SP11-SNAPSHOT-PARTIAL-BUDGET-NULL — budget source throws → budget null; others unaffected; no throw', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi.fn().mockImplementation(() => {
+              throw new Error('budget boom');
+            }),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockResolvedValue(createMockMaoSnapshot(1)),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.budget).toBeNull();
+      expect(result.backpressure).not.toBeNull();
+      expect(result.activeAgents).not.toBeNull();
+    });
+
+    it('IT-SP11-SNAPSHOT-PARTIAL-AGENTS-NULL — MAO source throws → activeAgents null; others unaffected; no throw', async () => {
+      const ctx = createMockContext(
+        makeAggregatorWithSystemStatus(createMockSystemStatusForSP11()),
+        {
+          supervisorService: {
+            getStatusSnapshot: vi.fn().mockResolvedValue(createMockSupervisorSnapshot()),
+          },
+          costGovernanceService: {
+            getBudgetStatus: vi.fn().mockReturnValue(createMockBudgetStatus()),
+          },
+          maoProjectionService: {
+            getSystemSnapshot: vi.fn().mockRejectedValue(new Error('mao boom')),
+          },
+        },
+      );
+      const caller = await getCaller(ctx);
+      const result = await caller.health.getStatusBarSnapshot({ projectId: 'project-1' });
+      expect(result.activeAgents).toBeNull();
+      expect(result.backpressure).not.toBeNull();
+      expect(result.budget).not.toBeNull();
+    });
+
+    it('IT-SP11-SNAPSHOT-ALL-NULL-THROW — backpressure + budget + agents all throw + cognitive structurally null → procedure throws', async () => {
+      const aggregator: IHealthAggregator = {
+        getSystemStatus: vi.fn().mockImplementation(() => {
+          throw new Error('boom');
+        }),
+        getProviderHealth: vi.fn().mockReturnValue(createMockProviderHealth()),
+        getAgentStatus: vi.fn().mockReturnValue(createMockAgentStatus()),
+        dispose: vi.fn(),
+      };
+      const ctx = createMockContext(aggregator, {
+        supervisorService: {
+          getStatusSnapshot: vi.fn().mockRejectedValue(new Error('supervisor boom')),
+        },
+        costGovernanceService: {
+          getBudgetStatus: vi.fn().mockImplementation(() => {
+            throw new Error('budget boom');
+          }),
+        },
+        maoProjectionService: {
+          getSystemSnapshot: vi.fn().mockRejectedValue(new Error('mao boom')),
+        },
+      });
+      const caller = await getCaller(ctx);
+      await expect(caller.health.getStatusBarSnapshot({ projectId: 'project-1' })).rejects.toThrow();
     });
   });
 });

--- a/self/apps/shared-server/src/trpc/routers/health.ts
+++ b/self/apps/shared-server/src/trpc/routers/health.ts
@@ -1,8 +1,97 @@
 /**
  * Health tRPC router.
  */
+import { z } from 'zod';
+import {
+  StatusBarSnapshotSchema,
+  type StatusBarBackpressure,
+  type StatusBarBudget,
+  type StatusBarActiveAgents,
+  type StatusBarCognitiveProfile,
+} from '@nous/shared';
+import type { NousContext } from '../../context';
 import { router, publicProcedure } from '../trpc';
 import { getOllamaEndpointFromContext } from '../../ollama-config';
+
+// WR-162 SP 11 (SUPV-SP11-011) — file-scope private helpers. NOT exported.
+// Per SDS-N3 closure (approach a): import the existing `NousContext` type
+// from '../../context'. Phase 0 Task 0c verified the type is exportable.
+// The helpers consume only a subset of `NousContext` fields, but the type
+// is shared with the procedure body so no cast is needed at the call site.
+
+async function safeBackpressure(
+  ctx: NousContext,
+): Promise<StatusBarBackpressure | null> {
+  try {
+    const systemStatus = ctx.healthAggregator.getSystemStatus();
+    const supervisorSnap = await ctx.supervisorService.getStatusSnapshot();
+    const queueDepth = systemStatus.backlogAnalytics.queuedCount;
+    const activeAgents = supervisorSnap.agentsMonitored;
+    // Field-name verified at code-time against `SystemStatusSnapshotSchema`:
+    // `pressureTrend` enum is `'increasing' | 'stable' | 'decreasing'` (NOT
+    // `'rising'`). Map `'increasing'` to the elevated branch.
+    const state: StatusBarBackpressure['state'] =
+      supervisorSnap.activeViolationCounts.s0 > 0
+        ? 'critical'
+        : supervisorSnap.activeViolationCounts.s1 > 0 ||
+            systemStatus.backlogAnalytics.pressureTrend === 'increasing'
+          ? 'elevated'
+          : 'nominal';
+    return { state, queueDepth, activeAgents };
+  } catch {
+    return null;
+  }
+}
+
+// SUPV-SP11-013 — Decision #7 Option D.2: server-side cognitive-profile reads
+// are forbidden in V1. Return `null` unconditionally. Signature accepts both
+// arguments for forward compatibility but the body does not read either.
+async function safeCognitiveProfile(
+  _ctx: NousContext,
+  _projectId: string | undefined,
+): Promise<StatusBarCognitiveProfile | null> {
+  return null;
+}
+
+async function safeBudget(
+  ctx: NousContext,
+  projectId: string | undefined,
+): Promise<StatusBarBudget | null> {
+  try {
+    if (!projectId) return null;
+    const budget = ctx.costGovernanceService.getBudgetStatus(projectId);
+    if (!budget.hasBudget) return null;
+    const ratio = budget.utilizationPercent / 100;
+    const state: StatusBarBudget['state'] = budget.hardCeilingFired
+      ? 'exceeded'
+      : budget.softAlertFired
+        ? 'caution'
+        : ratio >= 0.75
+          ? 'warning'
+          : 'nominal';
+    return {
+      state,
+      spent: budget.currentSpendUsd,
+      ceiling: budget.budgetCeilingUsd,
+      period: budget.periodStart,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function safeActiveAgents(
+  ctx: NousContext,
+): Promise<StatusBarActiveAgents | null> {
+  try {
+    const mao = await ctx.maoProjectionService.getSystemSnapshot({ densityMode: 'D2' });
+    const count = mao.agents.length;
+    const status: StatusBarActiveAgents['status'] = count > 0 ? 'active' : 'idle';
+    return { count, status };
+  } catch {
+    return null;
+  }
+}
 
 export const healthRouter = router({
   check: publicProcedure.query(async ({ ctx }) => {
@@ -69,4 +158,28 @@ export const healthRouter = router({
   agentStatus: publicProcedure.query(({ ctx }) => {
     return ctx.healthAggregator.getAgentStatus();
   }),
+
+  // WR-162 SP 11 (SUPV-SP11-016) — status-bar aggregator. Composes the four
+  // `safe*` helpers into the typed aggregate. Throws only when ALL FOUR slots
+  // return null (Decision #4 Failure Isolation Rule). Three-of-four null is
+  // acceptable; four-of-four is the aggregator-broken signal SP 12 needs
+  // to render an error state.
+  getStatusBarSnapshot: publicProcedure
+    .input(z.object({ projectId: z.string().optional() }))
+    .output(StatusBarSnapshotSchema)
+    .query(async ({ ctx, input }) => {
+      const backpressure = await safeBackpressure(ctx);
+      const cognitiveProfile = await safeCognitiveProfile(ctx, input.projectId);
+      const budget = await safeBudget(ctx, input.projectId);
+      const activeAgents = await safeActiveAgents(ctx);
+      if (
+        backpressure === null &&
+        cognitiveProfile === null &&
+        budget === null &&
+        activeAgents === null
+      ) {
+        throw new Error('status-bar aggregator: all four slots returned null');
+      }
+      return { backpressure, cognitiveProfile, budget, activeAgents };
+    }),
 });

--- a/self/ui/src/components/shell/CollapsibleObserveEdge.tsx
+++ b/self/ui/src/components/shell/CollapsibleObserveEdge.tsx
@@ -3,13 +3,18 @@
 import * as React from 'react'
 import { clsx } from 'clsx'
 import { ChevronLeft, PanelRightClose } from 'lucide-react'
+import { useShellContext } from './ShellContext'
 
-const COLLAPSED_THRESHOLD = 60
 const PEEK_WIDTH = 32
 
 export interface CollapsibleObserveEdgeProps
     extends React.HTMLAttributes<HTMLDivElement> {
-    /** Current observe column width in pixels */
+    /**
+     * Current observe column width in pixels. WR-162 SP 11 (SUPV-SP11-004) —
+     * `width` is now a STYLING-ONLY hint; the canonical collapsed/expanded
+     * state derives from `useShellContext().observePanelCollapsed`. The
+     * pixel width still drives the `width` style on the panel container.
+     */
     width: number
     /** The last expanded width — used to keep the panel at full size when collapsed */
     expandedWidth?: number
@@ -27,11 +32,21 @@ export function CollapsibleObserveEdge({
     style,
     ...props
 }: CollapsibleObserveEdgeProps) {
-    const isCollapsed = width < COLLAPSED_THRESHOLD
+    // SUPV-SP11-004 — `data-state` derives from shell context, not pixel width.
+    const { observePanelCollapsed, setObservePanelCollapsed } = useShellContext()
+    const isCollapsed = observePanelCollapsed
 
     // Panel always renders at full expanded width.
     // When collapsed, the grid column clips it to PEEK_WIDTH — no transform needed.
     const panelWidth = isCollapsed ? expandedWidth : width
+
+    // SUPV-SP11-005 — two-write batched click handler. Both writes happen
+    // inside one synchronous handler; React 18+ automatic batching collapses
+    // them into one re-render.
+    const handleClick = () => {
+        setObservePanelCollapsed(!observePanelCollapsed)
+        onExpandToggle()
+    }
 
     return (
         <div
@@ -54,13 +69,13 @@ export function CollapsibleObserveEdge({
             }}
             {...props}
         >
-            
+
             {/* Expand button */}
             <button
                 type="button"
                 aria-label={isCollapsed ? 'Expand observe panel' : 'Collapse observe panel'}
                 data-action={isCollapsed ? 'expand' : 'collapse'}
-                onClick={onExpandToggle}
+                onClick={handleClick}
                 style={{
                     ...styles.toggleButton,
                     ...(isCollapsed ? {
@@ -84,7 +99,7 @@ export function CollapsibleObserveEdge({
                 type="button"
                 aria-label={isCollapsed ? 'Expand observe panel' : 'Collapse observe panel'}
                 data-action={isCollapsed ? 'expand' : 'collapse'}
-                onClick={onExpandToggle}
+                onClick={handleClick}
                 style={{
                     ...styles.toggleButton,
                     ...(isCollapsed ? {

--- a/self/ui/src/components/shell/ObservePanel.tsx
+++ b/self/ui/src/components/shell/ObservePanel.tsx
@@ -2,32 +2,42 @@
 
 import { clsx } from 'clsx'
 import { useShellContext } from './ShellContext'
-import { MaoPanel } from '../mao'
-import { SystemActivitySurface } from './SystemActivitySurface'
-import type { ObservePanelProps } from './types'
+import type { ObservePanelProps, ObserveTab } from './types'
 
 /**
- * File-local observe-route union. WR-162 SP 2 removes `ObserveRoute` /
- * `OBSERVE_ROUTE_OVERRIDES` from `./types`. This panel keeps its existing
- * route-override behavior verbatim until SP 11 rewires the panel around
- * `ObserveTab`. Runtime behavior here is byte-identical to pre-SP-2.
+ * WR-162 SP 11 (SUPV-SP11-001 + SUPV-SP11-002 + SUPV-SP11-007) —
+ * keep-mounted-hide-inactive observe panel. Three sibling tab slots exist
+ * in the DOM at all times; inactive slots use `display: none`. Three
+ * placeholder children (one per tab) render `null`; SP 12 wires real tab
+ * hosts. The in-panel switcher renders three explicit buttons (closed-enum
+ * shape over `ObserveTab`); clicking a button calls `setActiveObserveTab`
+ * via shell context.
+ *
+ * The previous SP 2 route-conditional dispatch and `OBSERVE_ROUTE_OVERRIDES`
+ * map are removed (Goals SC-2). The panel no longer reads `activeRoute`.
  */
-type LocalObserveRoute = 'mao' | 'default' | 'system-activity'
+const TABS: ReadonlyArray<{ id: ObserveTab; label: string }> = [
+  { id: 'agents', label: 'Agents' },
+  { id: 'system-load', label: 'System Load' },
+  { id: 'cost-monitor', label: 'Cost Monitor' },
+]
 
-/** Routes that get special observe content (non-MAO). Everything else defaults to MAO. */
-const OBSERVE_ROUTE_OVERRIDES: Record<string, LocalObserveRoute> = {
-  home: 'default',
-  'system-activity': 'system-activity',
+function AgentsTabPlaceholder() {
+  return null
+}
+function SystemLoadTabPlaceholder() {
+  return null
+}
+function CostMonitorTabPlaceholder() {
+  return null
 }
 
 export function ObservePanel(props: ObservePanelProps) {
-  const { activeRoute } = useShellContext()
-
-  const observeRoute: LocalObserveRoute = OBSERVE_ROUTE_OVERRIDES[activeRoute] ?? 'mao'
-
+  const { activeObserveTab, setActiveObserveTab } = useShellContext()
   return (
     <div
       className={clsx(props.className)}
+      data-shell-component="observe-panel"
       style={{
         display: 'flex',
         flexDirection: 'column',
@@ -35,26 +45,55 @@ export function ObservePanel(props: ObservePanelProps) {
         color: 'var(--nous-fg)',
       }}
     >
-      {observeRoute === 'mao' ? (
-        <MaoPanel />
-      ) : observeRoute === 'system-activity' ? (
-        <SystemActivitySurface />
-      ) : (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            height: '100%',
-            color: 'var(--nous-fg-subtle)',
-            fontSize: 'var(--nous-font-size-sm)',
-            padding: 'var(--nous-space-2xl)',
-            textAlign: 'center',
-          }}
-        >
-          No observe content for this view
-        </div>
-      )}
+      <div
+        role="tablist"
+        aria-label="Observe panel tabs"
+        data-shell-component="observe-tab-switcher"
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 'var(--nous-space-xs)',
+          padding: 'var(--nous-space-sm)',
+        }}
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeObserveTab === tab.id}
+            data-tab-id={tab.id}
+            data-active={activeObserveTab === tab.id ? 'true' : 'false'}
+            onClick={() => setActiveObserveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div
+        role="tabpanel"
+        data-tab-slot="agents"
+        aria-hidden={activeObserveTab !== 'agents'}
+        style={{ display: activeObserveTab === 'agents' ? 'flex' : 'none', height: '100%' }}
+      >
+        <AgentsTabPlaceholder />
+      </div>
+      <div
+        role="tabpanel"
+        data-tab-slot="system-load"
+        aria-hidden={activeObserveTab !== 'system-load'}
+        style={{ display: activeObserveTab === 'system-load' ? 'flex' : 'none', height: '100%' }}
+      >
+        <SystemLoadTabPlaceholder />
+      </div>
+      <div
+        role="tabpanel"
+        data-tab-slot="cost-monitor"
+        aria-hidden={activeObserveTab !== 'cost-monitor'}
+        style={{ display: activeObserveTab === 'cost-monitor' ? 'flex' : 'none', height: '100%' }}
+      >
+        <CostMonitorTabPlaceholder />
+      </div>
     </div>
   )
 }

--- a/self/ui/src/components/shell/ShellContext.tsx
+++ b/self/ui/src/components/shell/ShellContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, type PropsWithChildren } from 'react'
+import { createContext, useContext, useState, type PropsWithChildren } from 'react'
 import {
   defaultConversationContext,
   type NavigationState,
@@ -31,7 +31,10 @@ export interface ShellProviderProps extends PropsWithChildren {
   navigate?: (routeId: string, params?: Record<string, unknown>) => void
   goBack?: () => void
   onProjectChange?: (projectId: string) => void
-  // --- WR-162 SP 2 additions (contract-only; SP 11 wires useState) ---
+  // --- WR-162 SP 11 (SUPV-SP11-003) — uncontrolled `useState` pattern ---
+  // Host-provided values seed initial state on mount; host-provided setters
+  // are forward-invoked alongside the internal setter so a host can observe
+  // state changes without owning them.
   activeObserveTab?: ObserveTab
   setActiveObserveTab?: (tab: ObserveTab) => void
   observePanelCollapsed?: boolean
@@ -52,12 +55,30 @@ export function ShellProvider({
   navigate = noop,
   goBack = noop,
   onProjectChange,
-  activeObserveTab = 'agents',
-  setActiveObserveTab = noop,
-  observePanelCollapsed = false,
-  setObservePanelCollapsed = noop,
+  activeObserveTab: activeObserveTabProp,
+  setActiveObserveTab: setActiveObserveTabProp,
+  observePanelCollapsed: observePanelCollapsedProp,
+  setObservePanelCollapsed: setObservePanelCollapsedProp,
 }: ShellProviderProps) {
   const resolvedActiveRoute = navigation?.activeRoute ?? activeRoute
+
+  // SP 11 SUPV-SP11-003 — runtime state wired here. Internal useState is the
+  // canonical source; host-provided value props seed initial state on mount;
+  // host-provided setter props are forward-invoked alongside the internal setter
+  // so a host can observe state changes without owning them.
+  const [activeObserveTabInternal, setActiveObserveTabInternal] =
+    useState<ObserveTab>(activeObserveTabProp ?? 'agents')
+  const [observePanelCollapsedInternal, setObservePanelCollapsedInternal] =
+    useState<boolean>(observePanelCollapsedProp ?? false)
+
+  const setActiveObserveTabResolved = (tab: ObserveTab) => {
+    setActiveObserveTabInternal(tab)
+    setActiveObserveTabProp?.(tab)
+  }
+  const setObservePanelCollapsedResolved = (v: boolean) => {
+    setObservePanelCollapsedInternal(v)
+    setObservePanelCollapsedProp?.(v)
+  }
 
   const value: ShellContextValue = {
     mode,
@@ -74,10 +95,10 @@ export function ShellProvider({
     navigate,
     goBack,
     onProjectChange,
-    activeObserveTab,
-    setActiveObserveTab,
-    observePanelCollapsed,
-    setObservePanelCollapsed,
+    activeObserveTab: activeObserveTabInternal,
+    setActiveObserveTab: setActiveObserveTabResolved,
+    observePanelCollapsed: observePanelCollapsedInternal,
+    setObservePanelCollapsed: setObservePanelCollapsedResolved,
   }
 
   return (

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { clsx } from 'clsx'
 import { ColumnDivider } from './ColumnDivider'
 import { CollapsibleObserveEdge } from './CollapsibleObserveEdge'
+import { useShellContext } from './ShellContext'
 import type { ChatStage, ShellBreakpoint, SimpleShellLayoutProps } from './types'
 
 const DEFAULT_SIDEBAR_WIDTH = 320
@@ -57,6 +58,13 @@ export function SimpleShellLayout({
 }: SimpleShellLayoutProps & Omit<React.HTMLAttributes<HTMLDivElement>, 'content'>) {
     const containerRef = React.useRef<HTMLDivElement | null>(null)
     const chatOverlayRef = React.useRef<HTMLDivElement | null>(null)
+    // SUPV-SP11-006 — single-site mirror-write reconciles the boolean
+    // (context) channel with the pixel (host) channel. The host owns the
+    // actual `grid-template-column` value via `observeWidth`; the context
+    // owns the boolean `observePanelCollapsed`. The edge writes both via
+    // its own `handleClick`; this layout re-asserts the boolean from the
+    // post-flip width inside `handleObserveExpandToggle`.
+    const { setObservePanelCollapsed } = useShellContext()
     // Use prop if provided, otherwise fallback to internal state (backwards compat)
     const [internalStage, setInternalStage] = React.useState<ChatStage>('small')
     const chatStage = chatStageProp ?? internalStage
@@ -125,10 +133,14 @@ export function SimpleShellLayout({
         observeWidthRef.current = next
         setObserveWidth(next)
         onColumnResize?.({ sidebar: sidebarWidthRef.current, observe: next })
+        // SUPV-SP11-006 — single-site mirror-write reconciles boolean (context)
+        // with pixel (host) channel. The post-flip width is the authoritative
+        // value; mirror it to the boolean to keep both channels aligned.
+        setObservePanelCollapsed(next < COLLAPSED_THRESHOLD)
         setIsAnimating(true)
         if (animationTimerRef.current) clearTimeout(animationTimerRef.current)
         animationTimerRef.current = setTimeout(() => setIsAnimating(false), 200)
-    }, [onColumnResize])
+    }, [onColumnResize, setObservePanelCollapsed])
 
     const showObserve = breakpoint === 'full'
     const observeExpanded = showObserve && observeWidth >= COLLAPSED_THRESHOLD

--- a/self/ui/src/components/shell/__tests__/CollapsibleObserveEdge.test.tsx
+++ b/self/ui/src/components/shell/__tests__/CollapsibleObserveEdge.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CollapsibleObserveEdge } from '../CollapsibleObserveEdge'
+import { ShellProvider } from '../ShellContext'
 
 let container: HTMLDivElement
 let root: Root
@@ -17,20 +18,40 @@ async function flush() {
   await new Promise((resolve) => window.setTimeout(resolve, 0))
 }
 
-async function renderEdge(
-  overrides: Partial<React.ComponentProps<typeof CollapsibleObserveEdge>> = {},
-) {
-  const defaultProps = {
-    width: 20,
-    onExpandToggle: vi.fn(),
+interface RenderOverrides {
+  width?: number
+  expandedWidth?: number
+  onExpandToggle?: () => void
+  collapsed?: boolean
+  setCollapsed?: (v: boolean) => void
+}
+
+let renderSeq = 0
+
+async function renderEdge(overrides: RenderOverrides = {}) {
+  const props = {
+    width: overrides.width ?? 20,
+    expandedWidth: overrides.expandedWidth ?? 280,
+    onExpandToggle: overrides.onExpandToggle ?? vi.fn(),
     children: <div data-testid="observe-content">Observe Panel</div>,
-    ...overrides,
   }
+  const collapsed = overrides.collapsed ?? props.width < 60
+  // Use a fresh `key` on each render so ShellProvider remounts and the
+  // uncontrolled `useState` re-seeds from the new prop value.
+  renderSeq += 1
   await act(async () => {
-    root.render(<CollapsibleObserveEdge {...defaultProps} />)
+    root.render(
+      <ShellProvider
+        key={renderSeq}
+        observePanelCollapsed={collapsed}
+        setObservePanelCollapsed={overrides.setCollapsed}
+      >
+        <CollapsibleObserveEdge {...props} />
+      </ShellProvider>,
+    )
     await flush()
   })
-  return defaultProps
+  return props
 }
 
 beforeEach(() => {
@@ -48,17 +69,17 @@ afterEach(async () => {
 })
 
 describe('CollapsibleObserveEdge', () => {
-  it('renders collapsed state with chevron when width < threshold', async () => {
-    await renderEdge({ width: 20 })
+  it('renders collapsed state when shell-context observePanelCollapsed === true', async () => {
+    await renderEdge({ collapsed: true })
     const edge = container.querySelector('[data-shell-component="collapsible-observe-edge"]')
     expect(edge?.getAttribute('data-state')).toBe('collapsed')
     expect(container.querySelector('[data-action="expand"]')).toBeTruthy()
-    // Children are always in the DOM now (clipped by overflow:hidden when collapsed)
+    // Children are always in the DOM (clipped by overflow:hidden when collapsed)
     expect(container.querySelector('[data-testid="observe-content"]')).toBeTruthy()
   })
 
-  it('renders expanded state with children when width >= threshold', async () => {
-    await renderEdge({ width: 280 })
+  it('renders expanded state when shell-context observePanelCollapsed === false', async () => {
+    await renderEdge({ collapsed: false })
     const edge = container.querySelector('[data-shell-component="collapsible-observe-edge"]')
     expect(edge?.getAttribute('data-state')).toBe('expanded')
     expect(container.querySelector('[data-action="expand"]')).toBeNull()
@@ -66,56 +87,73 @@ describe('CollapsibleObserveEdge', () => {
   })
 
   it('calls onExpandToggle when chevron is clicked', async () => {
-    const props = await renderEdge({ width: 20 })
+    const onExpandToggle = vi.fn()
+    await renderEdge({ collapsed: true, onExpandToggle })
     const chevron = container.querySelector('[data-action="expand"]') as HTMLButtonElement
     await act(async () => {
       chevron.click()
       await flush()
     })
-    expect(props.onExpandToggle).toHaveBeenCalled()
-  })
-
-  it('shows children at width exactly at threshold (60)', async () => {
-    await renderEdge({ width: 60 })
-    expect(container.querySelector('[data-testid="observe-content"]')).toBeTruthy()
-  })
-
-  it('shows chevron at width just below threshold (59)', async () => {
-    await renderEdge({ width: 59 })
-    expect(container.querySelector('[data-action="expand"]')).toBeTruthy()
-    // Children are always in the DOM now (clipped by overflow:hidden when collapsed)
-    expect(container.querySelector('[data-testid="observe-content"]')).toBeTruthy()
+    expect(onExpandToggle).toHaveBeenCalled()
   })
 
   it('expand button has accessible label', async () => {
-    await renderEdge({ width: 20 })
+    await renderEdge({ collapsed: true })
     const btn = container.querySelector('[data-action="expand"]') as HTMLButtonElement
     expect(btn.getAttribute('aria-label')).toBe('Expand observe panel')
   })
 
   it('renders Lucide SVG icons for expand and collapse buttons', async () => {
     // Collapsed state — expand button has ChevronLeft SVG
-    await renderEdge({ width: 20 })
+    await renderEdge({ collapsed: true })
     const expandBtn = container.querySelector('[data-action="expand"]')
     expect(expandBtn?.querySelector('svg')).toBeTruthy()
 
     // Expanded state — at least one collapse button has PanelRightClose SVG
-    await renderEdge({ width: 280 })
+    await renderEdge({ collapsed: false })
     const collapseBtns = container.querySelectorAll('[data-action="collapse"]')
-    const hasSvg = Array.from(collapseBtns).some(btn => btn.querySelector('svg'))
+    const hasSvg = Array.from(collapseBtns).some((btn) => btn.querySelector('svg'))
     expect(hasSvg).toBeTruthy()
   })
 
   it('expand/collapse buttons have hover-capable styles (default transparent background with border-radius)', async () => {
-    await renderEdge({ width: 20 })
+    await renderEdge({ collapsed: true })
     const expandBtn = container.querySelector('[data-action="expand"]') as HTMLElement
-    // Default background is transparent, ready for hover state
     expect(expandBtn.style.background).toBe('transparent')
     expect(expandBtn.style.borderRadius).toBe('var(--nous-radius-sm)')
 
-    await renderEdge({ width: 280 })
+    await renderEdge({ collapsed: false })
     const collapseBtn = container.querySelector('[data-action="collapse"]') as HTMLElement
     expect(collapseBtn.style.background).toBe('transparent')
     expect(collapseBtn.style.borderRadius).toBe('var(--nous-radius-sm)')
+  })
+
+  // ----- WR-162 SP 11 (SUPV-SP11-004 + SUPV-SP11-005) regression guards -----
+
+  it('UT-SP11-EDGE-READ-FROM-CONTEXT — data-state derives from context, not from the width prop', async () => {
+    // Pass a small width that would have been "collapsed" under the pre-SP-11
+    // pixel-threshold heuristic; the context says expanded → state is expanded.
+    await renderEdge({ width: 5, collapsed: false })
+    let edge = container.querySelector('[data-shell-component="collapsible-observe-edge"]')
+    expect(edge?.getAttribute('data-state')).toBe('expanded')
+
+    // Now flip context to collapsed with the SAME small width.
+    await renderEdge({ width: 5, collapsed: true })
+    edge = container.querySelector('[data-shell-component="collapsible-observe-edge"]')
+    expect(edge?.getAttribute('data-state')).toBe('collapsed')
+  })
+
+  it('UT-SP11-EDGE-CLICK-WRITES-CONTEXT — clicking writes the negated value to the context setter and invokes onExpandToggle', async () => {
+    const setCollapsed = vi.fn()
+    const onExpandToggle = vi.fn()
+    await renderEdge({ collapsed: false, onExpandToggle, setCollapsed })
+    const collapseBtn = container.querySelector('[data-action="collapse"]') as HTMLButtonElement
+    await act(async () => {
+      collapseBtn.click()
+      await flush()
+    })
+    expect(setCollapsed).toHaveBeenCalledTimes(1)
+    expect(setCollapsed).toHaveBeenCalledWith(true)
+    expect(onExpandToggle).toHaveBeenCalledTimes(1)
   })
 })

--- a/self/ui/src/components/shell/__tests__/ObservePanel.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ObservePanel.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import React from 'react'
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 import { ObservePanel } from '../ObservePanel'
 import { ShellProvider } from '../ShellContext'
 
@@ -12,212 +12,223 @@ class MockResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-;(globalThis as any).ResizeObserver = MockResizeObserver
+;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver
 
-// ---- Transport mock (required by MaoOperatingSurface) ----
-
-vi.mock('@nous/transport', () => ({
-  trpc: {
-    useUtils: vi.fn().mockReturnValue({
-      mao: {
-        getProjectSnapshot: { invalidate: vi.fn() },
-        getAgentInspectProjection: { invalidate: vi.fn() },
-        getProjectControlProjection: { invalidate: vi.fn() },
-        getControlAuditHistory: { invalidate: vi.fn() },
-        getSystemSnapshot: { invalidate: vi.fn() },
-      },
-      health: { systemStatus: { invalidate: vi.fn() } },
-      projects: { dashboardSnapshot: { invalidate: vi.fn() } },
-      escalations: { listProjectQueue: { invalidate: vi.fn() } },
-    }),
-    mao: {
-      getSystemSnapshot: {
-        useQuery: vi.fn().mockReturnValue({ data: null, isLoading: true }),
-      },
-      getProjectSnapshot: {
-        useQuery: vi.fn().mockReturnValue({ data: null, isLoading: true }),
-      },
-      getAgentInspectProjection: {
-        useQuery: vi.fn().mockReturnValue({ data: null, isLoading: true }),
-      },
-      getControlAuditHistory: {
-        useQuery: vi.fn().mockReturnValue({ data: null, isLoading: true }),
-      },
-      requestProjectControl: {
-        useMutation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
-      },
-    },
-    opctl: {
-      requestConfirmationProof: {
-        useMutation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
-      },
-    },
-    health: {
-      systemStatus: {
-        useQuery: vi.fn().mockReturnValue({ data: null, isLoading: true }),
-      },
-    },
-    projects: {
-      list: {
-        useQuery: vi.fn().mockReturnValue({ data: [], isLoading: false }),
-      },
-      dashboardSnapshot: {
-        useQuery: vi.fn().mockReturnValue({ data: null, isLoading: true }),
-      },
-    },
-  },
-  useEventSubscription: vi.fn(),
-}))
-
+/**
+ * WR-162 SP 11 — ObservePanel keep-mounted-hide-inactive contract.
+ *
+ * SUPV-SP11-001 (keep-mounted container) + SUPV-SP11-002 (closed-enum
+ * three-button switcher) verified here. The panel renders three sibling
+ * `<div data-tab-slot>` elements at all times; only the active slot has
+ * `display: 'flex'`. The switcher renders three `<button role="tab">`
+ * elements; clicking each updates `activeObserveTab` via shell context.
+ */
 describe('ObservePanel', () => {
-  it('renders without crashing when wrapped in ShellProvider', () => {
-    render(
+  it('UT-SP11-OBSERVE-RENDER — renders three sibling tab slots + tablist + three role=tab buttons', () => {
+    const { container } = render(
       <ShellProvider>
         <ObservePanel />
       </ShellProvider>,
     )
+    // Three tab slots present in DOM regardless of active state
+    expect(container.querySelector('[data-tab-slot="agents"]')).toBeTruthy()
+    expect(container.querySelector('[data-tab-slot="system-load"]')).toBeTruthy()
+    expect(container.querySelector('[data-tab-slot="cost-monitor"]')).toBeTruthy()
+    // Tablist + three buttons
+    expect(container.querySelector('[role="tablist"]')).toBeTruthy()
+    expect(container.querySelectorAll('[role="tab"]').length).toBe(3)
+    expect(container.querySelector('[data-tab-id="agents"]')).toBeTruthy()
+    expect(container.querySelector('[data-tab-id="system-load"]')).toBeTruthy()
+    expect(container.querySelector('[data-tab-id="cost-monitor"]')).toBeTruthy()
   })
 
-  it('accepts className prop', () => {
-    render(
+  it('UT-SP11-OBSERVE-AGENTS-ACTIVE — agents slot has display:flex; others have display:none', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="agents">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    const agents = container.querySelector('[data-tab-slot="agents"]') as HTMLElement
+    const systemLoad = container.querySelector('[data-tab-slot="system-load"]') as HTMLElement
+    const costMonitor = container.querySelector('[data-tab-slot="cost-monitor"]') as HTMLElement
+    expect(agents.style.display).toBe('flex')
+    expect(systemLoad.style.display).toBe('none')
+    expect(costMonitor.style.display).toBe('none')
+  })
+
+  it('UT-SP11-OBSERVE-SYSTEM-LOAD-ACTIVE — system-load slot has display:flex; others have display:none', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="system-load">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    const agents = container.querySelector('[data-tab-slot="agents"]') as HTMLElement
+    const systemLoad = container.querySelector('[data-tab-slot="system-load"]') as HTMLElement
+    const costMonitor = container.querySelector('[data-tab-slot="cost-monitor"]') as HTMLElement
+    expect(systemLoad.style.display).toBe('flex')
+    expect(agents.style.display).toBe('none')
+    expect(costMonitor.style.display).toBe('none')
+  })
+
+  it('UT-SP11-OBSERVE-COST-MONITOR-ACTIVE — cost-monitor slot has display:flex; others have display:none', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="cost-monitor">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    const agents = container.querySelector('[data-tab-slot="agents"]') as HTMLElement
+    const systemLoad = container.querySelector('[data-tab-slot="system-load"]') as HTMLElement
+    const costMonitor = container.querySelector('[data-tab-slot="cost-monitor"]') as HTMLElement
+    expect(costMonitor.style.display).toBe('flex')
+    expect(agents.style.display).toBe('none')
+    expect(systemLoad.style.display).toBe('none')
+  })
+
+  it('UT-SP11-OBSERVE-SWITCHER-AGENTS — clicking system-load button activates the system-load slot', () => {
+    const { container } = render(
+      <ShellProvider>
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    const systemLoadBtn = container.querySelector('[data-tab-id="system-load"]') as HTMLButtonElement
+    fireEvent.click(systemLoadBtn)
+    const systemLoad = container.querySelector('[data-tab-slot="system-load"]') as HTMLElement
+    const agents = container.querySelector('[data-tab-slot="agents"]') as HTMLElement
+    expect(systemLoad.style.display).toBe('flex')
+    expect(agents.style.display).toBe('none')
+  })
+
+  it('UT-SP11-OBSERVE-SWITCHER-SYSTEM-LOAD — clicking cost-monitor button activates the cost-monitor slot', () => {
+    const { container } = render(
+      <ShellProvider>
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    const costMonitorBtn = container.querySelector('[data-tab-id="cost-monitor"]') as HTMLButtonElement
+    fireEvent.click(costMonitorBtn)
+    const costMonitor = container.querySelector('[data-tab-slot="cost-monitor"]') as HTMLElement
+    expect(costMonitor.style.display).toBe('flex')
+  })
+
+  it('UT-SP11-OBSERVE-SWITCHER-COST-MONITOR — clicking agents button activates the agents slot', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="cost-monitor">
+        <ObservePanel />
+      </ShellProvider>,
+    )
+    const agentsBtn = container.querySelector('[data-tab-id="agents"]') as HTMLButtonElement
+    fireEvent.click(agentsBtn)
+    const agents = container.querySelector('[data-tab-slot="agents"]') as HTMLElement
+    expect(agents.style.display).toBe('flex')
+  })
+
+  it('UT-SP11-OBSERVE-CLASSNAME — accepts className prop and applies it to wrapper', () => {
+    const { container } = render(
       <ShellProvider>
         <ObservePanel className="test-class" />
       </ShellProvider>,
     )
+    const wrapper = container.querySelector('[data-shell-component="observe-panel"]') as HTMLElement
+    expect(wrapper.className).toContain('test-class')
   })
 
-  it('renders canonical MaoOperatingSurface when activeRoute is workflows', () => {
+  it('UT-SP11-OBSERVE-DELETION — no SP-2 placeholder text and no MAO Operating Surface render', () => {
     render(
-      <ShellProvider activeRoute="workflows">
+      <ShellProvider>
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+    // The SP 2 placeholder text is gone
+    expect(screen.queryByText('No observe content for this view')).toBeNull()
+    // MAO Operating Surface is no longer rendered (SP 12 wires real tab hosts later)
+    expect(screen.queryByText('MAO Operating Surface')).toBeNull()
   })
 
-  it('renders canonical MaoOperatingSurface when activeRoute is workflow-detail', () => {
-    render(
-      <ShellProvider activeRoute="workflow-detail">
+  it('UT-SP11-OBSERVE-ARIA-SELECTED — only the active tab button has aria-selected="true"', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="system-load">
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+    expect(
+      container.querySelector('[data-tab-id="system-load"]')?.getAttribute('aria-selected'),
+    ).toBe('true')
+    expect(
+      container.querySelector('[data-tab-id="agents"]')?.getAttribute('aria-selected'),
+    ).toBe('false')
+    expect(
+      container.querySelector('[data-tab-id="cost-monitor"]')?.getAttribute('aria-selected'),
+    ).toBe('false')
   })
 
-  it('renders default placeholder when activeRoute is home', () => {
-    render(
-      <ShellProvider activeRoute="home">
+  it('UT-SP11-OBSERVE-DATA-ACTIVE — only the active tab button has data-active="true"', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="cost-monitor">
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('No observe content for this view')).toBeTruthy()
+    expect(
+      container.querySelector('[data-tab-id="cost-monitor"]')?.getAttribute('data-active'),
+    ).toBe('true')
+    expect(
+      container.querySelector('[data-tab-id="agents"]')?.getAttribute('data-active'),
+    ).toBe('false')
+    expect(
+      container.querySelector('[data-tab-id="system-load"]')?.getAttribute('data-active'),
+    ).toBe('false')
   })
 
-  it('renders MaoOperatingSurface when activeRoute is skills', () => {
-    render(
-      <ShellProvider activeRoute="skills">
+  it('UT-SP11-OBSERVE-ARIA-HIDDEN — only the active tab slot has aria-hidden="false"', () => {
+    const { container } = render(
+      <ShellProvider activeObserveTab="agents">
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+    expect(container.querySelector('[data-tab-slot="agents"]')?.getAttribute('aria-hidden')).toBe(
+      'false',
+    )
+    expect(
+      container.querySelector('[data-tab-slot="system-load"]')?.getAttribute('aria-hidden'),
+    ).toBe('true')
+    expect(
+      container.querySelector('[data-tab-slot="cost-monitor"]')?.getAttribute('aria-hidden'),
+    ).toBe('true')
   })
 
-  it('renders MaoOperatingSurface when activeRoute is tasks', () => {
-    render(
-      <ShellProvider activeRoute="tasks">
+  it('UT-SP11-OBSERVE-TABLIST-LABEL — tablist has aria-label="Observe panel tabs"', () => {
+    const { container } = render(
+      <ShellProvider>
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+    expect(container.querySelector('[role="tablist"]')?.getAttribute('aria-label')).toBe(
+      'Observe panel tabs',
+    )
   })
 
-  it('renders MaoOperatingSurface when activeRoute is agents', () => {
-    render(
-      <ShellProvider activeRoute="agents">
+  it('UT-SP11-OBSERVE-TAB-LABELS — three buttons render the labels Agents / System Load / Cost Monitor', () => {
+    const { container } = render(
+      <ShellProvider>
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+    expect(container.querySelector('[data-tab-id="agents"]')?.textContent).toBe('Agents')
+    expect(container.querySelector('[data-tab-id="system-load"]')?.textContent).toBe('System Load')
+    expect(container.querySelector('[data-tab-id="cost-monitor"]')?.textContent).toBe(
+      'Cost Monitor',
+    )
   })
 
-  it('renders MaoOperatingSurface when activeRoute is agent-detail', () => {
-    render(
-      <ShellProvider activeRoute="agent-detail">
+  it('UT-SP11-OBSERVE-DEFAULT-TAB — default activeObserveTab is "agents" without an explicit prop', () => {
+    const { container } = render(
+      <ShellProvider>
         <ObservePanel />
       </ShellProvider>,
     )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface when activeRoute is task-detail', () => {
-    render(
-      <ShellProvider activeRoute="task-detail">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface when activeRoute is threads', () => {
-    render(
-      <ShellProvider activeRoute="threads">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface when activeRoute is apps', () => {
-    render(
-      <ShellProvider activeRoute="apps">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface when activeRoute is dashboard', () => {
-    render(
-      <ShellProvider activeRoute="dashboard">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface when activeRoute is org-chart', () => {
-    render(
-      <ShellProvider activeRoute="org-chart">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface when activeRoute is inbox', () => {
-    render(
-      <ShellProvider activeRoute="inbox">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface for dynamic sidebar routeIds (e.g. campaign-1)', () => {
-    render(
-      <ShellProvider activeRoute="campaign-1">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
-  })
-
-  it('renders MaoOperatingSurface for unknown routes (defaults to mao)', () => {
-    render(
-      <ShellProvider activeRoute="some-unknown-route">
-        <ObservePanel />
-      </ShellProvider>,
-    )
-    expect(screen.getByText('MAO Operating Surface')).toBeTruthy()
+    const agents = container.querySelector('[data-tab-slot="agents"]') as HTMLElement
+    expect(agents.style.display).toBe('flex')
+    expect(
+      container.querySelector('[data-tab-id="agents"]')?.getAttribute('aria-selected'),
+    ).toBe('true')
   })
 })

--- a/self/ui/src/components/shell/__tests__/ShellContext.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ShellContext.test.tsx
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 
 import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ShellProvider, useShellContext } from '../ShellContext'
+import type { ObserveTab } from '../types'
 
 function ShellContextConsumer() {
   const context = useShellContext()
@@ -72,5 +75,102 @@ describe('ShellContext', () => {
     )
 
     expect(markup).toContain('undefined')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SP 11 SUPV-SP11-003 — uncontrolled `useState` for activeObserveTab and
+// observePanelCollapsed. Internal state is the canonical source; the
+// host-provided value props seed initial state on mount.
+// ---------------------------------------------------------------------------
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true
+
+describe('ShellContext — SP 11 runtime fields', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function ActiveTabConsumer() {
+    const ctx = useShellContext()
+    return <div data-testid="active-tab">{ctx.activeObserveTab}</div>
+  }
+
+  function CollapsedConsumer() {
+    const ctx = useShellContext()
+    return <div data-testid="collapsed">{String(ctx.observePanelCollapsed)}</div>
+  }
+
+  function SetterTabConsumer({ tab }: { tab: ObserveTab }) {
+    const ctx = useShellContext()
+    React.useEffect(() => {
+      ctx.setActiveObserveTab(tab)
+    }, [ctx, tab])
+    return <div data-testid="active-tab">{ctx.activeObserveTab}</div>
+  }
+
+  function SetterCollapsedConsumer({ value }: { value: boolean }) {
+    const ctx = useShellContext()
+    React.useEffect(() => {
+      ctx.setObservePanelCollapsed(value)
+    }, [ctx, value])
+    return <div data-testid="collapsed">{String(ctx.observePanelCollapsed)}</div>
+  }
+
+  it("UT-SP11-CTX-DEFAULT-ACTIVE-TAB — defaults activeObserveTab to 'agents'", async () => {
+    await act(async () => {
+      root.render(
+        <ShellProvider>
+          <ActiveTabConsumer />
+        </ShellProvider>,
+      )
+    })
+    expect(container.querySelector('[data-testid="active-tab"]')?.textContent).toBe('agents')
+  })
+
+  it('UT-SP11-CTX-SETTER-ACTIVE-TAB — setActiveObserveTab updates the context value', async () => {
+    await act(async () => {
+      root.render(
+        <ShellProvider>
+          <SetterTabConsumer tab="system-load" />
+        </ShellProvider>,
+      )
+    })
+    expect(container.querySelector('[data-testid="active-tab"]')?.textContent).toBe('system-load')
+  })
+
+  it('UT-SP11-CTX-DEFAULT-COLLAPSED — defaults observePanelCollapsed to false', async () => {
+    await act(async () => {
+      root.render(
+        <ShellProvider>
+          <CollapsedConsumer />
+        </ShellProvider>,
+      )
+    })
+    expect(container.querySelector('[data-testid="collapsed"]')?.textContent).toBe('false')
+  })
+
+  it('UT-SP11-CTX-SETTER-COLLAPSED — setObservePanelCollapsed updates the context value', async () => {
+    await act(async () => {
+      root.render(
+        <ShellProvider>
+          <SetterCollapsedConsumer value={true} />
+        </ShellProvider>,
+      )
+    })
+    expect(container.querySelector('[data-testid="collapsed"]')?.textContent).toBe('true')
   })
 })

--- a/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
+++ b/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SimpleShellLayout } from '../SimpleShellLayout'
+import { ShellProvider } from '../ShellContext'
 
 let container: HTMLDivElement
 let root: Root
@@ -40,15 +41,17 @@ async function renderLayout(
 ) {
   await act(async () => {
     root.render(
-      <SimpleShellLayout
-        projectRail={<div>rail</div>}
-        sidebar={<div>sidebar</div>}
-        content={<div>content</div>}
-        observe={<div>observe</div>}
-        chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
-        chatStage="small"
-        {...overrides}
-      />,
+      <ShellProvider>
+        <SimpleShellLayout
+          projectRail={<div>rail</div>}
+          sidebar={<div>sidebar</div>}
+          content={<div>content</div>}
+          observe={<div>observe</div>}
+          chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
+          chatStage="small"
+          {...overrides}
+        />
+      </ShellProvider>,
     )
     await flush()
   })
@@ -202,16 +205,18 @@ describe('SimpleShellLayout', () => {
     // Re-render with collapsed=false — the underlying sidebarWidth state is still 300
     await act(async () => {
       root.render(
-        <SimpleShellLayout
-          projectRail={<div>rail</div>}
-          sidebar={<div>sidebar</div>}
-          content={<div>content</div>}
-          observe={<div>observe</div>}
-          chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
-          chatStage="small"
-          sidebarCollapsed={false}
-          initialWidths={{ sidebar: 300 }}
-        />,
+        <ShellProvider>
+          <SimpleShellLayout
+            projectRail={<div>rail</div>}
+            sidebar={<div>sidebar</div>}
+            content={<div>content</div>}
+            observe={<div>observe</div>}
+            chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
+            chatStage="small"
+            sidebarCollapsed={false}
+            initialWidths={{ sidebar: 300 }}
+          />
+        </ShellProvider>,
       )
       await flush()
     })
@@ -234,15 +239,17 @@ describe('SimpleShellLayout', () => {
     // Re-render with sidebarCollapsed: true
     await act(async () => {
       root.render(
-        <SimpleShellLayout
-          projectRail={<div>rail</div>}
-          sidebar={<div>sidebar</div>}
-          content={<div>content</div>}
-          observe={<div>observe</div>}
-          chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
-          chatStage="small"
-          sidebarCollapsed={true}
-        />,
+        <ShellProvider>
+          <SimpleShellLayout
+            projectRail={<div>rail</div>}
+            sidebar={<div>sidebar</div>}
+            content={<div>content</div>}
+            observe={<div>observe</div>}
+            chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
+            chatStage="small"
+            sidebarCollapsed={true}
+          />
+        </ShellProvider>,
       )
       await flush()
     })

--- a/self/ui/src/components/shell/__tests__/click-through-contract.test.tsx
+++ b/self/ui/src/components/shell/__tests__/click-through-contract.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+
+/**
+ * WR-162 SP 11 — Click-through contract.
+ *
+ * SUPV-SP11-008 (fake indicator stand-in) + SUPV-SP11-009 (render-count
+ * counter). The real status-bar indicator click site lands in SP 12; SP 11
+ * verifies the API contract here with a `FakeIndicator` test-internal
+ * component. The contract is:
+ *
+ *   onClick = () => {
+ *     setActiveObserveTab(tab);
+ *     if (observePanelCollapsed) setObservePanelCollapsed(false);
+ *   };
+ *
+ * The two `setState` calls happen inside one synchronous handler; React
+ * 18+ automatic batching collapses them into one re-render. The test
+ * counts commits via `useEffect`-no-deps semantics (runs on every commit).
+ *
+ * Render-count counter pattern: `useRef<number>(0)` incremented inside a
+ * `useEffect(() => { ref.current += 1 })` with no deps. Read the count
+ * before and after the click; the delta is exactly 1.
+ *
+ * The test renders WITHOUT `<StrictMode>` to match production runtime.
+ * No precedent file enforces this pattern; SP 11 is the first explicit
+ * use of render-count counter in this package — future tests can cite
+ * `click-through-contract.test.tsx` as the precedent.
+ */
+
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ShellProvider, useShellContext } from '../ShellContext'
+import type { ObserveTab } from '../types'
+
+let container: HTMLDivElement
+let root: Root
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true
+
+async function flush() {
+  await Promise.resolve()
+  await new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+    await flush()
+  })
+  container.remove()
+})
+
+const renderCountRef = { current: 0 }
+
+function RenderProbe() {
+  React.useEffect(() => {
+    renderCountRef.current += 1
+  })
+  const ctx = useShellContext()
+  return (
+    <div>
+      <span data-testid="active-tab">{ctx.activeObserveTab}</span>
+      <span data-testid="collapsed">{String(ctx.observePanelCollapsed)}</span>
+    </div>
+  )
+}
+
+function FakeIndicator({ tab, children }: { tab: ObserveTab; children: React.ReactNode }) {
+  const { setActiveObserveTab, observePanelCollapsed, setObservePanelCollapsed } =
+    useShellContext()
+  const handleClick = () => {
+    setActiveObserveTab(tab)
+    if (observePanelCollapsed) setObservePanelCollapsed(false)
+  }
+  return (
+    <>
+      <button data-testid="fake-indicator" onClick={handleClick}>
+        Indicator
+      </button>
+      {children}
+    </>
+  )
+}
+
+describe('Click-through contract', () => {
+  it('UT-SP11-CLICK-BATCHED-RENDER — clicking with collapsed=true commits exactly one re-render', async () => {
+    renderCountRef.current = 0
+    await act(async () => {
+      root.render(
+        <ShellProvider observePanelCollapsed={true}>
+          <FakeIndicator tab="cost-monitor">
+            <RenderProbe />
+          </FakeIndicator>
+        </ShellProvider>,
+      )
+      await flush()
+    })
+    const initial = renderCountRef.current
+    const indicator = container.querySelector('[data-testid="fake-indicator"]') as HTMLButtonElement
+    await act(async () => {
+      indicator.click()
+      await flush()
+    })
+    const delta = renderCountRef.current - initial
+    expect(delta).toBe(1)
+  })
+
+  it('UT-SP11-CLICK-TAB-SWITCH — collapsed=false: only activeObserveTab flips; collapsed remains false', async () => {
+    await act(async () => {
+      root.render(
+        <ShellProvider observePanelCollapsed={false}>
+          <FakeIndicator tab="system-load">
+            <RenderProbe />
+          </FakeIndicator>
+        </ShellProvider>,
+      )
+      await flush()
+    })
+    const indicator = container.querySelector('[data-testid="fake-indicator"]') as HTMLButtonElement
+    await act(async () => {
+      indicator.click()
+      await flush()
+    })
+    expect(container.querySelector('[data-testid="active-tab"]')?.textContent).toBe('system-load')
+    expect(container.querySelector('[data-testid="collapsed"]')?.textContent).toBe('false')
+  })
+
+  it('UT-SP11-CLICK-COLLAPSE-AWARE — collapsed=true: activeObserveTab flips AND collapsed flips to false', async () => {
+    await act(async () => {
+      root.render(
+        <ShellProvider observePanelCollapsed={true}>
+          <FakeIndicator tab="cost-monitor">
+            <RenderProbe />
+          </FakeIndicator>
+        </ShellProvider>,
+      )
+      await flush()
+    })
+    const indicator = container.querySelector('[data-testid="fake-indicator"]') as HTMLButtonElement
+    await act(async () => {
+      indicator.click()
+      await flush()
+    })
+    expect(container.querySelector('[data-testid="active-tab"]')?.textContent).toBe('cost-monitor')
+    expect(container.querySelector('[data-testid="collapsed"]')?.textContent).toBe('false')
+  })
+
+  it('UT-SP11-CLICK-FORWARDS-SETTER — host-provided setter is forward-invoked alongside the internal setter', async () => {
+    const hostSetTab = vi.fn<(tab: ObserveTab) => void>()
+    const hostSetCollapsed = vi.fn<(v: boolean) => void>()
+    await act(async () => {
+      root.render(
+        <ShellProvider
+          observePanelCollapsed={true}
+          setActiveObserveTab={hostSetTab}
+          setObservePanelCollapsed={hostSetCollapsed}
+        >
+          <FakeIndicator tab="system-load">
+            <RenderProbe />
+          </FakeIndicator>
+        </ShellProvider>,
+      )
+      await flush()
+    })
+    const indicator = container.querySelector('[data-testid="fake-indicator"]') as HTMLButtonElement
+    await act(async () => {
+      indicator.click()
+      await flush()
+    })
+    expect(hostSetTab).toHaveBeenCalledWith('system-load')
+    expect(hostSetCollapsed).toHaveBeenCalledWith(false)
+  })
+})

--- a/self/ui/src/components/shell/__tests__/closed-enum-admission.test.ts
+++ b/self/ui/src/components/shell/__tests__/closed-enum-admission.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  StatusBarBackpressureSchema,
+  StatusBarBudgetSchema,
+  StatusBarActiveAgentsSchema,
+  StatusBarSnapshotSchema,
+  MaoSystemSnapshotInputSchema,
+} from '@nous/shared'
+import { ObserveTabSchema } from '../types'
+
+/**
+ * WR-162 SP 11 (SUPV-SP11-010) — closed-enum admission tests.
+ *
+ * Read-side regression guards. SP 11 widens NO closed enums; these tests
+ * prove the literals SP 11 routes through remain admitted post-SP-2.
+ * Mirrors SP 8 / SP 9 / SP 10 UT-CAT* admission discipline.
+ */
+describe('SP 11 closed-enum admission (read-side regression guards)', () => {
+  it('UT-SP11-CAT1 — ObserveTab admits the three SP 11 literals', () => {
+    expect(ObserveTabSchema.safeParse('agents').success).toBe(true)
+    expect(ObserveTabSchema.safeParse('system-load').success).toBe(true)
+    expect(ObserveTabSchema.safeParse('cost-monitor').success).toBe(true)
+  })
+
+  it('UT-SP11-CAT2 — StatusBarBackpressure.state admits all three literals', () => {
+    for (const lit of ['nominal', 'elevated', 'critical'] as const) {
+      expect(
+        StatusBarBackpressureSchema.safeParse({ state: lit, queueDepth: 0, activeAgents: 0 })
+          .success,
+      ).toBe(true)
+    }
+  })
+
+  it('UT-SP11-CAT3 — StatusBarBudget.state admits all four literals', () => {
+    for (const lit of ['nominal', 'warning', 'caution', 'exceeded'] as const) {
+      expect(
+        StatusBarBudgetSchema.safeParse({
+          state: lit,
+          spent: 0,
+          ceiling: 0,
+          period: '2026-04-01',
+        }).success,
+      ).toBe(true)
+    }
+  })
+
+  it('UT-SP11-CAT4 — StatusBarActiveAgents.status admits both literals', () => {
+    expect(StatusBarActiveAgentsSchema.safeParse({ count: 0, status: 'idle' }).success).toBe(true)
+    expect(StatusBarActiveAgentsSchema.safeParse({ count: 1, status: 'active' }).success).toBe(true)
+  })
+
+  it('UT-SP11-CAT5 — StatusBarSnapshot accepts null for all four slots (.nullable() posture)', () => {
+    expect(
+      StatusBarSnapshotSchema.safeParse({
+        backpressure: null,
+        cognitiveProfile: null,
+        budget: null,
+        activeAgents: null,
+      }).success,
+    ).toBe(true)
+  })
+
+  it('UT-SP11-CAT6 — MaoSystemSnapshotInput admits densityMode "D2"', () => {
+    expect(MaoSystemSnapshotInputSchema.safeParse({ densityMode: 'D2' }).success).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

WR-162 SP 11 — Observe Panel Redesign + Tab Context + Status-Bar tRPC.

- **`ObservePanel`** flips from route-conditional dispatch to keep-mounted-hide-inactive container with three sibling `<div role="tabpanel">` slots gated by `display: flex|none`. Closed-enum three-button switcher over the three `ObserveTab` literals. `OBSERVE_ROUTE_OVERRIDES` + `LocalObserveRoute` deleted.
- **`ShellContext`** uncontrolled `useState` source-of-truth for `activeObserveTab` (default `'agents'`) and `observePanelCollapsed` (default `false`). No controlled-prop dual-mode; host setter props forward-invoked alongside internal setter.
- **`CollapsibleObserveEdge`** `data-state` derives from `useShellContext().observePanelCollapsed`; two-write batched click handler writes context + host callback in one synchronous handler. `width` retained as styling-only hint.
- **`SimpleShellLayout`** single-site mirror-write reconciles boolean (context) channel with pixel (host) `observeWidth` channel.
- **`health.getStatusBarSnapshot`** tRPC aggregator with four file-scope private `safe*` helpers (closed-form try/catch returning typed payload on success and `null` on caught throw — Decision #4 Failure Isolation Rule). `safeCognitiveProfile` returns `null` unconditionally per Decision #7 Option D.2. Aggregator throws only when all four slots return `null` (four-clause AND).

## Mechanism-named decisions

- Uncontrolled `useState` source-of-truth (no controlled-prop) — SUPV-SP11-003
- Keep-mounted-hide-inactive (not lazy) — SUPV-SP11-001
- Two-write batched click (not synthetic reducer) — SUPV-SP11-005
- Single-site mirror-write (not scattered) — SUPV-SP11-006
- Closed-form try/catch + threshold ladder (not heuristic classifier) — SUPV-SP11-012/014/015
- Unconditional null for cognitive profile (no fallback branch) — SUPV-SP11-013
- Four-clause AND aggregator throw (not heuristic majority) — SUPV-SP11-016

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors / 152 carry-forward warnings (= SP 10 baseline)
- [x] `pnpm build` — full cascade green; renderer-shim deviation boundary preserved (zero `node:*` imports in `self/ui/src/components/shell/`; throwing `createHash` not exercised — SP 10 SUPV-SP10-DEV-001 Note 1d carry-forward intact)
- [x] `pnpm test` — 640 files / 5891 tests green; **+29 net-new vs SP 10 baseline 5862** (above SC-20 floor ≥ 28)
- [x] BT deferred per `index.md § Behavioral Testing Cadence` — extends unbroken SP 1 → SP 10 chain to eleven sub-phases
- [x] Closed-enum admission discipline applied at SDS time (zero schema widening at code-time)

PR predecessor chain: #331 → #343 → #344 → #346 → #347 → #348 → #349 → #350 → #351 → #352 → this PR.

Correlation: `wr-162-phase-1.11-implementation`