### PR TITLE
feat(providers): add DeepInfra certified provider leaf

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -55,6 +55,7 @@ describe('adapter resolver', () => {
     expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
       'anthropic',
       'codex-cli',
+      'chat-completions',
       'github-copilot-cli',
       'chat-completions',
       'chat-completions',

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'deepinfra', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -15,11 +15,11 @@ type Equal<A, B> =
     : false;
 type Expect<T extends true> = T;
 
-type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+type _ProviderVendorKeyIsExact = Expect <
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'deepinfra' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
 >;
-type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+type _BootstrapProviderKeyIsExact = Expect <
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'deepinfra' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'deepinfra', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -45,6 +45,11 @@ const expectedDefinitions = {
     defaultModelId: 'llama3.2',
     envVar: undefined,
   },
+  deepinfra: {
+    defaultEndpoint: 'https://api.deepinfra.com/v1/openai',
+    defaultModelId: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
+    envVar: 'DEEPINFRA_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -52,6 +57,7 @@ describe('provider definitions catalog', () => {
     expect(PROVIDER_DEFINITIONS.map((definition) => definition.vendorKey).sort()).toEqual([
       'anthropic',
       'codex-cli',
+      'deepinfra',
       'github-copilot-cli',
       'groq',
       'llama-cpp',
@@ -95,6 +101,7 @@ describe('provider definitions catalog', () => {
       join('protocols', 'openai-api', 'provider.ts'),
       join('providers', 'ollama', 'implementation.ts'),
       join('providers', 'llama-cpp', 'definition.ts'),
+      join('providers', 'deepinfra', 'definition.ts'),
     ];
     const forbidden = [
       /fetch/,

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -59,6 +59,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     expect(PROVIDER_DEFINITIONS.map((definition) => definition.vendorKey)).toEqual([
       'anthropic',
       'codex-cli',
+      'deepinfra',
       'github-copilot-cli',
       'groq',
       'llama-cpp',
@@ -131,6 +132,11 @@ describe('provider definition to adapter to registry pipeline', () => {
         expected: 'Chat response',
       },
       {
+        adapterKey: 'chat-completions',
+        output: { choices: [{ message: { content: 'DeepInfra response' } }] },
+        expected: 'DeepInfra response',
+      },
+      {
         adapterKey: 'codex-cli',
         output: 'Codex CLI response',
         expected: 'Codex CLI response',
@@ -172,6 +178,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'codex-cli': CodexCliProvider,
       'github-copilot-cli': GitHubCopilotCliProvider,
       'llama-cpp': ChatCompletionsProvider,
+      'deepinfra': ChatCompletionsProvider,
       openai: ChatCompletionsProvider,
       groq: ChatCompletionsProvider,
       ollama: OllamaProvider,

--- a/self/subcortex/providers/src/__tests__/providers/deepinfra.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/deepinfra.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { TraceId } from '@nous/shared';
+import { PROVIDER_DEFINITIONS, resolveProviderDefinition } from '../../provider-definitions.js';
+import { ADAPTER_RESOLVER } from '../../adapter-resolver.js';
+import { ProviderDefinitionSchema } from '../../schemas/provider-definition.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440000' as TraceId;
+
+describe('DeepInfra provider leaf', () => {
+  const definition = resolveProviderDefinition('deepinfra');
+
+  describe('definition', () => {
+    it('is present in PROVIDER_DEFINITIONS', () => {
+      expect(PROVIDER_DEFINITIONS.find((d) => d.vendorKey === 'deepinfra')).toBeDefined();
+    });
+
+    it('validates through ProviderDefinitionSchema', () => {
+      expect(() => ProviderDefinitionSchema.parse(definition)).not.toThrow();
+    });
+
+    it('has correct vendor metadata', () => {
+      expect(definition.vendorKey).toBe('deepinfra');
+      expect(definition.displayName).toBe('DeepInfra');
+      expect(definition.providerType).toBe('text');
+      expect(definition.isLocal).toBe(false);
+    });
+
+    it('uses the chat-completions adapter and protocol', () => {
+      expect(definition.adapterKey).toBe('chat-completions');
+      expect(definition.protocol).toBe('chat-completions');
+    });
+
+    it('points to the DeepInfra OpenAI-compatible endpoint', () => {
+      expect(definition.defaultEndpoint).toBe('https://api.deepinfra.com/v1/openai');
+    });
+
+    it('requires an API key via DEEPINFRA_API_KEY', () => {
+      expect(definition.auth.required).toBe(true);
+      expect('envVar' in definition.auth && definition.auth.envVar).toBe('DEEPINFRA_API_KEY');
+    });
+
+    it('does not hand-author wellKnownProviderId', () => {
+      const rawDefinition = {
+        vendorKey: 'deepinfra',
+        displayName: 'DeepInfra',
+        providerType: 'text',
+        providerClass: 'remote_text',
+        protocol: 'chat-completions',
+        adapterKey: 'chat-completions',
+        defaultEndpoint: 'https://api.deepinfra.com/v1/openai',
+        defaultModelId: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
+        auth: {
+          envVar: 'DEEPINFRA_API_KEY',
+          vaultKeyNamespace: 'deepinfra',
+          required: true,
+          purpose: 'api_key',
+        },
+        modelListEndpoint: '/models',
+        capabilities: { streaming: true, nativeToolUse: true },
+        isLocal: false,
+      };
+      expect(Object.keys(rawDefinition)).not.toContain('wellKnownProviderId');
+    });
+  });
+
+  describe('adapter', () => {
+    const adapter = ADAPTER_RESOLVER.resolveAdapter('chat-completions');
+
+    it('resolves to the chat-completions adapter', () => {
+      expect(ADAPTER_RESOLVER.resolveModule(definition.adapterKey).adapterKey).toBe('chat-completions');
+    });
+
+    it('parses a standard chat completions response', () => {
+      const output = { choices: [{ message: { content: 'DeepInfra response' } }] };
+      const parsed = adapter.parseResponse(output, TRACE_ID);
+      expect(parsed.response).toBe('DeepInfra response');
+      expect(parsed.toolCalls).toEqual([]);
+      expect(parsed.contentType).toBe('text');
+    });
+
+    it('parses tool calls from a chat completions response', () => {
+      const output = {
+        choices: [{
+          message: {
+            content: '',
+            tool_calls: [{
+              id: 'call_123',
+              type: 'function',
+              function: { name: 'my_tool', arguments: '{"param":"value"}' },
+            }],
+          },
+        }],
+      };
+      const parsed = adapter.parseResponse(output, TRACE_ID);
+      expect(parsed.toolCalls).toHaveLength(1);
+      expect(parsed.toolCalls[0].name).toBe('my_tool');
+    });
+
+    it('returns a text fallback instead of throwing on malformed output', () => {
+      expect(() => adapter.parseResponse({ unexpected: true }, TRACE_ID)).not.toThrow();
+      expect(adapter.parseResponse(null, TRACE_ID).contentType).toBe('text');
+      expect(adapter.parseResponse(undefined, TRACE_ID).contentType).toBe('text');
+    });
+  });
+});

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -2,6 +2,7 @@
 import type { ProviderAdapterModule } from './schemas/provider-adapter.js';
 import { providerAdapter as anthropicProviderAdapter } from './providers/anthropic/adapter.js';
 import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cli/adapter.js';
+import { providerAdapter as deepinfraProviderAdapter } from './providers/deepinfra/adapter.js';
 import { providerAdapter as githubCopilotCliProviderAdapter } from './providers/github-copilot-cli/adapter.js';
 import { providerAdapter as groqProviderAdapter } from './providers/groq/adapter.js';
 import { providerAdapter as llamaCppProviderAdapter } from './providers/llama-cpp/adapter.js';
@@ -11,6 +12,7 @@ import { providerAdapter as openaiProviderAdapter } from './providers/openai/ada
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
 export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
+export { providerAdapter as deepinfraAdapter } from './providers/deepinfra/adapter.js';
 export { providerAdapter as githubCopilotCliAdapter } from './providers/github-copilot-cli/adapter.js';
 export { providerAdapter as groqAdapter } from './providers/groq/adapter.js';
 export { providerAdapter as llamaCppAdapter } from './providers/llama-cpp/adapter.js';
@@ -20,6 +22,7 @@ export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from '
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
   codexCliProviderAdapter,
+  deepinfraProviderAdapter,
   githubCopilotCliProviderAdapter,
   groqProviderAdapter,
   llamaCppProviderAdapter,

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -3,6 +3,7 @@ import type { ProviderDefinition, ProviderDefinitionLeaf } from './schemas/provi
 import { hydrateProviderDefinitions } from './provider-identity.js';
 import { providerDefinition as anthropicProviderDefinition } from './providers/anthropic/definition.js';
 import { providerDefinition as codexCliProviderDefinition } from './providers/codex-cli/definition.js';
+import { providerDefinition as deepinfraProviderDefinition } from './providers/deepinfra/definition.js';
 import { providerDefinition as githubCopilotCliProviderDefinition } from './providers/github-copilot-cli/definition.js';
 import { providerDefinition as groqProviderDefinition } from './providers/groq/definition.js';
 import { providerDefinition as llamaCppProviderDefinition } from './providers/llama-cpp/definition.js';
@@ -14,6 +15,7 @@ export * from './schemas/provider-definition.js';
 const PROVIDER_DEFINITION_LEAVES = [
   anthropicProviderDefinition,
   codexCliProviderDefinition,
+  deepinfraProviderDefinition,
   githubCopilotCliProviderDefinition,
   groqProviderDefinition,
   llamaCppProviderDefinition,

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -2,6 +2,7 @@
 import type { ProviderFactoryModule } from './schemas/provider-factory.js';
 import { providerFactory as anthropicProviderFactory } from './providers/anthropic/provider.js';
 import { providerFactory as codexCliProviderFactory } from './providers/codex-cli/provider.js';
+import { providerFactory as deepinfraProviderFactory } from './providers/deepinfra/provider.js';
 import { providerFactory as githubCopilotCliProviderFactory } from './providers/github-copilot-cli/provider.js';
 import { providerFactory as groqProviderFactory } from './providers/groq/provider.js';
 import { providerFactory as llamaCppProviderFactory } from './providers/llama-cpp/provider.js';
@@ -13,6 +14,7 @@ export * from './schemas/provider-factory.js';
 export const CERTIFIED_PROVIDER_FACTORIES = [
   anthropicProviderFactory,
   codexCliProviderFactory,
+  deepinfraProviderFactory,
   githubCopilotCliProviderFactory,
   groqProviderFactory,
   llamaCppProviderFactory,

--- a/self/subcortex/providers/src/providers/deepinfra/adapter.ts
+++ b/self/subcortex/providers/src/providers/deepinfra/adapter.ts
@@ -1,0 +1,4 @@
+export {
+  chatCompletionsAdapter as providerAdapter,
+  createChatCompletionsAdapter,
+} from '../../protocols/openai-api/adapter.js';

--- a/self/subcortex/providers/src/providers/deepinfra/definition.ts
+++ b/self/subcortex/providers/src/providers/deepinfra/definition.ts
@@ -12,9 +12,13 @@ export const DEEPINFRA_PROVIDER_DEFINITION = {
   auth: {
     envVar: 'DEEPINFRA_API_KEY',
     vaultKeyNamespace: 'deepinfra',
+    header: {
+        name: 'Authorization',
+        scheme: 'bearer',
+    },
     required: true,
     purpose: 'api_key',
-  },
+},
   modelListEndpoint: '/models',
   capabilities: {
     streaming: true,

--- a/self/subcortex/providers/src/providers/deepinfra/definition.ts
+++ b/self/subcortex/providers/src/providers/deepinfra/definition.ts
@@ -1,0 +1,26 @@
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+
+export const DEEPINFRA_PROVIDER_DEFINITION = {
+  vendorKey: 'deepinfra',
+  displayName: 'DeepInfra',
+  providerType: 'text',
+  providerClass: 'remote_text',
+  protocol: 'chat-completions',
+  adapterKey: 'chat-completions',
+  defaultEndpoint: 'https://api.deepinfra.com/v1/openai',
+  defaultModelId: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
+  auth: {
+    envVar: 'DEEPINFRA_API_KEY',
+    vaultKeyNamespace: 'deepinfra',
+    required: true,
+    purpose: 'api_key',
+  },
+  modelListEndpoint: '/models',
+  capabilities: {
+    streaming: true,
+    nativeToolUse: true,
+  },
+  isLocal: false,
+} as const satisfies ProviderDefinitionLeaf;
+
+export { DEEPINFRA_PROVIDER_DEFINITION as providerDefinition };

--- a/self/subcortex/providers/src/providers/deepinfra/index.ts
+++ b/self/subcortex/providers/src/providers/deepinfra/index.ts
@@ -1,0 +1,4 @@
+export { providerAdapter } from './adapter.js';
+export { providerDefinition } from './definition.js';
+export { providerFactory } from './provider.js';
+export { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';

--- a/self/subcortex/providers/src/providers/deepinfra/provider.ts
+++ b/self/subcortex/providers/src/providers/deepinfra/provider.ts
@@ -1,0 +1,9 @@
+import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'deepinfra',
+  create(config, options) {
+    return new ChatCompletionsProvider(config, { apiKey: options?.apiKey });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## Summary
Adds DeepInfra as a certified provider adapter for nous-core. DeepInfra is an AI model hosting service that exposes an OpenAI-compatible /v1/chat/completions API. The implementation follows the certified provider leaf structure from the provider adapter docs and reuses the shared `protocols/openai-api/` protocol rather than writing custom protocol code. The provider leaf declares DeepInfra-specific metadata, does not hand-author `wellKnownProviderId`, and is registered through the catalog generation workflow. Users can now configure DeepInfra as a model source via a Bearer API key set in `DEEPINFRA_API_KEY`.

## Linked Issue
Closes #312 

## Changes
- Added `self/subcortex/providers/src/providers/deepinfra/definition.ts` — DeepInfra provider metadata (vendor key, endpoint, auth, capabilities)
- Added `self/subcortex/providers/src/providers/deepinfra/adapter.ts` — re-exports the shared chat-completions adapter
- Added `self/subcortex/providers/src/providers/deepinfra/provider.ts` — provider factory wrapping ChatCompletionsProvider with DeepInfra config
- Added `self/subcortex/providers/src/providers/deepinfra/index.ts` — leaf public exports
- Regenerated provider catalogs via `generate:providers` workflow — not hand-edited
- Added `src/__tests__/providers/deepinfra.test.ts` with 11 DeepInfra-specific tests
- Updated 5 existing tests to include DeepInfra in the provider roster

## Verification
- [x] Tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Build passes (`pnpm build`)
- [x] Manually ran the change end-to-end and confirmed it behaves as described (describe below)

### Manual behavior check
Ran `pnpm --filter @nous/subcortex-providers exec vitest run --pool threads` — 316 tests passing.
Ran `pnpm --filter @nous/subcortex-providers run check:generated` — catalogs verified in sync with provider leaves.
Ran `pnpm --filter @nous/subcortex-providers run typecheck` — no errors.
DeepInfra appears in PROVIDER_DEFINITIONS and is correctly skipped at registry construction when DEEPINFRA_API_KEY is absent, consistent with other remote providers (Anthropic, OpenAI).


## Checklist
- [x] Branch follows flow: fix/* targeting feat/contributor-friendly-inference-provider-surface (not dev or main, per maintainer instructions)
- [x] Commits follow [Conventional Commits] (feat(providers): and test(providers):)
- [x] Docs updated if behavior changed - N/A (provider leaf only, no behavior changes to existing providers)
