### PR TITLE
docs(wr-163): user + dev docs followup for sub-phase 1.3

### DIFF
--- a/docs/content/docs/development/meta.json
+++ b/docs/content/docs/development/meta.json
@@ -1,1 +1,1 @@
-{"title":"Development","pages":["testing-patterns","operator-control","benchmark-runbook","phase-1-retrospective"]}
+{"title":"Development","pages":["testing-patterns","shell-context","operator-control","benchmark-runbook","phase-1-retrospective"]}

--- a/docs/content/docs/development/shell-context.mdx
+++ b/docs/content/docs/development/shell-context.mdx
@@ -1,0 +1,58 @@
+---
+title: Shell Context Hooks
+description: Consumer guide for useShellContext and useShellContextOptional in @nous/ui
+---
+
+# Shell Context Hooks
+
+The web and desktop shells share a single React context — `ShellContext` (in `@nous/ui` at `self/ui/src/components/shell/ShellContext.tsx`) — that exposes the active project id, the project-change handler, and other shell-level state to components that render inside the shell tree.
+
+Sub-phase 1.3 of the project-model-and-settings work consolidated the previous web-only `ProjectContext` into this shared `ShellContext`. As part of that consolidation, two hooks are exported.
+
+## `useShellContext()` — strict variant (default)
+
+Use this hook in components that are always rendered inside `<ShellProvider>`. It throws if called outside the provider, which is the behavior you want for in-shell wiring — accidental renders outside the shell tree fail loudly at runtime instead of silently passing `undefined` through the consumer.
+
+```tsx
+import { useShellContext } from '@nous/ui';
+
+function InShellWidget() {
+  const { activeProjectId, onProjectChange } = useShellContext();
+  // ...
+}
+```
+
+This is the default. Reach for it unless you specifically need the non-throwing variant.
+
+## `useShellContextOptional()` — non-throwing variant
+
+Use this hook when the consuming component may render outside `<ShellProvider>` — most commonly in pages that Next.js statically prerenders, where the page component is analyzed without mounting the full shell.
+
+It returns `null` instead of throwing when no provider is in scope. Consumers handle the `null` case (typically by rendering a loading or empty state) until the shell mounts and the provider is in the tree.
+
+```tsx
+import { useShellContextOptional } from '@nous/ui';
+
+export default function ProjectsPage() {
+  const shell = useShellContextOptional();
+  if (!shell) return null; // SSR-prerender path
+  const { activeProjectId } = shell;
+  // ...
+}
+```
+
+### When to use the optional variant
+
+Pick `useShellContextOptional` when any of the following is true:
+
+- The component is a top-level Next.js page that participates in static prerendering and is reachable without the shell mounted.
+- The component is shared between in-shell and out-of-shell render paths and you cannot guarantee a provider in every path.
+- You are migrating a legacy consumer that previously read from a separate context and you want a defensive fallback during the migration window.
+
+Otherwise, prefer `useShellContext` so renders outside the shell tree continue to fail loudly.
+
+## Migration Notes
+
+The previous web-only `self/apps/web/lib/project-context.tsx` and its `useProject` / `<ProjectProvider>` exports have been removed. Migrated consumers read `activeProjectId` and `onProjectChange` directly from `useShellContextOptional()` (in pages) or `useShellContext()` (inside the shell subtree).
+
+For the MAO surface, the `MaoServicesContextValue.useProject` contract is preserved bit-for-bit by a thin web-side shim (`self/apps/web/lib/use-shell-project-shim.tsx`) that adapts `ShellContext` into the existing `useProject`-shaped contract. Existing MAO consumers do not need to change.

--- a/docs/content/docs/guides/projects.mdx
+++ b/docs/content/docs/guides/projects.mdx
@@ -24,12 +24,71 @@ pnpm dev:cli -- projects create --name "My Project"
 
 ## Switching Projects
 
-**Web UI:** Click a project in the sidebar. The chat, traces, and memory views update to that project's context.
+**Web UI:** Click a project avatar in the project switcher rail. The chat, traces, MAO, and memory views update to that project's context.
+
+**Desktop:** Same — click a project avatar in the rail.
+
+When you switch projects:
+
+- The active route resets to the project home view.
+- Navigation history clears, so the back affordance starts fresh on the new project.
+- Per-project view state (last-opened layout, focused entities, navigation breadcrumbs landed in earlier sub-phases) is restored automatically for the project you just switched to.
+
+This behavior is identical on web and desktop — switching feels the same on both surfaces.
 
 **CLI:**
 ```bash
 pnpm dev:cli -- projects switch -p <project-id>
 ```
+
+## Multi-Project Interaction (Phase 1.3)
+
+Phase 1.3 of the project-model-and-settings work brings the project switcher rail to parity across web and desktop and adds the archive lifecycle.
+
+### Project Avatars on the Rail
+
+Each project on the rail renders as a 32-pixel avatar circle. The avatar follows a deterministic precedence:
+
+1. If the project sets a `lucide:<IconName>` icon, the rail renders the named lucide icon at 18 pixels with a white foreground.
+2. If the project sets an `emoji:<glyph>` icon, the rail renders the glyph at 18 pixels.
+3. Otherwise, the rail renders the first letter of the project name.
+
+The avatar background uses the project's `color` if one is set, otherwise a deterministic color derived from the project id. Archived projects render at reduced opacity so they read as inactive at a glance.
+
+The picker UX for selecting an icon or color ships with the per-project Settings Identity page in sub-phase 1.4. In 1.3 the rail renders whatever icon and color the project record carries — choosing them is not yet a user-facing action.
+
+### Archive a Project
+
+Right-click on a project avatar in the rail (long-press on touch surfaces) to open the rail context menu. Choose **Archive**.
+
+If you archive a project that is not currently active, the project disappears from the default rail and becomes available under the Archived disclosure (see below).
+
+If you archive the project that is currently active, Nous handles the active-project handoff for you:
+
+- If at least one other active (non-archived) project exists, Nous switches the active project to the most-recently-used remaining peer (with a deterministic tie-break by project id when recency is unavailable).
+- If no other active projects remain, Nous auto-creates a new project named **Default** and makes it active.
+
+After the active-project handoff, the shell navigates to the project home and clears navigation history, the same way an explicit project switch behaves.
+
+### View Archived Projects
+
+The rail has an Archived disclosure (a toggle below the active project list). Expand it to see archived projects rendered as dimmed avatars. Archived avatars are not selectable as the active project — they are display-only until you unarchive them.
+
+### Unarchive a Project
+
+Right-click on an archived avatar in the Archived disclosure and choose **Unarchive**. The project moves back to the active rail and becomes selectable again.
+
+### When Archive or Unarchive is Blocked
+
+Projects that the runtime is currently operating on can be in a control state that blocks archive operations — for example `hard_stopped` or `resuming`. If you try to archive or unarchive a project in one of those states, Nous surfaces the server's reason inline on the rail as a non-blocking status strip and the project remains unchanged. Resolve the underlying control state (acknowledge the escalation, finish the resume, or wait for the hard-stop to clear) and try again.
+
+The archive UX is intentionally restricted to the right-click context menu in this version — there is no always-visible archive button on the rail. This keeps the rail compact and avoids accidental archive on click.
+
+## Settings Entry Point
+
+The asset sidebar header in the web shell now has a settings gear icon. Clicking it navigates to the Settings route scoped to the active project.
+
+The Settings route renders the per-project Settings UI pages (Identity, Budget and Limits, Models, Governance) starting in sub-phase 1.4 — in 1.3 the entry point is wired and reachable, and the page contents land in the next sub-phase.
 
 ## Project Types
 


### PR DESCRIPTION
## Summary

Lands the parent-repo `docs/` changes that the user-documentation implementation agent produced for sub-phase 1.3 but left uncommitted post-close.

## Why a followup sub-phase

Per `dispatch-model.md` flow, User Documentation runs *after* sub-phase close + BT sign-off. The Implementation Agent wrote the artifact to `.worklog/sprints/.../phase-1.3/user-documentation.mdx` (committed atomically, `4455280`) and also produced these parent-repo doc updates, but did not commit/push the parent-repo files. PR #345 (sub-phase 1.3 close) had already merged at that point. Direct push to the phase branch is blocked by `branch-pr-convention.md`. This followup sub-phase commits the parent-repo docs through the standard PR-merge path.

## Files

- `docs/content/docs/guides/projects.mdx` — archive/unarchive, archived view, self-archive flow, rail icon/color rendering, settings entry point
- `docs/content/docs/development/shell-context.mdx` (new) — consumer guide for `useShellContext` / `useShellContextOptional`
- `docs/content/docs/development/meta.json` — register `shell-context` page in dev nav

## Source artifacts

- Worklog: `.worklog/sprints/feat/project-model-and-settings/phase-1/phase-1.3/user-documentation.mdx` (4455280)
- Review: `.worklog/sprints/feat/project-model-and-settings/phase-1/phase-1.3/reviews/user-documentation.mdx` Approved cycle 1 (e54a334)

## Test plan

- [ ] CI passes (lint/typecheck/build/test — pure docs, no code change)
- [ ] Docs preview renders the new `development/shell-context.mdx` page in nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)