### PR TITLE
feat(shell): add Cortex Principal chat drawer

### DIFF
--- a/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
@@ -252,6 +252,10 @@ describe('App', () => {
     expect(screen.getByText('No observe content for this view')).toBeInTheDocument()
     expect(screen.queryByText('Dockview shell')).not.toBeInTheDocument()
     expect(screen.queryByText('Status bar')).not.toBeInTheDocument()
+    const chat = document.querySelector('[data-shell-area="chat"]') as HTMLElement | null
+    expect(chat?.dataset.chatOwner).toBe('Cortex:Principal')
+    expect(chat?.dataset.chatContainer).toBe('principal-drawer')
+    expect(chat?.getAttribute('aria-label')).toBe('Cortex Principal chat drawer')
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
   })
 
@@ -268,6 +272,7 @@ describe('App', () => {
 
     expect(await screen.findByText('Dockview shell')).toBeInTheDocument()
     expect(screen.getByText('Status bar')).toBeInTheDocument()
+    expect(document.querySelector('[data-chat-container="principal-drawer"]')).toBeNull()
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
   })
 

--- a/self/ui/src/components/shell/SimpleShellLayout.tsx
+++ b/self/ui/src/components/shell/SimpleShellLayout.tsx
@@ -22,6 +22,14 @@ export const CHAT_STAGE_HEIGHT: Record<ChatStage, string> = {
     full: 'var(--nous-chat-height-full)',
 }
 
+/** Maps chat stage → drawer width inside the simple-shell workspace. */
+export const CHAT_STAGE_DRAWER_WIDTH: Record<ChatStage, string> = {
+    small: 'var(--shell-chat-drawer-collapsed-width)',
+    ambient_small: 'var(--shell-chat-drawer-collapsed-width)',
+    ambient_large: 'min(var(--nous-chat-drawer-expanded-width), var(--shell-chat-drawer-available-width))',
+    full: 'var(--shell-chat-drawer-available-width)',
+}
+
 /** Sidebar width caps per breakpoint */
 const BREAKPOINT_SIDEBAR: Record<ShellBreakpoint, number> = {
     full: DEFAULT_SIDEBAR_WIDTH,
@@ -36,6 +44,8 @@ function clampWidth(width: number, minimum: number, maximum: number): number {
 type SimpleShellStyle = React.CSSProperties & {
     '--shell-sidebar-width': string
     '--shell-observe-width': string
+    '--shell-chat-drawer-collapsed-width': string
+    '--shell-chat-drawer-available-width': string
 }
 
 export function SimpleShellLayout({
@@ -145,6 +155,10 @@ export function SimpleShellLayout({
         : `${effectiveSidebarWidth}px`
 
     const chatOverlayHeight = CHAT_STAGE_HEIGHT[chatStage]
+    const chatDrawerWidth = CHAT_STAGE_DRAWER_WIDTH[chatStage]
+    const chatDrawerAvailableWidth = showObserve
+        ? 'calc(100% - var(--shell-observe-width) - 5px)'
+        : '100%'
 
     // Click-outside handler — single handler on the layout container
     const handleLayoutClick = React.useCallback((e: React.MouseEvent) => {
@@ -157,6 +171,8 @@ export function SimpleShellLayout({
     const layoutStyle: SimpleShellStyle = {
         '--shell-sidebar-width': resolvedSidebarWidthCss,
         '--shell-observe-width': `${observeWidth}px`,
+        '--shell-chat-drawer-collapsed-width': 'calc(var(--nous-project-rail-width) + var(--shell-sidebar-width))',
+        '--shell-chat-drawer-available-width': chatDrawerAvailableWidth,
         display: 'grid',
         minWidth: 0,
         gridTemplateAreas: '"rail sidebar . content . observe"',
@@ -177,7 +193,7 @@ export function SimpleShellLayout({
         ...style,
     }
 
-    const chatOverlayBackground = chatStage === 'full' ? 'var(--nous-bg-chat-full)' : 'rgba(0, 0, 0, 0)';
+    const chatOverlayBackground = chatStage === 'full' ? 'var(--nous-bg-chat-full)' : 'var(--nous-chat-drawer-bg)'
 
     return (
         <div
@@ -222,30 +238,33 @@ export function SimpleShellLayout({
                 </CollapsibleObserveEdge>
             </div>
 
-            {/* Chat overlay — anchored to bottom of rail+sidebar area */}
+            {/* Chat drawer — Cortex:Principal container inside the simple-shell workspace. */}
             <div
                 ref={chatOverlayRef}
                 data-shell-area="chat"
+                data-chat-owner="Cortex:Principal"
+                data-chat-container="principal-drawer"
                 data-chat-stage={chatStage}
+                role="complementary"
+                aria-label="Cortex Principal chat drawer"
                 style={{
                     position: 'absolute',
-                    bottom: 0,
-                    left: 0,
-                    width: `calc(var(--nous-project-rail-width) + var(--shell-sidebar-width))`,
-                    // WR-141 — unconditional floor so the overlay does not visually break
-                    // in `chat:small` when the sidebar collapses to 32px (rail+sidebar = 94px).
-                    // Overhang into the content area is accepted; bubble mode is deferred to WR-143.
+                    bottom: 'var(--nous-chat-drawer-bottom-offset)',
+                    left: 'var(--nous-chat-drawer-left-offset)',
+                    width: chatDrawerWidth,
                     minWidth: 'var(--nous-chat-overlay-min-width)',
+                    maxWidth: 'var(--shell-chat-drawer-available-width)',
                     height: chatOverlayHeight,
                     zIndex: 10,
                     pointerEvents: 'auto',
                     background: chatOverlayBackground,
-                    border: 'none',
-                    borderRadius: '0px',
+                    border: '1px solid var(--nous-chat-drawer-border)',
+                    borderRadius: 'var(--nous-chat-drawer-radius)',
+                    boxShadow: chatStage === 'small' ? 'none' : 'var(--nous-chat-drawer-shadow)',
                     display: 'flex',
                     flexDirection: 'column',
                     overflow: 'hidden',
-                    transition: 'height var(--nous-duration-slow) var(--nous-ease-out), background var(--nous-duration-slow) var(--nous-ease-out)',
+                    transition: 'width var(--nous-duration-slow) var(--nous-ease-out), height var(--nous-duration-slow) var(--nous-ease-out), background var(--nous-duration-slow) var(--nous-ease-out)',
                 }}
             >
                 {chatSlot({ stage: chatStage, onStageChange: internalSetChatStage ?? (() => { }) })}

--- a/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
+++ b/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
@@ -99,13 +99,17 @@ describe('SimpleShellLayout', () => {
     expect(layout.style.gridTemplateRows).toBe('minmax(0, 1fr)')
   })
 
-  it('chat overlay is positioned absolutely', async () => {
+  it('chat drawer is positioned as a Cortex Principal simple-shell container', async () => {
     await renderLayout()
     const chat = getArea('chat')
     expect(chat.style.position).toBe('absolute')
-    expect(chat.style.bottom).toBe('0px')
-    expect(chat.style.left).toBe('0px')
+    expect(chat.style.bottom).toBe('var(--nous-chat-drawer-bottom-offset)')
+    expect(chat.style.left).toBe('var(--nous-chat-drawer-left-offset)')
     expect(chat.style.zIndex).toBe('10')
+    expect(chat.getAttribute('data-chat-owner')).toBe('Cortex:Principal')
+    expect(chat.getAttribute('data-chat-container')).toBe('principal-drawer')
+    expect(chat.getAttribute('role')).toBe('complementary')
+    expect(chat.getAttribute('aria-label')).toBe('Cortex Principal chat drawer')
   })
 
   it('applies initial widths as CSS custom properties', async () => {
@@ -176,16 +180,87 @@ describe('SimpleShellLayout', () => {
     expect(divider).toBeTruthy()
   })
 
-  it('chat overlay has transition for smooth animation', async () => {
+  it('chat drawer has transition for smooth animation', async () => {
     await renderLayout()
     const chat = getArea('chat')
-    expect(chat.style.transition).toBe('height var(--nous-duration-slow) var(--nous-ease-out), background var(--nous-duration-slow) var(--nous-ease-out)')
+    expect(chat.style.transition).toBe('width var(--nous-duration-slow) var(--nous-ease-out), height var(--nous-duration-slow) var(--nous-ease-out), background var(--nous-duration-slow) var(--nous-ease-out)')
   })
 
   it('sets data-chat-stage attribute on chat overlay', async () => {
     await renderLayout({ chatStage: 'ambient_large' })
     const chat = getArea('chat')
     expect(chat.getAttribute('data-chat-stage')).toBe('ambient_large')
+  })
+
+  it('keeps small and ambient_small stages scoped to the rail and asset-sidebar drawer width', async () => {
+    await renderLayout({ chatStage: 'small' })
+    let chat = getArea('chat')
+    expect(chat.style.width).toBe('var(--shell-chat-drawer-collapsed-width)')
+
+    await act(async () => {
+      root.render(
+        <SimpleShellLayout
+          projectRail={<div>rail</div>}
+          sidebar={<div>sidebar</div>}
+          content={<div>content</div>}
+          observe={<div>observe</div>}
+          chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
+          chatStage="ambient_small"
+        />,
+      )
+      await flush()
+    })
+    chat = getArea('chat')
+    expect(chat.style.width).toBe('var(--shell-chat-drawer-collapsed-width)')
+  })
+
+  it('expands ambient_large and full stages without creating drawer-local stage state', async () => {
+    await renderLayout({ chatStage: 'ambient_large' })
+    let chat = getArea('chat')
+    expect(chat.style.width).toBe('min(var(--nous-chat-drawer-expanded-width), var(--shell-chat-drawer-available-width))')
+    expect(chat.style.maxWidth).toBe('var(--shell-chat-drawer-available-width)')
+
+    await act(async () => {
+      root.render(
+        <SimpleShellLayout
+          projectRail={<div>rail</div>}
+          sidebar={<div>sidebar</div>}
+          content={<div>content</div>}
+          observe={<div>observe</div>}
+          chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
+          chatStage="full"
+        />,
+      )
+      await flush()
+    })
+    chat = getArea('chat')
+    expect(chat.style.width).toBe('var(--shell-chat-drawer-available-width)')
+    expect(chat.getAttribute('data-chat-stage')).toBe('full')
+  })
+
+  it('sets the available drawer width from desktop observe geometry', async () => {
+    await renderLayout({ initialWidths: { observe: 280 } })
+    const layout = container.firstElementChild as HTMLDivElement
+    expect(layout.style.getPropertyValue('--shell-chat-drawer-available-width')).toBe(
+      'calc(100% - var(--shell-observe-width) - 5px)',
+    )
+
+    await act(async () => {
+      root.render(
+        <SimpleShellLayout
+          projectRail={<div>rail</div>}
+          sidebar={<div>sidebar</div>}
+          content={<div>content</div>}
+          observe={<div>observe</div>}
+          chatSlot={({ stage }) => <div data-testid="chat">{stage}</div>}
+          chatStage="small"
+          breakpoint="medium"
+        />,
+      )
+      await flush()
+    })
+    const nextLayout = container.firstElementChild as HTMLDivElement
+    expect(nextLayout.style.getPropertyValue('--shell-chat-drawer-available-width')).toBe('100%')
   })
 
   // ── WR-141: whole-sidebar collapse ────────────────────────────────────
@@ -231,7 +306,7 @@ describe('SimpleShellLayout', () => {
     expect(sidebarDivider).toBeNull()
   })
 
-  it('chat overlay carries min-width: var(--nous-chat-overlay-min-width) regardless of sidebarCollapsed state', async () => {
+  it('chat drawer carries min-width: var(--nous-chat-overlay-min-width) regardless of sidebarCollapsed state', async () => {
     // Default (sidebarCollapsed undefined)
     await renderLayout()
     let chat = getArea('chat')

--- a/self/ui/src/components/shell/__tests__/useChatStageManager.test.ts
+++ b/self/ui/src/components/shell/__tests__/useChatStageManager.test.ts
@@ -289,4 +289,23 @@ describe('useChatStageManager', () => {
     act(() => result.current.handleClickOutside())
     expect(result.current.chatStage).toBe('small')
   })
+
+  it('preserves stage ownership across drawer geometry states without local duplication', () => {
+    const { result } = renderHook(() => useChatStageManager())
+
+    act(() => result.current.signalSending())
+    expect(result.current.chatStage).toBe('ambient_small')
+
+    act(() => result.current.signalPfcDecision())
+    expect(result.current.chatStage).toBe('ambient_large')
+
+    act(() => result.current.expandToFull())
+    expect(result.current.chatStage).toBe('full')
+
+    act(() => result.current.minimizeToAmbientLarge())
+    expect(result.current.chatStage).toBe('ambient_large')
+
+    act(() => result.current.collapseToSmall())
+    expect(result.current.chatStage).toBe('small')
+  })
 })

--- a/self/ui/src/styles/tokens.css
+++ b/self/ui/src/styles/tokens.css
@@ -230,6 +230,13 @@
   --nous-observe-expanded-width:        280px;
   --nous-observe-min-width:             32px;
   --nous-chat-overlay-min-width:        320px;  /* WR-141 — chat overlay floor when sidebar collapsed */
+  --nous-chat-drawer-expanded-width:    560px;
+  --nous-chat-drawer-bottom-offset:     12px;
+  --nous-chat-drawer-left-offset:       12px;
+  --nous-chat-drawer-radius:            14px;
+  --nous-chat-drawer-bg:                rgba(1, 1, 1, 0.82);
+  --nous-chat-drawer-border:            rgba(255, 255, 255, 0.08);
+  --nous-chat-drawer-shadow:            0 24px 60px rgba(0, 0, 0, 0.44);
   --nous-workspace-route-header-height: 64px;
   --nous-workspace-canvas-padding-x:    32px;
 


### PR DESCRIPTION
## Summary
- Adds Cortex Principal drawer identity and geometry to the simple-shell chat container.
- Covers drawer sizing, owner metadata, and stage ownership behavior with targeted tests.

## Verification
- pnpm --filter @nous/ui test -- SimpleShellLayout useChatStageManager
- pnpm --filter @nous/desktop test -- App (failed: configured include patterns do not match src/renderer/src/__tests__/App.test.tsx)