### PR TITLE
WR-175 Phase 1.10 drawer overlay reference fidelity

### DIFF
--- a/self/apps/desktop/src/renderer/src/App.tsx
+++ b/self/apps/desktop/src/renderer/src/App.tsx
@@ -341,8 +341,10 @@ export function App() {
   const [appPanels, setAppPanels] = useState<AppPanelSnapshot[]>([])
   const [mode, setMode] = useState<ShellMode>('simple')
   const [modeSource, setModeSource] = useState<ShellModeSource>('default')
+  const [modeHydrated, setModeHydrated] = useState(false)
   const [activeRoute, setActiveRoute] = useState(DEFAULT_ROUTE)
   const [isHomeContext, setIsHomeContext] = useState(false)
+  const [wr175ReferenceLaunchEligible, setWr175ReferenceLaunchEligible] = useState(true)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
   const [backendPort, setBackendPort] = useState<number | null>(null)
 
@@ -358,6 +360,8 @@ export function App() {
     setSavedLayout(undefined)
     setDockviewApi(null)
     setAppPanels([])
+    setModeHydrated(false)
+    setWr175ReferenceLaunchEligible(true)
 
     const startedAt = Date.now()
     let backendReady = false
@@ -485,6 +489,7 @@ export function App() {
         console.log(`[nous:mode] Using visual acceptance mode: ${visualAcceptanceMode}`)
         setMode(visualAcceptanceMode)
         setModeSource('visual-acceptance-override')
+        setModeHydrated(true)
         return
       }
 
@@ -495,6 +500,7 @@ export function App() {
       } else {
         setModeSource('default')
       }
+      setModeHydrated(true)
     })
 
     return () => {
@@ -542,6 +548,8 @@ export function App() {
     console.log('[nous:wizard] Phase: wizard → main')
     setSavedLayout(undefined)
     setDockviewApi(null)
+    setModeHydrated(false)
+    setWr175ReferenceLaunchEligible(true)
     setPhase('main')
   }, [])
 
@@ -552,6 +560,9 @@ export function App() {
   const [navigationParams, setNavigationParams] = useState<Record<string, unknown> | undefined>(undefined)
 
   const handleNavigate = useCallback((routeId: string, params?: Record<string, unknown>) => {
+    if (routeId !== DEFAULT_ROUTE) {
+      setWr175ReferenceLaunchEligible(false)
+    }
     setActiveRoute(routeId)
     setNavigationParams(params)
   }, [])
@@ -568,6 +579,7 @@ export function App() {
 
       console.log(`[nous:mode] Mode switched: ${previousMode} -> ${nextMode}`)
       setModeSource('persisted')
+      setWr175ReferenceLaunchEligible(false)
       void modePersistence.set(nextMode)
       return nextMode
     })
@@ -578,6 +590,7 @@ export function App() {
       const nextMode = previousMode === 'simple' ? 'developer' : 'simple'
       console.log(`[nous:mode] Mode switched: ${previousMode} -> ${nextMode}`)
       setModeSource('persisted')
+      setWr175ReferenceLaunchEligible(false)
       void modePersistence.set(nextMode)
       return nextMode
     })
@@ -650,7 +663,8 @@ export function App() {
     settings: { routeId: 'settings', label: 'Settings', surface: 'workspace' as const },
   }), [])
 
-  const handleDesktopProjectChange = useCallback((newProjectId: string) => {
+  const handleDesktopProjectChange = useCallback(() => {
+    setWr175ReferenceLaunchEligible(false)
     setIsHomeContext(false)
     setActiveRoute(DEFAULT_ROUTE) // reset content route on project switch
   }, [])
@@ -689,6 +703,7 @@ export function App() {
   })
 
   const panelDefs = [...nativePanelDefs, ...appPanels.map(toAppPanelDef)]
+  const wr175ReferenceAcceptance = modeHydrated && wr175ReferenceLaunchEligible && mode === 'simple' && activeRoute === DEFAULT_ROUTE && navigationParams === undefined
 
   const loadingShell = (
     <ChromeShell
@@ -784,7 +799,7 @@ export function App() {
           navigationParams={navigationParams}
           isHomeContext={isHomeContext}
           setIsHomeContext={setIsHomeContext}
-          visualAcceptance={modeSource === 'visual-acceptance-override'}
+          visualAcceptance={wr175ReferenceAcceptance}
         />
       ) : (
         <DockviewShell
@@ -917,10 +932,25 @@ function DesktopSimpleShell({
   const visualAcceptanceOpenedRef = useRef(false)
 
   useEffect(() => {
-    if (!visualAcceptance || visualAcceptanceOpenedRef.current) return
-    visualAcceptanceOpenedRef.current = true
-    chatStageManager.expandToAmbientLarge()
+    if (visualAcceptance) {
+      if (!visualAcceptanceOpenedRef.current) {
+        visualAcceptanceOpenedRef.current = true
+        chatStageManager.expandToAmbientLarge()
+      }
+      return
+    }
+
+    if (visualAcceptanceOpenedRef.current) {
+      visualAcceptanceOpenedRef.current = false
+      chatStageManager.collapseToSmall()
+    }
   }, [chatStageManager, visualAcceptance])
+
+  useEffect(() => {
+    if (visualAcceptance && !isHomeContext) {
+      setIsHomeContext(true)
+    }
+  }, [isHomeContext, setIsHomeContext, visualAcceptance])
 
   // WR-141 — single-call-plus-prop-drill per primary contract § State Ownership.
   // This call is intentionally placed inside `DesktopSimpleShell` (the wiring-site

--- a/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
+++ b/self/apps/desktop/src/renderer/src/__tests__/App.test.tsx
@@ -253,7 +253,11 @@ describe('App', () => {
     expect(chat?.dataset.chatOwner).toBe('Cortex:Principal')
     expect(chat?.dataset.chatContainer).toBe('principal-drawer')
     expect(chat?.getAttribute('aria-label')).toBe('Cortex Principal chat drawer')
+    await waitFor(() => {
+      expect(chat?.dataset.chatStage).toBe('ambient_large')
+    })
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
+    expect(mock.mode.set).not.toHaveBeenCalled()
   })
 
   it('loads developer mode from persisted state', async () => {
@@ -292,7 +296,34 @@ describe('App', () => {
     const shell = document.querySelector('[data-shell-mode-source="visual-acceptance-override"]') as HTMLElement | null
     expect(shell?.dataset.shellMode).toBe('simple')
     expect(screen.queryByText('Dockview shell')).not.toBeInTheDocument()
-    expect(document.querySelector('[data-chat-container="principal-drawer"]')).not.toBeNull()
+    const chat = document.querySelector('[data-chat-container="principal-drawer"]') as HTMLElement | null
+    expect(chat).not.toBeNull()
+    await waitFor(() => {
+      expect(chat?.dataset.chatStage).toBe('ambient_large')
+    })
+    expect(mock.mode.get).toHaveBeenCalledTimes(1)
+    expect(mock.mode.set).not.toHaveBeenCalled()
+  })
+
+  it('opens the WR-175 reference drawer for persisted simple mode without persisting drawer state', async () => {
+    const mock = installMock()
+    mock.mode.get.mockResolvedValue('simple')
+    trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.getWizardState') return createFirstRunState({ currentStep: 'complete', complete: true })
+      if (procedure === 'packages.listAppPanels') return []
+      return null
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-shell-area="rail"]')).not.toBeNull()
+    })
+
+    const chat = document.querySelector('[data-chat-container="principal-drawer"]') as HTMLElement | null
+    await waitFor(() => {
+      expect(chat?.dataset.chatStage).toBe('ambient_large')
+    })
     expect(mock.mode.get).toHaveBeenCalledTimes(1)
     expect(mock.mode.set).not.toHaveBeenCalled()
   })
@@ -676,5 +707,36 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
     })
+  })
+
+  it('does not keep the WR-175 reference drawer active after non-home navigation', async () => {
+    installMock()
+    trpcFetchMock.trpcQuery.mockImplementation(async (procedure: string) => {
+      if (procedure === 'firstRun.getWizardState') return createFirstRunState({ currentStep: 'complete', complete: true })
+      if (procedure === 'packages.listAppPanels') return []
+      return null
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-shell-area="rail"]')).not.toBeNull()
+    })
+
+    const chat = document.querySelector('[data-shell-area="chat"]') as HTMLElement | null
+    await waitFor(() => {
+      expect(chat?.dataset.chatStage).toBe('ambient_large')
+    })
+
+    fireEvent.keyDown(window, {
+      ctrlKey: true,
+      key: 'k',
+    })
+    fireEvent.click(screen.getByTestId('command-item-nav-threads'))
+
+    await waitFor(() => {
+      expect(chat?.dataset.chatStage).toBe('small')
+    })
+    expect(screen.getByText('MAO Operating Surface')).toBeInTheDocument()
   })
 })

--- a/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
+++ b/self/ui/src/components/shell/__tests__/SimpleShellLayout.test.tsx
@@ -107,10 +107,12 @@ describe('SimpleShellLayout', () => {
   it('chat drawer is positioned as a Cortex Principal simple-shell container', async () => {
     await renderLayout()
     const chat = getArea('chat')
+    const observe = getArea('observe')
     expect(chat.style.position).toBe('absolute')
     expect(chat.style.top).toBe('var(--nous-chat-drawer-top-offset)')
     expect(chat.style.right).toBe('var(--nous-chat-drawer-right-offset)')
     expect(chat.style.bottom).toBe('var(--nous-chat-drawer-bottom-offset)')
+    expect(observe.style.zIndex).toBe('1')
     expect(chat.style.zIndex).toBe('10')
     expect(chat.getAttribute('data-chat-owner')).toBe('Cortex:Principal')
     expect(chat.getAttribute('data-chat-container')).toBe('principal-drawer')
@@ -271,6 +273,7 @@ describe('SimpleShellLayout', () => {
   it('renders reference drawer tabs, topics, result, and command input when open', async () => {
     await renderLayout({ chatStage: 'ambient_large' })
     const chat = getArea('chat')
+    expect(chat.style.boxShadow).toBe('var(--nous-chat-drawer-shadow)')
     expect(chat.textContent).toContain('Client Onboarding')
     expect(chat.textContent).toContain('Review client intakes')
     expect(chat.textContent).toContain('Worked for 18s')


### PR DESCRIPTION
## Summary
- Scope WR-175 reference drawer launch to hydrated simple home state.
- Preserve non-persistence and collapse behavior when reference state deactivates.
- Add focused renderer/UI support coverage.

## Verification
- Focused desktop/UI tests passed per completion report and review.
- Broad typecheck/test/build blockers remain recorded as existing/carry-forward failures.
- Behavioral testing not run per sub-phase close constraint.