### PR TITLE
WR-162 SP 1.16: BT R1 fix — RC-2 batch cap + RC-1b hydration gate

### DIFF
--- a/self/transport/src/__tests__/provider-batch-cap.test.tsx
+++ b/self/transport/src/__tests__/provider-batch-cap.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+/**
+ * WR-162 SP 1.16 — RC-2 contract cap on `httpBatchLink`.
+ *
+ * Tier 1 contract tests + Tier 2 behavior assertion + SP 11 single-QueryClient
+ * regression. The link's split semantics are tRPC v11 internal; we assert the
+ * configuration-shape contract (the options literal at the call site) plus the
+ * SP 11 invariants (single QueryClient, single tRPC client per mount).
+ *
+ * Validates:
+ * - SUPV-SP1.16-001 (`maxURLLength` finite)
+ * - SUPV-SP1.16-002 (`maxItems` finite)
+ * - SUPV-SP1.16-003 (cap calibrated against Chromium ~8KB bound with ≥1KB headroom)
+ * - SUPV-SP1.16-004 (single QueryClient + single tRPC client per TransportProvider mount)
+ * - SUPV-SP1.16-005 (httpBatchLink retained — batching enabled)
+ */
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture httpBatchLink invocations.
+const httpBatchLinkSpy = vi.fn();
+
+vi.mock('@trpc/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@trpc/client')>();
+  return {
+    ...actual,
+    httpBatchLink: (opts: unknown) => {
+      httpBatchLinkSpy(opts);
+      return actual.httpBatchLink(opts as Parameters<typeof actual.httpBatchLink>[0]);
+    },
+  };
+});
+
+import { TransportProvider, type TransportConfig } from '../provider';
+
+const cfg: TransportConfig = {
+  trpcUrl: 'http://localhost:9999/api/trpc',
+  eventsUrl: 'http://localhost:9999/api/events',
+};
+
+beforeEach(() => {
+  httpBatchLinkSpy.mockClear();
+});
+
+afterEach(() => {
+  // jsdom cleanup happens via testing-library's automatic cleanup.
+});
+
+describe('TransportProvider — RC-2 batch cap contract', () => {
+  it('UT-SP1.16-RC2-MAX-URL-LENGTH — configures httpBatchLink with finite maxURLLength: 7000', () => {
+    render(
+      <TransportProvider config={cfg}>
+        <div>child</div>
+      </TransportProvider>,
+    );
+
+    expect(httpBatchLinkSpy).toHaveBeenCalled();
+    const opts = httpBatchLinkSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(opts.maxURLLength).toBe(7000);
+    expect(typeof opts.maxURLLength).toBe('number');
+    expect(Number.isFinite(opts.maxURLLength as number)).toBe(true);
+  });
+
+  it('UT-SP1.16-RC2-MAX-ITEMS — configures httpBatchLink with finite maxItems: 1000', () => {
+    render(
+      <TransportProvider config={cfg}>
+        <div>child</div>
+      </TransportProvider>,
+    );
+
+    const opts = httpBatchLinkSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(opts.maxItems).toBe(1000);
+    expect(typeof opts.maxItems).toBe('number');
+    expect(Number.isFinite(opts.maxItems as number)).toBe(true);
+  });
+
+  it('UT-SP1.16-RC2-CAP-CALIBRATION — maxURLLength is below Chromium ~8KB ceiling with ≥1KB headroom', () => {
+    render(
+      <TransportProvider config={cfg}>
+        <div>child</div>
+      </TransportProvider>,
+    );
+
+    const opts = httpBatchLinkSpy.mock.calls[0]![0] as Record<string, unknown>;
+    const cap = opts.maxURLLength as number;
+    // Chromium's effective binding bound for URL+headers on the request line is
+    // ~8192 bytes. SDS Mechanism Choice row 2 calls for ≥1KB headroom; this
+    // bound check enforces the ratified cap-value rationale.
+    expect(cap).toBeGreaterThanOrEqual(6000);
+    expect(cap).toBeLessThanOrEqual(7500);
+  });
+
+  it('UT-SP1.16-RC2-URL-AND-TRANSFORMER-PRESERVED — url and superjson transformer preserved in httpBatchLink options', () => {
+    render(
+      <TransportProvider config={cfg}>
+        <div>child</div>
+      </TransportProvider>,
+    );
+
+    const opts = httpBatchLinkSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(opts.url).toBe(cfg.trpcUrl);
+    expect(opts.transformer).toBeDefined();
+  });
+
+  it('UT-SP1.16-SP11-SINGLE-LINK-PER-MOUNT — httpBatchLink invoked exactly once per TransportProvider mount (single tRPC client)', () => {
+    const { rerender } = render(
+      <TransportProvider config={cfg}>
+        <div>child</div>
+      </TransportProvider>,
+    );
+
+    expect(httpBatchLinkSpy).toHaveBeenCalledTimes(1);
+
+    // Re-render with same config: useState initializer guards the client; the
+    // link factory is NOT called again. SP 11 single-QueryClient + single
+    // tRPC-client invariant.
+    rerender(
+      <TransportProvider config={cfg}>
+        <div>child-2</div>
+      </TransportProvider>,
+    );
+
+    expect(httpBatchLinkSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/self/transport/src/provider.tsx
+++ b/self/transport/src/provider.tsx
@@ -82,9 +82,22 @@ export function TransportProvider({ config, children }: TransportProviderProps) 
   const [trpcClient] = useState(() =>
     trpc.createClient({
       links: [
+        // WR-162 SP 1.16 (SUPV-SP1.16-001 / SUPV-SP1.16-002 / SUPV-SP1.16-003)
+        // — RC-2 contract cap: bound the link's per-batch URL length and item
+        // count to prevent first-paint fan-out from producing a single oversize
+        // GET URL that browsers reject (Chromium ~8KB header line ⇒ 431).
+        // `7000` lies ~1KB below the binding browser limit (defense-in-depth
+        // headroom); `1000` items is well above any plausible legitimate batch
+        // (~96 in BT R1 was the failure case) and well below pathological
+        // micro-query fan-outs. tRPC v11 splits any oversize batch into
+        // multiple sub-requests automatically; consumers above the link see
+        // per-operation results unchanged. See `phase-1.16/sds.mdx` Mechanism
+        // Choice rows 1-3 for cap-value rationale.
         httpBatchLink({
           url: config.trpcUrl,
           transformer: superjson,
+          maxURLLength: 7000,
+          maxItems: 1000,
         }),
       ],
     }),

--- a/self/ui/src/components/mao/mao-backlog-pressure-card.tsx
+++ b/self/ui/src/components/mao/mao-backlog-pressure-card.tsx
@@ -28,9 +28,14 @@ export function MaoBacklogPressureCard() {
   const utils = trpc.useUtils();
   const statusQuery = trpc.health.systemStatus.useQuery();
 
+  // WR-162 SP 1.16 (SUPV-SP1.16-008) — RC-1b first-data gate. SSE events
+  // arriving before the initial query resolves are absorbed by the initial
+  // fetch; invalidating before first data feeds the hydration-window
+  // batch-tick cascade (BT R1 32× amplifier).
   useEventSubscription({
     channels: ['mao:projection-changed'],
     onEvent: () => {
+      if (statusQuery.data === undefined) return;
       void utils.health.systemStatus.invalidate();
     },
     enabled: true,

--- a/self/ui/src/components/mao/mao-operating-surface.tsx
+++ b/self/ui/src/components/mao/mao-operating-surface.tsx
@@ -131,44 +131,6 @@ export function MaoOperatingSurface() {
     },
   });
 
-  // ---- System tab event subscription ----
-  useEventSubscription({
-    channels: [
-      'mao:projection-changed',
-      'mao:control-action',
-      'inference:stream-start',
-      'inference:stream-complete',
-      'inference:accumulator-snapshot',
-    ],
-    onEvent: () => {
-      void utils.mao.getSystemSnapshot.invalidate();
-    },
-    enabled: activeTab === 'system',
-  });
-
-  // ---- Projects tab event subscription ----
-  useEventSubscription({
-    channels: [
-      'mao:projection-changed',
-      'mao:control-action',
-      'inference:stream-start',
-      'inference:stream-complete',
-      'inference:accumulator-snapshot',
-    ],
-    onEvent: () => {
-      void utils.mao.getProjectSnapshot.invalidate();
-    },
-    enabled: activeTab === 'projects' && !!projectId,
-  });
-
-  // ---- Navigation context sync ----
-  React.useEffect(() => {
-    if (linkedProjectId && linkedProjectId !== projectId) {
-      setProjectId(linkedProjectId);
-      setActiveTab('projects');
-    }
-  }, [linkedProjectId, projectId, setProjectId]);
-
   // ---- System tab query ----
   const systemSnapshotQuery = trpc.mao.getSystemSnapshot.useQuery(
     { densityMode: systemTab.densityMode },
@@ -186,6 +148,51 @@ export function MaoOperatingSurface() {
       enabled: activeTab === 'projects' && projectId != null,
     },
   );
+
+  // ---- System tab event subscription ----
+  // WR-162 SP 1.16 (SUPV-SP1.16-008) — RC-1b first-data gate. SSE events
+  // arriving before the initial query resolves are absorbed by the initial
+  // fetch; invalidating before first data feeds the hydration-window
+  // batch-tick cascade (BT R1 32× amplifier).
+  useEventSubscription({
+    channels: [
+      'mao:projection-changed',
+      'mao:control-action',
+      'inference:stream-start',
+      'inference:stream-complete',
+      'inference:accumulator-snapshot',
+    ],
+    onEvent: () => {
+      if (systemSnapshotQuery.data === undefined) return;
+      void utils.mao.getSystemSnapshot.invalidate();
+    },
+    enabled: activeTab === 'system',
+  });
+
+  // ---- Projects tab event subscription ----
+  // WR-162 SP 1.16 (SUPV-SP1.16-008) — RC-1b first-data gate. See above.
+  useEventSubscription({
+    channels: [
+      'mao:projection-changed',
+      'mao:control-action',
+      'inference:stream-start',
+      'inference:stream-complete',
+      'inference:accumulator-snapshot',
+    ],
+    onEvent: () => {
+      if (snapshotQuery.data === undefined) return;
+      void utils.mao.getProjectSnapshot.invalidate();
+    },
+    enabled: activeTab === 'projects' && !!projectId,
+  });
+
+  // ---- Navigation context sync ----
+  React.useEffect(() => {
+    if (linkedProjectId && linkedProjectId !== projectId) {
+      setProjectId(linkedProjectId);
+      setActiveTab('projects');
+    }
+  }, [linkedProjectId, projectId, setProjectId]);
 
   // ---- Inspect popup state ----
   // For the popup, we derive the agent from the active tab's selectedTarget.

--- a/self/ui/src/components/shell/StatusBar.tsx
+++ b/self/ui/src/components/shell/StatusBar.tsx
@@ -62,9 +62,16 @@ export function StatusBar() {
     projectId: activeProjectId ?? undefined,
   })
 
+  // WR-162 SP 1.16 (SUPV-SP1.16-008) — RC-1b first-data gate. SSE events
+  // delivered BEFORE the initial tRPC query resolves are absorbed by the
+  // initial fetch itself; invalidating before first data multiplies the
+  // hydration-window batch tick (BT R1 32× amplifier). The R-8 contract
+  // ("one invalidate per change event in steady state") holds verbatim once
+  // first data has arrived.
   useEventSubscription({
     channels: STATUS_BAR_CHANNELS as EventChannel[],
     onEvent: () => {
+      if (snapshotQuery.data === undefined) return
       void utils.health.getStatusBarSnapshot.invalidate()
     },
   })

--- a/self/ui/src/components/shell/__tests__/StatusBar-hydration-gate.test.tsx
+++ b/self/ui/src/components/shell/__tests__/StatusBar-hydration-gate.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+/**
+ * WR-162 SP 1.16 — RC-1b first-data gate at StatusBar.
+ *
+ * Validates SUPV-SP1.16-008 (R-8 contract holds in steady state; hydration
+ * window absorbs SSE events into the initial fetch instead of multiplying
+ * `invalidate()` calls into the same batch tick).
+ *
+ * - Test 1: SSE event delivered BEFORE first query data does NOT trigger invalidate().
+ * - Test 2: SSE event delivered AFTER first query data triggers exactly one
+ *           invalidate() per event (R-8 steady-state preserved).
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { StatusBar, STATUS_BAR_CHANNELS } from '../StatusBar'
+import { ShellProvider } from '../ShellContext'
+
+let mockEventSubscriptions: Array<{ channels: string[]; onEvent: (...args: unknown[]) => void }> = []
+
+const mockInvalidate = vi.fn(async () => {})
+const mockGetStatusBarSnapshotUseQuery = vi.fn<(input: unknown) => unknown>()
+
+vi.mock('@nous/transport', () => ({
+  trpc: {
+    health: {
+      getStatusBarSnapshot: {
+        useQuery: (input: unknown) => mockGetStatusBarSnapshotUseQuery(input),
+      },
+    },
+    projects: {
+      get: {
+        useQuery: () => ({ data: undefined }),
+      },
+    },
+    useUtils: () => ({
+      health: {
+        getStatusBarSnapshot: { invalidate: mockInvalidate },
+      },
+    }),
+  },
+  useEventSubscription: (opts: { channels: string[]; onEvent: (...args: unknown[]) => void }) => {
+    mockEventSubscriptions.push(opts)
+  },
+}))
+
+const happySnapshot = {
+  backpressure: { state: 'nominal' as const, queueDepth: 1, activeAgents: 1 },
+  cognitiveProfile: null,
+  budget: { state: 'nominal' as const, spent: 1, ceiling: 10, period: '2026-04-01T00:00:00Z' },
+  activeAgents: { count: 2, status: 'active' as const },
+}
+
+beforeEach(() => {
+  mockEventSubscriptions = []
+  mockInvalidate.mockClear()
+  mockGetStatusBarSnapshotUseQuery.mockReset()
+})
+
+describe('StatusBar — RC-1b hydration-window first-data gate (SUPV-SP1.16-008)', () => {
+  it('UT-SP1.16-SB-PRE-DATA-GATE — SSE event delivered BEFORE first query data does NOT trigger invalidate()', () => {
+    // Pre-hydration state: query has no data yet.
+    mockGetStatusBarSnapshotUseQuery.mockReturnValue({ data: undefined })
+
+    render(
+      <ShellProvider>
+        <StatusBar />
+      </ShellProvider>,
+    )
+
+    expect(mockEventSubscriptions.length).toBeGreaterThan(0)
+    const sub = mockEventSubscriptions[0]!
+
+    // Deliver an SSE event during the hydration window — the gate must
+    // suppress invalidate() so the in-flight initial fetch is the canonical
+    // hydration path, not invalidation-driven refetch.
+    sub.onEvent('mao:projection-changed', {} as never)
+    sub.onEvent('app-health:change', {} as never)
+    sub.onEvent('cost:snapshot', {} as never)
+
+    expect(mockInvalidate).not.toHaveBeenCalled()
+  })
+
+  it('UT-SP1.16-SB-POST-DATA-INVALIDATE — SSE event delivered AFTER first query data triggers invalidate() per event (R-8 preserved)', () => {
+    // Steady state: query has resolved with data.
+    mockGetStatusBarSnapshotUseQuery.mockReturnValue({ data: happySnapshot })
+
+    render(
+      <ShellProvider>
+        <StatusBar />
+      </ShellProvider>,
+    )
+
+    const sub = mockEventSubscriptions[0]!
+
+    // Deliver three steady-state events.
+    sub.onEvent(STATUS_BAR_CHANNELS[0]!, {} as never)
+    sub.onEvent(STATUS_BAR_CHANNELS[1]!, {} as never)
+    sub.onEvent(STATUS_BAR_CHANNELS[2]!, {} as never)
+
+    // R-8: one invalidate per change event in steady state.
+    expect(mockInvalidate).toHaveBeenCalledTimes(3)
+  })
+})

--- a/self/ui/src/panels/dashboard/widgets/SystemStatusWidget.tsx
+++ b/self/ui/src/panels/dashboard/widgets/SystemStatusWidget.tsx
@@ -43,6 +43,10 @@ export function SystemStatusWidget(_props: IDockviewPanelProps) {
   const utils = trpc.useUtils()
   const { data, isLoading, error } = trpc.health.systemStatus.useQuery()
 
+  // WR-162 SP 1.16 (SUPV-SP1.16-008) — RC-1b first-data gate. SSE events
+  // arriving before the initial query resolves are absorbed by the initial
+  // fetch; invalidating before first data feeds the hydration-window
+  // batch-tick cascade (BT R1 32× amplifier).
   useEventSubscription({
     channels: [
       'health:boot-step',
@@ -51,6 +55,7 @@ export function SystemStatusWidget(_props: IDockviewPanelProps) {
       'health:backlog-analytics',
     ],
     onEvent: () => {
+      if (data === undefined) return
       void utils.health.systemStatus.invalidate()
     },
   })


### PR DESCRIPTION
## Summary

WR-162 Sub-phase 1.16 — BT R1 Issue 1 fix. Two co-operating contract changes that together resolve the initial-load tRPC batch URL failure (`net::ERR_FAILED 431` / CORS-by-no-headers) blocking Phase 1 close BT.

- **RC-2 (transport):** cap `httpBatchLink` `maxURLLength: 7000` + `maxItems: 1000` at `self/transport/src/provider.tsx`. tRPC v11 defaults both to `Infinity`; this closes the wire-level safety gap regardless of amplifier presence.
- **RC-1b (ui):** first-data hydration gate at four trio consumer call sites (`StatusBar.tsx`, `SystemStatusWidget.tsx`, `mao-backlog-pressure-card.tsx`, `mao-operating-surface.tsx`). Phase 0 audit (sprint-branch commit `f41d315`) selected RC-1b as the dominant amplifier. Typed `query.data === undefined` predicate at the hydration/steady-state boundary; R-8 contract preserved.
- **Tests:** +7 net-new (6090 vs SP 1.15 baseline 6083). RC-2 cap coverage + SP 11 single-link invariant + RC-1b pre/post-data gate.

## Mechanism (per `feedback_surface_mechanism_in_sds.md`)

- **RC-2:** typed numeric option on tRPC's link-options schema. Single-derivation deterministic split semantics. **Not** a heuristic warning threshold.
- **RC-1b:** typed react-query state predicate at the contract boundary. **Not** a debounce, **not** a content classifier, **not** a post-hoc detector.

Per `feedback_no_heuristic_bandaids.md`: every mechanism is contract-shaped. Verify-grep G10 confirms zero new heuristic patterns.

## Verify

- `pnpm typecheck`: pass (all workspace packages)
- `pnpm lint`: 0 errors / 153 warnings (no new)
- `pnpm test`: 6090 / 6090 pass (+7 vs SP 1.15 baseline 6083)
- `pnpm --filter @nous/desktop build`: pass

Installer-class verification deferred to BT R2 (out-of-lane Principal-driven runtime test) per `bt_cadence: per-sub-phase`. The runtime smoke test was infeasible from this lane (no GUI desktop session); build + typecheck + test-suite serve as the in-lane Verify proxy.

## Test plan

- [ ] BT R2 against integrated tip — fresh `pnpm dev:desktop` boot succeeds; trio batch returns 200 (or splits into <=4 sub-requests, each 200); no `ERR_FAILED 431`; observability surfaces render without console errors.
- [ ] Steady-state preserved: SSE events post-hydration trigger one invalidate per event per consumer.
- [ ] If BT R2 surfaces residual amplifier evidence inconsistent with RC-1b, audit's falsifiable runtime protocol re-evaluates RC-1a / RC-1c.

## Correlation

- `wr-162-phase-1.16-bt-r1-fix-implementation`
- HF-021 close
- Predecessor PR: #357 (SP 1.15 — terminal sub-phase of WR-162 Phase 1 implementation lane)