### PR TITLE
Update docs site for NueOS branding

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -1,3 +1,106 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
+
+:root {
+  --nous-docs-bg-canvas: #f8f9fc;
+  --nous-docs-bg-panel: #ffffff;
+  --nous-docs-bg-muted: rgba(33, 34, 38, 0.035);
+  --nous-docs-fg-title: #121317;
+  --nous-docs-fg-body: #45474d;
+  --nous-docs-fg-muted: #5f6670;
+  --nous-docs-stroke: rgba(33, 34, 38, 0.1);
+  --nous-docs-accent: #3279f9;
+  --nous-docs-accent-soft: rgba(50, 121, 249, 0.1);
+  --nous-font-sans:
+    var(--font-inter, Inter), Inter, ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --nous-font-mono:
+    var(--font-fira-code, "Fira Code"), "Fira Code", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, "Liberation Mono", monospace;
+  --nous-font-agent-mono:
+    var(--font-ibm-plex-mono, "IBM Plex Mono"), "IBM Plex Mono", ui-monospace, SFMono-Regular,
+    Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --font-sans: var(--nous-font-sans);
+  --font-mono: var(--nous-font-mono);
+
+  --fd-background: var(--nous-docs-bg-canvas);
+  --fd-foreground: var(--nous-docs-fg-title);
+  --fd-card: var(--nous-docs-bg-panel);
+  --fd-card-foreground: var(--nous-docs-fg-body);
+  --fd-popover: var(--nous-docs-bg-panel);
+  --fd-popover-foreground: var(--nous-docs-fg-body);
+  --fd-muted: var(--nous-docs-bg-muted);
+  --fd-muted-foreground: var(--nous-docs-fg-muted);
+  --fd-accent: var(--nous-docs-accent-soft);
+  --fd-accent-foreground: var(--nous-docs-fg-title);
+  --fd-primary: var(--nous-docs-accent);
+  --fd-primary-foreground: #ffffff;
+  --fd-secondary: var(--nous-docs-bg-muted);
+  --fd-secondary-foreground: var(--nous-docs-fg-title);
+  --fd-border: var(--nous-docs-stroke);
+  --fd-ring: rgba(50, 121, 249, 0.45);
+}
+
+.dark {
+  --nous-docs-bg-canvas: #050506;
+  --nous-docs-bg-panel: #101010;
+  --nous-docs-bg-muted: rgba(255, 255, 255, 0.045);
+  --nous-docs-fg-title: #fff7ff;
+  --nous-docs-fg-body: #bfc4cb;
+  --nous-docs-fg-muted: #8a8f98;
+  --nous-docs-stroke: rgba(255, 255, 255, 0.08);
+  --nous-docs-accent: #5b7cff;
+  --nous-docs-accent-soft: rgba(91, 124, 255, 0.13);
+  --fd-primary-foreground: #ffffff;
+}
+
+html,
+body {
+  background:
+    radial-gradient(circle at 12% -10%, rgba(36, 48, 62, 0.32), transparent 34vh),
+    var(--fd-background);
+  color: var(--fd-foreground);
+  font-family: var(--nous-font-sans);
+}
+
+body :where(:not(code):not(kbd):not(pre):not(samp)) {
+  font-family: var(--nous-font-sans);
+}
+
+body,
+.fd-docs,
+.fd-page,
+.fd-sidebar,
+.fd-nav,
+.fd-tocnav,
+[data-radix-scroll-area-viewport],
+article,
+main {
+  font-family: var(--nous-font-sans);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--nous-docs-fg-title);
+  font-family: var(--nous-font-sans);
+  letter-spacing: -0.035em;
+}
+
+p,
+li,
+dd,
+dt {
+  color: var(--nous-docs-fg-body);
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--nous-font-mono);
+}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,29 +1,41 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Fira_Code, IBM_Plex_Mono, Inter } from 'next/font/google';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import './globals.css';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  display: 'swap',
+  variable: '--font-inter',
   subsets: ['latin'],
 });
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const firaCode = Fira_Code({
+  display: 'swap',
+  variable: '--font-fira-code',
   subsets: ['latin'],
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  display: 'swap',
+  variable: '--font-ibm-plex-mono',
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
 });
 
 export const metadata: Metadata = {
-  title: 'Jarvis Docs',
-  description: 'Internal development documentation and project management',
+  title: {
+    default: 'NueOS Documentation',
+    template: '%s | NueOS Documentation',
+  },
+  description: 'Documentation for the local-first NueOS agent operating system',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col antialiased`}
+        className={`${inter.variable} ${firaCode.variable} ${ibmPlexMono.variable} flex min-h-screen flex-col antialiased`}
       >
         <RootProvider>{children}</RootProvider>
       </body>

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1,18 +1,5 @@
-import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
-      <h1 className="text-4xl font-bold tracking-tight">Jarvis</h1>
-      <p className="max-w-md text-lg text-fd-muted-foreground">
-        Internal development documentation and project management system.
-      </p>
-      <Link
-        href="/docs"
-        className="inline-flex h-10 items-center justify-center rounded-md bg-fd-primary px-6 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
-      >
-        Browse Documentation
-      </Link>
-    </main>
-  );
+  redirect('/docs');
 }

--- a/docs/content/docs/development/provider-adapters/anthropic-reference.mdx
+++ b/docs/content/docs/development/provider-adapters/anthropic-reference.mdx
@@ -15,7 +15,7 @@ Use `self/subcortex/providers/src/providers/anthropic/` as the reference leaf fo
 | `implementation.ts` | Owns the provider class, default endpoint/model, credential handling, request execution, streaming, and metadata constant |
 | `adapter.ts` | Exports `providerAdapter`, `anthropicAdapter`, and `createAnthropicAdapter(...)` |
 | `provider.ts` | Exports `providerFactory` for runtime construction |
-| `index.ts` | Re-exports the leaf surface for generator imports |
+| `index.ts` | Re-exports the leaf public surface; required by leaf validation |
 
 ## Definition Shape
 
@@ -33,15 +33,27 @@ The metadata constant uses the typed definition contract:
 export const ANTHROPIC_PROVIDER_DEFINITION = {
   vendorKey: 'anthropic',
   displayName: 'Anthropic',
+  wellKnownProviderId: '10000000-0000-0000-0000-000000000001' as ProviderId,
   providerType: 'text',
   providerClass: 'remote_text',
   protocol: 'anthropic-messages',
   adapterKey: 'anthropic',
+  defaultEndpoint: DEFAULT_ENDPOINT,
+  defaultModelId: DEFAULT_MODEL_ID,
   auth: {
     envVar: 'ANTHROPIC_API_KEY',
     vaultKeyNamespace: 'anthropic',
     required: true,
     purpose: 'api_key',
+  },
+  headers: {
+    'anthropic-version': ANTHROPIC_VERSION,
+  },
+  capabilities: {
+    streaming: true,
+    cacheControl: true,
+    extendedThinking: true,
+    nativeToolUse: true,
   },
   isLocal: false,
 } as const satisfies ProviderDefinition;

--- a/docs/content/docs/development/provider-adapters/provider-leaf-anatomy.mdx
+++ b/docs/content/docs/development/provider-adapters/provider-leaf-anatomy.mdx
@@ -13,7 +13,7 @@ self/subcortex/providers/src/providers/<vendor>/
 ├── adapter.ts          # exports providerAdapter
 ├── provider.ts         # exports providerFactory
 ├── implementation.ts   # provider class and constants, when leaf-owned
-└── index.ts            # leaf public exports for generator imports
+└── index.ts            # leaf public exports; required by leaf validation
 ```
 
 ## Required Files

--- a/docs/content/docs/development/provider-adapters/quickstart.mdx
+++ b/docs/content/docs/development/provider-adapters/quickstart.mdx
@@ -36,7 +36,7 @@ self/subcortex/providers/src/providers/<vendor>/
 1. In `definition.ts`, export `providerDefinition`.
 2. In `adapter.ts`, export `providerAdapter`.
 3. In `provider.ts`, export `providerFactory`.
-4. In `index.ts`, re-export the leaf's public exports for generator imports.
+4. In `index.ts`, re-export the leaf's public surface. The generator requires this file as part of leaf validation, but imports `definition.ts`, `adapter.ts`, and `provider.ts` directly.
 5. Keep definitions as metadata only: no environment reads, network calls, concrete provider instantiation, or bootstrap branches.
 
 The definition should use `as const satisfies ProviderDefinition`. The factory should use `as const satisfies ProviderFactoryModule`.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,9 +1,13 @@
 ---
-title: Nous-OSS
+title: NueOS Documentation
 description: A local-first agent operating system with structured orchestration, memory control, and secure extensibility.
 ---
 
-# Nous-OSS
+<Callout type="warning" title="Rename in progress: Nous is becoming Nue">
+  The project is being renamed from Nous to Nue. These docs remain current for contributors, and some pages may still contain Nous terminology while the transition is completed.
+</Callout>
+
+# NueOS Documentation
 
 **NOUS — Neural Operations Unification System**
 

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -3,7 +3,7 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: 'Jarvis Docs',
+      title: 'NueOS Documentation',
     },
   };
 }


### PR DESCRIPTION
## Summary
- Renames the docs surface to `NueOS Documentation`.
- Redirects `/` directly to `/docs` and removes the old landing page.
- Aligns docs styling with the Nue marketing direction and adds a rename-in-progress callout.
- Fixes provider adapter contributor docs inaccuracies found in the final audit.

## Verification
- `pnpm --filter docs run build`
- `git diff --check`
- Provider adapter docs audit findings resolved.