### PR TITLE
docs(repo): restore AGENTS.md as minimal public router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ yarn-error.log*
 /*.md
 !/README.md
 !/CONTRIBUTING.md
+!/AGENTS.md
 !/LICENSE
 !/LICENSE.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+Routing file for AI coding agents working in this repo.
+
+## If `.skills/` is present
+
+This is an internal/private clone. **Read `.skills/AGENTS.md` — it is authoritative and supersedes this file.** It covers mode selection, skill source policy, state detection, and role inference.
+
+## If `.skills/` is not present
+
+This is the public repo. There are no private recipes here — work from the code, `README.md`, and `CONTRIBUTING.md`. Treat the user's instructions as authoritative and ask when unsure.


### PR DESCRIPTION
## Summary
- Re-track `AGENTS.md` at the repo root as a minimal router (skills-present vs. public-repo branches).
- Whitelist `/AGENTS.md` in `.gitignore` alongside `README` / `CONTRIBUTING` / `LICENSE` so it tracks normally.
- Full prior operating-context content (mode selection, skill source policy, state detection, role inference) moved to `.skills/AGENTS.md` in the private repo — this public file just defers to it when `.skills/` is present.

Motivation: the original `AGENTS.md` was untracked in 35d84bbe to keep the public repo root minimal, but that meant agents in fresh clones had no entry point and the local copy could drift or get lost. A small router avoids that without leaking internal recipes.

## Test plan
- [ ] Prose-only change; no code or runtime impact.
- [ ] Verify `.gitignore` allowlist still excludes other root `*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)