### PR TITLE
feat(WR-162 SP 14): MAO project-controls + T3 dialog + audit-trail polish + tier-display extraction

### DIFF
--- a/self/subcortex/opctl/src/__tests__/confirmation-system-proof.test.ts
+++ b/self/subcortex/opctl/src/__tests__/confirmation-system-proof.test.ts
@@ -19,8 +19,8 @@ import { ConfirmationProofSchema } from '@nous/shared';
 import {
   issueSystemProof,
   validateConfirmationProof,
-  getRequiredTier,
 } from '../confirmation.js';
+import { getRequiredTier } from '../tier-display.js';
 
 const PROJECT_ID = randomUUID() as ProjectId;
 const HASH = createHash('sha256').update('payload').digest('hex');

--- a/self/subcortex/opctl/src/__tests__/tier-display.test.ts
+++ b/self/subcortex/opctl/src/__tests__/tier-display.test.ts
@@ -3,7 +3,7 @@ import {
   T3_COOLDOWN_MS,
   getTierDisplay,
   type ConfirmationTierDisplay,
-} from '../confirmation.js';
+} from '../tier-display.js';
 
 describe('ConfirmationTierDisplay — WR-162 SP 2 surface', () => {
   it('accepts a structurally valid literal (type-level compile guard)', () => {

--- a/self/subcortex/opctl/src/confirmation.ts
+++ b/self/subcortex/opctl/src/confirmation.ts
@@ -9,12 +9,12 @@ import type {
   ControlScope,
   ConfirmationProof,
   ConfirmationProofRequest,
-  ConfirmationTier,
 } from '@nous/shared';
 import {
   ConfirmationProofSchema,
   ConfirmationProofRequestSchema,
 } from '@nous/shared';
+import { getRequiredTier } from './tier-display.js';
 
 const PROOF_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -66,16 +66,6 @@ function hashScope(scope: { class: string; kind: string; target_ids?: string[]; 
     project_id: scope.project_id ?? null,
   });
   return createHash('sha256').update(str).digest('hex');
-}
-
-/**
- * Returns required confirmation tier for action. Per operator-control-architecture-v1.
- */
-export function getRequiredTier(action: ControlAction): ConfirmationTier {
-  if (action === 'hard_stop' || action === 'resume') return 'T3';
-  if (action === 'cancel' || action === 'revert_to_previous_state' || action === 'edit_submitted_prompt') return 'T2';
-  if (action === 'pause' || action === 'stop_response' || action === 'retry_step') return 'T1';
-  return 'T0';
 }
 
 /**
@@ -145,69 +135,7 @@ export function issueSystemProof(
 
 // --- WR-162 SP 2 additions — failure-recovery-ux-patterns-v1.md § 9c ---
 //
-// Presentation metadata for confirmation-tier display. Implementation lands
-// in SP 7; this sub-phase only ships the type, constant, and stub.
-
-/**
- * Presentation metadata for a confirmation tier — drives tier-display UI
- * (severity pill, rationale copy, T3 cooldown). Per Decision #9 § 9c.
- */
-export type ConfirmationTierDisplay = {
-  level: ConfirmationTier;
-  label: string;
-  severity: 'low' | 'medium' | 'high' | 'critical';
-  rationaleKey: string;
-  /** Present on T3 only. */
-  cooldownMs?: number;
-};
-
-/**
- * T3 cooldown duration, in milliseconds. V1 value is `0` (no cooldown wired);
- * SP 7 promotes this to the policy-configured value.
- */
-export const T3_COOLDOWN_MS = 0;
-
-/**
- * Returns presentation metadata for a confirmation tier. Per Decision #9 § 9c.
- *
- * WR-162 SP 7 replaces the SP 2 stub body with the 4-arm exhaustive switch.
- * `ConfirmationTier` is a closed Zod enum (`'T0' | 'T1' | 'T2' | 'T3'`);
- * TypeScript exhaustiveness covers all four arms at compile time — a future
- * `'T4'` widening of `ConfirmationTierSchema` surfaces as a compile-time
- * exhaustiveness error at this switch (the correct contract-defect surface).
- */
-export function getTierDisplay(
-  tier: ConfirmationTier,
-): ConfirmationTierDisplay {
-  switch (tier) {
-    case 'T0':
-      return {
-        level: 'T0',
-        label: 'Immediate',
-        severity: 'low',
-        rationaleKey: 'tier.t0.rationale',
-      };
-    case 'T1':
-      return {
-        level: 'T1',
-        label: 'Confirmation',
-        severity: 'medium',
-        rationaleKey: 'tier.t1.rationale',
-      };
-    case 'T2':
-      return {
-        level: 'T2',
-        label: 'Two-step',
-        severity: 'high',
-        rationaleKey: 'tier.t2.rationale',
-      };
-    case 'T3':
-      return {
-        level: 'T3',
-        label: 'Cooldown-gated',
-        severity: 'critical',
-        rationaleKey: 'tier.t3.rationale',
-        cooldownMs: T3_COOLDOWN_MS,
-      };
-  }
-}
+// Presentation metadata for confirmation-tier display moved to ./tier-display.ts
+// per WR-162 SP 14 SUPV-SP14-021 (renderer-safe extraction). The package barrel
+// re-exports `ConfirmationTierDisplay`, `T3_COOLDOWN_MS`, `getRequiredTier`,
+// and `getTierDisplay` from `./tier-display.js` directly.

--- a/self/subcortex/opctl/src/index.ts
+++ b/self/subcortex/opctl/src/index.ts
@@ -18,14 +18,17 @@ export { OpctlService } from './opctl-service.js';
 export {
   T3_COOLDOWN_MS,
   getTierDisplay,
+  getRequiredTier,
+} from './tier-display.js';
+
+export {
   issueConfirmationProof,
   validateConfirmationProof,
-  getRequiredTier,
   issueSupervisorProof,
   issueSystemProof,
 } from './confirmation.js';
 
-export type { ConfirmationTierDisplay } from './confirmation.js';
+export type { ConfirmationTierDisplay } from './tier-display.js';
 export type {
   ProjectControlStateStore,
   SupervisorEnforcementLockFields,

--- a/self/subcortex/opctl/src/opctl-service.ts
+++ b/self/subcortex/opctl/src/opctl-service.ts
@@ -19,7 +19,8 @@ import {
   type IWitnessService,
 } from '@nous/shared';
 import { validateEnvelope } from './envelope.js';
-import { issueConfirmationProof, validateConfirmationProof, getRequiredTier } from './confirmation.js';
+import { issueConfirmationProof, validateConfirmationProof } from './confirmation.js';
+import { getRequiredTier } from './tier-display.js';
 import { resolveScope } from './scope.js';
 import type { ReplayStore } from './replay-store.js';
 import type { StartLockStore } from './start-lock.js';

--- a/self/subcortex/opctl/src/tier-display.ts
+++ b/self/subcortex/opctl/src/tier-display.ts
@@ -1,0 +1,88 @@
+/**
+ * Tier-display module — pure presentation metadata for confirmation tiers.
+ *
+ * WR-162 SP 14 (SUPV-SP14-021): Extracted from confirmation.ts to provide a
+ * renderer-safe import path with ZERO `node:*` imports. The package barrel
+ * (`index.ts`) re-exports the four pure helpers from this module so
+ * consumer-side `import { getRequiredTier } from '@nous/subcortex-opctl'`
+ * resolves through the barrel to `tier-display.ts` first — the renderer-shim
+ * `createHash` path in `confirmation.ts` is NOT exercised post-extraction.
+ *
+ * SUPV-SP10-007 + SC-15 zero-diff is RELAXED at SP 14 for self/subcortex/opctl
+ * specifically — the only modify cell at SP 14 in self/subcortex.
+ */
+import type { ConfirmationTier, ControlAction } from '@nous/shared';
+
+/**
+ * Presentation metadata for a confirmation tier — drives tier-display UI
+ * (severity pill, rationale copy, T3 cooldown). Per Decision #9 § 9c.
+ */
+export type ConfirmationTierDisplay = {
+  level: ConfirmationTier;
+  label: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  rationaleKey: string;
+  /** Present on T3 only. */
+  cooldownMs?: number;
+};
+
+/**
+ * T3 cooldown duration, in milliseconds. V1 value is `0` (no cooldown wired);
+ * SP 7 promotes this to the policy-configured value.
+ */
+export const T3_COOLDOWN_MS = 0;
+
+/**
+ * Returns required confirmation tier for action. Per operator-control-architecture-v1.
+ */
+export function getRequiredTier(action: ControlAction): ConfirmationTier {
+  if (action === 'hard_stop' || action === 'resume') return 'T3';
+  if (action === 'cancel' || action === 'revert_to_previous_state' || action === 'edit_submitted_prompt') return 'T2';
+  if (action === 'pause' || action === 'stop_response' || action === 'retry_step') return 'T1';
+  return 'T0';
+}
+
+/**
+ * Returns presentation metadata for a confirmation tier. Per Decision #9 § 9c.
+ *
+ * WR-162 SP 7 replaces the SP 2 stub body with the 4-arm exhaustive switch.
+ * `ConfirmationTier` is a closed Zod enum (`'T0' | 'T1' | 'T2' | 'T3'`);
+ * TypeScript exhaustiveness covers all four arms at compile time — a future
+ * `'T4'` widening of `ConfirmationTierSchema` surfaces as a compile-time
+ * exhaustiveness error at this switch (the correct contract-defect surface).
+ */
+export function getTierDisplay(
+  tier: ConfirmationTier,
+): ConfirmationTierDisplay {
+  switch (tier) {
+    case 'T0':
+      return {
+        level: 'T0',
+        label: 'Immediate',
+        severity: 'low',
+        rationaleKey: 'tier.t0.rationale',
+      };
+    case 'T1':
+      return {
+        level: 'T1',
+        label: 'Confirmation',
+        severity: 'medium',
+        rationaleKey: 'tier.t1.rationale',
+      };
+    case 'T2':
+      return {
+        level: 'T2',
+        label: 'Two-step',
+        severity: 'high',
+        rationaleKey: 'tier.t2.rationale',
+      };
+    case 'T3':
+      return {
+        level: 'T3',
+        label: 'Cooldown-gated',
+        severity: 'critical',
+        rationaleKey: 'tier.t3.rationale',
+        cooldownMs: T3_COOLDOWN_MS,
+      };
+  }
+}

--- a/self/ui/src/components/mao/__tests__/mao-audit-trail-panel.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-audit-trail-panel.test.tsx
@@ -20,7 +20,12 @@ vi.mock('@nous/transport', () => ({
   useEventSubscription: vi.fn(),
 }));
 
-import { MaoAuditTrailPanel } from '../mao-audit-trail-panel';
+import {
+  MaoAuditTrailPanel,
+  ACTOR_VISUAL,
+  type ActorVisualTreatment,
+} from '../mao-audit-trail-panel';
+import type { ControlActorType } from '@nous/shared';
 
 const MOCK_PROJECT_ID = '550e8400-e29b-41d4-a716-446655445001' as any;
 
@@ -136,5 +141,150 @@ describe('MaoAuditTrailPanel', () => {
     expect(screen.getByText('not_applicable')).toBeTruthy();
     expect(screen.getByText('mao-control:cmd-001')).toBeTruthy();
     expect(screen.getByText('evidence://stop')).toBeTruthy();
+  });
+});
+
+// --- WR-162 SP 14 (SUPV-SP14-014..016) — audit-trail polish ---
+
+function makeEntry(overrides: Record<string, unknown>) {
+  return {
+    commandId: 'cmd-' + (overrides.commandId ?? '0000'),
+    action: 'pause_project',
+    actorId: 'actor-1',
+    reason: 'reason text',
+    reasonCode: 'mao_project_control_applied',
+    at: '2026-03-10T01:00:00.000Z',
+    evidenceRefs: ['evidence://ref-1'],
+    resumeReadinessStatus: 'not_applicable',
+    decisionRef: 'mao-control:cmd-x',
+    ...overrides,
+  };
+}
+
+describe('UT-SP14-AT — audit-trail polish (SUPV-SP14-014..016)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseQuery = vi.fn().mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // UT-SP14-AT-SUPERVISOR-ACTOR — five-literal coverage
+  it('UT-SP14-AT-SUPERVISOR-ACTOR — five ControlActorType literals route through ACTOR_VISUAL', () => {
+    const literals: ControlActorType[] = [
+      'principal',
+      'orchestration_agent',
+      'worker_agent',
+      'system_agent',
+      'supervisor',
+    ];
+    const entries = literals.map((literal, i) =>
+      makeEntry({
+        commandId: `${i}`,
+        actor_type: literal,
+        actorId: `${literal}-id`,
+      }),
+    );
+    mockUseQuery = vi.fn().mockReturnValue({
+      data: entries,
+      isLoading: false,
+      isError: false,
+    });
+    render(<MaoAuditTrailPanel projectId={MOCK_PROJECT_ID} />);
+    for (const literal of literals) {
+      const badge = screen.getByTestId(`audit-actor-${literal}`);
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toContain(ACTOR_VISUAL[literal].badge);
+    }
+    // Only the supervisor row carries the glyph distinction.
+    expect(screen.getByTestId('audit-actor-supervisor-glyph')).toBeTruthy();
+  });
+
+  // UT-SP14-AT-FALLBACK — entries without actor_type default to 'principal' baseline
+  it('UT-SP14-AT-FALLBACK — entries without actor_type default to principal baseline', () => {
+    mockUseQuery = vi.fn().mockReturnValue({
+      data: [makeEntry({ commandId: 'a' })],
+      isLoading: false,
+      isError: false,
+    });
+    render(<MaoAuditTrailPanel projectId={MOCK_PROJECT_ID} />);
+    expect(screen.getByTestId('audit-actor-principal')).toBeTruthy();
+    // No supervisor glyph when actor_type is absent.
+    expect(screen.queryByTestId('audit-actor-supervisor-glyph')).toBeNull();
+  });
+
+  // UT-SP14-AT-EVIDENCE-REF — three-attribute pattern (SUPV-SP14-014)
+  it('UT-SP14-AT-EVIDENCE-REF — expanded evidence refs render with the SP 13 three-attribute pattern', () => {
+    const fixedCommandId = 'aaaa-bbbb-cccc-dddd-eeeeeeee9999';
+    mockUseQuery = vi.fn().mockReturnValue({
+      data: [
+        {
+          commandId: fixedCommandId,
+          action: 'pause_project',
+          actorId: 'principal-1',
+          reason: 'reason text',
+          reasonCode: 'mao_project_control_applied',
+          at: '2026-03-10T01:00:00.000Z',
+          evidenceRefs: ['evidence://e1', 'evidence://e2'],
+          resumeReadinessStatus: 'not_applicable',
+          decisionRef: 'mao-control:cmd-x',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+    render(<MaoAuditTrailPanel projectId={MOCK_PROJECT_ID} />);
+    fireEvent.click(screen.getByText('reason text'));
+    const list = screen.getByTestId('audit-evidence-ref-list');
+    const refs = list.querySelectorAll('[data-mao-evidence-ref]');
+    expect(refs.length).toBe(2);
+    for (const node of Array.from(refs)) {
+      expect(node.getAttribute('data-mao-evidence-source')).toBe('audit-trail');
+      expect(node.getAttribute('data-mao-evidence-command-id')).toBe(fixedCommandId);
+    }
+  });
+
+  // UT-SP14-AT-DNR-I1 — eleven event-type non-suppression check via render-all
+  it('UT-SP14-AT-DNR-I1 — audit-trail renders all entries without filtering on event type', () => {
+    const entries = Array.from({ length: 11 }, (_, i) =>
+      makeEntry({ commandId: String(i), reason: `entry-${i}` }),
+    );
+    mockUseQuery = vi.fn().mockReturnValue({
+      data: entries,
+      isLoading: false,
+      isError: false,
+    });
+    render(<MaoAuditTrailPanel projectId={MOCK_PROJECT_ID} />);
+    for (let i = 0; i < 11; i++) {
+      expect(screen.getByText(`entry-${i}`)).toBeTruthy();
+    }
+  });
+});
+
+describe('UT-SP14-CAT-ACTOR-TYPE — closed Record over five-literal admit', () => {
+  it('ACTOR_VISUAL covers all five ControlActorType literals exhaustively', () => {
+    const expected: ControlActorType[] = [
+      'principal',
+      'orchestration_agent',
+      'worker_agent',
+      'system_agent',
+      'supervisor',
+    ];
+    expect(Object.keys(ACTOR_VISUAL).sort()).toEqual([...expected].sort());
+    // Only the supervisor row carries the glyph distinction.
+    const supervisorRow: ActorVisualTreatment = ACTOR_VISUAL.supervisor;
+    expect(supervisorRow.glyph).toBe('supervisor');
+    expect(supervisorRow.badge).toBe('Supervisor');
+    expect(supervisorRow.toneSeverity).toBe('high');
+    // Non-supervisor rows render no glyph.
+    for (const literal of expected.filter((x) => x !== 'supervisor')) {
+      expect(ACTOR_VISUAL[literal].glyph).toBeNull();
+    }
   });
 });

--- a/self/ui/src/components/mao/__tests__/mao-closed-enum-admission.test.ts
+++ b/self/ui/src/components/mao/__tests__/mao-closed-enum-admission.test.ts
@@ -2,9 +2,14 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  ControlActionSchema,
+  ControlActorTypeSchema,
+  ConfirmationTierSchema,
   GuardrailStatusSchema,
   MaoDensityModeSchema,
   MaoEventTypeSchema,
+  MaoProjectControlActionSchema,
+  OpctlSubmitResultSchema,
   WitnessIntegrityStatusSchema,
 } from '@nous/shared';
 import {
@@ -15,6 +20,14 @@ import {
   SEVERITY_TOKEN_TO_CSS_VAR,
   WITNESS_INTEGRITY_SEVERITY,
 } from '../mao-inspect-panel';
+import {
+  TOAST_BODY_BY_OUTCOME,
+  classifyOutcome,
+  type OpctlSubmitToastOutcome,
+} from '../mao-project-controls';
+import { ACTOR_VISUAL } from '../mao-audit-trail-panel';
+import { ACTION_MAP } from '../mao-t3-confirmation-dialog';
+import { randomUUID } from 'node:crypto';
 
 /**
  * UT-SP13-CAT-* + UT-SP13-SENTINEL-BANDS — D1-style closed-enum admission
@@ -113,6 +126,164 @@ describe('SP 13 closed-enum admission regression guards', () => {
     }
     // Negative — non-MAO suppressed event type rejected.
     expect(MaoEventTypeSchema.safeParse('mao_phantom_emission').success).toBe(false);
+  });
+
+  // --- WR-162 SP 14 (SUPV-SP14-017) — D1-style closed-enum admission carry-forward ---
+
+  it('UT-SP14-CAT-TIER — ConfirmationTierSchema admits T0..T3 and rejects unknown', () => {
+    expect(ConfirmationTierSchema.safeParse('T0').success).toBe(true);
+    expect(ConfirmationTierSchema.safeParse('T1').success).toBe(true);
+    expect(ConfirmationTierSchema.safeParse('T2').success).toBe(true);
+    expect(ConfirmationTierSchema.safeParse('T3').success).toBe(true);
+    expect(ConfirmationTierSchema.safeParse('T4').success).toBe(false);
+  });
+
+  it('UT-SP14-CAT-SEVERITY — tier-display severity union maps closed to four CSS-var literals', () => {
+    expect(SEVERITY_TOKEN_TO_CSS_VAR.low).toBeDefined();
+    expect(SEVERITY_TOKEN_TO_CSS_VAR.medium).toBeDefined();
+    expect(SEVERITY_TOKEN_TO_CSS_VAR.high).toBeDefined();
+    expect(SEVERITY_TOKEN_TO_CSS_VAR.critical).toBeDefined();
+  });
+
+  it('UT-SP14-CAT-PROJECT-CONTROL-ACTION-REASSERT — three literals; no cancel_queued literal', () => {
+    expect(MaoProjectControlActionSchema.safeParse('pause_project').success).toBe(true);
+    expect(MaoProjectControlActionSchema.safeParse('resume_project').success).toBe(true);
+    expect(MaoProjectControlActionSchema.safeParse('hard_stop_project').success).toBe(true);
+    expect(MaoProjectControlActionSchema.safeParse('cancel_queued').success).toBe(false);
+  });
+
+  it('UT-SP14-CAT-CONTROL-ACTION-REASSERT — SP 14 routes-through three of the eleven literals', () => {
+    expect(ControlActionSchema.safeParse('pause').success).toBe(true);
+    expect(ControlActionSchema.safeParse('resume').success).toBe(true);
+    expect(ControlActionSchema.safeParse('hard_stop').success).toBe(true);
+    // Non-action literal rejected.
+    expect(ControlActionSchema.safeParse('cancel_queued').success).toBe(false);
+    // ACTION_MAP exhaustively maps the three project-control actions to ControlAction.
+    expect(ACTION_MAP.pause_project).toBe('pause');
+    expect(ACTION_MAP.resume_project).toBe('resume');
+    expect(ACTION_MAP.hard_stop_project).toBe('hard_stop');
+  });
+
+  it('UT-SP14-CAT-ACTOR-TYPE — ControlActorTypeSchema admits all five literals; closed Record exhaustiveness', () => {
+    expect(ControlActorTypeSchema.safeParse('principal').success).toBe(true);
+    expect(ControlActorTypeSchema.safeParse('orchestration_agent').success).toBe(true);
+    expect(ControlActorTypeSchema.safeParse('worker_agent').success).toBe(true);
+    expect(ControlActorTypeSchema.safeParse('system_agent').success).toBe(true);
+    expect(ControlActorTypeSchema.safeParse('supervisor').success).toBe(true);
+    expect(ControlActorTypeSchema.safeParse('operator').success).toBe(false);
+    expect(Object.keys(ACTOR_VISUAL).sort()).toEqual([
+      'orchestration_agent',
+      'principal',
+      'supervisor',
+      'system_agent',
+      'worker_agent',
+    ]);
+  });
+
+  it('UT-SP14-CAT-OPCTL-REASON-CODE — OpctlSubmitResultSchema admits the four SP-14 routed reason codes; classifyOutcome maps correctly', () => {
+    const baseAccepted = {
+      command_id: randomUUID(),
+      project_id: randomUUID(),
+      accepted: true,
+      from_state: 'running' as const,
+      to_state: 'paused_review' as const,
+      decision_ref: 'mao-control:cmd-x',
+      impactSummary: {
+        activeRunCount: 0,
+        activeAgentCount: 0,
+        blockedAgentCount: 0,
+        urgentAgentCount: 0,
+        affectedScheduleCount: 0,
+        evidenceRefs: [] as string[],
+      },
+      evidenceRefs: [] as string[],
+      readiness_status: 'not_applicable' as const,
+    };
+    // applied
+    expect(
+      classifyOutcome({
+        ...baseAccepted,
+        status: 'applied',
+        reason_code: 'mao_project_control_applied',
+      } as any),
+    ).toBe('applied');
+    // rejected
+    expect(
+      classifyOutcome({
+        ...baseAccepted,
+        accepted: false,
+        status: 'rejected',
+        reason_code: 'OPCTL-006',
+      } as any),
+    ).toBe('rejected');
+    // blocked_conflict_resolved
+    expect(
+      classifyOutcome({
+        ...baseAccepted,
+        accepted: false,
+        status: 'blocked',
+        reason_code: 'opctl_conflict_resolved',
+      } as any),
+    ).toBe('blocked_conflict_resolved');
+    // blocked_other (e.g., supervisor_enforcement_lock or OPCTL-003)
+    expect(
+      classifyOutcome({
+        ...baseAccepted,
+        accepted: false,
+        status: 'blocked',
+        reason_code: 'supervisor_enforcement_lock',
+      } as any),
+    ).toBe('blocked_other');
+    // OpctlSubmitResultSchema admits a runtime sample with the four reason codes
+    const reasonCodes = [
+      'opctl_conflict_resolved',
+      'supervisor_enforcement_lock',
+      'OPCTL-003',
+      'OPCTL-006',
+    ];
+    for (const code of reasonCodes) {
+      const sample = OpctlSubmitResultSchema.safeParse({
+        control_command_id: randomUUID(),
+        status: 'blocked',
+        reason: 'sample',
+        reason_code: code,
+      });
+      expect(sample.success).toBe(true);
+    }
+  });
+
+  it('UT-SP14-CAT-MAO-EVENT-TYPES-REASSERT — eleven literals admitted; unknown rejected', () => {
+    const eleven = [
+      'mao_agent_state_projected',
+      'mao_density_mode_changed',
+      'mao_urgent_overlay_applied',
+      'mao_urgent_overlay_cleared',
+      'mao_project_control_requested',
+      'mao_project_control_applied',
+      'mao_project_control_blocked',
+      'mao_pfc_project_recommendation_updated',
+      'mao_project_resume_readiness_passed',
+      'mao_project_resume_readiness_blocked',
+      'mao_graph_lineage_rendered',
+    ] as const;
+    for (const literal of eleven) {
+      expect(MaoEventTypeSchema.safeParse(literal).success).toBe(true);
+    }
+    expect(MaoEventTypeSchema.safeParse('mao_phantom_emission').success).toBe(false);
+  });
+
+  it('UT-SP14-CAT-RATIONALE-KEY — TOAST_BODY_BY_OUTCOME closed Record over four OpctlSubmitToastOutcome literals', () => {
+    const expected: OpctlSubmitToastOutcome[] = [
+      'applied',
+      'rejected',
+      'blocked_conflict_resolved',
+      'blocked_other',
+    ];
+    expect(Object.keys(TOAST_BODY_BY_OUTCOME).sort()).toEqual([...expected].sort());
+    expect(TOAST_BODY_BY_OUTCOME.applied.tone).toBe('success');
+    expect(TOAST_BODY_BY_OUTCOME.rejected.tone).toBe('error');
+    expect(TOAST_BODY_BY_OUTCOME.blocked_conflict_resolved.tone).toBe('info');
+    expect(TOAST_BODY_BY_OUTCOME.blocked_other.tone).toBe('warn');
   });
 
   it('UT-SP13-SENTINEL-BANDS — boundary-value tests on the closed band-table', () => {

--- a/self/ui/src/components/mao/__tests__/mao-dnr-verification.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-dnr-verification.test.tsx
@@ -296,3 +296,160 @@ describe('UT-SP13-DNR-C4 — urgent overlay visibility unconditional on motion p
     expect(urgentBadge.getAttribute('data-mao-urgent-indicator')).toBe('present');
   });
 });
+
+// --- WR-162 SP 14 (SUPV-SP14-018) — DNR row regression guards ---
+
+import { MaoProjectControls } from '../mao-project-controls';
+import {
+  MaoT3ConfirmationDialog,
+  type MaoT3ConfirmationDialogProps,
+} from '../mao-t3-confirmation-dialog';
+
+vi.mock('@nous/transport', () => ({
+  trpc: {
+    useUtils: vi.fn().mockReturnValue({
+      mao: { getControlAuditHistory: { invalidate: vi.fn() } },
+    }),
+    mao: {
+      getControlAuditHistory: {
+        useQuery: vi.fn().mockReturnValue({ data: [], isLoading: false, isError: false }),
+      },
+    },
+    opctl: {
+      requestConfirmationProof: {
+        useMutation: vi.fn().mockReturnValue({
+          mutate: vi.fn(),
+          isPending: false,
+          isError: false,
+        }),
+      },
+    },
+  },
+  useEventSubscription: vi.fn(),
+}));
+
+function makeProjectControlsSnapshot(): MaoProjectSnapshot {
+  return {
+    projectId: '11111111-1111-1111-1111-111111111111',
+    densityMode: 'D2',
+    workflowRunId: '22222222-2222-2222-2222-222222222222',
+    controlProjection: {
+      project_id: '11111111-1111-1111-1111-111111111111',
+      project_control_state: 'running',
+      active_agent_count: 1,
+      blocked_agent_count: 0,
+      urgent_agent_count: 0,
+      pfc_project_review_status: 'none',
+      pfc_project_recommendation: 'continue',
+      resume_readiness_status: 'not_applicable',
+      resume_readiness_evidence_refs: [],
+    },
+    grid: [],
+    graph: { projectId: '11111111-1111-1111-1111-111111111111', nodes: [], edges: [], generatedAt: '2026-03-10T01:00:00.000Z' },
+    urgentOverlay: { urgentAgentIds: [], blockedAgentIds: [], generatedAt: '2026-03-10T01:00:00.000Z' },
+    summary: {
+      activeAgentCount: 1,
+      blockedAgentCount: 0,
+      failedAgentCount: 0,
+      waitingPfcAgentCount: 0,
+      urgentAgentCount: 0,
+    },
+    diagnostics: { runtimePosture: 'single_process_local' },
+    generatedAt: '2026-03-10T01:00:00.000Z',
+  } as unknown as MaoProjectSnapshot;
+}
+
+describe('UT-SP14-DNR — DNR row regression guards', () => {
+  afterEach(() => cleanup());
+
+  // UT-SP14-DNR-A4 / DNR-F1 — three project-control buttons remain present
+  it('UT-SP14-DNR-A4 / DNR-F1 — three project controls present in MaoProjectControls', () => {
+    render(
+      <MaoProjectControls
+        snapshot={makeProjectControlsSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Pause Project')).toBeTruthy();
+    expect(screen.getByText('Resume Project')).toBeTruthy();
+    expect(screen.getByText('Hard Stop Project')).toBeTruthy();
+  });
+
+  // UT-SP14-DNR-F3 — Cortex review surface preserved
+  it('UT-SP14-DNR-F3 — Cortex review surface preserved post-polish', () => {
+    render(
+      <MaoProjectControls
+        snapshot={makeProjectControlsSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('cortex-review-section')).toBeTruthy();
+  });
+
+  // UT-SP14-DNR-F4 — admission guardrails (Pause Project disabled when paused)
+  it('UT-SP14-DNR-F4 — admission guardrail visible: Pause disabled when state is paused_review', () => {
+    const snapshot = makeProjectControlsSnapshot();
+    (snapshot.controlProjection as any).project_control_state = 'paused_review';
+    render(
+      <MaoProjectControls
+        snapshot={snapshot}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const pauseBtn = screen.getByText('Pause Project').closest('button');
+    expect(pauseBtn).toBeTruthy();
+    expect((pauseBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // UT-SP14-DNR-F5 — reason capture flow preserved
+  it('UT-SP14-DNR-F5 — reason capture textarea preserved; submit blocked without reason', () => {
+    const onRequestControl = vi.fn();
+    render(
+      <MaoProjectControls
+        snapshot={makeProjectControlsSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={onRequestControl}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    expect(textarea).toBeTruthy();
+    // Without reason, button is disabled.
+    const pause = screen.getByText('Pause Project').closest('button');
+    expect((pause as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // UT-SP14-DNR-J1 — additive optional supervisorLocked + result props (no new required prop)
+  it('UT-SP14-DNR-J1 — MaoT3ConfirmationDialogProps remain shape-compatible (optional supervisorLocked + result)', () => {
+    // TypeScript-compile-time check via assignability.
+    const props: MaoT3ConfirmationDialogProps = {
+      open: true,
+      action: 'resume_project',
+      projectId: '550e8400-e29b-41d4-a716-446655445001' as any,
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+    };
+    expect(props.supervisorLocked).toBeUndefined();
+    expect(props.result).toBeUndefined();
+  });
+
+  // UT-SP14-DNR-J2 — render-contract under existing host
+  it('UT-SP14-DNR-J2 — MaoT3ConfirmationDialog mounts under existing host fixture without crashing', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={'550e8400-e29b-41d4-a716-446655445001' as any}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('t3-confirmation-dialog')).toBeTruthy();
+  });
+});

--- a/self/ui/src/components/mao/__tests__/mao-project-controls.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-project-controls.test.tsx
@@ -3,7 +3,12 @@
 import * as React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MaoProjectControls } from '../mao-project-controls';
+import {
+  MaoProjectControls,
+  TOAST_BODY_BY_OUTCOME,
+  classifyOutcome,
+  type OpctlSubmitToastOutcome,
+} from '../mao-project-controls';
 import type { MaoProjectControlResult, MaoProjectSnapshot } from '@nous/shared';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -270,5 +275,259 @@ describe('MaoProjectControls', () => {
         commandId: expect.stringMatching(UUID_REGEX),
       }),
     );
+  });
+});
+
+// --- WR-162 SP 14 (SUPV-SP14-001..006) — Project-controls polish ---
+
+function makeResult(
+  overrides: Partial<MaoProjectControlResult>,
+): MaoProjectControlResult {
+  return {
+    command_id: 'cmd-result',
+    project_id: '11111111-1111-1111-1111-111111111111',
+    accepted: true,
+    status: 'applied',
+    from_state: 'running',
+    to_state: 'paused_review',
+    reason_code: 'mao_project_control_applied',
+    decision_ref: 'mao-control:cmd-result',
+    impactSummary: {
+      activeRunCount: 0,
+      activeAgentCount: 0,
+      blockedAgentCount: 0,
+      urgentAgentCount: 0,
+      affectedScheduleCount: 0,
+      evidenceRefs: [],
+    },
+    evidenceRefs: [],
+    readiness_status: 'not_applicable',
+    ...overrides,
+  } as unknown as MaoProjectControlResult;
+}
+
+describe('UT-SP14-PC — project-controls polish (SUPV-SP14-001..006)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // UT-SP14-PC-BANNER-PRESENT
+  it('UT-SP14-PC-BANNER-PRESENT — renders scope-lock banner after submit', () => {
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Pause for review' } });
+    fireEvent.click(screen.getByText('Pause Project'));
+    expect(screen.getByTestId('scope-lock-banner')).toBeTruthy();
+    expect(screen.getByTestId('scope-lock-banner').getAttribute('data-banner-action')).toBe('pause_project');
+  });
+
+  // UT-SP14-PC-BANNER-ABSENT
+  it('UT-SP14-PC-BANNER-ABSENT — does not render banner before any submit', () => {
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('scope-lock-banner')).toBeNull();
+  });
+
+  // UT-SP14-PC-AUTO-CLEAR
+  it('UT-SP14-PC-AUTO-CLEAR — banner clears when lastResult.status === "applied"', () => {
+    const { rerender } = render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Pause' } });
+    fireEvent.click(screen.getByText('Pause Project'));
+    expect(screen.getByTestId('scope-lock-banner')).toBeTruthy();
+
+    rerender(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={makeResult({ status: 'applied' })}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('scope-lock-banner')).toBeNull();
+  });
+
+  // UT-SP14-PC-BANNER-PERSIST-ON-CONFLICT — banner persists for blocked_conflict_resolved
+  it('UT-SP14-PC-BANNER-PERSIST-ON-CONFLICT — banner persists when lastResult is blocked_conflict_resolved', () => {
+    const { rerender } = render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Pause' } });
+    fireEvent.click(screen.getByText('Pause Project'));
+    expect(screen.getByTestId('scope-lock-banner')).toBeTruthy();
+
+    rerender(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={makeResult({
+          status: 'blocked',
+          reason_code: 'opctl_conflict_resolved',
+        })}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('scope-lock-banner')).toBeTruthy();
+  });
+
+  // UT-SP14-PC-TOAST-PER-OUTCOME — closed Record exhaustiveness over four outcomes
+  it('UT-SP14-PC-TOAST-PER-OUTCOME — TOAST_BODY_BY_OUTCOME admits all four outcomes', () => {
+    const expected: OpctlSubmitToastOutcome[] = [
+      'applied',
+      'rejected',
+      'blocked_conflict_resolved',
+      'blocked_other',
+    ];
+    expect(Object.keys(TOAST_BODY_BY_OUTCOME).sort()).toEqual([...expected].sort());
+    expect(TOAST_BODY_BY_OUTCOME.applied.tone).toBe('success');
+    expect(TOAST_BODY_BY_OUTCOME.rejected.tone).toBe('error');
+    expect(TOAST_BODY_BY_OUTCOME.blocked_conflict_resolved.tone).toBe('info');
+    expect(TOAST_BODY_BY_OUTCOME.blocked_other.tone).toBe('warn');
+  });
+
+  // UT-SP14-PC-TOAST-CLASSIFY — closed pure discriminator
+  it('UT-SP14-PC-TOAST-CLASSIFY — classifyOutcome maps the four submit-result branches', () => {
+    expect(classifyOutcome(makeResult({ status: 'applied' }))).toBe('applied');
+    expect(classifyOutcome(makeResult({ status: 'rejected' }))).toBe('rejected');
+    expect(
+      classifyOutcome(
+        makeResult({
+          status: 'blocked',
+          reason_code: 'opctl_conflict_resolved',
+        }),
+      ),
+    ).toBe('blocked_conflict_resolved');
+    expect(
+      classifyOutcome(
+        makeResult({ status: 'blocked', reason_code: 'OPCTL-006' }),
+      ),
+    ).toBe('blocked_other');
+  });
+
+  // UT-SP14-PC-TOAST-RENDERED — toast surfaces in DOM after lastResult arrives
+  it('UT-SP14-PC-TOAST-RENDERED — toast renders on lastResult dispatch', () => {
+    const { rerender } = render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    rerender(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={makeResult({ status: 'applied' })}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const toast = screen.getByTestId('project-controls-toast');
+    expect(toast).toBeTruthy();
+    expect(toast.getAttribute('data-toast-tone')).toBe('success');
+    expect(toast.textContent).toContain('Command applied');
+  });
+
+  // UT-SP14-PC-CANCEL-QUEUED — renderer-only abandon-the-promise
+  it('UT-SP14-PC-CANCEL-QUEUED — clicking "Cancel queued" clears banner + emits info toast', () => {
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/operator reason/i);
+    fireEvent.change(textarea, { target: { value: 'Hard stop' } });
+    fireEvent.click(screen.getByText('Hard Stop Project'));
+    expect(screen.getByTestId('scope-lock-banner')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('scope-lock-cancel-queued'));
+    expect(screen.queryByTestId('scope-lock-banner')).toBeNull();
+
+    const toast = screen.getByTestId('project-controls-toast');
+    expect(toast.getAttribute('data-toast-tone')).toBe('info');
+    expect(toast.textContent).toContain('Cancellation visual');
+  });
+
+  // UT-SP14-PC-TIER-BADGE — each control button carries a tier badge
+  it('UT-SP14-PC-TIER-BADGE — three control buttons each render a tier badge', () => {
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const badges = document.querySelectorAll('[data-tier-badge]');
+    expect(badges.length).toBe(3);
+    const levels = Array.from(badges).map((el) => el.getAttribute('data-tier-badge'));
+    // pause_project → pause → T1; resume_project → resume → T3; hard_stop_project → hard_stop → T3.
+    expect(levels).toEqual(['T1', 'T3', 'T3']);
+  });
+
+  // UT-SP14-PC-TIER-BADGE-SEVERITY — severity-token reuses SP 13 CSS-var pipeline
+  it('UT-SP14-PC-TIER-BADGE-SEVERITY — tier badges carry the SP 13 severity-token', () => {
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    const badges = document.querySelectorAll('[data-tier-severity]');
+    const severities = Array.from(badges).map((el) =>
+      el.getAttribute('data-tier-severity'),
+    );
+    // pause→T1→medium; resume→T3→critical; hard_stop→T3→critical.
+    expect(severities).toEqual(['medium', 'critical', 'critical']);
+  });
+
+  // UT-SP14-PC-DNR-F1 / DNR-A4 — three controls present at all times
+  it('UT-SP14-PC-DNR-F1 — three project-control buttons remain present', () => {
+    render(
+      <MaoProjectControls
+        snapshot={createSnapshot()}
+        pending={false}
+        lastResult={null}
+        onRequestControl={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Pause Project')).toBeTruthy();
+    expect(screen.getByText('Resume Project')).toBeTruthy();
+    expect(screen.getByText('Hard Stop Project')).toBeTruthy();
   });
 });

--- a/self/ui/src/components/mao/__tests__/mao-t3-confirmation-dialog.test.tsx
+++ b/self/ui/src/components/mao/__tests__/mao-t3-confirmation-dialog.test.tsx
@@ -4,7 +4,12 @@ import * as React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MaoT3ConfirmationDialog } from '../mao-t3-confirmation-dialog';
+import {
+  MaoT3ConfirmationDialog,
+  RATIONALE_COPY,
+  resolveRationaleCopy,
+  type RationaleKey,
+} from '../mao-t3-confirmation-dialog';
 
 const MOCK_PROJECT_ID = '550e8400-e29b-41d4-a716-446655445001' as any;
 
@@ -313,5 +318,262 @@ describe('MaoT3ConfirmationDialog', () => {
     // Should show the confirmation view, not the proof display
     expect(screen.getByText('Confirm T3 action')).toBeTruthy();
     expect(screen.queryByText('Proof confirmed')).toBeNull();
+  });
+});
+
+// --- WR-162 SP 14 (SUPV-SP14-008..013) — T3 dialog metadata refactor ---
+
+describe('UT-SP14-T3 — T3 dialog metadata refactor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutate = vi.fn();
+    mockUseMutation = vi.fn().mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // UT-SP14-T3-LABEL-THREAD — display.label threads into render output
+  it('UT-SP14-T3-LABEL-THREAD — getTierDisplay("T3").label "Cooldown-gated" renders', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const label = screen.getByTestId('t3-tier-label');
+    expect(label.textContent).toBe('Cooldown-gated');
+    expect(label.getAttribute('data-tier-level')).toBe('T3');
+    expect(label.getAttribute('data-tier-severity')).toBe('critical');
+  });
+
+  // UT-SP14-T3-SEVERITY-TOKEN — replaces inline '#ef4444' with SP 13 CSS-var
+  it('UT-SP14-T3-SEVERITY-TOKEN — heading + tier label use SP 13 CSS-var, not "#ef4444"', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="hard_stop_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const heading = screen.getByText('Confirm T3 action');
+    const headingStyle = heading.getAttribute('style') ?? '';
+    expect(headingStyle).toContain('var(--nous-alert-critical)');
+    expect(headingStyle.toLowerCase()).not.toContain('#ef4444');
+  });
+
+  // UT-SP14-T3-METADATA-CALL — display surface anchored on tier metadata
+  it('UT-SP14-T3-METADATA-CALL — render reads getTierDisplay("T3") shape (label + severity + rationaleKey)', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const label = screen.getByTestId('t3-tier-label');
+    const rationale = screen.getByTestId('t3-rationale-copy');
+    expect(label.getAttribute('data-tier-level')).toBe('T3');
+    expect(rationale.getAttribute('data-rationale-key')).toBe('tier.t3.rationale');
+  });
+
+  // UT-SP14-T3-SUPERVISOR-RATIONALE — supervisor-locked variant
+  it('UT-SP14-T3-SUPERVISOR-RATIONALE — supervisor-locked renders the ESC-001 acknowledgment copy', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="hard_stop_project"
+        projectId={MOCK_PROJECT_ID}
+        supervisorLocked={true}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const rationale = screen.getByTestId('t3-rationale-copy');
+    expect(rationale.getAttribute('data-supervisor-locked')).toBe('true');
+    expect(rationale.textContent).toContain('Supervisor lock active');
+    expect(rationale.textContent).toContain('ESC-001');
+  });
+
+  // UT-SP14-T3-RATIONALE-DEFAULT — supervisorLocked omitted == false
+  it('UT-SP14-T3-RATIONALE-DEFAULT — without supervisorLocked, the standard rationale copy renders', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const rationale = screen.getByTestId('t3-rationale-copy');
+    expect(rationale.getAttribute('data-supervisor-locked')).toBe('false');
+    expect(rationale.textContent).toContain('Cooldown-gated');
+  });
+
+  // UT-SP14-T3-COOLDOWN-V1 — countdown not rendered when T3_COOLDOWN_MS === 0
+  it('UT-SP14-T3-COOLDOWN-V1 — no cooldown countdown rendered at V1 (T3_COOLDOWN_MS === 0)', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('t3-cooldown')).toBeNull();
+  });
+
+  // UT-SP14-T3-IMPACT-SUMMARY — closes Goals N4 (impact-summary block preserved)
+  it('UT-SP14-T3-IMPACT-SUMMARY — impactSummary block continues to render under fixture', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        impactSummary={{
+          activeRunCount: 2,
+          activeAgentCount: 5,
+          blockedAgentCount: 1,
+          urgentAgentCount: 0,
+        }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('active runs: 2')).toBeTruthy();
+    expect(screen.getByText('active agents: 5')).toBeTruthy();
+    expect(screen.getByText('blocked agents: 1')).toBeTruthy();
+    expect(screen.getByText('urgent agents: 0')).toBeTruthy();
+  });
+
+  // UT-SP14-T3-REASON-CODE — reason-code block renders when result.reason_code present
+  it('UT-SP14-T3-REASON-CODE — reason-code surface renders when result.reason_code is provided', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        result={{ reason_code: 'OPCTL-003' }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const reasonBlock = screen.getByTestId('t3-reason-code');
+    expect(reasonBlock).toBeTruthy();
+    expect(reasonBlock.textContent).toContain('OPCTL-003');
+  });
+
+  // UT-SP14-T3-REASON-CODE-ABSENT
+  it('UT-SP14-T3-REASON-CODE-ABSENT — reason-code surface absent when result.reason_code undefined', () => {
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('t3-reason-code')).toBeNull();
+  });
+
+  // UT-SP14-DNR-H1 — proof-flow state machine intact
+  it('UT-SP14-DNR-H1 — proof-flow state machine: mutate → confirmedProof → Done', async () => {
+    const onConfirm = vi.fn();
+    mockUseMutation = vi.fn().mockImplementation(
+      (opts?: { onSuccess?: (proof: any) => void }) => ({
+        mutate: () => opts?.onSuccess?.(MOCK_PROOF),
+        isPending: false,
+        isError: false,
+      }),
+    );
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="hard_stop_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('proof-done-button')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('proof-done-button'));
+    expect(onConfirm).toHaveBeenCalledWith(MOCK_PROOF);
+  });
+
+  // UT-SP14-DNR-H2 — four data-testid anchors resolve
+  it('UT-SP14-DNR-H2 — t3-confirmation-dialog + proof-details + proof-id + proof-done-button anchors resolve', async () => {
+    mockUseMutation = vi.fn().mockImplementation(
+      (opts?: { onSuccess?: (proof: any) => void }) => ({
+        mutate: () => opts?.onSuccess?.(MOCK_PROOF),
+        isPending: false,
+        isError: false,
+      }),
+    );
+    render(
+      <MaoT3ConfirmationDialog
+        open={true}
+        action="resume_project"
+        projectId={MOCK_PROJECT_ID}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('t3-confirmation-dialog')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('proof-details')).toBeTruthy();
+      expect(screen.getByTestId('proof-id')).toBeTruthy();
+      expect(screen.getByTestId('proof-done-button')).toBeTruthy();
+    });
+  });
+});
+
+describe('UT-SP14-T3 — RationaleKey closed Record', () => {
+  // UT-SP14-CAT-RATIONALE-KEY — closed Record exhaustiveness
+  it('UT-SP14-CAT-RATIONALE-KEY — RATIONALE_COPY admits exactly five RationaleKey literals', () => {
+    const expected: RationaleKey[] = [
+      'tier.t0.rationale',
+      'tier.t1.rationale',
+      'tier.t2.rationale',
+      'tier.t3.rationale',
+      'tier.t3.supervisor_locked',
+    ];
+    expect(Object.keys(RATIONALE_COPY).sort()).toEqual([...expected].sort());
+    for (const key of expected) {
+      expect(typeof RATIONALE_COPY[key]).toBe('string');
+      expect(RATIONALE_COPY[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  // resolveRationaleCopy contract
+  it('resolveRationaleCopy — supervisor-locked rewrites tier.t3.rationale only', () => {
+    expect(resolveRationaleCopy('tier.t3.rationale', false)).toBe(
+      RATIONALE_COPY['tier.t3.rationale'],
+    );
+    expect(resolveRationaleCopy('tier.t3.rationale', true)).toBe(
+      RATIONALE_COPY['tier.t3.supervisor_locked'],
+    );
+    // Non-T3 keys do NOT get rewritten when supervisorLocked === true.
+    expect(resolveRationaleCopy('tier.t1.rationale', true)).toBe(
+      RATIONALE_COPY['tier.t1.rationale'],
+    );
   });
 });

--- a/self/ui/src/components/mao/mao-audit-trail-panel.tsx
+++ b/self/ui/src/components/mao/mao-audit-trail-panel.tsx
@@ -1,11 +1,99 @@
 'use client';
 
 import * as React from 'react';
-import type { ProjectId } from '@nous/shared';
+import type { ControlActorType, ProjectId } from '@nous/shared';
 import { SYSTEM_SCOPE_SENTINEL_PROJECT_ID } from '@nous/shared';
 import { Badge } from '../badge';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
 import { trpc, useEventSubscription } from '@nous/transport';
+import { SEVERITY_TOKEN_TO_CSS_VAR } from './mao-inspect-panel';
+
+// --- WR-162 SP 14 SUPV-SP14-015 — Closed Record over five-literal ControlActorType admit ---
+//
+// The closed `Record<ControlActorType, ActorVisualTreatment>` provides
+// per-actor visual treatment for audit-trail entries. The supervisor row
+// renders the visual distinction (glyph + caution-tone badge); other rows
+// render neutral baseline. TypeScript exhaustiveness over the five-literal
+// admit (`'principal' | 'orchestration_agent' | 'worker_agent' |
+// 'system_agent' | 'supervisor'`) catches drift at compile time.
+//
+// Renderer-side gap: `MaoControlAuditHistoryEntrySchema` does NOT currently
+// carry an `actor_type` field (only `actorId`). The renderer reads the field
+// defensively when present; otherwise falls back to the `'principal'` baseline.
+// The data-plane gap is tracked at SUPV-SP14-AI-AUDIT-ACTOR-TYPE-DATA-PLANE-GAP
+// for phase-close follow-up. The closed `Record` shape preserves the SDS
+// admission discipline (UT-SP14-CAT-ACTOR-TYPE) and enables transparent wiring
+// once the upstream contract surfaces actor_type.
+export type ActorVisualTreatment = {
+  glyph: 'supervisor' | null;
+  badge: string;
+  /** Mapped to `SEVERITY_TOKEN_TO_CSS_VAR` for color semantics. */
+  toneSeverity: 'low' | 'medium' | 'high' | 'critical';
+};
+
+export const ACTOR_VISUAL: Record<ControlActorType, ActorVisualTreatment> = {
+  principal: { glyph: null, badge: 'Principal', toneSeverity: 'low' },
+  orchestration_agent: {
+    glyph: null,
+    badge: 'Orchestrator',
+    toneSeverity: 'low',
+  },
+  worker_agent: { glyph: null, badge: 'Worker', toneSeverity: 'low' },
+  system_agent: { glyph: null, badge: 'System', toneSeverity: 'medium' },
+  supervisor: { glyph: 'supervisor', badge: 'Supervisor', toneSeverity: 'high' },
+};
+
+/**
+ * SUPV-SP14-015 — Defensive actor-type read. The audit-history entry
+ * schema currently does not surface `actor_type`; this resolver reads the
+ * field if the runtime payload carries it (e.g., once the data plane lands
+ * the contract widening) and otherwise defaults to `'principal'` baseline.
+ */
+function readActorType(entry: unknown): ControlActorType {
+  if (entry !== null && typeof entry === 'object' && 'actor_type' in entry) {
+    const candidate = (entry as { actor_type?: unknown }).actor_type;
+    if (
+      candidate === 'principal' ||
+      candidate === 'orchestration_agent' ||
+      candidate === 'worker_agent' ||
+      candidate === 'system_agent' ||
+      candidate === 'supervisor'
+    ) {
+      return candidate;
+    }
+  }
+  return 'principal';
+}
+
+/**
+ * SUPV-SP14-015 — Supervisor glyph component. Inline SVG to avoid adding a new
+ * dependency or a new asset import. Render contract: presence of the glyph
+ * IS the visual distinction.
+ */
+function SupervisorGlyph() {
+  return (
+    <span
+      data-testid="audit-actor-supervisor-glyph"
+      aria-label="Supervisor actor"
+      role="img"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '0.875rem',
+        height: '0.875rem',
+        marginRight: 'var(--nous-space-2xs)',
+        color: SEVERITY_TOKEN_TO_CSS_VAR.high,
+      }}
+    >
+      {/* triangle alert glyph — preserves the existing supervisor visual
+          vocabulary across MAO surfaces */}
+      <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+        <path d="M8 1L15 14H1L8 1Z M8 6V10 M8 11.5V12.5" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" fill="none" />
+      </svg>
+    </span>
+  );
+}
 
 export interface MaoAuditTrailPanelProps {
   projectId: ProjectId | null;
@@ -63,11 +151,15 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-sm)' }}>
             {entries.map((entry) => {
               const isExpanded = expandedId === entry.commandId;
+              const actorType = readActorType(entry);
+              const treatment = ACTOR_VISUAL[actorType];
 
               return (
                 <button
                   key={entry.commandId}
                   type="button"
+                  data-actor-type={actorType}
+                  data-actor-badge={treatment.badge}
                   style={{
                     width: '100%',
                     borderRadius: 'var(--nous-radius-sm)',
@@ -87,6 +179,22 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
                       <Badge variant="outline">
                         {entry.action.replace(/_/g, ' ')}
                       </Badge>
+                      <span
+                        data-testid={`audit-actor-${actorType}`}
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 'var(--nous-space-2xs)',
+                          fontSize: 'var(--nous-font-size-xs)',
+                          color: SEVERITY_TOKEN_TO_CSS_VAR[treatment.toneSeverity],
+                          fontWeight: 500,
+                        }}
+                      >
+                        {treatment.glyph === 'supervisor' ? (
+                          <SupervisorGlyph />
+                        ) : null}
+                        {treatment.badge}
+                      </span>
                       <span style={{ fontSize: 'var(--nous-font-size-xs)', color: 'var(--nous-fg-muted)' }}>
                         {entry.actorId}
                       </span>
@@ -120,7 +228,39 @@ export function MaoAuditTrailPanel({ projectId }: MaoAuditTrailPanelProps) {
                       {entry.evidenceRefs.length > 0 ? (
                         <div>
                           <span style={{ fontWeight: 500 }}>Evidence refs:</span>{' '}
-                          {entry.evidenceRefs.join(', ')}
+                          <span
+                            data-testid="audit-evidence-ref-list"
+                            style={{
+                              display: 'inline-flex',
+                              flexWrap: 'wrap',
+                              gap: 'var(--nous-space-2xs)',
+                            }}
+                          >
+                            {entry.evidenceRefs.map((ref) => (
+                              // SUPV-SP14-014 — three-attribute evidence-ref pattern
+                              // (reuses SP 13 SUPV-SP13-013 vocabulary). When a
+                              // routable href surfaces (future data-plane work),
+                              // this can switch to a `<Link>` element; today the
+                              // muted-span fall-through is the deliberate render
+                              // shape per SP 13 precedent.
+                              <span
+                                key={ref}
+                                data-mao-evidence-ref={ref}
+                                data-mao-evidence-source="audit-trail"
+                                data-mao-evidence-command-id={entry.commandId}
+                                style={{
+                                  borderRadius: 'var(--nous-radius-sm)',
+                                  border: '1px solid var(--nous-border-subtle)',
+                                  paddingInline: 'var(--nous-space-2xs)',
+                                  paddingBlock: '0',
+                                  fontFamily: 'var(--nous-font-family-mono)',
+                                  color: 'var(--nous-fg-muted)',
+                                }}
+                              >
+                                {ref}
+                              </span>
+                            ))}
+                          </span>
                         </div>
                       ) : null}
                     </div>

--- a/self/ui/src/components/mao/mao-project-controls.tsx
+++ b/self/ui/src/components/mao/mao-project-controls.tsx
@@ -2,13 +2,72 @@
 
 import * as React from 'react';
 import type {
+  ControlAction,
   MaoProjectControlAction,
   MaoProjectControlResult,
   MaoProjectSnapshot,
 } from '@nous/shared';
+import {
+  getRequiredTier,
+  getTierDisplay,
+  type ConfirmationTierDisplay,
+} from '@nous/subcortex-opctl';
 import { Badge } from '../badge';
 import { Button } from '../button';
 import { Card, CardContent, CardHeader, CardTitle } from '../card';
+import { ACTION_MAP } from './mao-t3-confirmation-dialog';
+import { SEVERITY_TOKEN_TO_CSS_VAR } from './mao-inspect-panel';
+
+// --- WR-162 SP 14 (SUPV-SP14-002 + SUPV-SP14-003 + SUPV-SP14-004) ---
+//
+// Closed-form per-submission toast taxonomy. The four outcomes form a
+// `Record<OpctlSubmitToastOutcome, ToastBody>` admit so closed-enum
+// exhaustiveness catches drift at compile time. `classifyOutcome` is the
+// closed pure discriminator over `OpctlSubmitResult`'s `status` + `reason_code`
+// surface.
+export type OpctlSubmitToastOutcome =
+  | 'applied'
+  | 'rejected'
+  | 'blocked_conflict_resolved'
+  | 'blocked_other';
+
+export type ToastBody = {
+  tone: 'success' | 'error' | 'info' | 'warn';
+  body: string;
+};
+
+export const TOAST_BODY_BY_OUTCOME: Record<OpctlSubmitToastOutcome, ToastBody> = {
+  applied: { tone: 'success', body: 'Command applied' },
+  rejected: { tone: 'error', body: 'Command rejected' },
+  blocked_conflict_resolved: {
+    tone: 'info',
+    body: 'Command queued behind another control',
+  },
+  blocked_other: { tone: 'warn', body: 'Command blocked' },
+};
+
+/**
+ * Closed pure discriminator over `MaoProjectControlResult` (which mirrors
+ * `OpctlSubmitResult` for project-control surfaces). Returns the closed
+ * `OpctlSubmitToastOutcome` literal that keys into `TOAST_BODY_BY_OUTCOME`.
+ *
+ * SP 14 uses `MaoProjectControlResult` (the renderer-side projection) instead
+ * of importing `OpctlSubmitResult` directly — the renderer already consumes
+ * the projection-side type via `MaoProjectControlsProps.lastResult`.
+ */
+export function classifyOutcome(
+  result: MaoProjectControlResult,
+): OpctlSubmitToastOutcome {
+  if (result.status === 'applied') return 'applied';
+  if (result.status === 'rejected') return 'rejected';
+  if (
+    result.status === 'blocked' &&
+    result.reason_code === 'opctl_conflict_resolved'
+  ) {
+    return 'blocked_conflict_resolved';
+  }
+  return 'blocked_other';
+}
 
 export interface MaoProjectControlsProps {
   snapshot: MaoProjectSnapshot;
@@ -21,6 +80,142 @@ export interface MaoProjectControlsProps {
   }) => void;
 }
 
+interface ScopeLockBannerState {
+  commandId: string;
+  action: MaoProjectControlAction;
+  submittedAt: string;
+}
+
+/**
+ * SUPV-SP14-006 — Per-control tier badge. Closed pipeline through SP 7 helpers
+ * (`getRequiredTier` → `getTierDisplay`) + SP 13 severity-token CSS-var. The
+ * `ACTION_MAP` lookup converts `MaoProjectControlAction` → `ControlAction`.
+ *
+ * Reference: SDS § Mechanism Choice "tier-badge closed pipeline."
+ */
+function TierBadge({ action }: { action: MaoProjectControlAction }) {
+  const controlAction: ControlAction = ACTION_MAP[action];
+  const display: ConfirmationTierDisplay = getTierDisplay(
+    getRequiredTier(controlAction),
+  );
+  return (
+    <span
+      data-tier-badge={display.level}
+      data-tier-severity={display.severity}
+      style={{
+        marginLeft: 'var(--nous-space-2xs)',
+        fontSize: 'var(--nous-font-size-xs)',
+        fontWeight: 500,
+        color: SEVERITY_TOKEN_TO_CSS_VAR[display.severity],
+      }}
+    >
+      {display.label}
+    </span>
+  );
+}
+
+/**
+ * SUPV-SP14-001 — Submit-result-driven scope-lock banner. State derives from
+ * the renderer-side submission lifecycle (NOT a `ScopeLockStore` event seam —
+ * the seam doesn't exist; Phase 0 audit 0b verified `InMemoryScopeLockStore`
+ * has no `EventEmitter`/`emit(`/`.on(` surface). The banner clears on
+ * applied/rejected/blocked_other and persists on
+ * `blocked_conflict_resolved` (queued) until the next submit.
+ *
+ * SUPV-SP14-005 — Cancel-queued is a renderer-only abandon-the-promise UX with
+ * an honest copy ("Cancellation visual; underlying queued command continues").
+ * The data-plane gap is tracked at SUPV-SP14-AI-CANCEL-QUEUED-DATA-PLANE-GAP
+ * for phase-close follow-up.
+ */
+function ScopeLockBanner({
+  state,
+  onCancelQueued,
+}: {
+  state: ScopeLockBannerState;
+  onCancelQueued: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="scope-lock-banner"
+      data-banner-action={state.action}
+      data-banner-command-id={state.commandId}
+      style={{
+        borderRadius: 'var(--nous-radius-sm)',
+        border: '1px solid var(--nous-border-subtle)',
+        backgroundColor: 'var(--nous-bg-card)',
+        paddingInline: 'var(--nous-space-md)',
+        paddingBlock: 'var(--nous-space-sm)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 'var(--nous-space-sm)',
+        fontSize: 'var(--nous-font-size-sm)',
+      }}
+    >
+      <span>
+        Command queued: <code data-testid="scope-lock-banner-action">{state.action}</code>
+      </span>
+      <button
+        type="button"
+        data-testid="scope-lock-cancel-queued"
+        onClick={onCancelQueued}
+        style={{
+          borderRadius: 'var(--nous-radius-sm)',
+          border: '1px solid var(--nous-border-subtle)',
+          paddingInline: 'var(--nous-space-sm)',
+          paddingBlock: 'var(--nous-space-2xs)',
+          fontSize: 'var(--nous-font-size-xs)',
+          backgroundColor: 'transparent',
+          cursor: 'pointer',
+        }}
+      >
+        Cancel queued
+      </button>
+    </div>
+  );
+}
+
+/**
+ * SUPV-SP14-003 — Project Toast fallback. Phase 0 Task 0j showed no shared
+ * project Toast component exists; we render a minimal renderer-side ephemeral
+ * `<div role="status" aria-live="polite">` with auto-dismiss after 4s. When a
+ * shared Toast component lands, this resolver migrates without API changes
+ * to consumers.
+ */
+function InlineToast({ toast }: { toast: ToastBody | null }) {
+  if (!toast) return null;
+  const tonePalette: Record<ToastBody['tone'], { bg: string; fg: string }> = {
+    success: { bg: 'rgba(34,197,94,0.1)', fg: 'rgb(34,197,94)' },
+    error: { bg: 'rgba(239,68,68,0.1)', fg: 'rgb(239,68,68)' },
+    info: { bg: 'rgba(59,130,246,0.1)', fg: 'rgb(59,130,246)' },
+    warn: { bg: 'rgba(234,179,8,0.1)', fg: 'rgb(234,179,8)' },
+  };
+  const palette = tonePalette[toast.tone];
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="project-controls-toast"
+      data-toast-tone={toast.tone}
+      style={{
+        borderRadius: 'var(--nous-radius-sm)',
+        border: `1px solid ${palette.fg}`,
+        backgroundColor: palette.bg,
+        color: palette.fg,
+        paddingInline: 'var(--nous-space-md)',
+        paddingBlock: 'var(--nous-space-sm)',
+        fontSize: 'var(--nous-font-size-sm)',
+      }}
+    >
+      {toast.body}
+    </div>
+  );
+}
+
+const TOAST_AUTO_DISMISS_MS = 4000;
+
 export function MaoProjectControls({
   snapshot,
   pending,
@@ -28,9 +223,40 @@ export function MaoProjectControls({
   onRequestControl,
 }: MaoProjectControlsProps) {
   const [reason, setReason] = React.useState('');
+  const [scopeLockBanner, setScopeLockBanner] =
+    React.useState<ScopeLockBannerState | null>(null);
+  const [toast, setToast] = React.useState<ToastBody | null>(null);
+
   const control = snapshot.controlProjection;
   const activeRunCount = snapshot.workflowRunId ? 1 : 0;
   const reasonTrimmed = reason.trim();
+
+  const pushToast = React.useCallback((body: ToastBody) => {
+    setToast(body);
+  }, []);
+
+  // Auto-dismiss toast after fixed duration (cleared on unmount or replacement).
+  React.useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), TOAST_AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  // SUPV-SP14-002 + SUPV-SP14-004 — Submit-result-driven banner lifecycle.
+  // When a new lastResult arrives, classify and dispatch the toast + clear
+  // the banner UNLESS the outcome is blocked_conflict_resolved (the queued
+  // case — the banner persists to surface the in-flight queued command).
+  const lastResultRef = React.useRef<MaoProjectControlResult | null>(null);
+  React.useEffect(() => {
+    if (!lastResult) return;
+    if (lastResult === lastResultRef.current) return;
+    lastResultRef.current = lastResult;
+    const outcome = classifyOutcome(lastResult);
+    pushToast(TOAST_BODY_BY_OUTCOME[outcome]);
+    if (outcome !== 'blocked_conflict_resolved') {
+      setScopeLockBanner(null);
+    }
+  }, [lastResult, pushToast]);
 
   const controlButtons: Array<{
     action: MaoProjectControlAction;
@@ -56,6 +282,37 @@ export function MaoProjectControls({
       disabled: pending || control.project_control_state === 'hard_stopped',
     },
   ];
+
+  const handleSubmit = React.useCallback(
+    (action: MaoProjectControlAction) => {
+      const commandId = crypto.randomUUID();
+      // SUPV-SP14-001 — set the banner pre-submit; lifecycle below clears or
+      // persists based on the resulting `lastResult`.
+      setScopeLockBanner({
+        commandId,
+        action,
+        submittedAt: new Date().toISOString(),
+      });
+      onRequestControl({
+        action,
+        reason: reasonTrimmed,
+        commandId,
+      });
+    },
+    [onRequestControl, reasonTrimmed],
+  );
+
+  // SUPV-SP14-005 — Renderer-only abandon-the-promise. Underlying queued
+  // command continues at the data plane until it applies or fails. Honest UX
+  // copy via toast.
+  const handleCancelQueued = React.useCallback(() => {
+    setScopeLockBanner(null);
+    pushToast({
+      tone: 'info',
+      body:
+        'Cancellation visual; underlying queued command continues until it applies or fails per data-plane',
+    });
+  }, [pushToast]);
 
   const cellBase: React.CSSProperties = {
     borderRadius: 'var(--nous-radius-sm)',
@@ -91,6 +348,15 @@ export function MaoProjectControls({
         </CardTitle>
       </CardHeader>
       <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-lg)', paddingTop: 'var(--nous-space-lg)', fontSize: 'var(--nous-font-size-sm)' }}>
+        {scopeLockBanner !== null ? (
+          <ScopeLockBanner
+            state={scopeLockBanner}
+            onCancelQueued={handleCancelQueued}
+          />
+        ) : null}
+
+        <InlineToast toast={toast} />
+
         <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' }}>
           <div style={cellBase}>
             <div style={labelStyle}>Resume readiness</div>
@@ -180,19 +446,15 @@ export function MaoProjectControls({
 
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--nous-space-sm)' }}>
           {controlButtons.map((button) => (
-            <Button
-              key={button.action}
-              disabled={button.disabled || !reasonTrimmed}
-              onClick={() =>
-                onRequestControl({
-                  action: button.action,
-                  reason: reasonTrimmed,
-                  commandId: crypto.randomUUID(),
-                })
-              }
-            >
-              {button.label}
-            </Button>
+            <span key={button.action} style={{ display: 'inline-flex', alignItems: 'center' }}>
+              <Button
+                disabled={button.disabled || !reasonTrimmed}
+                onClick={() => handleSubmit(button.action)}
+              >
+                {button.label}
+              </Button>
+              <TierBadge action={button.action} />
+            </span>
           ))}
         </div>
 

--- a/self/ui/src/components/mao/mao-t3-confirmation-dialog.tsx
+++ b/self/ui/src/components/mao/mao-t3-confirmation-dialog.tsx
@@ -7,8 +7,13 @@ import type {
   MaoProjectControlAction,
   ProjectId,
 } from '@nous/shared';
+import {
+  getTierDisplay,
+  type ConfirmationTierDisplay,
+} from '@nous/subcortex-opctl';
 import { Button } from '../button';
 import { trpc } from '@nous/transport';
+import { SEVERITY_TOKEN_TO_CSS_VAR } from './mao-inspect-panel';
 
 /**
  * T3 actions that require a confirmation dialog before mutation.
@@ -37,6 +42,70 @@ const IMPACT_LABELS: Record<MaoProjectControlAction, string> = {
     'Immediately halt all activity for this project. Active agents will be terminated.',
 };
 
+// --- WR-162 SP 14 SUPV-SP14-011 — closed RationaleKey + supervisor-state resolver ---
+//
+// Closed `Record<RationaleKey, string>` covers the four tier rationales plus the
+// supervisor-locked T3 variant (per ESC-001 acknowledgment outcome at Goals SC-11).
+// `resolveRationaleCopy` is the closed pure resolver: when a T3 dialog is shown
+// against a supervisor-locked scope (`MaoAgentProjection.guardrail_status ===
+// 'enforced'` per SP 6 read), the supervisor-locked copy renders.
+export type RationaleKey =
+  | 'tier.t0.rationale'
+  | 'tier.t1.rationale'
+  | 'tier.t2.rationale'
+  | 'tier.t3.rationale'
+  | 'tier.t3.supervisor_locked';
+
+export const RATIONALE_COPY: Record<RationaleKey, string> = {
+  'tier.t0.rationale':
+    'Immediate execution. No additional confirmation required.',
+  'tier.t1.rationale':
+    'One-step confirmation. The action proceeds once you confirm.',
+  'tier.t2.rationale':
+    'Two-step confirmation. Review the impact summary before confirming.',
+  'tier.t3.rationale':
+    'Cooldown-gated confirmation. Destructive scope requires explicit acknowledgment.',
+  'tier.t3.supervisor_locked':
+    'Supervisor lock active (ESC-001). Acknowledge the supervisor-enforced state before this destructive action proceeds.',
+};
+
+export function resolveRationaleCopy(
+  rationaleKey: RationaleKey,
+  supervisorLocked: boolean,
+): string {
+  if (supervisorLocked && rationaleKey === 'tier.t3.rationale') {
+    return RATIONALE_COPY['tier.t3.supervisor_locked'];
+  }
+  return RATIONALE_COPY[rationaleKey];
+}
+
+/**
+ * SUPV-SP14-012 — Closed conditional cooldown structure. V1 `T3_COOLDOWN_MS = 0`
+ * means the countdown is not rendered today. The closed conditional is forward-
+ * compatible: when SP 7 promotes `T3_COOLDOWN_MS` to a positive value, the
+ * countdown wires up automatically without component-shape change.
+ */
+function Countdown({ ms }: { ms: number }) {
+  const [remaining, setRemaining] = React.useState(ms);
+  React.useEffect(() => {
+    setRemaining(ms);
+    if (ms <= 0) return;
+    const start = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - start;
+      const next = Math.max(0, ms - elapsed);
+      setRemaining(next);
+      if (next <= 0) clearInterval(interval);
+    }, 100);
+    return () => clearInterval(interval);
+  }, [ms]);
+  return (
+    <span data-testid="t3-cooldown" data-cooldown-remaining-ms={remaining}>
+      Cooldown: {Math.ceil(remaining / 1000)}s
+    </span>
+  );
+}
+
 export interface MaoT3ConfirmationDialogProps {
   open: boolean;
   action: MaoProjectControlAction;
@@ -48,6 +117,21 @@ export interface MaoT3ConfirmationDialogProps {
     blockedAgentCount: number;
     urgentAgentCount: number;
   };
+  /**
+   * SUPV-SP14-011 — Optional supervisor-locked-scope flag derived by parent
+   * from `MaoAgentProjection.guardrail_status === 'enforced'` (SP 6 read).
+   * Defaults to `false`; existing consumers see no behavior change. DNR-J1
+   * holds: this is an additive optional prop justified at SDS.
+   */
+  supervisorLocked?: boolean;
+  /**
+   * SUPV-SP14-013 — Optional last-submission result. When `reason_code` is
+   * non-undefined, the dialog renders the reason-code surface in the dialog
+   * body. Renders nothing otherwise. Additive optional prop (DNR-J1).
+   */
+  result?: {
+    reason_code?: string;
+  };
   onConfirm: (proof: ConfirmationProof) => void;
   onCancel: () => void;
 }
@@ -58,6 +142,8 @@ export function MaoT3ConfirmationDialog({
   projectId,
   projectName,
   impactSummary,
+  supervisorLocked,
+  result,
   onConfirm,
   onCancel,
 }: MaoT3ConfirmationDialogProps) {
@@ -69,6 +155,22 @@ export function MaoT3ConfirmationDialog({
       setConfirmedProof(proof);
     },
   });
+
+  // SUPV-SP14-008 — `useMemo` over `getTierDisplay('T3')`. The resolver is
+  // pure but stable across renders; memoizing avoids redundant work and pins
+  // the closed `display.label` / `display.severity` / `display.rationaleKey`
+  // / `display.cooldownMs` surface for the rest of the render tree.
+  const display: ConfirmationTierDisplay = React.useMemo(
+    () => getTierDisplay('T3'),
+    [],
+  );
+
+  // SUPV-SP14-011 — supervisor-locked rationale copy (closed Record over
+  // five-literal `RationaleKey` admit).
+  const rationaleCopy = resolveRationaleCopy(
+    display.rationaleKey as RationaleKey,
+    supervisorLocked ?? false,
+  );
 
   // Reset proof display state when dialog opens/closes
   React.useEffect(() => {
@@ -233,12 +335,45 @@ export function MaoT3ConfirmationDialog({
     <div style={overlayBase} data-testid="t3-confirmation-dialog">
       <div style={backdropStyle} onClick={onCancel} aria-hidden="true" />
       <div style={panelStyle}>
-        <h2 style={{ fontSize: 'var(--nous-font-size-lg)', fontWeight: 600 }}>
+        <h2
+          style={{
+            fontSize: 'var(--nous-font-size-lg)',
+            fontWeight: 600,
+            // SUPV-SP14-008 — severity-token replaces inline `'#ef4444'` hardcode.
+            color: SEVERITY_TOKEN_TO_CSS_VAR[display.severity],
+          }}
+        >
           Confirm T3 action
         </h2>
-        <p style={{ marginTop: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}>
-          This action requires explicit confirmation before it can proceed.
+        {/* SUPV-SP14-008 — `display.label` thread (sibling node preserves the
+            DNR-H1 `'Confirm T3 action'` heading verbatim per SC-39). */}
+        <div
+          data-testid="t3-tier-label"
+          data-tier-level={display.level}
+          data-tier-severity={display.severity}
+          style={{
+            marginTop: 'var(--nous-space-2xs)',
+            fontSize: 'var(--nous-font-size-sm)',
+            color: SEVERITY_TOKEN_TO_CSS_VAR[display.severity],
+            fontWeight: 500,
+          }}
+        >
+          {display.label}
+        </div>
+        <p
+          style={{ marginTop: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-sm)', color: 'var(--nous-fg-muted)' }}
+          data-testid="t3-rationale-copy"
+          data-rationale-key={display.rationaleKey}
+          data-supervisor-locked={(supervisorLocked ?? false) ? 'true' : 'false'}
+        >
+          {rationaleCopy}
         </p>
+
+        {display.cooldownMs !== undefined && display.cooldownMs > 0 ? (
+          <div style={{ marginTop: 'var(--nous-space-md)' }}>
+            <Countdown ms={display.cooldownMs} />
+          </div>
+        ) : null}
 
         <div style={{ marginTop: 'var(--nous-space-2xl)', display: 'flex', flexDirection: 'column', gap: 'var(--nous-space-md)' }}>
           <div style={cellBase}>
@@ -267,10 +402,41 @@ export function MaoT3ConfirmationDialog({
               </div>
             ) : null}
           </div>
+
+          {/* SUPV-SP14-013 — Reason-code surface. Renders only when result?.reason_code is non-undefined. */}
+          {result?.reason_code !== undefined ? (
+            <dl
+              data-testid="t3-reason-code"
+              style={{
+                ...cellBase,
+                margin: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 'var(--nous-space-2xs)',
+              }}
+            >
+              <dt style={labelStyle}>Reason</dt>
+              <dd style={{ margin: 0, fontSize: 'var(--nous-font-size-sm)' }}>
+                {result.reason_code}
+              </dd>
+            </dl>
+          ) : null}
         </div>
 
         {proofMutation.isError ? (
-          <div style={{ marginTop: 'var(--nous-space-md)', borderRadius: 'var(--nous-radius-sm)', border: '1px solid rgba(239,68,68,0.4)', backgroundColor: 'rgba(239,68,68,0.1)', paddingInline: 'var(--nous-space-md)', paddingBlock: 'var(--nous-space-sm)', fontSize: 'var(--nous-font-size-sm)', color: '#ef4444' }}>
+          <div
+            style={{
+              marginTop: 'var(--nous-space-md)',
+              borderRadius: 'var(--nous-radius-sm)',
+              border: '1px solid rgba(239,68,68,0.4)',
+              backgroundColor: 'rgba(239,68,68,0.1)',
+              paddingInline: 'var(--nous-space-md)',
+              paddingBlock: 'var(--nous-space-sm)',
+              fontSize: 'var(--nous-font-size-sm)',
+              // SUPV-SP14-008 — severity-token replaces inline `'#ef4444'` hardcode.
+              color: SEVERITY_TOKEN_TO_CSS_VAR[display.severity],
+            }}
+          >
             Failed to obtain confirmation proof. Please try again.
           </div>
         ) : null}


### PR DESCRIPTION
## Summary

WR-162 SP 14 — MAO renderer-side polish (project-controls / T3 confirmation dialog / audit-trail panel) + Phase A `tier-display.ts` extraction from `confirmation.ts` (closes SP 10 Note 1b).

- **Phase A (`@nous/subcortex-opctl`):** new `tier-display.ts` module hosts the four pure presentation helpers (`getRequiredTier`, `getTierDisplay`, `T3_COOLDOWN_MS`, `ConfirmationTierDisplay`). Zero `node:*` imports. Package barrel re-routes consumer imports through `./tier-display.js`; `confirmation.ts` retains `node:crypto` for proof-issuance and is no longer reached by renderer chunks. SUPV-SP14-021 closure.
- **MAO project-controls:** submit-result-driven scope-lock banner; four-outcome closed `Record<OpctlSubmitToastOutcome, ToastBody>` toast; renderer-only abandon-the-promise cancel-queued (data-plane gap forwarded to phase-close); per-control closed-pipeline tier badge.
- **MAO T3 confirmation dialog:** `useMemo` over `getTierDisplay('T3')`; severity-token CSS-var color (replaces inline `'#ef4444'`); supervisor-state rationale via closed `Record<RationaleKey, string>`; additive optional `supervisorLocked?: boolean` prop (DNR-J1-respecting). DNR-H1 heading + proof-flow + DNR-H2 testid anchors preserved verbatim.
- **MAO audit-trail panel:** closed `Record<ControlActorType, ActorVisualTreatment>` over five literals; defensive `readActorType(entry)` resolver (data-plane gap forwarded to phase-close); SP 13 three-attribute evidence-ref pattern reused.
- **Tests:** +43 net-new (workspace 652 files / 6030 tests). Zero revision cycles across all five gates.

## Action items carried forward to phase-close

- **AI-1 (SUPV-SP14-AI-CANCEL-QUEUED-DATA-PLANE-GAP):** renderer-only cancel-queued; data plane lacks cancel API.
- **AI-2 (SUPV-SP14-AI-AUDIT-ACTOR-TYPE-DATA-PLANE-GAP):** closed `Record` over `ControlActorType` lands; upstream schema needs `actor_type` widening.
- **E1 / SDS internal monotonicity:** `supervisorLocked?` additive optional prop respects DNR-J1.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 151 carry-forward warnings; 0 SP 14 new
- [x] `pnpm test` — 652 files / 6030 tests green (Δ +43 vs SP 13 baseline 5987)
- [x] `pnpm -F @nous/desktop build` — green renderer-bundle build, no `createHash` resolution errors
- [x] Phase G grep audit: 14 verifications all green (`@nous/shared` zero-diff; renderer paths zero `node:*` / proof-issuance; service surfaces zero-diff)
- [ ] Phase 1 close BT (deferred per WR-162 BT cadence — 14-sub-phase unbroken chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)