### PR TITLE
feat(shell): add workspace route identity projection

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -45,7 +45,7 @@ import { panelComponents } from './desktop-panel-map'
 import { RAIL_SECTIONS } from './desktop-rail-config'
 import { buildDesktopCommands } from './desktop-command-config'
 import { DESKTOP_TOP_NAV, buildDesktopSidebarSections } from './desktop-sidebar-config'
-import { BASE_SIMPLE_MODE_ROUTES } from './desktop-routes'
+import { BASE_SIMPLE_MODE_ROUTES, BASE_SIMPLE_MODE_ROUTE_IDENTITIES } from './desktop-routes'
 import { useTasks, buildTasksSection } from '@nous/ui/hooks/useTasks'
 import { useWorkflows, buildWorkflowsSection } from '@nous/ui/hooks/useWorkflows'
 import { ConfirmDeleteDialog, NotificationProvider, useNotificationBadge } from '@nous/ui/components'
@@ -591,6 +591,11 @@ export function App() {
     settings: SettingsRouteRenderer,
   }), [SettingsRouteRenderer])
 
+  const simpleModeRouteIdentities = useMemo(() => ({
+    ...BASE_SIMPLE_MODE_ROUTE_IDENTITIES,
+    settings: { routeId: 'settings', label: 'Settings', surface: 'workspace' as const },
+  }), [])
+
   const handleDesktopProjectChange = useCallback((newProjectId: string) => {
     setIsHomeContext(false)
     setActiveRoute(DEFAULT_ROUTE) // reset content route on project switch
@@ -719,6 +724,7 @@ export function App() {
           activeRoute={activeRoute}
           handleNavigate={handleNavigate}
           simpleModeRoutes={simpleModeRoutes}
+          simpleModeRouteIdentities={simpleModeRouteIdentities}
           navigationParams={navigationParams}
           isHomeContext={isHomeContext}
           setIsHomeContext={setIsHomeContext}
@@ -834,6 +840,7 @@ function DesktopSimpleShell({
   activeRoute,
   handleNavigate,
   simpleModeRoutes,
+  simpleModeRouteIdentities,
   navigationParams,
   isHomeContext,
   setIsHomeContext,
@@ -841,6 +848,7 @@ function DesktopSimpleShell({
   activeRoute: string
   handleNavigate: (routeId: string, params?: Record<string, unknown>) => void
   simpleModeRoutes: Record<string, any>
+  simpleModeRouteIdentities: Record<string, any>
   navigationParams?: Record<string, unknown>
   isHomeContext: boolean
   setIsHomeContext: (value: boolean) => void
@@ -898,6 +906,7 @@ function DesktopSimpleShell({
         <ContentRouter
           activeRoute={activeRoute}
           routes={simpleModeRoutes}
+          routeIdentities={simpleModeRouteIdentities}
           onNavigate={handleNavigate}
           navigationParams={navigationParams}
         />

--- a/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createElectronAPIMock,
@@ -12,7 +13,90 @@ const trpcFetchMock = vi.hoisted(() => ({
   trpcMutate: vi.fn(),
 }))
 
+const transportMock = vi.hoisted(() => ({
+  createDesktopTransport: vi.fn((config: unknown) => config),
+  useEventSubscription: vi.fn(),
+  useUtils: vi.fn(() => ({
+    notifications: {
+      countActive: { invalidate: vi.fn() },
+    },
+    mao: {
+      getSystemSnapshot: { invalidate: vi.fn() },
+      getProjectSnapshot: { invalidate: vi.fn() },
+      getAgentInspectProjection: { invalidate: vi.fn() },
+      getProjectControlProjection: { invalidate: vi.fn() },
+      getControlAuditHistory: { invalidate: vi.fn() },
+    },
+    health: {
+      systemStatus: { invalidate: vi.fn() },
+    },
+    escalations: {
+      listProjectQueue: { invalidate: vi.fn() },
+    },
+    tasks: {
+      list: { invalidate: vi.fn() },
+      get: { invalidate: vi.fn() },
+      executions: { invalidate: vi.fn() },
+    },
+    projects: {
+      listWorkflowDefinitions: { invalidate: vi.fn() },
+      dashboardSnapshot: { invalidate: vi.fn() },
+    },
+  })),
+  projectListQuery: vi.fn(() => ({ data: [{ id: 'project-1', name: 'Project' }] })),
+  projectCreateMutation: vi.fn(() => ({ mutateAsync: vi.fn(async () => ({ id: 'project-1' })) })),
+  notificationCountQuery: vi.fn(() => ({ data: 0 })),
+}))
+
 vi.mock('../components/wizard/trpc-fetch', () => trpcFetchMock)
+
+vi.mock('@nous/transport', () => {
+  return {
+    TransportProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+    createDesktopTransport: transportMock.createDesktopTransport,
+    useEventSubscription: transportMock.useEventSubscription,
+    trpc: {
+      useUtils: transportMock.useUtils,
+      projects: {
+        list: { useQuery: transportMock.projectListQuery },
+        create: { useMutation: transportMock.projectCreateMutation },
+        listWorkflowDefinitions: { useQuery: vi.fn(() => ({ data: [] })) },
+        saveWorkflowSpec: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        renameWorkflowDefinition: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        deleteWorkflowDefinition: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+      },
+      tasks: {
+        list: { useQuery: vi.fn(() => ({ data: [] })) },
+        get: { useQuery: vi.fn(() => ({ data: null })) },
+        executions: { useQuery: vi.fn(() => ({ data: [] })) },
+        create: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        update: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        delete: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        toggle: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        trigger: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+      },
+      notifications: {
+        countActive: { useQuery: transportMock.notificationCountQuery },
+      },
+      mao: {
+        requestProjectControl: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+        getSystemSnapshot: { useQuery: vi.fn(() => ({ data: null })) },
+        getProjectSnapshot: { useQuery: vi.fn(() => ({ data: null })) },
+        getAgentInspectProjection: { useQuery: vi.fn(() => ({ data: null })) },
+        getControlAuditHistory: { useQuery: vi.fn(() => ({ data: [] })) },
+      },
+      health: {
+        systemStatus: { useQuery: vi.fn(() => ({ data: null })) },
+      },
+      escalations: {
+        listProjectQueue: { useQuery: vi.fn(() => ({ data: [] })) },
+      },
+      opctl: {
+        requestConfirmationProof: { useMutation: vi.fn(() => ({ mutateAsync: vi.fn() })) },
+      },
+    },
+  }
+})
 
 const dockviewApiMock = vi.hoisted(() => ({
   panels: [] as never[],
@@ -68,6 +152,8 @@ vi.mock('@nous/ui/panels', () => {
     AgentPanel: Panel,
     PreferencesPanel: Panel,
     WorkflowBuilderPanel: Panel,
+    TaskDetailView: Panel,
+    TaskCreateForm: Panel,
     useCodexBarApi: () => null,
     useDashboardApi: () => null,
   }
@@ -84,6 +170,11 @@ vi.mock('../components/TitleBar', () => ({
 
 vi.mock('../components/StatusBar', () => ({
   StatusBar: () => <div>Status bar</div>,
+}))
+
+vi.mock('../desktop-chat-wrappers', () => ({
+  DesktopChatPanel: () => <div>Desktop chat panel</div>,
+  ConnectedChatSurface: () => <div>Chat surface</div>,
 }))
 
 vi.mock('../components/FirstRunWizard', () => ({
@@ -131,6 +222,12 @@ describe('App', () => {
     })
     trpcFetchMock.trpcMutate.mockResolvedValue(null)
     trpcFetchMock.setBackendPort.mockClear()
+    transportMock.createDesktopTransport.mockClear()
+    transportMock.useEventSubscription.mockClear()
+    transportMock.useUtils.mockClear()
+    transportMock.projectListQuery.mockClear()
+    transportMock.projectCreateMutation.mockClear()
+    transportMock.notificationCountQuery.mockClear()
   })
 
   it('starts in simple mode by default', async () => {
@@ -154,6 +251,7 @@ describe('App', () => {
     // Observe column renders (ObservePanel default view text)
     expect(screen.getByText('No observe content for this view')).toBeInTheDocument()
     expect(screen.queryByText('Dockview shell')).not.toBeInTheDocument()
+    expect(screen.queryByText('Status bar')).not.toBeInTheDocument()
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
   })
 
@@ -169,6 +267,7 @@ describe('App', () => {
     render(<App />)
 
     expect(await screen.findByText('Dockview shell')).toBeInTheDocument()
+    expect(screen.getByText('Status bar')).toBeInTheDocument()
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
   })
 
@@ -234,6 +333,7 @@ describe('App', () => {
 
   it('skips persisting the layout when serialization fails', async () => {
     const mock = installMock()
+    mock.mode.get.mockResolvedValue('developer')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const circularLayout: Record<string, unknown> = {}
     circularLayout.self = circularLayout
@@ -272,6 +372,7 @@ describe('App', () => {
 
   it('catches synchronous layout persistence errors without crashing', async () => {
     const mock = installMock()
+    mock.mode.get.mockResolvedValue('developer')
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const syncError = new Error('An object could not be cloned')
 
@@ -316,7 +417,8 @@ describe('App', () => {
   })
 
   it('shows the dockview shell when first-run is already complete', async () => {
-    installMock()
+    const mock = installMock()
+    mock.mode.get.mockResolvedValue('developer')
     trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
       if (procedure === 'firstRun.getWizardState') return createFirstRunState({ currentStep: 'complete', complete: true })
       if (procedure === 'packages.listAppPanels') return []
@@ -329,7 +431,8 @@ describe('App', () => {
   })
 
   it('transitions from the wizard shell to dockview after completion', async () => {
-    installMock()
+    const mock = installMock()
+    mock.mode.get.mockResolvedValue('developer')
     // Default trpcQuery mock returns incomplete wizard state
 
     render(<App />)
@@ -400,7 +503,8 @@ describe('App', () => {
   })
 
   it('wires the preferences panel reset callback back into app initialization', async () => {
-    installMock()
+    const mock = installMock()
+    mock.mode.get.mockResolvedValue('developer')
     let wizardCallCount = 0
     trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
       if (procedure === 'firstRun.getWizardState') {
@@ -437,7 +541,7 @@ describe('App', () => {
   })
 
   it('opens command palette with Ctrl+K', async () => {
-    const mock = installMock()
+    installMock()
     trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
       if (procedure === 'firstRun.getWizardState') return createFirstRunState({ currentStep: 'complete', complete: true })
       if (procedure === 'packages.listAppPanels') return []
@@ -463,7 +567,7 @@ describe('App', () => {
   })
 
   it('closes command palette with Escape', async () => {
-    const mock = installMock()
+    installMock()
     trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
       if (procedure === 'firstRun.getWizardState') return createFirstRunState({ currentStep: 'complete', complete: true })
       if (procedure === 'packages.listAppPanels') return []
@@ -494,7 +598,7 @@ describe('App', () => {
   })
 
   it('navigates via command palette', async () => {
-    const mock = installMock()
+    installMock()
     trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
       if (procedure === 'firstRun.getWizardState') return createFirstRunState({ currentStep: 'complete', complete: true })
       if (procedure === 'packages.listAppPanels') return []

--- a/self/apps/desktop/src/renderer/src/__tests__/workspace-shell-route-identity.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/workspace-shell-route-identity.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AssetSidebar, ContentRouter, type ContentRouterRenderProps } from '@nous/ui/components'
+import { DESKTOP_TOP_NAV, buildDesktopSidebarSections } from '../desktop-sidebar-config'
+import { BASE_SIMPLE_MODE_ROUTE_IDENTITIES } from '../desktop-routes'
+
+let container: HTMLDivElement
+let root: Root
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+async function flush() {
+  await Promise.resolve()
+  await new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function RouteProbe({ params, routeIdentity }: ContentRouterRenderProps) {
+  return (
+    <div data-testid="route-probe">
+      {routeIdentity?.label}:{routeIdentity?.surface}:{params?.definitionId as string ?? params?.taskId as string ?? 'none'}
+    </div>
+  )
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+    await flush()
+  })
+  container.remove()
+})
+
+describe('desktop workspace shell route identity', () => {
+  it('keeps Chat in the desktop asset-sidebar top-nav component path', () => {
+    const chat = DESKTOP_TOP_NAV.find((item) => item.id === 'chat')
+
+    expect(chat).toMatchObject({ id: 'chat', label: 'Chat', routeId: 'chat' })
+    expect(BASE_SIMPLE_MODE_ROUTE_IDENTITIES.chat).toMatchObject({
+      routeId: 'chat',
+      label: 'Chat',
+      surface: 'chat',
+    })
+  })
+
+  it('maps desktop detail routes to visible route ID plus params without URL state', async () => {
+    await act(async () => {
+      root.render(
+        <ContentRouter
+          activeRoute="workflow-detail"
+          routes={{ 'workflow-detail': RouteProbe }}
+          routeIdentities={BASE_SIMPLE_MODE_ROUTE_IDENTITIES}
+          navigationParams={{ definitionId: 'wf-1' }}
+        />,
+      )
+      await flush()
+    })
+
+    const router = container.querySelector('.nous-content-router') as HTMLElement
+    expect(router.dataset.workspaceRouteId).toBe('workflow-detail')
+    expect(router.dataset.workspaceRouteSurface).toBe('project')
+    expect(container.textContent).toContain('Workflow Detail:project:wf-1')
+    expect(window.location.href).not.toContain('wf-1')
+  })
+
+  it('renders Project and Chat selections as asset-sidebar content, not status or menu chrome', async () => {
+    const onNavigate = vi.fn()
+    await act(async () => {
+      root.render(
+        <AssetSidebar
+          projectName="Client onboarding"
+          topNav={DESKTOP_TOP_NAV}
+          sections={buildDesktopSidebarSections()}
+          activeRoute="chat"
+          onNavigate={onNavigate}
+        />,
+      )
+      await flush()
+    })
+
+    const chat = container.querySelector('[data-list-item="chat"]') as HTMLButtonElement
+    expect(chat).toBeTruthy()
+    expect(chat.getAttribute('data-state')).toBe('active')
+    expect(container.querySelector('[data-shell-component="status-bar"]')).toBeNull()
+    expect(container.querySelector('[data-shell-component="menu-bar"]')).toBeNull()
+
+    await act(async () => {
+      chat.click()
+      await flush()
+    })
+    expect(onNavigate).toHaveBeenCalledWith('chat')
+  })
+})

--- a/self/apps/desktop/src/renderer/src/components/__tests__/MenuBar.test.tsx
+++ b/self/apps/desktop/src/renderer/src/components/__tests__/MenuBar.test.tsx
@@ -33,7 +33,9 @@ function createDockviewApi(openPanelIds: string[] = []): DockviewApi {
 
 async function openViewMenu() {
   const trigger = screen.getByText('View')
-  fireEvent.pointerDown(trigger)
+  trigger.focus()
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+  fireEvent.keyDown(trigger, { key: 'ArrowDown' })
   fireEvent.click(trigger)
 
   await waitFor(() => {
@@ -100,7 +102,7 @@ describe('AppMenuBar', () => {
     expect(screen.getByText('Toggle Developer Mode')).toBeInTheDocument()
     expect(screen.getByText('Ctrl+Shift+D')).toBeInTheDocument()
     expect(screen.getByText('Ctrl+K')).toBeInTheDocument()
-    expect(screen.getByText('Command Palette')).toHaveAttribute('data-disabled')
+    expect(screen.getByText('Command Palette').closest('[role="menuitem"]')).toHaveAttribute('data-disabled')
 
     rerender(
       <AppMenuBar
@@ -114,7 +116,7 @@ describe('AppMenuBar', () => {
     await openViewMenu()
 
     expect(screen.getByText('Toggle Developer Mode')).toBeInTheDocument()
-    expect(screen.getByText('Command Palette')).toHaveAttribute('data-disabled')
+    expect(screen.getByText('Command Palette').closest('[role="menuitem"]')).toHaveAttribute('data-disabled')
   })
 
   it('calls onModeToggle when the developer mode item is selected', async () => {

--- a/self/apps/desktop/src/renderer/src/desktop-routes.tsx
+++ b/self/apps/desktop/src/renderer/src/desktop-routes.tsx
@@ -6,6 +6,7 @@ import {
   InboxView,
   ChatTabView,
   type ContentRouterRenderProps,
+  type WorkspaceRouteIdentity,
 } from '@nous/ui/components'
 import {
   STUB_THREADS,
@@ -35,4 +36,24 @@ export const BASE_SIMPLE_MODE_ROUTES: Record<string, React.ComponentType<Content
   chat: ChatTabView,
   usage: (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Usage" />,
   marketplace: (props: ContentRouterRenderProps) => <PlaceholderRoute {...props} label="Marketplace" />,
+}
+
+export const BASE_SIMPLE_MODE_ROUTE_IDENTITIES: Record<string, Omit<WorkspaceRouteIdentity, 'params'>> = {
+  home: { routeId: 'home', label: 'Workspace Home', surface: 'workspace' },
+  threads: { routeId: 'threads', label: 'Threads', surface: 'workspace' },
+  workflows: { routeId: 'workflows', label: 'Workflows', surface: 'project' },
+  skills: { routeId: 'skills', label: 'Skills', surface: 'workspace' },
+  apps: { routeId: 'apps', label: 'Apps', surface: 'workspace' },
+  dashboard: { routeId: 'dashboard', label: 'Dashboard', surface: 'project' },
+  'org-chart': { routeId: 'org-chart', label: 'Organization Chart', surface: 'project' },
+  inbox: { routeId: 'inbox', label: 'Inbox', surface: 'project' },
+  'workflow-detail': { routeId: 'workflow-detail', label: 'Workflow Detail', surface: 'project' },
+  tasks: { routeId: 'tasks', label: 'Tasks', surface: 'project' },
+  'task-detail': { routeId: 'task-detail', label: 'Task Detail', surface: 'project' },
+  'task-create': { routeId: 'task-create', label: 'Create Task', surface: 'project' },
+  agents: { routeId: 'agents', label: 'Agents', surface: 'project' },
+  'agent-detail': { routeId: 'agent-detail', label: 'Agent Detail', surface: 'project' },
+  chat: { routeId: 'chat', label: 'Chat', surface: 'chat' },
+  usage: { routeId: 'usage', label: 'Usage', surface: 'workspace' },
+  marketplace: { routeId: 'marketplace', label: 'Marketplace', surface: 'workspace' },
 }

--- a/self/ui/src/components/shell/ContentRouter.tsx
+++ b/self/ui/src/components/shell/ContentRouter.tsx
@@ -2,18 +2,21 @@
 
 import * as React from 'react'
 import { clsx } from 'clsx'
+import type { WorkspaceRouteIdentity } from './types'
 
 export interface ContentRouterRenderProps {
   navigate: (routeId: string, params?: Record<string, unknown>) => void
   goBack: () => void
   canGoBack: boolean
   params?: Record<string, unknown>
+  routeIdentity?: WorkspaceRouteIdentity
 }
 
 export interface ContentRouterProps
   extends React.HTMLAttributes<HTMLDivElement> {
   activeRoute: string
   routes: Record<string, React.ComponentType<ContentRouterRenderProps>>
+  routeIdentities?: Record<string, Omit<WorkspaceRouteIdentity, 'params'>>
   onNavigate?: (route: string, params?: Record<string, unknown>) => void
   /** Params to pass to the component when navigation is driven by the activeRoute prop */
   navigationParams?: Record<string, unknown>
@@ -28,6 +31,7 @@ function stackEntryEquals(a: StackEntry, b: StackEntry): boolean {
 export function ContentRouter({
   activeRoute,
   routes,
+  routeIdentities,
   onNavigate,
   navigationParams: externalParams,
   className,
@@ -100,10 +104,24 @@ export function ContentRouter({
   const currentRoute = stack[stack.length - 1]?.route ?? ''
   const ActiveRoute = routes[currentRoute]
   const canGoBack = stack.length > 1
+  const currentIdentityTemplate = routeIdentities?.[currentRoute]
+  const currentIdentity: WorkspaceRouteIdentity | undefined = currentIdentityTemplate
+    ? { ...currentIdentityTemplate, params: navigationParams }
+    : currentRoute
+      ? {
+          routeId: currentRoute,
+          label: currentRoute,
+          surface: currentRoute === 'chat' ? 'chat' : 'workspace',
+          params: navigationParams,
+        }
+      : undefined
 
   return (
     <div
       className={clsx('nous-content-router', className)}
+      data-workspace-route-id={currentIdentity?.routeId}
+      data-workspace-route-label={currentIdentity?.label}
+      data-workspace-route-surface={currentIdentity?.surface}
       style={{
         display: 'flex',
         height: '100%',
@@ -112,8 +130,27 @@ export function ContentRouter({
         gap: 'var(--nous-space-sm)',
         ...style,
       }}
-      {...props}
+        {...props}
     >
+      {currentIdentity ? (
+        <div
+          data-workspace-route-identity="true"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--nous-space-sm)',
+            minHeight: 'var(--nous-workspace-route-header-height)',
+            padding: '0 var(--nous-workspace-canvas-padding-x)',
+            borderBottom: '1px solid var(--nous-workspace-shell-border)',
+            color: 'var(--nous-workspace-route-label-fg)',
+            fontSize: 'var(--nous-font-size-sm)',
+            fontWeight: 600,
+          }}
+        >
+          <span>{currentIdentity.label}</span>
+        </div>
+      ) : null}
+
       {canGoBack ? (
         <div
           style={{
@@ -153,8 +190,20 @@ export function ContentRouter({
             goBack={goBack}
             canGoBack={canGoBack}
             params={navigationParams}
+            routeIdentity={currentIdentity}
           />
-        ) : null}
+        ) : (
+          <div
+            role="status"
+            data-workspace-route-missing="true"
+            style={{
+              padding: 'var(--nous-space-3xl)',
+              color: 'var(--nous-text-secondary)',
+            }}
+          >
+            Workspace route unavailable: {currentRoute || 'none'}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -172,7 +172,7 @@ export function SimpleShellLayout({
         position: 'relative',
         width: '100%',
         height: '100%',
-        background: 'var(--nous-bg-base)',
+        background: 'var(--nous-workspace-canvas-bg)',
         transition: isAnimating ? 'grid-template-columns var(--nous-duration-normal) var(--nous-ease-out)' : undefined,
         ...style,
     }

--- a/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
+++ b/self/ui/src/components/shell/__tests__/AssetSidebar.test.tsx
@@ -21,6 +21,7 @@ async function flush() {
 const TOP_NAV: SidebarTopNavItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: <span>D</span>, routeId: 'dashboard' },
   { id: 'inbox', label: 'Inbox', icon: <span>I</span>, routeId: 'inbox' },
+  { id: 'chat', label: 'Chat', icon: <span>C</span>, routeId: 'chat' },
 ]
 
 const SECTIONS: AssetSection[] = [
@@ -93,6 +94,19 @@ describe('AssetSidebar', () => {
     const inbox = container.querySelector('[data-list-item="inbox"]')
     expect(dashboard).toBeTruthy()
     expect(inbox).toBeTruthy()
+  })
+
+  it('renders Project and Chat navigation through the same sidebar list-item path', async () => {
+    await renderSidebar({ activeRoute: 'chat' })
+
+    const dashboard = container.querySelector('[data-list-item="dashboard"]')
+    const chat = container.querySelector('[data-list-item="chat"]')
+    expect(dashboard?.tagName).toBe('BUTTON')
+    expect(chat?.tagName).toBe('BUTTON')
+    expect(chat?.getAttribute('data-state')).toBe('active')
+    expect(chat?.getAttribute('aria-current')).toBe('page')
+    expect(container.querySelector('[data-shell-component="status-bar"]')).toBeNull()
+    expect(container.querySelector('[data-shell-component="menu-bar"]')).toBeNull()
   })
 
   it('highlights active route in top nav', async () => {

--- a/self/ui/src/components/shell/__tests__/ContentRouter.test.tsx
+++ b/self/ui/src/components/shell/__tests__/ContentRouter.test.tsx
@@ -36,10 +36,26 @@ function ParamRoute({ params }: ContentRouterRenderProps) {
   return <div data-testid="param-route">Param: {params?.definitionId as string ?? 'none'}</div>
 }
 
+function IdentityRoute({ routeIdentity }: ContentRouterRenderProps) {
+  return (
+    <div data-testid="identity-route">
+      {routeIdentity?.routeId}:{routeIdentity?.surface}:{routeIdentity?.params?.taskId as string ?? 'none'}
+    </div>
+  )
+}
+
 const routes = {
   home: HomeRoute,
   details: DetailsRoute,
   'workflow-detail': ParamRoute,
+  'task-detail': IdentityRoute,
+}
+
+const routeIdentities = {
+  home: { routeId: 'home', label: 'Workspace Home', surface: 'workspace' as const },
+  details: { routeId: 'details', label: 'Details', surface: 'workspace' as const },
+  'workflow-detail': { routeId: 'workflow-detail', label: 'Workflow Detail', surface: 'project' as const },
+  'task-detail': { routeId: 'task-detail', label: 'Task Detail', surface: 'project' as const },
 }
 
 async function renderRouter(
@@ -50,6 +66,7 @@ async function renderRouter(
       <ContentRouter
         activeRoute="home"
         routes={routes}
+        routeIdentities={routeIdentities}
         {...overrides}
       />,
     )
@@ -116,12 +133,27 @@ describe('ContentRouter', () => {
     expect(onNavigate).toHaveBeenCalledWith('home', undefined)
   })
 
-  it('renders nothing when the active route is unknown', async () => {
+  it('renders visible fallback when the active route is unknown', async () => {
     await renderRouter({
       activeRoute: 'missing',
     })
 
-    expect(container.textContent?.trim()).toBe('')
+    expect(container.textContent).toContain('Workspace route unavailable: missing')
+    expect(container.querySelector('[data-workspace-route-missing="true"]')).toBeTruthy()
+  })
+
+  it('renders route identity as visible workspace projection metadata', async () => {
+    await renderRouter({
+      activeRoute: 'task-detail',
+      navigationParams: { taskId: 'task-1' },
+    })
+
+    const router = container.querySelector('.nous-content-router') as HTMLElement
+    expect(router.dataset.workspaceRouteId).toBe('task-detail')
+    expect(router.dataset.workspaceRouteLabel).toBe('Task Detail')
+    expect(router.dataset.workspaceRouteSurface).toBe('project')
+    expect(container.querySelector('[data-workspace-route-identity="true"]')?.textContent).toContain('Task Detail')
+    expect(container.textContent).toContain('task-detail:project:task-1')
   })
 
   it('pushes distinct stack entries for same route with different params', async () => {
@@ -143,6 +175,7 @@ describe('ContentRouter', () => {
           activeRoute="workflow-detail"
           navigationParams={{ definitionId: 'b' }}
           routes={routes}
+          routeIdentities={routeIdentities}
           onNavigate={onNavigate}
         />,
       )
@@ -184,6 +217,7 @@ describe('ContentRouter', () => {
           activeRoute="workflow-detail"
           navigationParams={{ definitionId: 'a' }}
           routes={routes}
+          routeIdentities={routeIdentities}
           onNavigate={onNavigate}
         />,
       )

--- a/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
+++ b/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
@@ -81,6 +81,12 @@ describe('SimpleShellLayout', () => {
     expect(getArea('chat')).toBeTruthy()
   })
 
+  it('uses the shell-specific workspace canvas token for the frame background', async () => {
+    await renderLayout()
+    const layout = container.firstElementChild as HTMLDivElement
+    expect(layout.style.background).toBe('var(--nous-workspace-canvas-bg)')
+  })
+
   it('sets single-row grid-template-areas on the container', async () => {
     await renderLayout()
     const layout = container.firstElementChild as HTMLDivElement

--- a/self/ui/src/components/shell/__tests__/types.test.ts
+++ b/self/ui/src/components/shell/__tests__/types.test.ts
@@ -27,6 +27,8 @@ import {
   AssetSidebarPropsSchema,
   ProjectSwitcherRailPropsSchema,
   SimpleShellLayoutPropsSchema,
+  WorkspaceRouteIdentitySchema,
+  WorkspaceRouteParamsSchema,
 } from '../types'
 
 describe('shell type schemas', () => {
@@ -148,6 +150,44 @@ describe('shell type schemas', () => {
         id: 'home',
         label: 'Home',
         component: 'not-a-component',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('parses workspace route identity as UI projection metadata', () => {
+    expect(
+      WorkspaceRouteIdentitySchema.safeParse({
+        routeId: 'workflow-detail',
+        label: 'Workflow Detail',
+        surface: 'project',
+        params: { definitionId: 'wf-1' },
+      }).success,
+    ).toBe(true)
+
+    expect(WorkspaceRouteParamsSchema.safeParse({ taskId: 'task-1' }).success).toBe(true)
+    expect(WorkspaceRouteParamsSchema.safeParse(undefined).success).toBe(true)
+
+    expect(
+      WorkspaceRouteIdentitySchema.safeParse({
+        routeId: '',
+        label: 'Workflow Detail',
+        surface: 'project',
+      }).success,
+    ).toBe(false)
+
+    expect(
+      WorkspaceRouteIdentitySchema.safeParse({
+        routeId: 'chat',
+        label: '',
+        surface: 'chat',
+      }).success,
+    ).toBe(false)
+
+    expect(
+      WorkspaceRouteIdentitySchema.safeParse({
+        routeId: 'chat',
+        label: 'Chat',
+        surface: 'browser-url',
       }).success,
     ).toBe(false)
   })

--- a/self/ui/src/components/shell/types.ts
+++ b/self/ui/src/components/shell/types.ts
@@ -72,6 +72,16 @@ export const ContentRouteSchema = z.object({
 })
 export type ContentRoute = z.infer<typeof ContentRouteSchema>
 
+export const WorkspaceRouteParamsSchema = z.record(z.string(), z.unknown()).optional()
+
+export const WorkspaceRouteIdentitySchema = z.object({
+  routeId: z.string().min(1),
+  label: z.string().min(1),
+  surface: z.enum(['project', 'chat', 'workspace']),
+  params: WorkspaceRouteParamsSchema,
+})
+export type WorkspaceRouteIdentity = z.infer<typeof WorkspaceRouteIdentitySchema>
+
 export interface NavigationState {
   activeRoute: string
   history: string[]

--- a/self/ui/src/styles/components.css
+++ b/self/ui/src/styles/components.css
@@ -56,6 +56,9 @@
   /* ── Panel content ─────────────────────────────────────────────────── */
   --nous-content-bg:    var(--nous-bg-base);
   --nous-chat-full-bg:  #1A1A1A;
+  --nous-workspace-shell-border:   var(--nous-border-subtle);
+  --nous-workspace-canvas-bg:      var(--nous-bg-base);
+  --nous-workspace-route-label-fg: var(--nous-fg-muted);
 
   /* ── Tab bar ─────────────────────────────────────────────────────── */
   --nous-tab-bar-bg:      var(--nous-bg);

--- a/self/ui/src/styles/tokens.css
+++ b/self/ui/src/styles/tokens.css
@@ -230,6 +230,8 @@
   --nous-observe-expanded-width:        280px;
   --nous-observe-min-width:             32px;
   --nous-chat-overlay-min-width:        320px;  /* WR-141 — chat overlay floor when sidebar collapsed */
+  --nous-workspace-route-header-height: 64px;
+  --nous-workspace-canvas-padding-x:    32px;
 
   /* -- Chat overlay heights (per stage) */
   --nous-chat-height-small:             fit-content;


### PR DESCRIPTION
## Summary
- Adds explicit workspace route identity metadata for simple-mode shell routes.
- Surfaces route identity on the content router and keeps missing routes visible.
- Covers desktop route identity, shell router, sidebar, and schema behavior with tests.

Review artifact: .worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.1/reviews/user-documentation.mdx