### PR TITLE
Fix provider generated checks on Windows

### DIFF
--- a/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
+++ b/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
@@ -241,7 +241,7 @@ async function checkGenerated(generated) {
       staleFiles.push(toPosix(path.relative(packageRoot, filePath)));
       continue;
     }
-    if (actual !== expected) {
+    if (normalizeLineEndings(actual) !== expected) {
       staleFiles.push(toPosix(path.relative(packageRoot, filePath)));
     }
   }
@@ -276,4 +276,8 @@ async function checkGenerated(generated) {
 
 function toPosix(value) {
   return value.split(path.sep).join('/');
+}
+
+function normalizeLineEndings(value) {
+  return value.replace(/\r\n/g, '\n');
 }


### PR DESCRIPTION
## Summary
- Normalizes CRLF to LF before comparing generated provider catalog files in check mode.
- Fixes Windows CI reporting generated files as stale after checkout line-ending conversion.

## Verification
- `pnpm --filter @nous/subcortex-providers run check:generated`
- `pnpm --filter @nous/subcortex-providers run build`
- `git diff --check`