### PR TITLE
feat: CLI agent persistent chat lifecycle / chat latency fix (Phase 1.20)

### DIFF
--- a/self/apps/shared-server/src/bootstrap.ts
+++ b/self/apps/shared-server/src/bootstrap.ts
@@ -88,6 +88,7 @@ import { DocumentNotificationStore, NotificationService } from '@nous/subcortex-
 import { ModelRouter } from '@nous/subcortex-router';
 import {
   PROVIDER_DEFINITIONS,
+  CliSessionManager,
   ProviderRegistry,
   type ProviderDefinition,
   type ProviderVendorKey,
@@ -155,6 +156,7 @@ const MOCK_PROVIDER_ID = '00000000-0000-0000-0000-000000000001' as ProviderId;
 type ProviderName = ProviderVendorKey;
 type ProviderDefinitionEntry = (typeof PROVIDER_DEFINITIONS)[number];
 type ParsedModelSpec = { provider: ProviderName; modelId: string };
+const registeredCliSessionShutdownManagers = new WeakSet<CliSessionManager>();
 
 export const WELL_KNOWN_PROVIDER_IDS: Record<ProviderVendorKey, ProviderId> =
   Object.fromEntries(
@@ -816,6 +818,8 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     eventBus,
     credentialVaultService,
   });
+  const cliSessionManager = new CliSessionManager();
+  registerCliSessionShutdown(cliSessionManager);
   const credentialOAuthBroker = new CredentialOAuthBroker({
     vaultService: credentialVaultService,
   });
@@ -1328,6 +1332,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     recoveryLedgerStore,
     recoveryOrchestrator,
     logger,
+    cliSessionManager,
     // SP 1.3 — Decision 4 production wiring of PersonalityConfig.
     // The cortex-runtime call sites (cortex-runtime.ts:308-310 / 335-336)
     // consume `configReader.getPersonalityConfig()` for the Principal/System
@@ -1409,6 +1414,7 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
     appRuntimeService,
     credentialVaultService,
     providerRegistry,
+    cliSessionManager,
     panelTranspiler,
     dataDir,
     codingAgentMaoEvents,
@@ -1422,6 +1428,19 @@ export function createNousServices(config?: BootstrapConfig): NousContext {
 
   console.log(`[nous:${runtimeLabel}] bootstrap complete`);
   return context;
+}
+
+function registerCliSessionShutdown(cliSessionManager: CliSessionManager): void {
+  if (registeredCliSessionShutdownManagers.has(cliSessionManager)) return;
+  registeredCliSessionShutdownManagers.add(cliSessionManager);
+
+  const teardown = () => {
+    cliSessionManager.teardownAll();
+  };
+
+  process.once('beforeExit', teardown);
+  process.once('SIGINT', teardown);
+  process.once('SIGTERM', teardown);
 }
 
 /**

--- a/self/apps/shared-server/src/context.ts
+++ b/self/apps/shared-server/src/context.ts
@@ -35,7 +35,7 @@ import type {
 } from '@nous/shared';
 import type { PanelTranspiler } from '@nous/subcortex-apps';
 import type { TokenAccumulatorService } from '@nous/subcortex-inference-runtime';
-import type { ProviderRegistry } from '@nous/subcortex-providers';
+import type { CliSessionManager, ProviderRegistry } from '@nous/subcortex-providers';
 import type { CostGovernanceService } from '@nous/subcortex-cost';
 import type {
   IPrincipalSystemGatewayRuntime,
@@ -105,6 +105,7 @@ export interface NousContext {
   panelTranspiler: PanelTranspiler;
   credentialVaultService: ICredentialVaultService;
   providerRegistry: ProviderRegistry;
+  cliSessionManager: CliSessionManager;
   dataDir: string;
   /** MAO events emitted by coding agent runs. */
   codingAgentMaoEvents: Array<{ type: string; data: unknown; timestamp: string }>;

--- a/self/cortex/core/src/agent-gateway/agent-gateway.ts
+++ b/self/cortex/core/src/agent-gateway/agent-gateway.ts
@@ -26,6 +26,7 @@ import {
   type IAgentGatewayFactory,
   type IModelProvider,
   type ModelRole,
+  type ModelProviderConfig,
   type ProjectId,
   type ThinkingUnavailable,
   type ToolDefinition,
@@ -85,6 +86,10 @@ const DEFAULT_MODEL_ROLE_BY_CLASS: Record<AgentClass, ModelRole> = {
 function deriveDefaultModelRole(agentClass: AgentClass | undefined): ModelRole {
   if (!agentClass) return 'cortex-chat'; // I5 first-run fallback
   return DEFAULT_MODEL_ROLE_BY_CLASS[agentClass];
+}
+
+function deriveEffectiveAgentClass(agentClass: AgentClass | undefined): AgentClass {
+  return agentClass ?? 'Cortex::Principal';
 }
 
 /**
@@ -227,6 +232,18 @@ export class AgentGateway implements IAgentGateway {
     return this.cachedAdapter;
   }
 
+  private tryGetProviderConfig(provider: IModelProvider): ModelProviderConfig | undefined {
+    try {
+      return provider.getConfig();
+    } catch (error) {
+      this.log.warn('provider config unavailable', {
+        agentClass: this.agentClass,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
   getInboxHandle() {
     return this.inbox.getHandle();
   }
@@ -277,21 +294,22 @@ export class AgentGateway implements IAgentGateway {
         const provider = await this.resolveProvider(validInput, traceId);
 
         const adapter = this.resolveAdapterFromProvider(provider);
-        const providerConfig = provider.getConfig();
+        const providerConfig = this.tryGetProviderConfig(provider);
+        const effectiveAgentClass = deriveEffectiveAgentClass(this.agentClass);
         const providerType = resolveProviderTypeFromConfig(provider);
         const promptOutput = this.config.harness?.promptFormatter
           ? this.config.harness.promptFormatter({
-              agentClass: this.agentClass,
+              agentClass: effectiveAgentClass,
               taskInstructions: validInput.taskInstructions,
               baseSystemPrompt: this.config.baseSystemPrompt,
               execution: validInput.execution,
               tools,
             })
           : composeFromProfile(
-              resolveAgentProfile(this.agentClass, providerType),
+              resolveAgentProfile(effectiveAgentClass, providerType),
               adapter.capabilities,
               {
-                agentClass: this.agentClass,
+                agentClass: effectiveAgentClass,
                 taskInstructions: validInput.taskInstructions,
                 baseSystemPrompt: this.config.baseSystemPrompt,
                 execution: validInput.execution,
@@ -326,7 +344,7 @@ export class AgentGateway implements IAgentGateway {
 
         this.log.debug('invoke provider', {
           agentClass: this.agentClass,
-          providerId: providerConfig.id,
+          providerId: providerConfig?.id,
           providerType,
           hasHarness: !!this.config.harness,
           inputKeys: Object.keys(formatted.input),

--- a/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
+++ b/self/cortex/core/src/gateway-runtime/cortex-runtime.ts
@@ -36,10 +36,12 @@ import type {
   TraceId,
   HarnessStrategies,
   ILogChannel,
+  IModelProvider,
   PromptFormatterInput,
   ProviderVendor,
 } from '@nous/shared';
 import { GatewayContextFrameSchema, type EmptyResponseKind } from '@nous/shared';
+import { CODEX_CLI_EXECUTION_CAPABILITY_PROFILE } from '@nous/subcortex-providers';
 import { markerForKind } from '../agent-gateway/agent-gateway.js';
 import { AgentGatewayFactory, createInboxFrame } from '../agent-gateway/index.js';
 import {
@@ -504,7 +506,7 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
   async handleChatTurn(input: ChatTurnInput): Promise<ChatTurnResult> {
     this.checkAttachOrWarn();
     const parsed = ChatTurnInputSchema.parse(input);
-    const { message, projectId, traceId, sessionId, scope } = parsed;
+    const { traceId } = parsed;
 
     // Emit turn-start lifecycle event for subscribers like useAgentActivity
     // (BT Round 2, RC-2). The deprecated GatewayBackedTurnExecutor was the
@@ -581,7 +583,21 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
     // Run Principal gateway (with turn-in-progress guard for recompose safety)
     this.turnInProgressByClass.set('Cortex::Principal', true);
     let result;
+    const previousPrincipalProvider = this.principalGatewayConfig.modelProvider;
+    const previousPrincipalRouter = this.principalGatewayConfig.modelRouter;
+    const previousPrincipalGetProvider = this.principalGatewayConfig.getProvider;
+    const chatProvider = await this.resolveChatTurnProvider({
+      projectId,
+      traceId,
+      sessionId,
+      scope,
+    });
     try {
+      if (chatProvider) {
+        this.principalGatewayConfig.modelProvider = chatProvider;
+        this.principalGatewayConfig.modelRouter = undefined;
+        this.principalGatewayConfig.getProvider = undefined;
+      }
       result = await this.principalGateway.run({
         taskInstructions: `Handle the current user chat turn. Respond conversationally.\n\n${WORKFLOW_PROMPT_FRAGMENT}\n\n${CARD_PROMPT_FRAGMENT}`,
         context: chatContext,
@@ -600,6 +616,9 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
         modelRequirements: this.deps.defaultModelRequirements,
       });
     } finally {
+      this.principalGatewayConfig.modelProvider = previousPrincipalProvider;
+      this.principalGatewayConfig.modelRouter = previousPrincipalRouter;
+      this.principalGatewayConfig.getProvider = previousPrincipalGetProvider;
       this.turnInProgressByClass.set('Cortex::Principal', false);
       this.checkPendingRecompose('Cortex::Principal');
     }
@@ -647,6 +666,53 @@ implements IPrincipalSystemGatewayRuntime, ISystemInboxSubmissionService {
 
   async whenIdle(): Promise<void> {
     await this.systemBacklogQueue.whenIdle();
+  }
+
+  private async resolveChatTurnProvider(args: {
+    projectId?: string;
+    traceId: string;
+    sessionId?: string;
+    scope?: ChatTurnInput['scope'];
+  }): Promise<IModelProvider | undefined> {
+    if (!this.deps.cliSessionManager) return undefined;
+
+    const providerId = await this.resolvePrincipalProviderId(args);
+    if (!providerId || !this.deps.getProvider) return undefined;
+
+    const provider = this.deps.getProvider(providerId);
+    if (!provider) return undefined;
+    const providerConfig = provider.getConfig();
+    const isCodexCliProvider = providerConfig.vendor === 'codex-cli';
+
+    return this.deps.cliSessionManager.resolveForChatTurn({
+      providerId: providerId as never,
+      sessionId: args.sessionId,
+      scope: args.scope,
+      projectId: args.projectId,
+      provider,
+      providerProtocol: isCodexCliProvider ? 'agent-cli' : undefined,
+      executionCapabilityProfile: isCodexCliProvider ? CODEX_CLI_EXECUTION_CAPABILITY_PROFILE : undefined,
+    });
+  }
+
+  private async resolvePrincipalProviderId(args: {
+    projectId?: string;
+    traceId: string;
+  }): Promise<string | undefined> {
+    if (this.deps.modelRouter) {
+      const route = await this.deps.modelRouter.routeWithEvidence('cortex-chat', {
+        projectId: args.projectId as never,
+        traceId: args.traceId as never,
+        modelRequirements:
+          this.deps.defaultModelRequirements ?? {
+            profile: 'fast',
+            fallbackPolicy: 'block_if_unmet',
+          },
+      });
+      return route.providerId;
+    }
+
+    return this.deps.providerIdByClass?.['Cortex::Principal'];
   }
 
   async listBacklogEntries(filter?: { status?: import('./backlog-types.js').BacklogEntryStatus }): Promise<BacklogEntry[]> {

--- a/self/cortex/core/src/gateway-runtime/types.ts
+++ b/self/cortex/core/src/gateway-runtime/types.ts
@@ -31,6 +31,7 @@ import type {
   IAppCredentialInstallService,
   ICredentialVaultService,
   ICredentialInjector,
+  ICliSessionManager,
   ILogger,
   IOpctlService,
   IThoughtEmitter,
@@ -265,6 +266,7 @@ export interface PrincipalSystemGatewayRuntimeDeps {
   agentGatewayFactory?: IAgentGatewayFactory;
   modelRouter?: IModelRouter;
   getProvider?: (providerId: string) => IModelProvider | null;
+  cliSessionManager?: ICliSessionManager;
   modelProviderByClass?: Partial<Record<AgentClass, IModelProvider>>;
   /**
    * Per-agent-class map from AgentClass to a provider UUID that bootstrap has

--- a/self/shared/src/interfaces/index.ts
+++ b/self/shared/src/interfaces/index.ts
@@ -14,6 +14,9 @@ export type {
 export type {
   IModelRouter,
   IModelProvider,
+  CliSessionContext,
+  TeardownScope,
+  ICliSessionManager,
   IToolExecutor,
   WorkflowStartRequest,
   IWorkflowEngine,

--- a/self/shared/src/interfaces/subcortex.ts
+++ b/self/shared/src/interfaces/subcortex.ts
@@ -31,6 +31,9 @@ import type {
   ModelRequest,
   ModelResponse,
   ModelStreamChunk,
+  ChatFixtureScope,
+  CliExecutionCapabilityProfile,
+  CliSessionTeardownReason,
   ToolResult,
   ToolDefinition,
   ProjectConfig,
@@ -290,6 +293,36 @@ export interface IModelProvider {
 
   /** Get provider configuration */
   getConfig(): ModelProviderConfig;
+}
+
+export interface CliSessionContext {
+  readonly providerId: ProviderId;
+  readonly sessionId?: string;
+  readonly scope?: ChatFixtureScope;
+  readonly projectId?: string;
+  readonly provider: IModelProvider;
+  readonly providerProtocol?: string;
+  readonly executionCapabilityProfile?: CliExecutionCapabilityProfile;
+}
+
+export interface TeardownScope {
+  readonly providerId?: ProviderId;
+  readonly sessionId?: string;
+  readonly fixtureRole?: ChatFixtureScope;
+}
+
+export interface ICliSessionManager {
+  /**
+   * Return a chat-turn provider. Agent-CLI chat fixtures receive a
+   * session-aware wrapper; non-CLI or non-chat invocations pass through.
+   */
+  resolveForChatTurn(context: CliSessionContext): IModelProvider;
+
+  /** Tear down sessions matching the provided reason and scope. */
+  teardown(reason: CliSessionTeardownReason, scope: TeardownScope): void;
+
+  /** Tear down all managed CLI sessions, used during app/backend shutdown. */
+  teardownAll(): void;
 }
 
 export interface IToolExecutor {

--- a/self/shared/src/types/cli-session.ts
+++ b/self/shared/src/types/cli-session.ts
@@ -1,0 +1,57 @@
+/**
+ * CLI provider session lifecycle contracts.
+ *
+ * These types describe provider process/session identity only. Conversation
+ * history and STM remain owned by the cortex layer.
+ */
+import { z } from 'zod';
+import { ProviderIdSchema } from './ids.js';
+
+export const ChatFixtureScopeSchema = z.enum([
+  'principal',
+  'project_thread',
+  'orphan_thread',
+]);
+export type ChatFixtureScope = z.infer<typeof ChatFixtureScopeSchema>;
+
+export const ProviderSessionKeySchema = z.object({
+  providerId: ProviderIdSchema,
+  fixtureRole: ChatFixtureScopeSchema,
+  projectId: z.string().uuid().optional(),
+  chatSessionId: z.string().uuid(),
+}).strict();
+export type ProviderSessionKey = z.infer<typeof ProviderSessionKeySchema>;
+
+export const CliSessionStateSchema = z.enum([
+  'active',
+  'busy',
+  'dead',
+  'teardown',
+]);
+export type CliSessionState = z.infer<typeof CliSessionStateSchema>;
+
+export const CliSessionTeardownReasonSchema = z.enum([
+  'chat_close',
+  'provider_reassignment',
+  'app_shutdown',
+  'explicit_cancellation',
+  'process_crash',
+]);
+export type CliSessionTeardownReason = z.infer<typeof CliSessionTeardownReasonSchema>;
+
+export const CliExecutionCapabilityProfileSchema = z.enum([
+  'one_shot_command',
+  'session_bound_command',
+  'persistent_process',
+]);
+export type CliExecutionCapabilityProfile = z.infer<typeof CliExecutionCapabilityProfileSchema>;
+
+export function serializeProviderSessionKey(key: ProviderSessionKey): string {
+  const parsed = ProviderSessionKeySchema.parse(key);
+  return [
+    parsed.providerId,
+    parsed.fixtureRole,
+    parsed.projectId ?? '',
+    parsed.chatSessionId,
+  ].join('::');
+}

--- a/self/shared/src/types/index.ts
+++ b/self/shared/src/types/index.ts
@@ -16,6 +16,7 @@ export * from './workflow-monitoring.js';
 export * from './project-surface.js';
 export * from './project.js';
 export * from './provider.js';
+export * from './cli-session.js';
 export * from './cortex.js';
 export * from './routing.js';
 export * from './tools.js';

--- a/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
+++ b/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
@@ -137,7 +137,7 @@ export type CertifiedProviderAdapterKey =
 function providerAdapterExtraExports(vendor) {
   const extrasByVendor = new Map([
     ['anthropic', ['createAnthropicAdapter']],
-    ['codex-cli', ['createCodexCliAdapter', 'renderCodexCliPrompt']],
+    ['codex-cli', ['CODEX_CLI_EXECUTION_CAPABILITY_PROFILE', 'createCodexCliAdapter', 'renderCodexCliPrompt']],
     ['ollama', ['createOllamaAdapter', 'isToolCapableModel']],
     ['openai', ['createChatCompletionsAdapter']],
   ]);

--- a/self/subcortex/providers/src/__tests__/provider-registry.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-registry.test.ts
@@ -9,6 +9,7 @@ import { OllamaProvider } from '../providers/ollama/implementation.js';
 afterEach(() => {
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.OPENAI_API_KEY;
+  vi.restoreAllMocks();
 });
 
 describe('ProviderRegistry', () => {
@@ -113,6 +114,55 @@ describe('ProviderRegistry', () => {
         capabilities: ['text'],
       }),
     ).toThrow(ConfigError);
+  });
+
+  it('does not emit unknown-vendor fallback diagnostics for generated providers with factories', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    registry.registerProvider({
+      id: '10000000-0000-0000-0000-000000000004' as any,
+      name: 'Codex CLI',
+      type: 'text',
+      endpoint: 'http://localhost',
+      modelId: 'codex-cli/default',
+      isLocal: true,
+      capabilities: ['text', 'streaming'],
+      providerClass: 'local_text',
+      vendor: 'codex-cli',
+    });
+
+    expect(info.mock.calls.flat().join('\n')).not.toContain('adapter will fall back to text');
+  });
+
+  it('keeps unknown-vendor fallback diagnostics when no generated factory exists', () => {
+    process.env.OPENAI_API_KEY = 'test-openai-key';
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const registry = new ProviderRegistry({
+      get: () => ({ providers: [] }),
+      getSection: vi.fn(),
+      update: vi.fn(),
+      reload: vi.fn(),
+    } as any);
+
+    registry.registerProvider({
+      id: '00000000-0000-0000-0000-000000000020' as any,
+      name: 'Unknown Local Provider',
+      type: 'text',
+      endpoint: 'http://localhost',
+      modelId: 'unknown/default',
+      isLocal: true,
+      capabilities: ['text'],
+      providerClass: 'local_text',
+      vendor: 'unknown-generated-provider',
+    });
+
+    expect(info.mock.calls.flat().join('\n')).toContain('adapter will fall back to text');
   });
 
   it('removeProvider removes an existing provider and returns true', () => {

--- a/self/subcortex/providers/src/__tests__/providers/codex-cli.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/codex-cli.test.ts
@@ -9,10 +9,12 @@ import {
 import {
   CODEX_CLI_AGENT_ADAPTER,
   CODEX_CLI_DEFAULT_MODEL_ID,
+  CODEX_CLI_EXECUTION_CAPABILITY_PROFILE,
   CODEX_CLI_PROVIDER_DEFINITION,
   CodexCliProvider,
   type CodexCliCommandResolver,
   createCodexCliAdapter,
+  providerAdapter,
   providerDefinition,
   providerFactory,
   renderCodexCliPrompt,
@@ -108,6 +110,8 @@ describe('Codex CLI provider leaf', () => {
   it('exposes a ProviderAdapter module for codex-cli with text-safe parsing', () => {
     const adapter = createCodexCliAdapter();
 
+    expect(providerAdapter.executionCapabilityProfile).toBe(CODEX_CLI_EXECUTION_CAPABILITY_PROFILE);
+    expect(CODEX_CLI_EXECUTION_CAPABILITY_PROFILE).toBe('session_bound_command');
     expect(adapter.capabilities.streaming).toBe(true);
     expect(adapter.formatRequest({
       systemPrompt: 'Act as Codex.',
@@ -206,6 +210,33 @@ describe('Codex CLI provider leaf', () => {
       '-',
     ]);
     expect(runner.invocations[0]?.input).toBe('user: Summarize this.');
+  });
+
+  it('preserves the one-shot codex exec path for transient invocations', async () => {
+    const runner = createFakeAgentCliRunner([
+      { exitCode: 0, stdout: 'first', startedAt: 1, endedAt: 2 },
+      { exitCode: 0, stdout: 'second', startedAt: 3, endedAt: 4 },
+    ]);
+    const provider = new CodexCliProvider(createConfig(), { runner });
+
+    await provider.invoke({
+      role: 'workers',
+      input: { prompt: 'first transient task' },
+      traceId: TRACE_ID,
+    });
+    await provider.invoke({
+      role: 'workers',
+      input: { prompt: 'second transient task' },
+      traceId: TRACE_ID,
+    });
+
+    expect(runner.invocations).toHaveLength(2);
+    expect(runner.invocations.map((call) => call.command.args?.slice(0, 7))).toEqual([
+      ['--ask-for-approval', 'never', 'exec', '--ignore-user-config', '--sandbox', 'read-only', '--color'],
+      ['--ask-for-approval', 'never', 'exec', '--ignore-user-config', '--sandbox', 'read-only', '--color'],
+    ]);
+    expect(runner.invocations[0]?.input).toBe('first transient task');
+    expect(runner.invocations[1]?.input).toBe('second transient task');
   });
 
   it('constructs a provider with the default live runner without invoking it in tests', () => {

--- a/self/subcortex/providers/src/__tests__/runtime/cli-session-manager.test.ts
+++ b/self/subcortex/providers/src/__tests__/runtime/cli-session-manager.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamChunk,
+  ProviderId,
+  TraceId,
+} from '@nous/shared';
+import { NousError, serializeProviderSessionKey } from '@nous/shared';
+import {
+  CliSessionManager,
+  deriveProviderSessionKey,
+} from '../../runtime/cli-session-manager.js';
+import { AGENT_CLI_PROTOCOL_ID } from '../../protocols/agent-cli/index.js';
+
+const PROVIDER_ID = '10000000-0000-0000-0000-000000000004' as ProviderId;
+const OTHER_PROVIDER_ID = '10000000-0000-0000-0000-000000000005' as ProviderId;
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440177' as TraceId;
+const SESSION_ID = '550e8400-e29b-41d4-a716-446655440101';
+const PROJECT_ID = '550e8400-e29b-41d4-a716-446655440202';
+
+function config(id: ProviderId = PROVIDER_ID): ModelProviderConfig {
+  return {
+    id,
+    name: 'Codex CLI',
+    type: 'text',
+    endpoint: 'http://localhost',
+    modelId: 'codex-cli/default',
+    isLocal: true,
+    capabilities: ['text'],
+    providerClass: 'local_text',
+    vendor: 'codex-cli',
+  };
+}
+
+function request(input = 'hello'): ModelRequest {
+  return {
+    role: 'workers',
+    input: { prompt: input },
+    traceId: TRACE_ID,
+  };
+}
+
+class FakeProvider implements IModelProvider {
+  invokeCount = 0;
+  streamCount = 0;
+  disposed = false;
+  failNext = false;
+
+  constructor(private readonly providerConfig: ModelProviderConfig = config()) {}
+
+  getConfig(): ModelProviderConfig {
+    return this.providerConfig;
+  }
+
+  async invoke(modelRequest: ModelRequest): Promise<ModelResponse> {
+    this.invokeCount += 1;
+    if (this.failNext) {
+      this.failNext = false;
+      throw new NousError('process crashed', 'PROVIDER_UNAVAILABLE');
+    }
+    return {
+      output: `ok:${(modelRequest.input as { prompt: string }).prompt}`,
+      providerId: this.providerConfig.id,
+      usage: { computeMs: 1 },
+      traceId: modelRequest.traceId,
+    };
+  }
+
+  async *stream(): AsyncIterable<ModelStreamChunk> {
+    this.streamCount += 1;
+    yield { content: 'ok', done: false };
+    yield { content: '', done: true };
+  }
+
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+describe('CliSessionManager', () => {
+  it('derives project-scoped and system-wide provider session keys', () => {
+    const projectKey = deriveProviderSessionKey({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'project_thread',
+      projectId: PROJECT_ID,
+      provider: new FakeProvider(),
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    expect(projectKey).toEqual({
+      providerId: PROVIDER_ID,
+      fixtureRole: 'project_thread',
+      projectId: PROJECT_ID,
+      chatSessionId: SESSION_ID,
+    });
+
+    const systemKey = deriveProviderSessionKey({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      projectId: PROJECT_ID,
+      provider: new FakeProvider(),
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    expect(systemKey).toEqual({
+      providerId: PROVIDER_ID,
+      fixtureRole: 'principal',
+      chatSessionId: SESSION_ID,
+    });
+    expect(serializeProviderSessionKey(systemKey)).toBe(
+      `${PROVIDER_ID}::principal::::${SESSION_ID}`,
+    );
+  });
+
+  it('returns passthrough provider for non-agent-cli or missing session context', () => {
+    const provider = new FakeProvider();
+    const manager = new CliSessionManager();
+
+    expect(manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: 'openai',
+    })).toBe(provider);
+    expect(manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    })).toBe(provider);
+    expect(manager.getActiveSessionCount()).toBe(0);
+  });
+
+  it('creates and reuses a session-aware provider for the same chat key', async () => {
+    const provider = new FakeProvider();
+    const createPinnedProvider = vi.fn(({ provider: inner }) => inner);
+    const manager = new CliSessionManager({ createPinnedProvider });
+
+    const first = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+      executionCapabilityProfile: 'session_bound_command',
+    });
+    const second = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+
+    expect(second).toBe(first);
+    expect(createPinnedProvider).toHaveBeenCalledTimes(1);
+    expect(manager.getActiveSessionCount()).toBe(1);
+
+    await first.invoke(request('one'));
+    await second.invoke(request('two'));
+
+    expect(provider.invokeCount).toBe(2);
+    expect(manager.getSessionSnapshots()[0]).toMatchObject({
+      executionCapabilityProfile: 'session_bound_command',
+      state: 'active',
+      turnCount: 2,
+    });
+  });
+
+  it('uses fixture scope and project id to isolate sessions', () => {
+    const provider = new FakeProvider();
+    const manager = new CliSessionManager();
+
+    const principal = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    const projectA = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'project_thread',
+      projectId: PROJECT_ID,
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    const projectB = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'project_thread',
+      projectId: '550e8400-e29b-41d4-a716-446655440303',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+
+    expect(new Set([principal, projectA, projectB]).size).toBe(3);
+    expect(manager.getActiveSessionCount()).toBe(3);
+  });
+
+  it('tears down chat close, provider reassignment, and app shutdown scopes', () => {
+    const provider = new FakeProvider();
+    const manager = new CliSessionManager();
+
+    manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    manager.resolveForChatTurn({
+      providerId: OTHER_PROVIDER_ID,
+      sessionId: '550e8400-e29b-41d4-a716-446655440404',
+      scope: 'principal',
+      provider: new FakeProvider(config(OTHER_PROVIDER_ID)),
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+
+    manager.teardown('chat_close', { sessionId: SESSION_ID });
+    expect(manager.getActiveSessionCount()).toBe(1);
+
+    manager.teardown('provider_reassignment', { providerId: OTHER_PROVIDER_ID });
+    expect(manager.getActiveSessionCount()).toBe(0);
+
+    manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    manager.teardownAll();
+    expect(manager.getActiveSessionCount()).toBe(0);
+  });
+
+  it('defers explicit cancellation teardown until a busy turn completes', async () => {
+    let release!: () => void;
+    const provider = new FakeProvider();
+    vi.spyOn(provider, 'invoke').mockImplementationOnce(async (modelRequest) => {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return {
+        output: 'done',
+        providerId: provider.getConfig().id,
+        usage: {},
+        traceId: modelRequest.traceId,
+      };
+    });
+    const manager = new CliSessionManager();
+    const wrapped = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+
+    const pending = wrapped.invoke(request());
+    manager.teardown('explicit_cancellation', { sessionId: SESSION_ID });
+    expect(manager.getSessionSnapshots()[0]?.state).toBe('teardown');
+
+    release();
+    await pending;
+    expect(manager.getActiveSessionCount()).toBe(0);
+  });
+
+  it('removes crashed sessions and creates a fresh session on the next turn', async () => {
+    const provider = new FakeProvider();
+    const createPinnedProvider = vi.fn(({ provider: inner }) => inner);
+    const manager = new CliSessionManager({ createPinnedProvider });
+    const wrapped = manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+
+    provider.failNext = true;
+    await expect(wrapped.invoke(request())).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE',
+    });
+    expect(manager.getActiveSessionCount()).toBe(0);
+
+    manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider,
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    });
+    expect(createPinnedProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces restart failure without one-shot fallback', () => {
+    const manager = new CliSessionManager({
+      createPinnedProvider: () => {
+        throw new Error('spawn failed');
+      },
+    });
+
+    expect(() => manager.resolveForChatTurn({
+      providerId: PROVIDER_ID,
+      sessionId: SESSION_ID,
+      scope: 'principal',
+      provider: new FakeProvider(),
+      providerProtocol: AGENT_CLI_PROTOCOL_ID,
+    })).toThrowError(/restart failed/i);
+  });
+});

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -40,6 +40,14 @@ export { ChatCompletionsProvider } from './protocols/openai-api/provider.js';
 export { ProviderRegistry } from './runtime/provider-runtime.js';
 export type { ProviderRegistryOptions } from './runtime/provider-runtime.js';
 export {
+  CliSessionManager,
+  deriveProviderSessionKey,
+} from './runtime/cli-session-manager.js';
+export type {
+  CliSessionManagerOptions,
+  CliSessionSnapshot,
+} from './runtime/cli-session-manager.js';
+export {
   InferenceLane,
   InferenceLaneRegistry,
   LaneAwareProvider,

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -7,7 +7,7 @@ import { providerAdapter as openaiProviderAdapter } from './providers/openai/ada
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
-export { providerAdapter as codexCliAdapter, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
+export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
 

--- a/self/subcortex/providers/src/providers/codex-cli/adapter.ts
+++ b/self/subcortex/providers/src/providers/codex-cli/adapter.ts
@@ -16,6 +16,8 @@ const CODEX_CLI_ADAPTER_CAPABILITIES: AdapterCapabilities = {
   streaming: true,
 };
 
+export const CODEX_CLI_EXECUTION_CAPABILITY_PROFILE = 'session_bound_command' as const;
+
 export function createCodexCliAdapter(): ProviderAdapter {
   return {
     capabilities: CODEX_CLI_ADAPTER_CAPABILITIES,
@@ -80,6 +82,7 @@ export const providerAdapter = defineProviderAdapter({
   displayName: 'Codex CLI',
   protocol: AGENT_CLI_PROTOCOL_ID,
   capabilities: CODEX_CLI_ADAPTER_CAPABILITIES,
+  executionCapabilityProfile: CODEX_CLI_EXECUTION_CAPABILITY_PROFILE,
   create() {
     return createCodexCliAdapter();
   },

--- a/self/subcortex/providers/src/providers/codex-cli/definition.ts
+++ b/self/subcortex/providers/src/providers/codex-cli/definition.ts
@@ -68,6 +68,7 @@ export const CODEX_CLI_PROVIDER_DEFINITION = {
       spawnErrorKind: 'spawn_error',
     },
     caveats: [
+      'Transient and batch execution use the one-shot `codex exec` command path; chat-bound fixtures are mediated by the runtime CLI session manager using the adapter execution capability profile, currently `session_bound_command` for Codex CLI rather than a strict long-lived process protocol.',
       'Live process execution shells out to the local Codex CLI; tests must inject a fake runner.',
       'Provider output prefers Codex CLI `--output-last-message` so chat receives the final assistant response rather than the execution transcript.',
       'Streaming uses `codex exec --json` JSONL events and falls back to `--output-last-message` only when no assistant deltas were parsed.',

--- a/self/subcortex/providers/src/providers/codex-cli/index.ts
+++ b/self/subcortex/providers/src/providers/codex-cli/index.ts
@@ -1,4 +1,5 @@
 export {
+  CODEX_CLI_EXECUTION_CAPABILITY_PROFILE,
   createCodexCliAdapter,
   providerAdapter,
   renderCodexCliPrompt,

--- a/self/subcortex/providers/src/runtime/cli-session-manager.ts
+++ b/self/subcortex/providers/src/runtime/cli-session-manager.ts
@@ -1,0 +1,324 @@
+import {
+  NousError,
+  serializeProviderSessionKey,
+  type ChatFixtureScope,
+  type CliExecutionCapabilityProfile,
+  type CliSessionContext,
+  type CliSessionState,
+  type CliSessionTeardownReason,
+  type ICliSessionManager,
+  type IModelProvider,
+  type ModelProviderConfig,
+  type ModelRequest,
+  type ModelResponse,
+  type ModelStreamChunk,
+  type ProviderSessionKey,
+  type TeardownScope,
+} from '@nous/shared';
+import { AGENT_CLI_PROTOCOL_ID } from '../protocols/agent-cli/index.js';
+
+export interface CliSessionManagerOptions {
+  readonly createPinnedProvider?: (input: {
+    readonly key: ProviderSessionKey;
+    readonly serializedKey: string;
+    readonly executionCapabilityProfile: CliExecutionCapabilityProfile;
+    readonly provider: IModelProvider;
+  }) => IModelProvider;
+  readonly now?: () => number;
+}
+
+interface PinnedSession {
+  readonly key: ProviderSessionKey;
+  readonly serializedKey: string;
+  readonly executionCapabilityProfile: CliExecutionCapabilityProfile;
+  readonly provider: IModelProvider;
+  readonly wrapper: IModelProvider;
+  state: CliSessionState;
+  restartCount: number;
+  turnCount: number;
+  createdAt: number;
+  lastTurnAt: number;
+  pendingTeardownReason?: CliSessionTeardownReason;
+}
+
+export interface CliSessionSnapshot {
+  readonly key: ProviderSessionKey;
+  readonly serializedKey: string;
+  readonly executionCapabilityProfile: CliExecutionCapabilityProfile;
+  readonly state: CliSessionState;
+  readonly restartCount: number;
+  readonly turnCount: number;
+  readonly createdAt: number;
+  readonly lastTurnAt: number;
+}
+
+export class CliSessionManager implements ICliSessionManager {
+  private readonly sessions = new Map<string, PinnedSession>();
+  private readonly createPinnedProvider: NonNullable<CliSessionManagerOptions['createPinnedProvider']>;
+  private readonly now: () => number;
+
+  constructor(options: CliSessionManagerOptions = {}) {
+    this.createPinnedProvider = options.createPinnedProvider ?? ((input) => input.provider);
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  resolveForChatTurn(context: CliSessionContext): IModelProvider {
+    if (!isChatBoundAgentCliContext(context)) {
+      return context.provider;
+    }
+
+    const key = deriveProviderSessionKey(context);
+    const serializedKey = serializeProviderSessionKey(key);
+    const existing = this.sessions.get(serializedKey);
+    if (existing && existing.state !== 'dead' && existing.state !== 'teardown') {
+      return existing.wrapper;
+    }
+
+    const restartCount = existing ? existing.restartCount + 1 : 0;
+    const executionCapabilityProfile = resolveExecutionCapabilityProfile(context);
+    this.sessions.delete(serializedKey);
+    const provider = this.createSessionProvider(
+      key,
+      serializedKey,
+      executionCapabilityProfile,
+      context.provider,
+    );
+    const session: PinnedSession = {
+      key,
+      serializedKey,
+      executionCapabilityProfile,
+      provider,
+      wrapper: new SessionBoundProvider(this, serializedKey),
+      state: 'active',
+      restartCount,
+      turnCount: 0,
+      createdAt: this.now(),
+      lastTurnAt: 0,
+    };
+    this.sessions.set(serializedKey, session);
+    return session.wrapper;
+  }
+
+  teardown(reason: CliSessionTeardownReason, scope: TeardownScope = {}): void {
+    for (const [serializedKey, session] of this.sessions) {
+      if (!matchesTeardownScope(session.key, scope)) continue;
+
+      if (session.state === 'busy') {
+        session.state = 'teardown';
+        session.pendingTeardownReason = reason;
+        continue;
+      }
+
+      this.disposeSession(serializedKey);
+    }
+  }
+
+  teardownAll(): void {
+    this.teardown('app_shutdown', {});
+  }
+
+  getActiveSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  getSessionSnapshots(): CliSessionSnapshot[] {
+    return Array.from(this.sessions.values()).map((session) => ({
+      key: session.key,
+      serializedKey: session.serializedKey,
+      executionCapabilityProfile: session.executionCapabilityProfile,
+      state: session.state,
+      restartCount: session.restartCount,
+      turnCount: session.turnCount,
+      createdAt: session.createdAt,
+      lastTurnAt: session.lastTurnAt,
+    }));
+  }
+
+  private createSessionProvider(
+    key: ProviderSessionKey,
+    serializedKey: string,
+    executionCapabilityProfile: CliExecutionCapabilityProfile,
+    provider: IModelProvider,
+  ): IModelProvider {
+    try {
+      return this.createPinnedProvider({
+        key,
+        serializedKey,
+        executionCapabilityProfile,
+        provider,
+      });
+    } catch (error) {
+      throw new NousError(
+        'CLI provider session restart failed.',
+        'PROVIDER_SESSION_RESTART_FAILED',
+        {
+          providerId: key.providerId,
+          fixtureRole: key.fixtureRole,
+          chatSessionId: key.chatSessionId,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  runInvoke(serializedKey: string, request: ModelRequest): Promise<ModelResponse> {
+    return this.invoke(serializedKey, request);
+  }
+
+  runStream(serializedKey: string, request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    return this.stream(serializedKey, request);
+  }
+
+  getProviderConfig(serializedKey: string): ModelProviderConfig {
+    return this.requireSession(serializedKey).provider.getConfig();
+  }
+
+  private async invoke(serializedKey: string, request: ModelRequest): Promise<ModelResponse> {
+    const session = this.requireSession(serializedKey);
+    session.state = 'busy';
+    session.turnCount += 1;
+    session.lastTurnAt = this.now();
+
+    try {
+      const response = await session.provider.invoke(request);
+      this.completeTurn(serializedKey);
+      return response;
+    } catch (error) {
+      this.markDead(serializedKey);
+      throw error;
+    }
+  }
+
+  private async *stream(
+    serializedKey: string,
+    request: ModelRequest,
+  ): AsyncIterable<ModelStreamChunk> {
+    const session = this.requireSession(serializedKey);
+    session.state = 'busy';
+    session.turnCount += 1;
+    session.lastTurnAt = this.now();
+
+    try {
+      for await (const chunk of session.provider.stream(request)) {
+        yield chunk;
+      }
+      this.completeTurn(serializedKey);
+    } catch (error) {
+      this.markDead(serializedKey);
+      throw error;
+    }
+  }
+
+  private requireSession(serializedKey: string): PinnedSession {
+    const session = this.sessions.get(serializedKey);
+    if (!session || session.state === 'dead' || session.state === 'teardown') {
+      throw new NousError(
+        'CLI provider session is not available.',
+        'PROVIDER_SESSION_RESTART_FAILED',
+        { serializedKey },
+      );
+    }
+    return session;
+  }
+
+  private completeTurn(serializedKey: string): void {
+    const session = this.sessions.get(serializedKey);
+    if (!session) return;
+
+    if (session.pendingTeardownReason || session.state === 'teardown') {
+      this.disposeSession(serializedKey);
+      return;
+    }
+
+    session.state = 'active';
+  }
+
+  private markDead(serializedKey: string): void {
+    const session = this.sessions.get(serializedKey);
+    if (!session) return;
+    session.state = 'dead';
+    this.disposeSession(serializedKey);
+  }
+
+  private disposeSession(serializedKey: string): void {
+    const session = this.sessions.get(serializedKey);
+    if (!session) return;
+    this.sessions.delete(serializedKey);
+    disposeProvider(session.provider);
+  }
+}
+
+class SessionBoundProvider implements IModelProvider {
+  constructor(
+    private readonly manager: CliSessionManager,
+    private readonly serializedKey: string,
+  ) {}
+
+  getConfig() {
+    return this.manager.getProviderConfig(this.serializedKey);
+  }
+
+  invoke(request: ModelRequest): Promise<ModelResponse> {
+    return this.manager.runInvoke(this.serializedKey, request);
+  }
+
+  stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    return this.manager.runStream(this.serializedKey, request);
+  }
+}
+
+function isChatBoundAgentCliContext(context: CliSessionContext): boolean {
+  return context.providerProtocol === AGENT_CLI_PROTOCOL_ID &&
+    typeof context.sessionId === 'string' &&
+    context.sessionId.length > 0 &&
+    context.scope !== undefined;
+}
+
+function resolveExecutionCapabilityProfile(
+  context: CliSessionContext,
+): CliExecutionCapabilityProfile {
+  return context.executionCapabilityProfile ?? 'session_bound_command';
+}
+
+export function deriveProviderSessionKey(context: CliSessionContext): ProviderSessionKey {
+  if (!context.sessionId || !context.scope) {
+    throw new NousError(
+      'CLI session context is missing chat session identity.',
+      'PROVIDER_SESSION_RESTART_FAILED',
+      { providerId: context.providerId },
+    );
+  }
+
+  const fixtureRole = context.scope;
+  return {
+    providerId: context.providerId,
+    fixtureRole,
+    ...(isProjectScoped(fixtureRole, context.projectId)
+      ? { projectId: context.projectId }
+      : {}),
+    chatSessionId: context.sessionId,
+  };
+}
+
+function isProjectScoped(
+  fixtureRole: ChatFixtureScope,
+  projectId: string | undefined,
+): projectId is string {
+  return fixtureRole === 'project_thread' && typeof projectId === 'string' && projectId.length > 0;
+}
+
+function matchesTeardownScope(key: ProviderSessionKey, scope: TeardownScope): boolean {
+  if (scope.providerId !== undefined && key.providerId !== scope.providerId) return false;
+  if (scope.sessionId !== undefined && key.chatSessionId !== scope.sessionId) return false;
+  if (scope.fixtureRole !== undefined && key.fixtureRole !== scope.fixtureRole) return false;
+  return true;
+}
+
+function disposeProvider(provider: IModelProvider): void {
+  const disposable = provider as { dispose?: () => void };
+  try {
+    disposable.dispose?.();
+  } catch {
+    // Teardown must be best-effort and never mask the original lifecycle path.
+  }
+}

--- a/self/subcortex/providers/src/runtime/provider-runtime.ts
+++ b/self/subcortex/providers/src/runtime/provider-runtime.ts
@@ -238,7 +238,11 @@ export class ProviderRegistry {
     // honors any upstream stamping (constructor entry loop / registerProvider)
     // and fills in the field if the caller bypassed the upstream sites.
     const resolvedVendor = baseConfig.vendor ?? this.resolveVendor(baseConfig);
-    if (!KNOWN_PROVIDER_VENDORS.includes(resolvedVendor as (typeof KNOWN_PROVIDER_VENDORS)[number])) {
+    const providerFactory = resolveProviderFactory(resolvedVendor);
+    if (
+      !providerFactory &&
+      !KNOWN_PROVIDER_VENDORS.includes(resolvedVendor as (typeof KNOWN_PROVIDER_VENDORS)[number])
+    ) {
       console.info(
         `[nous:providers] Provider ${baseConfig.id} stamped with unknown vendor ` +
           `'${resolvedVendor}' — adapter will fall back to text. Add a vendor ` +
@@ -249,7 +253,6 @@ export class ProviderRegistry {
       ...baseConfig,
       vendor: resolvedVendor,
     };
-    const providerFactory = resolveProviderFactory(resolvedVendor);
     const provider = providerFactory
       ? providerFactory.create(normalizedConfig, {
           apiKey: this.resolveRemoteApiKey(normalizedConfig),

--- a/self/subcortex/providers/src/schemas/provider-adapter.ts
+++ b/self/subcortex/providers/src/schemas/provider-adapter.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type {
+  CliExecutionCapabilityProfile,
   GatewayContextFrame,
   ILogChannel,
   ModelRequirements,
@@ -29,6 +30,12 @@ export const AdapterCapabilitiesSchema = z.object({
   extendedThinking: z.boolean(),
   streaming: z.boolean(),
 }).strict();
+
+export const AdapterExecutionCapabilityProfileSchema = z.enum([
+  'one_shot_command',
+  'session_bound_command',
+  'persistent_process',
+]);
 
 /**
  * Input to the adapter's request formatter.
@@ -88,6 +95,7 @@ export interface ProviderAdapterModule {
   readonly displayName: string;
   readonly protocol: string;
   readonly capabilities: AdapterCapabilities;
+  readonly executionCapabilityProfile?: CliExecutionCapabilityProfile;
   create(options?: ProviderAdapterCreateOptions): ProviderAdapter;
 }
 
@@ -96,6 +104,7 @@ export const ProviderAdapterModuleSchema = z.object({
   displayName: z.string().min(1),
   protocol: z.string().min(1),
   capabilities: AdapterCapabilitiesSchema,
+  executionCapabilityProfile: AdapterExecutionCapabilityProfileSchema.optional(),
   create: z.function(),
 }).strict();
 


### PR DESCRIPTION
## Summary

- Add shared CLI session contracts (fixture scopes, session keys, teardown, execution capability profiles)
- Implement `CliSessionManager` with fixture-aware session key derivation, chat-bound provider wrapper reuse, scoped teardown, and restart failure surfacing
- Codex CLI adapter declares `session_bound_command` execution capability profile
- CortexRuntime propagates chat fixture context and adapter execution capability into session management
- Shared-server bootstrap creates, wires, and tears down the session manager
- Fix: suppress unknown-vendor warning only when a generated factory is absent
- Tests cover session lifecycle, one-shot preservation, adapter capability, and provider diagnostic behavior

## WR

WR-177

## Test plan

- [x] `pnpm typecheck` — all affected packages pass
- [x] `pnpm lint` — 0 errors (140 pre-existing warnings)
- [x] `pnpm test` — 609 files, 6085 tests passed
- [x] `pnpm build` — deferred under approved external EBUSY exception

Generated with Claude Code