### PR TITLE
Phase 1.4 desktop launch native compatibility guard

### DIFF
--- a/.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/reviews/root-cause-manifest-review.mdx
+++ b/.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/reviews/root-cause-manifest-review.mdx
@@ -1,0 +1,108 @@
+---
+title: "Root Cause Manifest Review"
+description: "WR-175 Phase 1.4 BT Round 2 root cause manifest review"
+date: 2026-05-14
+status: complete
+verdict: "Approved With Notes"
+---
+
+# Root Cause Manifest Review - WR-175 Phase 1.4 BT Round 2
+
+## Cycle 1
+
+**Reviewing:** Cycle 1 of root-cause-manifest.mdx
+
+**Verdict:** Approved With Notes
+
+## Scope Guard
+
+| Field | Finding | Disposition |
+|---|---|---|
+| Target identity | Dispatch identifies `research-planning-sop::Worker::discovery-review::review-discovery`; this maps to `Worker::discovery-review`. | Valid |
+| Review lane | Fix-track Root Cause Manifest review for BT Round 2 residual desktop launch failure. | Valid |
+| Artifact under review | `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/root-cause-manifest.mdx` | Valid |
+| Output path | `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/reviews/root-cause-manifest-review.mdx` | Valid |
+| Boundary | Review only; no product/source/process edits. | Valid |
+
+## Criterion Analysis
+
+### C1: Bug Chain Completeness - Pass
+
+The symptom is observable and specific: desktop launch reaches backend startup, logs `better-sqlite3` native ABI facts, exits, schedules restart, and does not reach an observable workspace shell (`root-cause-manifest.mdx:54-58`; source evidence from `round-2.mdx:23-82`).
+
+The proximate cause traces through concrete runtime surfaces: Electron main forks the backend with PATH `node` (`self/apps/desktop/src/main/index.ts:568-613`), backend startup constructs shared services before listen/readiness (`self/apps/desktop/server/main.ts:207-219`), shared-server bootstrap constructs SQLite stores (`self/apps/shared-server/src/bootstrap.ts:677-699`), and storage loads `better-sqlite3` at construction (`self/autonomic/storage/src/sqlite-document-store.ts:10-15`, `self/autonomic/storage/src/sqlite-document-store.ts:29-36`). The parent restart loop is also cited accurately (`self/apps/desktop/src/main/index.ts:646-664`).
+
+The root causes are logically connected to the symptom: Phase 1.3 added a dev-wrapper check and server-side diagnostics, but Round 2 evidence shows the observed path still reached Electron main/backend startup and then repeated restart after deterministic native incompatibility (`root-cause-manifest.mdx:66-72`). This distinguishes the prior fix's diagnostic success from the remaining launch-contract failure.
+
+### C2: Schema Constraint Accuracy - Pass
+
+The schema/contract table is accurate against inspected sources. Root package Node/pnpm policy is `node >=22` and `pnpm@10.6.2` (`package.json:7-10`). Desktop `dev` routes through `node scripts/start-dev.mjs`, while `preview` and build/dist scripts are separate paths (`self/apps/desktop/package.json:7-18`). The dev launcher compatibility check and pass/fail behavior are at `self/apps/desktop/scripts/start-dev.mjs:92-163`. Backend runtime selection is PATH `node` with `fork(..., execPath: systemNode)` (`self/apps/desktop/src/main/index.ts:580-613`). Server bundling targets `node22` and externalizes `better-sqlite3` (`self/apps/desktop/vite.server.config.ts:15-28`). The diagnostic shape matches `NativeCompatibilityDiagnostic` (`self/apps/desktop/server/native-compatibility.ts:1-10`). Native dependency and lockfile refs match `better-sqlite3 ^11.9.1` and locked `11.10.0` (`self/autonomic/storage/package.json:20-26`, `pnpm-lock.yaml:641-648`, `pnpm-lock.yaml:3862-3864`).
+
+### C3: Fix Map Completeness - Pass
+
+The fix map lists the required modification surfaces for the residual failure: backend spawn/runtime enforcement, restart-loop classification, reusable bounded diagnostics, wrapper/package path verification, regression tests, and worklog verification (`root-cause-manifest.mdx:196-205`). This covers all links in the bug chain without requiring storage semantics redesign or WR-176 baseline cleanup.
+
+No obvious missing implementation surface appears for the stated fix ratification input. The map intentionally keeps `self/autonomic/storage/**` out of the change set because the manifest preserves fail-fast storage construction and places enforcement before or at the desktop launch/runtime boundary.
+
+### C4: Fix Map Ordering - Pass
+
+The dependency order is coherent. The authoritative backend spawn/runtime contract is first, restart-loop handling depends on native failure classification and launch-boundary behavior, diagnostic alignment supports both earlier entries, package-wrapper verification follows the new authoritative contract, and tests depend on the selected behavior (`root-cause-manifest.mdx:198-205`). Worklog verification is correctly last.
+
+### C5: Regression Risk Coverage - Pass
+
+The regression risk assessment covers each affected surface or fix outcome: backend process manager, native classification/restart suppression, runtime mismatch between probe and `execPath`, server readiness, storage fail-fast behavior, WR-176 scope boundary, docs, and tests (`root-cause-manifest.mdx:283-294`). Mitigations are concrete and cite exact behaviors/tests to preserve, not generic "add tests" language.
+
+### C6: Evidence Quality - Pass
+
+The artifact uses concrete repo-root paths and file:line references throughout. Spot checks against source and carry-forward artifacts confirm the key citations are reasonable: Round 2 raw log and classification (`round-2.mdx:23-103`), Phase 1.3 completion and preserved restart behavior (`phase-1.3/completion-report.mdx:24-42`, `phase-1.3/completion-report.mdx:76-84`), backend spawn/restart source (`self/apps/desktop/src/main/index.ts:568-664`), fatal diagnostic source (`self/apps/desktop/server/main.ts:379-386`, `self/apps/desktop/server/native-compatibility.ts:34-71`), and test seams (`self/apps/desktop/__tests__/native-compatibility.test.ts:17-138`).
+
+### C7: No Scope Creep - Pass
+
+The fix map stays on the desktop launch/runtime startup blocker and explicitly excludes WR-176 typecheck/build/build-output failures, web parity, shell UI redesign, and storage semantic redesign (`root-cause-manifest.mdx:104-111`, `root-cause-manifest.mdx:149-154`, `root-cause-manifest.mdx:287-294`). This is aligned with Round 2's `Fix it` classification and `track_separately_count: 0` (`round-2.mdx:97-103`).
+
+### C8: Outcome Completeness - Pass
+
+The preflight outcome required the manifest to explain what Phase 1.3 changed, why Round 2 still failed, classify scope, and audit regression/downstream risk (`preflight.mdx:30-32`). The manifest satisfies this end-to-end: it records Phase 1.3's wrapper/diagnostic changes (`root-cause-manifest.mdx:35-42`), identifies the residual backend launch/restart path (`root-cause-manifest.mdx:44-49`, `root-cause-manifest.mdx:66-72`), classifies the issue as in scope for WR-175 BT (`root-cause-manifest.mdx:104-111`), and includes downstream/risk audits (`root-cause-manifest.mdx:209-294`).
+
+The unknown exact Round 2 command is not hidden. It is carried as a remaining unknown and bounded by observed runtime behavior (`root-cause-manifest.mdx:21-25`). That is sufficient for fix ratification because the raw log proves Electron main/backend startup occurred and the fix map targets that observed path.
+
+### C9: Cross-Cut Grouping - Pass
+
+The cross-cut analysis separates the three recurrence contributors without conflating them: wrapper-only enforcement coverage, restart classification, and insufficient regression coverage (`root-cause-manifest.mdx:115-123`). It also states the shared architectural finding: Phase 1.3 improved diagnosis but did not make native compatibility an authoritative launch invariant for every path that reaches `spawnBackendServer()`.
+
+### C10: Fix-Layer Justification - Pass
+
+Each root cause evaluates Symptom, Contract, and Boundary options (`root-cause-manifest.mdx:162-193`). The chosen Contract layer is justified by authority and blast radius: enforce compatibility at the runtime boundary that selects PATH `node`, bound deterministic native failures before they become restart loops, and add deterministic launch/restart-path tests. The manifest does not choose a symptom-layer heuristic over a broken upstream contract.
+
+### C11: Hardening Test - Pass
+
+Every root cause has a hardening entry (`root-cause-manifest.mdx:273-279`). The answers are specific to the codebase and recurrence class: backend spawn refuses/fails boundedly under selected PATH Node incompatibility, deterministic native ABI failures do not become generic restarts, and tests simulate the Round 2 backend launch/restart path.
+
+### C12: Downstream Effect Audit - Pass
+
+Every fix map entry has corresponding downstream analysis (`root-cause-manifest.mdx:209-269`). Very likely classifications cite call paths and behavior evidence; maybe classifications stop without deeper recursion, as required. Very likely Risk conclusions are reflected in the regression risk table, including ordinary restart suppression risk, test-source-level insufficiency, readiness/storage preservation, and runtime mismatch risk (`root-cause-manifest.mdx:231-269`, `root-cause-manifest.mdx:283-294`). Recursion halts below the depth limit.
+
+### C13: Surface Ownership (structural only) - Pass
+
+The Surface Ownership section is present between Cross-Cut Analysis and Fix-Layer Decision (`root-cause-manifest.mdx:127-160`). Every root cause appears in the owning-surface table, owning surfaces are concrete, existing contract refs use file:line format, Constraint Space is populated with citations, Rejected Alternatives cite evidence, and Surface-Gap Finding states that all root causes have existing owners.
+
+## Issues Found
+
+None.
+
+## Notes
+
+- Non-blocking: the exact command used by the Principal for Round 2 remains unknown, but the manifest does not overclaim command-line causality. It grounds the fix map in the observed Electron main/backend runtime path and records the unknown explicitly (`root-cause-manifest.mdx:21-25`).
+- Non-blocking: this is a feature-sprint worklog path carrying a fix-track artifact for BT fix routing. The artifact itself declares `track: fix`, and the review criteria are the fix-track Root Cause Manifest criteria.
+
+## Observation for Orchestrator Escalation (not a review issue)
+
+None.
+
+## Required Changes
+
+None.
+
+## Verdict
+
+Approved With Notes. The manifest is evidence-grounded, distinguishes Phase 1.3 diagnostic/guard improvements from the remaining Round 2 launchability failure, and is sufficient to feed fix ratification.

--- a/docs/content/docs/development/testing-patterns.mdx
+++ b/docs/content/docs/development/testing-patterns.mdx
@@ -82,9 +82,17 @@ Aim for **80% coverage on behavioral code**. Exclude type definitions, stub impl
 
 `pnpm dev:desktop` delegates to `@nous/desktop dev`, which runs `node scripts/start-dev.mjs` before Electron starts. The desktop dev launcher preflights the external `better-sqlite3` native addon with the PATH `node` runtime, matching the desktop backend child-process runtime contract.
 
-The preflight validates that PATH `node` can load `better-sqlite3` and reports runtime/native ABI facts when it cannot. It does not install packages, rebuild native dependencies, or mutate the workspace. Recovery remains an explicit developer action: rebuild or reinstall dependencies with the PATH Node runtime, then rerun `pnpm dev:desktop`.
+The wrapper preflight validates that PATH `node` can load `better-sqlite3` and reports runtime/native ABI facts when it cannot. Electron main also enforces the same native compatibility contract at the backend spawn boundary before backend `fork()`, child assignment, readiness waiting, or restart scheduling. Both checks must avoid installing packages, rebuilding native dependencies, or mutating the workspace. Recovery remains an explicit developer action: rebuild or reinstall dependencies with the PATH Node runtime, then rerun `pnpm dev:desktop`.
 
-Tests for this launch path should model the seam deterministically instead of relying on the current workstation ABI state. Mock the native compatibility probe and assert the behavior around pass/fail diagnostics, PATH `node` usage, no install/rebuild side effects, and the fact that `electron-vite dev` starts only after a compatibility pass.
+Tests for this launch path should model the seams deterministically instead of relying on the current workstation ABI state. Mock the native compatibility probe and assert the behavior around pass/fail diagnostics, PATH `node` usage, no install/rebuild side effects, and the fact that `electron-vite dev` starts only after a wrapper compatibility pass.
+
+Backend spawn-boundary coverage should separately assert that:
+
+- successful probe output requires the expected deterministic facts, including `moduleName=better-sqlite3`, `runtime=PATH node`, `nodeVersion`, and `nodeAbi` or an approved equivalent contract;
+- malformed successful probe output such as `{ "ok": true }` fails closed instead of allowing backend spawn;
+- mismatched module or runtime identity fails closed;
+- deterministic native compatibility failure is rejected before backend `fork()`, child assignment, readiness waiting, or restart scheduling;
+- ordinary non-native backend exits remain restartable under the existing parent restart policy.
 
 Do not treat this launch preflight as evidence that baseline typecheck/build issues are fixed. WR-176 continues to own private package/type resolution and desktop server-vite `@nous/shared` build failures.
 

--- a/docs/content/docs/playbooks/troubleshooting.mdx
+++ b/docs/content/docs/playbooks/troubleshooting.mdx
@@ -32,13 +32,26 @@ ollama pull llama3.2:3b
 
 **Symptom:** `pnpm dev:desktop` exits before Electron opens and prints a native compatibility failure for `better-sqlite3`. The diagnostic may include fields such as `runtime=PATH node`, `errorCode=ERR_DLOPEN_FAILED`, `NODE_MODULE_VERSION`, `compiledAbi`, or `requiredAbi`.
 
-**Meaning:** The installed `better-sqlite3` native addon was compiled for a different Node ABI than the PATH `node` runtime used by the desktop backend child process. The launcher fails before `electron-vite dev` starts so the app does not enter an opaque backend restart loop.
+If the dev wrapper is bypassed or a failure reaches Electron main, the primary backend launch-boundary diagnostic is:
+
+```text
+[nous:desktop] native compatibility check failed for better-sqlite3
+runtime=PATH node
+node=<PATH node version>
+abi=<PATH node ABI>
+errorCode=<loader or probe error code>
+```
+
+If the native compatibility probe itself returns malformed successful output, such as `{ "ok": true }` without the expected runtime facts, backend launch fails closed with `errorCode=INVALID_PROBE_OUTPUT` rather than treating the probe as compatible.
+
+**Meaning:** The installed `better-sqlite3` native addon was compiled for a different Node ABI than the PATH `node` runtime used by the desktop backend child process, or the compatibility probe could not prove the required runtime facts. The wrapper can fail before `electron-vite dev` starts. Electron main also checks before backend `fork()`, so bypassed-launch failures stop before backend child assignment, readiness waiting, or repeated backend restart scheduling.
 
 **Fix:**
 - Confirm that `node` on PATH is the intended desktop backend runtime.
 - Rebuild or reinstall dependencies so `better-sqlite3` is compiled for that PATH Node runtime.
 - Re-run `pnpm dev:desktop` after the native dependency is rebuilt or reinstalled.
-- If you bypassed the launcher and see `[nous:desktop-server] native compatibility diagnostic`, treat it as the same native ABI issue; backend startup still fails closed and readiness is not sent.
+- If you bypassed the wrapper, first look for `[nous:desktop] native compatibility check failed for better-sqlite3`; this is the Electron main launch-boundary check and it stops backend spawn before the restart loop can begin.
+- If you run the backend directly or hit a lower-level fallback and see `[nous:desktop-server] native compatibility diagnostic`, treat it as the same native ABI issue; backend startup still fails closed and readiness is not sent.
 - Do not treat this as fixing WR-176 baseline typecheck/build failures; those remain tracked separately.
 
 ## pnpm install Fails (EPERM, Windows)

--- a/self/apps/desktop/__tests__/native-compatibility.test.ts
+++ b/self/apps/desktop/__tests__/native-compatibility.test.ts
@@ -3,8 +3,12 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createNativeCompatibilityProbeSource,
   formatNativeCompatibilityDiagnostic,
+  formatNativeCompatibilityFailure,
   getNativeCompatibilityDiagnostic,
+  normalizeInvalidNativeCompatibilityCheck,
+  normalizeNativeCompatibilityResult,
 } from '../server/native-compatibility';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -116,6 +120,102 @@ describe('desktop native compatibility launch contract', () => {
     expect(formatNativeCompatibilityDiagnostic(diagnostic!)).toContain('native compatibility diagnostic');
   });
 
+  it('normalizes PATH node probe results with the shared bounded diagnostic contract', () => {
+    const result = normalizeNativeCompatibilityResult({
+      ok: false,
+      moduleName: 'better-sqlite3',
+      runtime: 'PATH node',
+      nodeVersion: 'v24.0.0',
+      nodeAbi: '137',
+      errorCode: 'ERR_DLOPEN_FAILED',
+      errorMessage: 'compiled against NODE_MODULE_VERSION 127 but requires NODE_MODULE_VERSION 137',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      diagnostic: {
+        moduleName: 'better-sqlite3',
+        runtime: 'PATH node',
+        nodeVersion: 'v24.0.0',
+        nodeAbi: '137',
+        errorCode: 'ERR_DLOPEN_FAILED',
+        compiledAbi: '127',
+        requiredAbi: '137',
+        remediation: 'Rebuild or reinstall better-sqlite3 with the PATH node runtime before launching the desktop app.',
+      },
+    });
+    expect(formatNativeCompatibilityFailure(result.diagnostic)).toContain(
+      '[nous:desktop] native compatibility check failed for better-sqlite3',
+    );
+  });
+
+  it('fails closed for malformed successful native compatibility probe output', () => {
+    expect(normalizeNativeCompatibilityResult({ ok: true })).toMatchObject({
+      ok: false,
+      diagnostic: {
+        moduleName: 'better-sqlite3',
+        runtime: 'PATH node',
+        errorCode: 'INVALID_PROBE_OUTPUT',
+      },
+    });
+  });
+
+  it('fails closed for successful probe output with mismatched identity fields', () => {
+    expect(
+      normalizeNativeCompatibilityResult({
+        ok: true,
+        moduleName: 'some-other-addon',
+        runtime: 'PATH node',
+        nodeVersion: 'v24.0.0',
+        nodeAbi: '137',
+      }),
+    ).toMatchObject({
+      ok: false,
+      diagnostic: {
+        moduleName: 'better-sqlite3',
+        runtime: 'PATH node',
+        nodeVersion: 'v24.0.0',
+        nodeAbi: '137',
+        errorCode: 'INVALID_PROBE_OUTPUT',
+      },
+    });
+
+    expect(
+      normalizeNativeCompatibilityResult({
+        ok: true,
+        moduleName: 'better-sqlite3',
+        runtime: 'Electron node',
+        nodeVersion: 'v24.0.0',
+        nodeAbi: '137',
+      }),
+    ).toMatchObject({
+      ok: false,
+      diagnostic: {
+        moduleName: 'better-sqlite3',
+        runtime: 'PATH node',
+        nodeVersion: 'v24.0.0',
+        nodeAbi: '137',
+        errorCode: 'INVALID_PROBE_OUTPUT',
+      },
+    });
+  });
+
+  it('fails closed for invalid native compatibility probe output', () => {
+    expect(
+      normalizeInvalidNativeCompatibilityCheck(
+        'INVALID_PROBE_OUTPUT',
+        'The better-sqlite3 compatibility check produced an invalid diagnostic result.',
+      ),
+    ).toMatchObject({
+      ok: false,
+      diagnostic: {
+        moduleName: 'better-sqlite3',
+        runtime: 'PATH node',
+        errorCode: 'INVALID_PROBE_OUTPUT',
+      },
+    });
+  });
+
   it('does not classify unrelated dlopen or generic text failures as native ABI authority', () => {
     const unrelatedDlopen = Object.assign(new Error('some other native addon failed'), {
       code: 'ERR_DLOPEN_FAILED',
@@ -132,8 +232,54 @@ describe('desktop native compatibility launch contract', () => {
     const mainSource = readFileSync(resolve(__dirname, '..', 'src', 'main', 'index.ts'), 'utf8');
     const buildTestSource = readFileSync(resolve(__dirname, 'build-output.test.ts'), 'utf8');
 
-    expect(mainSource).toContain('if (!isAppQuitting && code !== 0)');
+    expect(mainSource).toContain('!options.appQuitting && options.exitCode !== 0 && !options.nativeCompatibilityFailure');
     expect(mainSource).toContain('execPath: systemNode');
     expect(buildTestSource).toContain('keeps better-sqlite3 external in the server bundle');
+  });
+
+  it('checks native compatibility at the backend spawn boundary before child assignment', () => {
+    const mainSource = readFileSync(resolve(__dirname, '..', 'src', 'main', 'index.ts'), 'utf8');
+
+    const compatibilityIndex = mainSource.indexOf('await runBackendNativeCompatibilityCheck(systemNode)');
+    const forkIndex = mainSource.indexOf('child = fork(serverPath, args');
+    const childAssignmentIndex = mainSource.indexOf('backendChild = child');
+    const registerChildIndex = mainSource.indexOf('registerChild(child.pid)', compatibilityIndex);
+
+    expect(compatibilityIndex).toBeGreaterThan(-1);
+    expect(forkIndex).toBeGreaterThan(compatibilityIndex);
+    expect(childAssignmentIndex).toBeGreaterThan(compatibilityIndex);
+    expect(registerChildIndex).toBeGreaterThan(compatibilityIndex);
+    expect(mainSource).toContain('console.error(formatNativeCompatibilityFailure(compatibility.diagnostic))');
+    expect(mainSource).toContain('reject(new Error(\'Desktop backend native compatibility check failed.\'))');
+  });
+
+  it('keeps ordinary backend exits restartable while native failures stay pre-spawn', () => {
+    const mainSource = readFileSync(resolve(__dirname, '..', 'src', 'main', 'index.ts'), 'utf8');
+
+    expect(mainSource).toContain('function shouldRestartBackendAfterExit');
+    expect(mainSource).toContain('!options.appQuitting && options.exitCode !== 0 && !options.nativeCompatibilityFailure');
+    expect(mainSource).toContain('nativeCompatibilityFailure: false');
+    expect(mainSource).toContain('Deterministic native compatibility failures are rejected before spawn.');
+  });
+
+  it('keeps backend readiness after service graph startup and server listen', () => {
+    const serverSource = readFileSync(resolve(__dirname, '..', 'server', 'main.ts'), 'utf8');
+
+    expect(serverSource.indexOf('createNousServices({')).toBeLessThan(
+      serverSource.indexOf("server.listen(args.port, '127.0.0.1'"),
+    );
+    expect(serverSource.indexOf("server.listen(args.port, '127.0.0.1'")).toBeLessThan(
+      serverSource.indexOf("process.send({ type: 'ready', port: args.port })"),
+    );
+  });
+
+  it('uses the same probe source for launch-boundary compatibility checks', () => {
+    const probeSource = createNativeCompatibilityProbeSource();
+
+    expect(probeSource).toContain('require("better-sqlite3")');
+    expect(probeSource).toContain('runtime: "PATH node"');
+    expect(probeSource).toContain('process.versions.modules');
+    expect(probeSource).not.toContain('pnpm rebuild');
+    expect(probeSource).not.toContain('npm install');
   });
 });

--- a/self/apps/desktop/server/native-compatibility.ts
+++ b/self/apps/desktop/server/native-compatibility.ts
@@ -9,6 +9,15 @@ export interface NativeCompatibilityDiagnostic {
   remediation: string;
 }
 
+export interface NativeCompatibilityCheckResult {
+  ok: boolean;
+  diagnostic: NativeCompatibilityDiagnostic;
+}
+
+const NATIVE_MODULE_NAME = 'better-sqlite3';
+const NATIVE_RUNTIME_LABEL = 'PATH node';
+const NATIVE_REMEDIATION = `Rebuild or reinstall ${NATIVE_MODULE_NAME} with the PATH node runtime before launching the desktop app.`;
+
 function readErrorCode(error: unknown): string | undefined {
   if (typeof error === 'object' && error !== null && 'code' in error) {
     const code = (error as { code?: unknown }).code;
@@ -22,12 +31,100 @@ function readErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function extractNativeAbiVersions(message: string): Pick<NativeCompatibilityDiagnostic, 'compiledAbi' | 'requiredAbi'> {
+export function extractNativeAbiVersions(message: string): Pick<NativeCompatibilityDiagnostic, 'compiledAbi' | 'requiredAbi'> {
   const matches = [...message.matchAll(/NODE_MODULE_VERSION\s+(\d+)/g)].map((match) => match[1]);
 
   return {
     compiledAbi: matches[0],
     requiredAbi: matches[1],
+  };
+}
+
+export function createNativeCompatibilityProbeSource(): string {
+  return `
+const result = {
+  moduleName: ${JSON.stringify(NATIVE_MODULE_NAME)},
+  runtime: ${JSON.stringify(NATIVE_RUNTIME_LABEL)},
+  nodeVersion: process.version,
+  nodeAbi: process.versions.modules,
+};
+try {
+  require(${JSON.stringify(NATIVE_MODULE_NAME)});
+  result.ok = true;
+} catch (error) {
+  result.ok = false;
+  result.errorCode = error && typeof error === 'object' ? error.code : undefined;
+  result.errorMessage = error instanceof Error ? error.message : String(error);
+}
+console.log(JSON.stringify(result));
+process.exit(result.ok ? 0 : 1);
+`;
+}
+
+function readStringField(value: unknown, field: string): string | undefined {
+  if (typeof value !== 'object' || value === null || !(field in value)) {
+    return undefined;
+  }
+
+  const fieldValue = (value as Record<string, unknown>)[field];
+  return typeof fieldValue === 'string' ? fieldValue : undefined;
+}
+
+function readBooleanField(value: unknown, field: string): boolean | undefined {
+  if (typeof value !== 'object' || value === null || !(field in value)) {
+    return undefined;
+  }
+
+  const fieldValue = (value as Record<string, unknown>)[field];
+  return typeof fieldValue === 'boolean' ? fieldValue : undefined;
+}
+
+function hasValidSuccessfulProbeShape(result: unknown): boolean {
+  return readBooleanField(result, 'ok') === true &&
+    readStringField(result, 'moduleName') === NATIVE_MODULE_NAME &&
+    readStringField(result, 'runtime') === NATIVE_RUNTIME_LABEL &&
+    typeof readStringField(result, 'nodeVersion') === 'string' &&
+    typeof readStringField(result, 'nodeAbi') === 'string';
+}
+
+export function normalizeNativeCompatibilityResult(
+  result: unknown,
+  fallback: Partial<NativeCompatibilityDiagnostic> = {},
+): NativeCompatibilityCheckResult {
+  const requestedOk = readBooleanField(result, 'ok') === true;
+  const errorMessage = readStringField(result, 'errorMessage') ?? '';
+  const { compiledAbi, requiredAbi } = extractNativeAbiVersions(errorMessage);
+  const ok = requestedOk && hasValidSuccessfulProbeShape(result);
+
+  return {
+    ok,
+    diagnostic: {
+      moduleName: NATIVE_MODULE_NAME,
+      runtime: NATIVE_RUNTIME_LABEL,
+      nodeVersion: readStringField(result, 'nodeVersion') ?? fallback.nodeVersion,
+      nodeAbi: readStringField(result, 'nodeAbi') ?? fallback.nodeAbi,
+      errorCode: readStringField(result, 'errorCode') ?? fallback.errorCode ?? (requestedOk && !ok ? 'INVALID_PROBE_OUTPUT' : undefined),
+      compiledAbi,
+      requiredAbi,
+      remediation: fallback.remediation ?? (requestedOk && !ok
+        ? 'The better-sqlite3 compatibility check produced an invalid success result and was rejected before launching the desktop backend.'
+        : NATIVE_REMEDIATION),
+    },
+  };
+}
+
+export function normalizeInvalidNativeCompatibilityCheck(
+  errorCode: string,
+  remediation: string,
+): NativeCompatibilityCheckResult {
+  return {
+    ok: false,
+    diagnostic: {
+      moduleName: NATIVE_MODULE_NAME,
+      runtime: NATIVE_RUNTIME_LABEL,
+      errorCode,
+      remediation,
+    },
   };
 }
 
@@ -46,15 +143,28 @@ export function getNativeCompatibilityDiagnostic(error: unknown): NativeCompatib
   const { compiledAbi, requiredAbi } = extractNativeAbiVersions(message);
 
   return {
-    moduleName: 'better-sqlite3',
-    runtime: 'PATH node',
+    moduleName: NATIVE_MODULE_NAME,
+    runtime: NATIVE_RUNTIME_LABEL,
     nodeVersion: process.version,
     nodeAbi: process.versions.modules,
     errorCode,
     compiledAbi,
     requiredAbi,
-    remediation: 'Rebuild or reinstall better-sqlite3 with the PATH node runtime before launching the desktop app.',
+    remediation: NATIVE_REMEDIATION,
   };
+}
+
+export function formatNativeCompatibilityFailure(diagnostic: NativeCompatibilityDiagnostic): string {
+  return [
+    `[nous:desktop] native compatibility check failed for ${diagnostic.moduleName}`,
+    `runtime=${diagnostic.runtime}`,
+    diagnostic.nodeVersion ? `node=${diagnostic.nodeVersion}` : undefined,
+    diagnostic.nodeAbi ? `abi=${diagnostic.nodeAbi}` : undefined,
+    diagnostic.errorCode ? `errorCode=${diagnostic.errorCode}` : undefined,
+    diagnostic.compiledAbi ? `compiledAbi=${diagnostic.compiledAbi}` : undefined,
+    diagnostic.requiredAbi ? `requiredAbi=${diagnostic.requiredAbi}` : undefined,
+    diagnostic.remediation,
+  ].filter(Boolean).join('\n');
 }
 
 export function formatNativeCompatibilityDiagnostic(diagnostic: NativeCompatibilityDiagnostic): string {

--- a/self/apps/desktop/src/main/index.ts
+++ b/self/apps/desktop/src/main/index.ts
@@ -27,6 +27,13 @@ import {
   type UpdateProgress,
   type UpdateResult,
 } from './ollama-installer'
+import {
+  createNativeCompatibilityProbeSource,
+  formatNativeCompatibilityFailure,
+  normalizeInvalidNativeCompatibilityCheck,
+  normalizeNativeCompatibilityResult,
+  type NativeCompatibilityCheckResult,
+} from '../../server/native-compatibility'
 
 interface StoredLayout {
   version: 1
@@ -96,6 +103,66 @@ let ollamaStopPromise: Promise<void> | null = null
 let ollamaSuppressRestartOnExit = false
 let ollamaHealthCheckInFlight = false
 let activeOllamaPull: Promise<void> | null = null
+
+function parseNativeCompatibilityProbeOutput(output: string): NativeCompatibilityCheckResult {
+  const lastJsonLine = output.trim().split(/\r?\n/).filter(Boolean).at(-1)
+
+  if (!lastJsonLine) {
+    return normalizeInvalidNativeCompatibilityCheck(
+      'EMPTY_PROBE_OUTPUT',
+      'The better-sqlite3 compatibility check did not produce a diagnostic result.',
+    )
+  }
+
+  try {
+    return normalizeNativeCompatibilityResult(JSON.parse(lastJsonLine))
+  } catch {
+    return normalizeInvalidNativeCompatibilityCheck(
+      'INVALID_PROBE_OUTPUT',
+      'The better-sqlite3 compatibility check produced an invalid diagnostic result.',
+    )
+  }
+}
+
+async function runBackendNativeCompatibilityCheck(nodeCommand: string): Promise<NativeCompatibilityCheckResult> {
+  try {
+    const { stdout } = await execFileAsync(nodeCommand, ['-e', createNativeCompatibilityProbeSource()], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: undefined,
+      },
+    })
+
+    return parseNativeCompatibilityProbeOutput(stdout)
+  } catch (err) {
+    const stdout = typeof err === 'object' && err !== null && 'stdout' in err
+      ? String((err as { stdout?: unknown }).stdout ?? '')
+      : ''
+
+    const parsed = parseNativeCompatibilityProbeOutput(stdout)
+    if (parsed.diagnostic.errorCode !== 'EMPTY_PROBE_OUTPUT') {
+      return parsed
+    }
+
+    const errorCode = typeof err === 'object' && err !== null && 'code' in err && typeof (err as { code?: unknown }).code === 'string'
+      ? (err as { code: string }).code
+      : 'PROBE_EXEC_FAILED'
+
+    return normalizeInvalidNativeCompatibilityCheck(
+      errorCode,
+      'Unable to execute PATH node for the better-sqlite3 compatibility check. Ensure Node.js >=22 is available on PATH.',
+    )
+  }
+}
+
+function shouldRestartBackendAfterExit(options: {
+  appQuitting: boolean
+  exitCode: number | null
+  nativeCompatibilityFailure: boolean
+}): boolean {
+  return !options.appQuitting && options.exitCode !== 0 && !options.nativeCompatibilityFailure
+}
 
 function buildOllamaStatus(
   state: OllamaLifecycleState,
@@ -567,102 +634,120 @@ function resolveServerEntryPath(): string {
  */
 function spawnBackendServer(port: number): Promise<number> {
   return new Promise((resolve, reject) => {
-    const serverPath = resolveServerEntryPath()
-    const args = [`--port=${port}`]
+    void (async () => {
+      const serverPath = resolveServerEntryPath()
+      const args = [`--port=${port}`]
 
-    // Set data dir to app's userData directory for production isolation
-    const dataDir = app.getPath('userData')
-    args.push(`--data-dir=${join(dataDir, 'data')}`)
-    args.push(`--config-path=${join(dataDir, 'data', 'config.json')}`)
+      // Set data dir to app's userData directory for production isolation
+      const dataDir = app.getPath('userData')
+      args.push(`--data-dir=${join(dataDir, 'data')}`)
+      args.push(`--config-path=${join(dataDir, 'data', 'config.json')}`)
 
-    console.log(`[nous:desktop] spawning backend server: ${serverPath} ${args.join(' ')}`)
+      console.log(`[nous:desktop] spawning backend server: ${serverPath} ${args.join(' ')}`)
 
-    const isDev = process.env['NODE_ENV'] === 'development'
+      const isDev = process.env['NODE_ENV'] === 'development'
 
-    // Use system Node.js (not Electron's embedded Node) to avoid native module
-    // version mismatches (better-sqlite3 compiled for system Node, not Electron).
-    // fork() with explicit execPath uses system node while preserving IPC channel.
-    // Use 'node' from PATH — fork with execPath bypasses Electron's embedded Node
-    const systemNode = 'node'
+      // Use system Node.js (not Electron's embedded Node) to avoid native module
+      // version mismatches (better-sqlite3 compiled for system Node, not Electron).
+      // fork() with explicit execPath uses system node while preserving IPC channel.
+      // Use 'node' from PATH — fork with execPath bypasses Electron's embedded Node
+      const systemNode = 'node'
 
-    console.log(
-      `[nous:desktop] backend runtime contract: execPath=${systemNode} (PATH), parentNode=${process.version}, parentAbi=${process.versions.modules ?? 'unknown'}`,
-    )
+      console.log(
+        `[nous:desktop] backend runtime contract: execPath=${systemNode} (PATH), parentNode=${process.version}, parentAbi=${process.versions.modules ?? 'unknown'}`,
+      )
 
-    let child: ChildProcess
-    if (isDev) {
-      child = fork(serverPath, args, {
-        stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
-        execPath: systemNode,
-        env: {
-          ...process.env,
-          NODE_ENV: 'development',
-          ELECTRON_RUN_AS_NODE: undefined,
-        },
-        execArgv: ['--import', 'tsx'],
-      })
-    } else {
-      child = fork(serverPath, args, {
-        stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
-        execPath: systemNode,
-        env: {
-          ...process.env,
-          NODE_ENV: 'production',
-          ELECTRON_RUN_AS_NODE: undefined,
-        },
-      })
-    }
-
-    backendChild = child
-    if (child.pid != null) registerChild(child.pid)
-
-    const timeout = setTimeout(() => {
-      reject(new Error('Backend server did not signal readiness within 30 seconds'))
-    }, 30_000)
-
-    child.on('message', (msg: unknown) => {
-      if (typeof msg === 'object' && msg !== null && (msg as any).type === 'ready') {
-        clearTimeout(timeout)
-        backendPort = (msg as any).port ?? port
-        backendReady = true
-        console.log(`[nous:desktop] backend server ready on port ${backendPort}`)
-        resolve(backendPort!)
+      const compatibility = await runBackendNativeCompatibilityCheck(systemNode)
+      if (!compatibility.ok) {
+        console.error(formatNativeCompatibilityFailure(compatibility.diagnostic))
+        reject(new Error('Desktop backend native compatibility check failed.'))
         return
       }
 
-      if (isBackendOllamaRequestMessage(msg)) {
-        void handleBackendOllamaRequest(msg).then((response) => {
-          child.send?.(response)
+      console.log(
+        `[nous:desktop] backend native compatibility check passed: module=${compatibility.diagnostic.moduleName} runtime=${compatibility.diagnostic.runtime} node=${compatibility.diagnostic.nodeVersion ?? 'unknown'} abi=${compatibility.diagnostic.nodeAbi ?? 'unknown'}`,
+      )
+
+      let child: ChildProcess
+      if (isDev) {
+        child = fork(serverPath, args, {
+          stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
+          execPath: systemNode,
+          env: {
+            ...process.env,
+            NODE_ENV: 'development',
+            ELECTRON_RUN_AS_NODE: undefined,
+          },
+          execArgv: ['--import', 'tsx'],
+        })
+      } else {
+        child = fork(serverPath, args, {
+          stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
+          execPath: systemNode,
+          env: {
+            ...process.env,
+            NODE_ENV: 'production',
+            ELECTRON_RUN_AS_NODE: undefined,
+          },
         })
       }
-    })
 
-    child.on('error', (err) => {
-      clearTimeout(timeout)
-      console.error('[nous:desktop] backend server error:', err)
-      reject(err)
-    })
+      backendChild = child
+      if (child.pid != null) registerChild(child.pid)
 
-    child.on('exit', (code, signal) => {
-      clearTimeout(timeout)
-      console.log(`[nous:desktop] backend server exited (code=${code}, signal=${signal})`)
-      backendChild = null
-      backendReady = false
-      backendReadyPromise = null
-      backendPort = null
+      const timeout = setTimeout(() => {
+        reject(new Error('Backend server did not signal readiness within 30 seconds'))
+      }, 30_000)
 
-      // Auto-restart if the app is still running and it wasn't a clean shutdown
-      if (!isAppQuitting && code !== 0) {
-        console.log('[nous:desktop] scheduling backend restart...')
-        setTimeout(() => {
-          if (!isAppQuitting) {
-            startBackend().catch((err) => {
-              console.error('[nous:desktop] backend restart failed:', err)
-            })
-          }
-        }, 2000)
-      }
-    })
+      child.on('message', (msg: unknown) => {
+        if (typeof msg === 'object' && msg !== null && (msg as any).type === 'ready') {
+          clearTimeout(timeout)
+          backendPort = (msg as any).port ?? port
+          backendReady = true
+          console.log(`[nous:desktop] backend server ready on port ${backendPort}`)
+          resolve(backendPort!)
+          return
+        }
+
+        if (isBackendOllamaRequestMessage(msg)) {
+          void handleBackendOllamaRequest(msg).then((response) => {
+            child.send?.(response)
+          })
+        }
+      })
+
+      child.on('error', (err) => {
+        clearTimeout(timeout)
+        console.error('[nous:desktop] backend server error:', err)
+        reject(err)
+      })
+
+      child.on('exit', (code, signal) => {
+        clearTimeout(timeout)
+        console.log(`[nous:desktop] backend server exited (code=${code}, signal=${signal})`)
+        backendChild = null
+        backendReady = false
+        backendReadyPromise = null
+        backendPort = null
+
+        // Auto-restart if the app is still running and it wasn't a clean shutdown.
+        // Deterministic native compatibility failures are rejected before spawn.
+        if (shouldRestartBackendAfterExit({
+          appQuitting: isAppQuitting,
+          exitCode: code,
+          nativeCompatibilityFailure: false,
+        })) {
+          console.log('[nous:desktop] scheduling backend restart...')
+          setTimeout(() => {
+            if (!isAppQuitting) {
+              startBackend().catch((err) => {
+                console.error('[nous:desktop] backend restart failed:', err)
+              })
+            }
+          }, 2000)
+        }
+      })
+    })().catch(reject)
   })
 }
 


### PR DESCRIPTION
## Cycle 1

**Reviewing:** Cycle 1 of user-documentation.mdx
**Verdict:** Needs Revision

## Scope

Reviewed Phase 1.4 User Documentation against the documentation pillar checklist, Phase 1.4 Goals, Completion Report Cycle 2, Completion Report review, the existing docs-site pages called out by the artifact, and the delivered desktop native compatibility implementation.

Artifacts and docs read:

- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/user-documentation.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/goals.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/completion-report.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/reviews/completion-report.mdx`
- `docs/content/docs/development/testing-patterns.mdx`
- `docs/content/docs/playbooks/troubleshooting.mdx`
- `docs/content/docs/architecture/tech-stack.mdx`
- `docs/content/docs/architecture/interaction-surfaces.mdx`
- `self/apps/desktop/server/native-compatibility.ts`
- `self/apps/desktop/src/main/index.ts`
- `self/apps/desktop/scripts/start-dev.mjs`

Requested runtime response evidence was unavailable: `.opencode/state/WR-175-BT-R2-20260514-UDR14/runtime-response.md` was not present in the supplied worktree. This review uses durable worklog, docs-site, and implementation evidence.

## Criterion-by-Criterion Analysis

### Criterion 1 — Pillar coverage

**Fail.** The artifact correctly marks Getting Started, Configuration, CLI Reference, API Reference, User Guides, and Architecture as not requiring content changes for this sub-phase. However, the Development and Playbooks pillars are affected and are incorrectly marked `Current` with no docs-site update required.

Development is affected because Phase 1.4 changes the desktop native compatibility testing target from wrapper-only launch preflight to authoritative backend spawn-boundary enforcement in Electron main. The existing testing guidance at `docs/content/docs/development/testing-patterns.mdx:81-89` still describes only the `pnpm dev:desktop` / `@nous/desktop dev` wrapper path and says tests should assert `electron-vite dev` starts only after compatibility pass. It does not mention the new backend spawn-boundary compatibility contract, malformed successful probe rejection, or the need to preserve ordinary backend restart semantics.

Playbooks is affected because Phase 1.4 changes the bypassed-launch failure surface. `docs/content/docs/playbooks/troubleshooting.mdx:31-42` still says that if the launcher is bypassed and the native issue appears, the user should expect `[nous:desktop-server] native compatibility diagnostic`. The delivered implementation now checks in Electron main before backend `fork()` and prints `[nous:desktop] native compatibility check failed for better-sqlite3` before rejecting backend startup (`self/apps/desktop/src/main/index.ts:660-664`, `self/apps/desktop/server/native-compatibility.ts:157-167`). The server diagnostic remains a lower-level fallback, but the docs no longer describe the primary bypassed-launch diagnostic accurately.

### Criterion 2 — Accuracy

**Fail.** The User Documentation artifact states that the existing Development and Playbooks docs remain accurate for Phase 1.4, but both pages contain stale or incomplete descriptions of the current behavior.

Accuracy issues:

- `user-documentation.mdx:18` says `testing-patterns.mdx` already documents the native compatibility check sufficiently. It documents the wrapper preflight, but not the new authoritative backend launch-boundary check in `spawnBackendServer()`.
- `user-documentation.mdx:19` says `troubleshooting.mdx` already describes bypassed-launch diagnostics and fail-closed backend startup. It describes a bypassed-launch server diagnostic, but the new primary diagnostic is emitted by Electron main before backend spawn.
- `user-documentation.mdx:41` says no docs-site update is needed because the new behavior is not a changed troubleshooting procedure. The recovery procedure is unchanged, but the symptoms and diagnostic prefix users should look for are changed enough that the playbook should be updated.

### Criterion 3 — Audience

**Pass With Note.** The artifact is written mostly for workflow reviewers rather than end users, which is appropriate for a worklog user-documentation gate artifact. The missing docs-site updates should remain user/developer oriented: explain visible symptoms, expected diagnostics, and recovery steps without exposing unnecessary implementation detail.

### Criterion 4 — Examples

**Fail.** Existing docs examples are insufficient for the changed behavior. The troubleshooting page should include or update concrete diagnostic examples for the Phase 1.4 primary failure surface, especially the `[nous:desktop] native compatibility check failed for better-sqlite3` prefix and representative bounded fields. The development page should provide concrete testing guidance for the backend spawn-boundary contract, not just the wrapper/electron-vite path.

### Criterion 5 — Completeness

**Fail.** A user or developer reading only the current docs-site pages would not understand the complete Phase 1.4 behavior:

- Normal `pnpm dev:desktop` still fails before Electron opens when the wrapper detects incompatibility.
- If the wrapper is bypassed or insufficient, Electron main now performs the authoritative pre-spawn compatibility check and fails backend startup before child assignment/restart scheduling.
- Direct backend execution can still surface `[nous:desktop-server] native compatibility diagnostic` as a lower-level fallback.
- Malformed successful probe output fails closed as invalid probe output rather than being accepted.

The artifact should require targeted docs-site updates for the affected Development and Playbooks pillars or explicitly document why these user-visible diagnostics do not need to be represented. The current rationale does not support marking both pillars current.

### Criterion 6 — Structure

**Pass.** The worklog artifact has frontmatter, a pillar review table, documentation delta, file lists, and links. The existing docs-site pages also follow site conventions with frontmatter and clear headings.

### Criterion 7 — Consistency

**Pass With Note.** The artifact uses terminology consistent with Phase 1.4 artifacts and existing docs. The required docs-site changes should preserve the current concise troubleshooting and testing-patterns style.

### Criterion 8 — No architecture drift

**Pass.** The artifact does not introduce architecture claims that contradict reviewed architecture pages. It correctly states that Phase 1.4 preserves the child-process backend model, shared service graph ownership, storage fail-fast behavior, and interaction surfaces.

### Criterion 9 — Revision History

**N/A.** Cycle 1 review; no Revision History is required yet.

## Issues Found

### Should-fix — Development pillar marked current despite missing backend launch-boundary testing guidance

`user-documentation.mdx:18`, `docs/content/docs/development/testing-patterns.mdx:81-89`

The development page still documents only the desktop dev wrapper native compatibility preflight and tests around `electron-vite dev`. Phase 1.4 adds authoritative backend spawn-boundary compatibility enforcement in Electron main, strict successful-probe shape validation, and ordinary restart preservation. Developers need the docs to identify this as a separate deterministic contract from the wrapper preflight.

Required change:

- Update `docs/content/docs/development/testing-patterns.mdx` to mention the backend spawn-boundary native compatibility contract and targeted deterministic coverage expectations.
- Update `user-documentation.mdx` Files Updated and pillar status accordingly.

### Should-fix — Playbook bypassed-launch diagnostic is stale after Phase 1.4

`user-documentation.mdx:19`, `docs/content/docs/playbooks/troubleshooting.mdx:31-42`, `self/apps/desktop/src/main/index.ts:660-664`, `self/apps/desktop/server/native-compatibility.ts:157-167`

The troubleshooting page tells users who bypassed the launcher to look for `[nous:desktop-server] native compatibility diagnostic`. After Phase 1.4, the primary bypassed-launch failure is caught earlier by Electron main and emits `[nous:desktop] native compatibility check failed for better-sqlite3` before backend spawn. The server diagnostic still exists for direct backend execution or lower-level fallback, but the playbook should distinguish these surfaces.

Required change:

- Update `docs/content/docs/playbooks/troubleshooting.mdx` so the Phase 1.4 main-process diagnostic is the primary bypassed-launch symptom, while retaining the server diagnostic as a lower-level fallback where applicable.
- Include representative bounded fields and keep the rebuild/reinstall recovery steps unchanged.
- Update `user-documentation.mdx` Files Updated and pillar status accordingly.

### Minor — User Documentation artifact overstates that no docs-site update is needed

`user-documentation.mdx:17-19`, `user-documentation.mdx:37-41`

The artifact says no docs-site files were updated because the recovery path is unchanged. Recovery is unchanged, but user-visible diagnostics and developer test guidance changed. The artifact should distinguish unchanged remediation from changed symptoms/coverage guidance.

Required change:

- Revise the Phase 1.4 Documentation Delta to state what changed in docs-site terms.
- Replace `Files Updated: None` with the actual docs-site files updated after the revision.

## Observation for OrchestrationAgent Escalation (not a review issue)

None.

## Required Changes

1. Criterion 1 and 5: Reclassify Development and Playbooks as affected by Phase 1.4 and update the docs-site pages instead of marking them current with no changes.
2. Criterion 2 and 4: Update `docs/content/docs/playbooks/troubleshooting.mdx` to describe the Phase 1.4 primary `[nous:desktop] native compatibility check failed for better-sqlite3` diagnostic at the Electron main/backend launch boundary, while preserving the existing recovery steps and lower-level server diagnostic context.
3. Criterion 2, 4, and 5: Update `docs/content/docs/development/testing-patterns.mdx` to include deterministic testing guidance for the backend spawn-boundary compatibility check, malformed successful probe rejection, no install/rebuild side effects, and ordinary non-native backend restart preservation.
4. Criterion 1, 2, and 5: Update `user-documentation.mdx` so its Pillar Review, Documentation Delta, Files Updated, and Links sections accurately reflect the docs-site changes.

---

**Implementation Agent action required (Revision Cycle Protocol):**
1. Apply the required changes to the main content of `user-documentation.mdx` and the affected docs-site pages.
2. Append a **Revision History** section at the bottom of `user-documentation.mdx` with a `Cycle 1 → 2` entry listing every change and the review criterion number it addresses.
3. STOP and wait for re-review.
---

## Cycle 2

**Reviewing:** Cycle 2 of user-documentation.mdx (post-revision)
**Verdict:** Approved

## Scope

Reviewed Phase 1.4 User Documentation Cycle 2 against the documentation pillar checklist, Phase 1.4 Goals, Completion Report Cycle 2, Completion Report review, Cycle 1 User Documentation review, the updated docs-site pages, and the delivered desktop native compatibility implementation.

Artifacts and docs read:

- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/user-documentation.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/goals.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/completion-report.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/reviews/completion-report.mdx`
- `.worklog/sprints/feat/shell-redesign-workspace-first-ui-system/phase-1/phase-1.4/reviews/user-documentation.mdx`
- `docs/content/docs/development/testing-patterns.mdx`
- `docs/content/docs/playbooks/troubleshooting.mdx`
- `self/apps/desktop/server/native-compatibility.ts`
- `self/apps/desktop/src/main/index.ts`

Requested runtime response evidence was unavailable: `.opencode/state/WR-175-BT-R2-20260514-UDR14-cycle2/runtime-response.md` was not present in the supplied worktree. This review uses durable worklog, docs-site, and implementation evidence.

## Criterion-by-Criterion Analysis

### Criterion 1 — Pillar coverage

**Pass.** The artifact now correctly marks Development and Playbooks as `Updated` and leaves Getting Started, Configuration, CLI Reference, API Reference, User Guides, and Architecture as not requiring content updates for this sub-phase. This matches the Phase 1.4 scope: the user/developer-facing change is launch failure-mode hardening, diagnostics, and testing guidance rather than new setup, config, CLI, API, UI, or architecture-page behavior.

The updated Development entry covers backend spawn-boundary native compatibility testing in addition to the wrapper preflight. The updated Playbooks entry covers the new primary Electron main diagnostic and distinguishes it from the lower-level server fallback diagnostic.

### Criterion 2 — Accuracy

**Pass.** The artifact and docs-site updates now match the delivered implementation and Completion Report review findings.

Evidence:

- `docs/content/docs/development/testing-patterns.mdx:81-97` states that Electron main enforces native compatibility before backend `fork()`, child assignment, readiness waiting, or restart scheduling, and calls out strict successful-probe facts, malformed success rejection, mismatched identity rejection, no install/rebuild side effects, and ordinary restart preservation.
- `docs/content/docs/playbooks/troubleshooting.mdx:31-55` identifies `[nous:desktop] native compatibility check failed for better-sqlite3` as the primary backend launch-boundary diagnostic when the wrapper is bypassed or failure reaches Electron main, while retaining `[nous:desktop-server] native compatibility diagnostic` for direct backend/lower-level fallback cases.
- `self/apps/desktop/server/native-compatibility.ts:82-111` requires expected module/runtime/version/ABI facts before accepting `ok: true` and emits `INVALID_PROBE_OUTPUT` for malformed successful results.
- `self/apps/desktop/src/main/index.ts:660-665` rejects backend startup before `fork()` when the compatibility result is not `ok`.

### Criterion 3 — Audience

**Pass.** The worklog artifact remains appropriately reviewer-facing, while the docs-site changes are written for developers and operators: they describe expected diagnostics, testing expectations, and recovery steps without overloading users with internal implementation details beyond user-relevant process boundaries.

### Criterion 4 — Examples

**Pass.** The troubleshooting page now includes the concrete primary diagnostic prefix and representative bounded fields for the Phase 1.4 failure surface. The development page now includes concrete examples of fail-closed test cases, including `{ "ok": true }`, mismatched module/runtime identity, pre-`fork()` rejection, and ordinary restart preservation.

### Criterion 5 — Completeness

**Pass.** A reader of the updated docs-site pages can now understand the full Phase 1.4 user/developer-visible behavior:

- normal `pnpm dev:desktop` still uses the wrapper preflight before Electron starts;
- Electron main now enforces the same contract before backend spawn when the wrapper is bypassed or insufficient;
- malformed successful probe output fails closed rather than allowing backend launch;
- direct backend/lower-level startup can still surface the server diagnostic;
- recovery remains rebuild/reinstall for PATH Node compatibility;
- WR-176 baseline typecheck/build/build-output failures remain separately tracked.

### Criterion 6 — Structure

**Pass.** The artifact retains frontmatter, a pillar review table, documentation delta, file lists, links, and revision history. The docs-site pages preserve existing structure, frontmatter, headings, concise paragraphs, and bullet-list conventions.

### Criterion 7 — Consistency

**Pass.** Terminology is consistent across the artifact, Completion Report, implementation, and docs-site pages: `PATH node`, `better-sqlite3`, `backend spawn boundary`, `Electron main`, `native compatibility`, `INVALID_PROBE_OUTPUT`, and WR-176/baseline carry-forward are used consistently.

### Criterion 8 — No architecture drift

**Pass.** The updated docs do not introduce architecture claims that contradict reviewed architecture pages. They preserve the existing child-process backend model and describe the compatibility check as a launch-boundary guard, not a storage, service graph, packaging/runtime, or shell UI redesign.

### Criterion 9 — Revision History

**Pass.** The `Cycle 1 → 2` revision history accurately describes the changes made in response to Cycle 1 and traces them to the correct criteria: pillar reclassification, docs-site accuracy updates, diagnostic examples, completeness across wrapper/main/server failure surfaces, and the prior file-list/delta issue.

## Issues Found

No blocker, should-fix, or minor issues found for Cycle 2.

## Observation for OrchestrationAgent Escalation (not a review issue)

None.

## Required Changes

None.
