### PR TITLE
Add docs build CI workflow

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+# Advisory docs validation. Required product promotion gates keep their
+# documentation-only no-op behavior in ci-gate/release workflows.
+
+on:
+  push:
+    branches:
+      - dev
+      - staging
+      - main
+      - 'feat/**'
+      - 'fix/**'
+      - 'refactor/**'
+      - 'chore/**'
+    paths:
+      - 'docs/**'
+  pull_request:
+    branches:
+      - dev
+      - 'feat/**'
+      - 'fix/**'
+      - 'refactor/**'
+      - 'chore/**'
+      - staging
+      - main
+    paths:
+      - 'docs/**'
+
+jobs:
+  docs-build:
+    name: Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build docs
+        run: pnpm --filter docs run build


### PR DESCRIPTION
## Summary
- Adds a lightweight non-required `Docs` workflow scoped to `docs/**` changes.
- Runs the docs/Nextra build without changing required product promotion gates.

## Verification
- `pnpm --filter docs run build`
- `pnpm dlx github-actionlint@latest .github/workflows/docs-ci.yml`
- `git diff --check`