### PR TITLE
feat(providers): add OpenClaw CLI provider leaf

### DIFF
--- a/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
+++ b/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
@@ -139,6 +139,7 @@ function providerAdapterExtraExports(vendor) {
     ['anthropic', ['createAnthropicAdapter']],
     ['codex-cli', ['CODEX_CLI_EXECUTION_CAPABILITY_PROFILE', 'createCodexCliAdapter', 'renderCodexCliPrompt']],
     ['ollama', ['createOllamaAdapter', 'isToolCapableModel']],
+    ['openclaw', ['OPENCLAW_EXECUTION_CAPABILITY_PROFILE', 'createOpenClawAdapter', 'renderOpenClawPrompt']],
     ['openai', ['createChatCompletionsAdapter']],
   ]);
   const extras = extrasByVendor.get(vendor) ?? [];

--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -54,6 +54,7 @@ describe('adapter resolver', () => {
       'codex-cli',
       'ollama',
       'chat-completions',
+      'openclaw',
       'text',
     ]);
   });

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai', 'openclaw']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama' | 'openclaw'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama' | 'openclaw'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai', 'openclaw']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -30,6 +30,11 @@ const expectedDefinitions = {
     defaultModelId: 'llama3.2',
     envVar: undefined,
   },
+  openclaw: {
+    defaultEndpoint: 'http://localhost',
+    defaultModelId: 'openclaw/default',
+    envVar: undefined,
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -39,6 +44,7 @@ describe('provider definitions catalog', () => {
       'codex-cli',
       'ollama',
       'openai',
+      'openclaw',
     ]);
   });
 
@@ -74,6 +80,7 @@ describe('provider definitions catalog', () => {
     const providerFiles = [
       join('providers', 'anthropic', 'implementation.ts'),
       join('providers', 'codex-cli', 'definition.ts'),
+      join('providers', 'openclaw', 'definition.ts'),
       join('protocols', 'openai-api', 'provider.ts'),
       join('providers', 'ollama', 'implementation.ts'),
     ];

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -9,6 +9,7 @@ import {
   CERTIFIED_PROVIDER_FACTORIES,
   CodexCliProvider,
   OllamaProvider,
+  OpenClawProvider,
   PROVIDER_DEFINITIONS,
   ProviderRegistry,
   buildAdapterResolver,
@@ -55,6 +56,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'codex-cli',
       'ollama',
       'openai',
+      'openclaw',
     ]);
     expect(resolveProviderDefinition('anthropic').defaultModelId).toBe(
       'claude-sonnet-4-20250514',
@@ -162,6 +164,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'codex-cli': CodexCliProvider,
       openai: ChatCompletionsProvider,
       ollama: OllamaProvider,
+      openclaw: OpenClawProvider,
     };
 
     for (const definition of PROVIDER_DEFINITIONS) {

--- a/self/subcortex/providers/src/__tests__/providers/openclaw.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/openclaw.test.ts
@@ -15,11 +15,14 @@ import {
   OPENCLAW_PROVIDER_DEFINITION,
   OpenClawProvider,
   createOpenClawAdapter,
+  createOpenClawProcessRunner,
+  planOpenClawSpawn,
   providerAdapter,
   providerDefinition,
   providerFactory,
   renderOpenClawPrompt,
   selectOpenClawExecutable,
+  type OpenClawRunnerOptions,
 } from '../../providers/openclaw/index.js';
 import { createFakeAgentCliRunner } from '../../protocols/agent-cli/index.js';
 import { AgentCliProviderMetadataSchema } from '../../schemas/provider-definition.js';
@@ -271,3 +274,130 @@ describe('OpenClaw provider leaf', () => {
     expect(OPENCLAW_AGENT_ADAPTER.metadata.protocolId).toBe('agent-cli');
   });
 });
+
+describe('planOpenClawSpawn (shell-safe argv)', () => {
+  it('spawns the executable directly with literal argv on POSIX', () => {
+    const plan = planOpenClawSpawn('openclaw', ['run', '--model', 'pro && rm -rf /'], {
+      platform: 'linux',
+    });
+
+    expect(plan).toEqual({
+      command: 'openclaw',
+      args: ['run', '--model', 'pro && rm -rf /'],
+      windowsVerbatimArguments: false,
+    });
+  });
+
+  it('prefers a native .exe over a .cmd shim on Windows and keeps literal argv', () => {
+    const plan = planOpenClawSpawn('openclaw', ['--model', 'pro'], {
+      platform: 'win32',
+      commandResolver: () => 'C:\\bin\\openclaw.cmd\r\nC:\\bin\\openclaw.exe\r\n',
+    });
+
+    expect(plan).toEqual({
+      command: 'C:\\bin\\openclaw.exe',
+      args: ['--model', 'pro'],
+      windowsVerbatimArguments: false,
+    });
+  });
+
+  it('routes a .cmd shim through cmd.exe with every argument escaped', () => {
+    const plan = planOpenClawSpawn('openclaw', ['--model', 'pro && echo INJECTED'], {
+      platform: 'win32',
+      comspec: 'cmd.exe',
+      commandResolver: () => 'C:\\bin\\openclaw.cmd\r\n',
+    });
+
+    expect(plan.command).toBe('cmd.exe');
+    expect(plan.windowsVerbatimArguments).toBe(true);
+    expect(plan.args.slice(0, 3)).toEqual(['/d', '/s', '/c']);
+    // The model id reaches cmd.exe with its metacharacters caret-escaped, never
+    // interpreted as a command separator.
+    const modelArg = plan.args.at(-1) ?? '';
+    expect(modelArg).toContain('^&^&');
+    expect(modelArg).not.toMatch(/(^|[^^])&&/);
+  });
+
+  it('uses an explicit executable path verbatim without PATH resolution', () => {
+    const plan = planOpenClawSpawn('/custom/openclaw.cmd', ['--model', 'pro'], {
+      platform: 'win32',
+      comspec: 'cmd.exe',
+      commandResolver: () => {
+        throw new Error('resolver should not be called for explicit paths');
+      },
+    });
+
+    expect(plan.args[3]).toBe(escapeForAssertion('/custom/openclaw.cmd'));
+  });
+});
+
+describe('OpenClaw live process runner', () => {
+  it('passes user-controlled args as literal argv without shell interpretation', async () => {
+    const runner = createOpenClawProcessRunner();
+    const malicious = 'pro && echo INJECTED';
+
+    const result = await runner.run({
+      command: {
+        executable: process.execPath,
+        // `--` ends node's own option parsing; everything after is script argv.
+        args: ['-e', 'process.stdout.write(JSON.stringify(process.argv.slice(1)))', '--', '--model', malicious],
+      },
+      timeoutMs: 15_000,
+    });
+
+    expect(result.ok).toBe(true);
+    const argv = JSON.parse(result.stdout) as string[];
+    // The dangerous value survives as a single literal argv token; the `&&` is
+    // never executed (no standalone "INJECTED" was produced by a shell).
+    expect(argv).toEqual(['--model', malicious]);
+  });
+
+  it('kills the child process when the abort signal fires after spawn', async () => {
+    const runner = createOpenClawProcessRunner();
+    const controller = new AbortController();
+    const options: OpenClawRunnerOptions = { abortSignal: controller.signal };
+
+    const started = Date.now();
+    const pending = runner.run(
+      {
+        command: {
+          executable: process.execPath,
+          // Sleep far longer than the test would tolerate if abort did nothing.
+          args: ['-e', 'setInterval(() => {}, 1000)'],
+        },
+        timeoutMs: 30_000,
+      },
+      options,
+    );
+
+    setTimeout(() => controller.abort(), 100);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    // Resolved promptly because the child was terminated, not run to timeout.
+    expect(Date.now() - started).toBeLessThan(10_000);
+  });
+
+  it('reports a pre-start abort without spawning a process', async () => {
+    const runner = createOpenClawProcessRunner();
+    const controller = new AbortController();
+    controller.abort();
+    const options: OpenClawRunnerOptions = { abortSignal: controller.signal };
+
+    const result = await runner.run(
+      {
+        command: { executable: process.execPath, args: ['-e', 'process.exit(0)'] },
+        timeoutMs: 5_000,
+      },
+      options,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+// Mirrors the cmd.exe escaping in planOpenClawSpawn for assertion purposes.
+function escapeForAssertion(arg: string): string {
+  const quoted = `"${arg.replace(/"/g, '""')}"`;
+  return quoted.replace(/[()%!^"<>&|]/g, '^$&');
+}

--- a/self/subcortex/providers/src/__tests__/providers/openclaw.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/openclaw.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+import {
+  NousError,
+  type GatewayContextFrame,
+  type ModelProviderConfig,
+  type ModelStreamChunk,
+  type ProviderId,
+  type ToolDefinition,
+  type TraceId,
+} from '@nous/shared';
+import {
+  OPENCLAW_AGENT_ADAPTER,
+  OPENCLAW_DEFAULT_MODEL_ID,
+  OPENCLAW_EXECUTION_CAPABILITY_PROFILE,
+  OPENCLAW_PROVIDER_DEFINITION,
+  OpenClawProvider,
+  createOpenClawAdapter,
+  providerAdapter,
+  providerDefinition,
+  providerFactory,
+  renderOpenClawPrompt,
+  selectOpenClawExecutable,
+} from '../../providers/openclaw/index.js';
+import { createFakeAgentCliRunner } from '../../protocols/agent-cli/index.js';
+import { AgentCliProviderMetadataSchema } from '../../schemas/provider-definition.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440177' as TraceId;
+const PROVIDER_ID = '20000000-0000-0000-0000-0000000000c1' as ProviderId;
+const CREATED_AT = '2026-06-21T00:00:00.000Z';
+
+function createConfig(modelId = OPENCLAW_DEFAULT_MODEL_ID): ModelProviderConfig {
+  return {
+    id: PROVIDER_ID,
+    name: 'OpenClaw',
+    type: 'text',
+    endpoint: 'http://localhost',
+    modelId,
+    isLocal: true,
+    capabilities: ['text'],
+    providerClass: 'local_text',
+    vendor: 'openclaw',
+  };
+}
+
+function frame(role: GatewayContextFrame['role'], content: string): GatewayContextFrame {
+  return {
+    role,
+    source: 'initial_context',
+    content,
+    createdAt: CREATED_AT,
+  };
+}
+
+function toolDefinition(): ToolDefinition {
+  return {
+    name: 'lookup',
+    version: '1.0.0',
+    description: 'Lookup data',
+    inputSchema: { type: 'object' },
+    outputSchema: { type: 'object' },
+    capabilities: ['lookup'],
+    permissionScope: 'test',
+  };
+}
+
+async function collectStream(
+  stream: AsyncIterable<ModelStreamChunk>,
+): Promise<ModelStreamChunk[]> {
+  const chunks: ModelStreamChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+describe('OpenClaw provider leaf', () => {
+  it('declares Agent CLI catalog metadata without introducing nested taxonomy', () => {
+    expect(providerDefinition).toBe(OPENCLAW_PROVIDER_DEFINITION);
+    expect(providerDefinition).toMatchObject({
+      vendorKey: 'openclaw',
+      protocol: 'agent-cli',
+      adapterKey: 'openclaw',
+      providerClass: 'local_text',
+      isLocal: true,
+      executionCapabilityProfile: 'session_bound_command',
+      capabilities: {
+        streaming: true,
+      },
+    });
+    expect(AgentCliProviderMetadataSchema.parse(providerDefinition.agentCli))
+      .toEqual(providerDefinition.agentCli);
+    expect(providerDefinition.agentCli.command.defaultArgs).toEqual([
+      'run',
+      '--headless',
+      '--no-color',
+    ]);
+    expect(providerFactory.vendorKey).toBe('openclaw');
+  });
+
+  it('formats canonical gateway input into an OpenClaw prompt string', () => {
+    const prompt = renderOpenClawPrompt({
+      systemPrompt: ['system one', 'system two'],
+      context: [
+        frame('user', 'hello'),
+        frame('assistant', 'hi there'),
+      ],
+      toolDefinitions: [toolDefinition()],
+    });
+
+    expect(prompt).toContain('system one\n\nsystem two');
+    expect(prompt).toContain('user: hello');
+    expect(prompt).toContain('assistant: hi there');
+    expect(prompt).toContain('Available tools:');
+    expect(prompt).toContain('"name": "lookup"');
+  });
+
+  it('exposes a ProviderAdapter module for openclaw with text-safe parsing', () => {
+    const adapter = createOpenClawAdapter();
+
+    expect(providerAdapter.executionCapabilityProfile).toBe(OPENCLAW_EXECUTION_CAPABILITY_PROFILE);
+    expect(OPENCLAW_EXECUTION_CAPABILITY_PROFILE).toBe('session_bound_command');
+    expect(adapter.capabilities.streaming).toBe(true);
+    expect(adapter.formatRequest({
+      systemPrompt: 'Act as OpenClaw.',
+      context: [frame('user', 'Implement the task.')],
+    })).toEqual({
+      input: {
+        prompt: 'Act as OpenClaw.\n\nuser: Implement the task.',
+      },
+    });
+    // Non-JSON output falls back to a plain text response instead of throwing.
+    expect(adapter.parseResponse('done', TRACE_ID)).toMatchObject({
+      response: 'done',
+      toolCalls: [],
+      contentType: 'text',
+    });
+  });
+
+  it('invokes an injected Agent CLI runner and returns stdout as model output', async () => {
+    const runner = createFakeAgentCliRunner([
+      (invocation) => ({
+        exitCode: 0,
+        stdout: `openclaw saw: ${invocation.input}\n`,
+        startedAt: 100,
+        endedAt: 180,
+      }),
+    ]);
+    const provider = new OpenClawProvider(createConfig('claw-pro'), { runner });
+
+    const response = await provider.invoke({
+      role: 'workers',
+      input: { prompt: 'Build the provider leaf.' },
+      traceId: TRACE_ID,
+    });
+
+    expect(response).toEqual({
+      output: 'openclaw saw: Build the provider leaf.',
+      providerId: PROVIDER_ID,
+      usage: { computeMs: 80 },
+      traceId: TRACE_ID,
+    });
+    expect(runner.invocations[0]).toMatchObject({
+      command: {
+        executable: 'openclaw',
+        env: { NO_COLOR: '1' },
+      },
+      input: 'Build the provider leaf.',
+      timeoutMs: 300_000,
+      metadata: {
+        provider: 'openclaw',
+        providerId: PROVIDER_ID,
+        modelId: 'claw-pro',
+        traceId: TRACE_ID,
+      },
+    });
+    expect(runner.invocations[0]?.command.args).toEqual([
+      'run',
+      '--headless',
+      '--no-color',
+      '--model',
+      'claw-pro',
+    ]);
+  });
+
+  it('uses OpenClaw defaults without passing a synthetic default model', async () => {
+    const runner = createFakeAgentCliRunner();
+    const provider = new OpenClawProvider(createConfig(), { runner });
+
+    await provider.invoke({
+      role: 'workers',
+      input: {
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+      },
+      traceId: TRACE_ID,
+    });
+
+    expect(runner.invocations[0]?.command.args).toEqual([
+      'run',
+      '--headless',
+      '--no-color',
+    ]);
+    expect(runner.invocations[0]?.input).toBe('user: Summarize this.');
+  });
+
+  it('maps a non-zero CLI exit into a typed provider error', async () => {
+    const runner = createFakeAgentCliRunner([
+      { exitCode: 1, stderr: 'openclaw: model not found', startedAt: 1, endedAt: 2 },
+    ]);
+    const provider = new OpenClawProvider(createConfig('missing'), { runner });
+
+    await expect(provider.invoke({
+      role: 'workers',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    })).rejects.toBeInstanceOf(NousError);
+  });
+
+  it('streams stdout transcript chunks followed by a terminal done chunk', async () => {
+    const runner = createFakeAgentCliRunner(
+      [],
+      [
+        [
+          { stream: 'stdout', text: 'Hello ' },
+          { stream: 'stdout', text: 'world' },
+          { stream: 'system', result: { ok: true, stdout: 'Hello world', stderr: '', transcript: { entries: [], stdout: 'Hello world', stderr: '' } } },
+        ],
+      ],
+    );
+    const provider = new OpenClawProvider(createConfig(), { runner });
+
+    const chunks = await collectStream(provider.stream({
+      role: 'workers',
+      input: { prompt: 'greet' },
+      traceId: TRACE_ID,
+    }));
+
+    expect(chunks.filter((chunk) => !chunk.done).map((chunk) => chunk.content)).toEqual([
+      'Hello ',
+      'world',
+    ]);
+    expect(chunks.at(-1)).toEqual({ content: '', done: true });
+  });
+
+  it('selects the OpenClaw executable override deterministically before PATH lookup', () => {
+    expect(selectOpenClawExecutable({
+      explicitExecutable: '/tools/openclaw-explicit',
+      env: {
+        NOUS_OPENCLAW_CLI_BIN: '/tools/openclaw-nous',
+        OPENCLAW_CLI_BIN: '/tools/openclaw-generic',
+      },
+    })).toBe('/tools/openclaw-explicit');
+
+    expect(selectOpenClawExecutable({
+      env: {
+        NOUS_OPENCLAW_CLI_BIN: '/tools/openclaw-nous',
+        OPENCLAW_CLI_BIN: '/tools/openclaw-generic',
+      },
+    })).toBe('/tools/openclaw-nous');
+
+    expect(selectOpenClawExecutable({
+      env: { OPENCLAW_CLI_BIN: '/tools/openclaw-generic' },
+    })).toBe('/tools/openclaw-generic');
+
+    expect(selectOpenClawExecutable({ env: {} })).toBe('openclaw');
+  });
+
+  it('constructs a provider with the default live runner without invoking it in tests', () => {
+    const provider = new OpenClawProvider(createConfig());
+
+    expect(provider.getConfig().vendor).toBe('openclaw');
+    expect(OPENCLAW_AGENT_ADAPTER.metadata.protocolId).toBe('agent-cli');
+  });
+});

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from './protocols/openai-api/adapter.js';
 export * from './protocols/agent-cli/index.js';
 export { CodexCliProvider } from './providers/codex-cli/implementation.js';
+export { OpenClawProvider } from './providers/openclaw/implementation.js';
 export {
   createTextAdapter,
   textAdapter,

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -4,18 +4,21 @@ import { providerAdapter as anthropicProviderAdapter } from './providers/anthrop
 import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cli/adapter.js';
 import { providerAdapter as ollamaProviderAdapter } from './providers/ollama/adapter.js';
 import { providerAdapter as openaiProviderAdapter } from './providers/openai/adapter.js';
+import { providerAdapter as openclawProviderAdapter } from './providers/openclaw/adapter.js';
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
 export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
+export { providerAdapter as openclawAdapter, OPENCLAW_EXECUTION_CAPABILITY_PROFILE, createOpenClawAdapter, renderOpenClawPrompt } from './providers/openclaw/adapter.js';
 
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
   codexCliProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
+  openclawProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];
 
 export type CertifiedProviderAdapterKey =

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -5,6 +5,7 @@ import { providerDefinition as anthropicProviderDefinition } from './providers/a
 import { providerDefinition as codexCliProviderDefinition } from './providers/codex-cli/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
+import { providerDefinition as openclawProviderDefinition } from './providers/openclaw/definition.js';
 
 export * from './schemas/provider-definition.js';
 
@@ -13,6 +14,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   codexCliProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
+  openclawProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];
 
 export const PROVIDER_DEFINITIONS = hydrateProviderDefinitions(PROVIDER_DEFINITION_LEAVES);

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -4,6 +4,7 @@ import { providerFactory as anthropicProviderFactory } from './providers/anthrop
 import { providerFactory as codexCliProviderFactory } from './providers/codex-cli/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
+import { providerFactory as openclawProviderFactory } from './providers/openclaw/provider.js';
 
 export * from './schemas/provider-factory.js';
 
@@ -12,6 +13,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   codexCliProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
+  openclawProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];
 
 export type CertifiedProviderFactoryVendorKey =

--- a/self/subcortex/providers/src/providers/openclaw/adapter.ts
+++ b/self/subcortex/providers/src/providers/openclaw/adapter.ts
@@ -1,0 +1,91 @@
+import type { GatewayContextFrame, TraceId } from '@nous/shared';
+import { AGENT_CLI_PROTOCOL_ID } from '../../protocols/agent-cli/index.js';
+import {
+  defineProviderAdapter,
+  type AdapterCapabilities,
+  type AdapterFormatInput,
+  type AdapterFormattedRequest,
+  type ProviderAdapter,
+} from '../../schemas/provider-adapter.js';
+import { parseModelOutput, type ParsedModelOutput } from '../../shared/output.js';
+
+const OPENCLAW_ADAPTER_CAPABILITIES: AdapterCapabilities = {
+  nativeToolUse: false,
+  cacheControl: false,
+  extendedThinking: false,
+  streaming: true,
+};
+
+export const OPENCLAW_EXECUTION_CAPABILITY_PROFILE = 'session_bound_command' as const;
+
+export function createOpenClawAdapter(): ProviderAdapter {
+  return {
+    capabilities: OPENCLAW_ADAPTER_CAPABILITIES,
+    formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
+      return {
+        input: {
+          prompt: renderOpenClawPrompt(input),
+        },
+      };
+    },
+    parseResponse(output: unknown, traceId: TraceId): ParsedModelOutput {
+      try {
+        return parseModelOutput(output, traceId);
+      } catch {
+        return {
+          response: String(output ?? ''),
+          toolCalls: [],
+          memoryCandidates: [],
+          contentType: 'text',
+        };
+      }
+    },
+  };
+}
+
+export function renderOpenClawPrompt(input: AdapterFormatInput): string {
+  const sections: string[] = [];
+  const systemPrompt = Array.isArray(input.systemPrompt)
+    ? input.systemPrompt.join('\n\n')
+    : input.systemPrompt;
+
+  if (systemPrompt.trim().length > 0) {
+    sections.push(systemPrompt.trim());
+  }
+
+  for (const frame of input.context) {
+    const rendered = renderContextFrame(frame);
+    if (rendered.length > 0) {
+      sections.push(rendered);
+    }
+  }
+
+  if (input.toolDefinitions && input.toolDefinitions.length > 0) {
+    sections.push(`Available tools:\n${JSON.stringify(input.toolDefinitions, null, 2)}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+function renderContextFrame(frame: GatewayContextFrame): string {
+  const content = typeof frame.content === 'string'
+    ? frame.content
+    : JSON.stringify(frame.content);
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return '';
+
+  return `${frame.role}: ${trimmed}`;
+}
+
+export const providerAdapter = defineProviderAdapter({
+  adapterKey: 'openclaw',
+  displayName: 'OpenClaw',
+  protocol: AGENT_CLI_PROTOCOL_ID,
+  capabilities: OPENCLAW_ADAPTER_CAPABILITIES,
+  executionCapabilityProfile: OPENCLAW_EXECUTION_CAPABILITY_PROFILE,
+  create() {
+    return createOpenClawAdapter();
+  },
+});
+
+export { providerAdapter as openClawAdapter };

--- a/self/subcortex/providers/src/providers/openclaw/definition.ts
+++ b/self/subcortex/providers/src/providers/openclaw/definition.ts
@@ -1,0 +1,81 @@
+import { AGENT_CLI_PROTOCOL_ID } from '../../protocols/agent-cli/index.js';
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+
+export const OPENCLAW_DEFAULT_ENDPOINT = 'http://localhost';
+export const OPENCLAW_DEFAULT_MODEL_ID = 'openclaw/default';
+export const OPENCLAW_DEFAULT_TIMEOUT_MS = 300_000;
+export const OPENCLAW_MAX_TIMEOUT_MS = 1_800_000;
+
+export const OPENCLAW_PROVIDER_DEFINITION = {
+  vendorKey: 'openclaw',
+  displayName: 'OpenClaw',
+  providerType: 'text',
+  providerClass: 'local_text',
+  protocol: AGENT_CLI_PROTOCOL_ID,
+  adapterKey: 'openclaw',
+  defaultEndpoint: OPENCLAW_DEFAULT_ENDPOINT,
+  defaultModelId: OPENCLAW_DEFAULT_MODEL_ID,
+  auth: {
+    required: false,
+    purpose: 'api_key',
+  },
+  capabilities: {
+    streaming: true,
+    cacheControl: false,
+    extendedThinking: false,
+    nativeToolUse: false,
+    healthCheck: false,
+  },
+  executionCapabilityProfile: 'session_bound_command',
+  isLocal: true,
+  agentCli: {
+    command: {
+      executable: 'openclaw',
+      defaultArgs: ['run', '--headless', '--no-color'],
+    },
+    install: {
+      command: 'npm install -g openclaw',
+      packageName: 'openclaw',
+      versionCommand: 'openclaw --version',
+      notes: 'The OpenClaw CLI must be installed and authenticated locally before use.',
+    },
+    auth: {
+      kind: 'local_session',
+      description: 'Uses the local OpenClaw CLI session; run `openclaw login` outside Nous.',
+    },
+    headless: {
+      supported: true,
+      requiredArgs: [],
+      nonInteractiveEnv: {
+        NO_COLOR: '1',
+      },
+    },
+    transcript: {
+      supported: true,
+      streams: ['stdout', 'stderr'],
+      format: 'text',
+    },
+    timeout: {
+      defaultMs: OPENCLAW_DEFAULT_TIMEOUT_MS,
+      maxMs: OPENCLAW_MAX_TIMEOUT_MS,
+    },
+    failureBehavior: {
+      timeoutKind: 'timeout',
+      nonZeroExitKind: 'non_zero_exit',
+      spawnErrorKind: 'spawn_error',
+    },
+    caveats: [
+      'Transient and batch execution use the one-shot `openclaw run --headless` command path. OpenClaw declares `session_bound_command`, not `persistent_process`, so Cortex persistent-chat surfaces must reject it through adapter capability guardrails rather than pretending it can provide a strict long-lived chat process.',
+      'Live process execution shells out to the local OpenClaw CLI; tests must inject a fake runner via createFakeAgentCliRunner.',
+      'The prompt is delivered to the CLI over stdin; the final assistant response is read back from stdout (transcript format `text`).',
+      'Set NOUS_OPENCLAW_CLI_BIN, or OPENCLAW_CLI_BIN, when another openclaw executable shadows the desired system OpenClaw CLI on PATH.',
+      'The endpoint is a local placeholder because provider definitions currently require URLs.',
+      'Set a concrete modelId to pass `--model`; the default model uses the OpenClaw CLI profile/config.',
+    ],
+    targetIssueRefs: ['#299'],
+  },
+} as const satisfies ProviderDefinitionLeaf;
+
+export {
+  OPENCLAW_PROVIDER_DEFINITION as providerDefinition,
+};

--- a/self/subcortex/providers/src/providers/openclaw/implementation.ts
+++ b/self/subcortex/providers/src/providers/openclaw/implementation.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { NousError, ValidationError } from '@nous/shared';
 import type {
   IModelProvider,
@@ -37,9 +37,41 @@ export interface OpenClawProviderOptions {
   readonly executable?: string;
 }
 
+/**
+ * Resolves a bare command name to one or more absolute candidates (one per
+ * line, `where.exe`/`which` style). Injected in tests so executable resolution
+ * never shells out to the host.
+ */
+export type OpenClawCommandResolver = (
+  command: string,
+  args: readonly string[],
+  options: { readonly env?: NodeJS.ProcessEnv },
+) => string;
+
 export interface OpenClawProcessRunnerOptions {
   readonly baseEnv?: Readonly<Record<string, string | undefined>>;
   readonly platform?: NodeJS.Platform;
+  readonly commandResolver?: OpenClawCommandResolver;
+  /** Override for `cmd.exe` (defaults to `%ComSpec%`); used only for `.cmd`/`.bat` shims. */
+  readonly comspec?: string;
+}
+
+/**
+ * OpenClaw's runner options extend the shared agent-cli options with a *live*
+ * `AbortSignal`. The shared {@link AgentCliRunnerOptions.signal} is only a
+ * pre-start snapshot (`{ aborted }`); the live signal lets the process runner
+ * kill the child after it has spawned. The agent-cli adapter forwards runner
+ * options verbatim, so the extra field reaches {@link createOpenClawProcessRunner}.
+ */
+export type OpenClawRunnerOptions = AgentCliRunnerOptions & {
+  readonly abortSignal?: AbortSignal;
+};
+
+/** Literal-argv spawn plan — never a shell command string. */
+export interface OpenClawSpawnPlan {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly windowsVerbatimArguments: boolean;
 }
 
 export const OPENCLAW_INVOCATION_DEFAULTS: AgentCliInvocationDefaults = {
@@ -213,18 +245,22 @@ export class OpenClawProvider implements IModelProvider {
     return ['--model', this.config.modelId];
   }
 
-  private mergeRunnerOptions(request: ModelRequest): AgentCliRunnerOptions | undefined {
-    const signal = request.abortSignal
-      ? { aborted: request.abortSignal.aborted }
+  private mergeRunnerOptions(request: ModelRequest): OpenClawRunnerOptions | undefined {
+    const abortSignal = request.abortSignal;
+    // Keep the pre-start snapshot for the shared contract, but also forward the
+    // live signal so the runner can kill the child after spawn (post-start abort).
+    const signal = abortSignal
+      ? { aborted: abortSignal.aborted }
       : this.runnerOptions?.signal;
 
-    if (!signal && !this.runnerOptions) {
+    if (!signal && !abortSignal && !this.runnerOptions) {
       return undefined;
     }
 
     return {
       ...this.runnerOptions,
       ...(signal ? { signal } : {}),
+      ...(abortSignal ? { abortSignal } : {}),
     };
   }
 }
@@ -291,12 +327,13 @@ export function createOpenClawProcessRunner(
 
 function runOpenClawProcessRaw(
   invocation: AgentCliInvocation,
-  runnerOptions: AgentCliRunnerOptions | undefined,
+  runnerOptions: OpenClawRunnerOptions | undefined,
   options: OpenClawProcessRunnerOptions,
   onTranscriptEvent?: (event: AgentCliStreamEvent) => void,
 ): Promise<AgentCliRawResult> {
   const startedAt = Date.now();
-  if (runnerOptions?.signal?.aborted) {
+  const abortSignal = runnerOptions?.abortSignal;
+  if (runnerOptions?.signal?.aborted || abortSignal?.aborted) {
     return Promise.resolve({
       startedAt,
       endedAt: Date.now(),
@@ -304,18 +341,25 @@ function runOpenClawProcessRaw(
     });
   }
 
-  const platform = options.platform ?? process.platform;
-
   return new Promise((resolve) => {
     let child;
     try {
       const env = buildProcessEnv(invocation.command.env, runnerOptions, options);
-      child = spawn(invocation.command.executable, [...(invocation.command.args ?? [])], {
+      // Never run user-controlled args (model id, prompt-derived values) through
+      // a shell: resolve the executable and pass args as a literal argv array so
+      // shell metacharacters can never be interpreted (Windows command injection).
+      const plan = planOpenClawSpawn(
+        invocation.command.executable,
+        invocation.command.args ?? [],
+        { platform: options.platform, commandResolver: options.commandResolver, env, comspec: options.comspec },
+      );
+      child = spawn(plan.command, [...plan.args], {
         cwd: invocation.command.cwd,
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
-        shell: platform === 'win32',
+        shell: false,
+        windowsVerbatimArguments: plan.windowsVerbatimArguments,
       });
     } catch (error) {
       resolve({ error, startedAt, endedAt: Date.now() });
@@ -325,6 +369,7 @@ function runOpenClawProcessRaw(
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    let aborted = false;
     let settled = false;
     const timeout = invocation.timeoutMs === undefined
       ? undefined
@@ -332,6 +377,19 @@ function runOpenClawProcessRaw(
         timedOut = true;
         child.kill('SIGTERM');
       }, invocation.timeoutMs);
+
+    // Live abort: once the process is running, terminate it if the caller cancels.
+    const onAbort = (): void => {
+      aborted = true;
+      child.kill('SIGTERM');
+    };
+    if (abortSignal) {
+      abortSignal.addEventListener('abort', onAbort, { once: true });
+    }
+    const cleanup = (): void => {
+      if (timeout) clearTimeout(timeout);
+      abortSignal?.removeEventListener('abort', onAbort);
+    };
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -346,18 +404,119 @@ function runOpenClawProcessRaw(
     child.on('error', (error) => {
       if (settled) return;
       settled = true;
-      if (timeout) clearTimeout(timeout);
+      cleanup();
       resolve({ stdout, stderr, error, timedOut, startedAt, endedAt: Date.now() });
     });
     child.on('close', (exitCode, signal) => {
       if (settled) return;
       settled = true;
-      if (timeout) clearTimeout(timeout);
+      cleanup();
+      if (aborted) {
+        resolve({
+          stdout,
+          stderr,
+          signal,
+          error: new Error('Agent CLI invocation aborted.'),
+          startedAt,
+          endedAt: Date.now(),
+        });
+        return;
+      }
       resolve({ exitCode, signal, stdout, stderr, timedOut, startedAt, endedAt: Date.now() });
     });
 
     child.stdin.end(invocation.input ?? '');
   });
+}
+
+/**
+ * Builds a literal-argv spawn plan. The returned `command`/`args` are always
+ * passed to `spawn` with `shell: false`, so user-controlled values can never be
+ * interpreted by a shell.
+ *
+ * - POSIX / native Windows executables: spawn the resolved path directly with
+ *   the args as a literal argv array.
+ * - Windows `.cmd`/`.bat` shims: Node refuses to spawn these without a shell, so
+ *   they are routed through `cmd.exe /d /s /c` with every argument explicitly
+ *   escaped (`windowsVerbatimArguments: true`), keeping shell metacharacters
+ *   inert rather than relying on `shell: true` to join the whole command line.
+ */
+export function planOpenClawSpawn(
+  executable: string,
+  args: readonly string[],
+  options: {
+    readonly platform?: NodeJS.Platform;
+    readonly commandResolver?: OpenClawCommandResolver;
+    readonly env?: NodeJS.ProcessEnv;
+    readonly comspec?: string;
+  } = {},
+): OpenClawSpawnPlan {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'win32') {
+    return { command: executable, args: [...args], windowsVerbatimArguments: false };
+  }
+
+  const resolved = resolveWindowsExecutable(executable, options);
+  if (/\.(cmd|bat)$/i.test(resolved)) {
+    const comspec = options.comspec ?? process.env.ComSpec ?? 'cmd.exe';
+    return {
+      command: comspec,
+      args: ['/d', '/s', '/c', escapeCmdArg(resolved), ...args.map(escapeCmdArg)],
+      windowsVerbatimArguments: true,
+    };
+  }
+
+  return { command: resolved, args: [...args], windowsVerbatimArguments: false };
+}
+
+/**
+ * Resolves a bare `openclaw` command name to a concrete Windows path via
+ * `where.exe`, preferring a native `.exe`/`.com` over a `.cmd`/`.bat` shim so we
+ * can spawn directly without a shell whenever possible. An explicit path (one
+ * that differs from the default executable) is used verbatim.
+ */
+function resolveWindowsExecutable(
+  executable: string,
+  options: {
+    readonly commandResolver?: OpenClawCommandResolver;
+    readonly env?: NodeJS.ProcessEnv;
+  },
+): string {
+  if (executable !== OPENCLAW_PROVIDER_DEFINITION.agentCli.command.executable) {
+    return executable;
+  }
+
+  const resolver = options.commandResolver ?? defaultCommandResolver;
+  let candidates: readonly string[];
+  try {
+    candidates = resolver('where.exe', [executable], { env: options.env })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch {
+    candidates = [];
+  }
+
+  const nativeExecutable = candidates.find((candidate) => /\.(exe|com)$/i.test(candidate));
+  return nativeExecutable ?? candidates[0] ?? executable;
+}
+
+function defaultCommandResolver(
+  command: string,
+  args: readonly string[],
+  options: { readonly env?: NodeJS.ProcessEnv },
+): string {
+  return execFileSync(command, [...args], { encoding: 'utf8', env: options.env });
+}
+
+/**
+ * Escapes a single argument for `cmd.exe`: wraps it in double quotes (doubling
+ * embedded quotes) and caret-escapes the metacharacters cmd would otherwise
+ * interpret. Used only on the `.cmd`/`.bat` shim path.
+ */
+function escapeCmdArg(arg: string): string {
+  const quoted = `"${arg.replace(/"/g, '""')}"`;
+  return quoted.replace(/[()%!^"<>&|]/g, '^$&');
 }
 
 function buildProcessEnv(

--- a/self/subcortex/providers/src/providers/openclaw/implementation.ts
+++ b/self/subcortex/providers/src/providers/openclaw/implementation.ts
@@ -1,0 +1,459 @@
+import { spawn } from 'node:child_process';
+import { NousError, ValidationError } from '@nous/shared';
+import type {
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamChunk,
+  ProviderId,
+} from '@nous/shared';
+import {
+  createAgentCliProviderAdapter,
+  normalizeAgentCliRunResult,
+  type AgentCliFailure,
+  type AgentCliInvocation,
+  type AgentCliInvocationDefaults,
+  type AgentCliRawResult,
+  type AgentCliRunResult,
+  type AgentCliRunner,
+  type AgentCliRunnerOptions,
+  type AgentCliStreamEvent,
+} from '../../protocols/agent-cli/index.js';
+import { TextModelInputSchema, type TextModelInput } from '../../schemas/text-model-input.js';
+import {
+  OPENCLAW_DEFAULT_MODEL_ID,
+  OPENCLAW_DEFAULT_TIMEOUT_MS,
+  OPENCLAW_MAX_TIMEOUT_MS,
+  OPENCLAW_PROVIDER_DEFINITION,
+} from './definition.js';
+
+const OPENCLAW_NOUS_BIN_ENV = 'NOUS_OPENCLAW_CLI_BIN';
+const OPENCLAW_BIN_ENV = 'OPENCLAW_CLI_BIN';
+
+export interface OpenClawProviderOptions {
+  readonly runner?: AgentCliRunner;
+  readonly runnerOptions?: AgentCliRunnerOptions;
+  readonly executable?: string;
+}
+
+export interface OpenClawProcessRunnerOptions {
+  readonly baseEnv?: Readonly<Record<string, string | undefined>>;
+  readonly platform?: NodeJS.Platform;
+}
+
+export const OPENCLAW_INVOCATION_DEFAULTS: AgentCliInvocationDefaults = {
+  command: {
+    executable: OPENCLAW_PROVIDER_DEFINITION.agentCli.command.executable,
+    defaultArgs: OPENCLAW_PROVIDER_DEFINITION.agentCli.command.defaultArgs,
+  },
+  headless: {
+    supported: OPENCLAW_PROVIDER_DEFINITION.agentCli.headless.supported,
+    requiredArgs: OPENCLAW_PROVIDER_DEFINITION.agentCli.headless.requiredArgs,
+    nonInteractiveEnv: OPENCLAW_PROVIDER_DEFINITION.agentCli.headless.nonInteractiveEnv,
+  },
+  timeout: {
+    defaultMs: OPENCLAW_DEFAULT_TIMEOUT_MS,
+    maxMs: OPENCLAW_MAX_TIMEOUT_MS,
+  },
+};
+
+export const OPENCLAW_AGENT_ADAPTER = createAgentCliProviderAdapter({
+  defaults: OPENCLAW_INVOCATION_DEFAULTS,
+});
+
+export function createOpenClawInvocationDefaults(
+  executable: string = OPENCLAW_PROVIDER_DEFINITION.agentCli.command.executable,
+): AgentCliInvocationDefaults {
+  return {
+    ...OPENCLAW_INVOCATION_DEFAULTS,
+    command: {
+      ...OPENCLAW_INVOCATION_DEFAULTS.command,
+      executable,
+    },
+  };
+}
+
+export class OpenClawProvider implements IModelProvider {
+  private readonly config: ModelProviderConfig;
+  private readonly runner: AgentCliRunner;
+  private readonly runnerOptions: AgentCliRunnerOptions | undefined;
+  private readonly agentAdapter: typeof OPENCLAW_AGENT_ADAPTER;
+
+  constructor(config: ModelProviderConfig, options?: OpenClawProviderOptions) {
+    this.config = config;
+    this.runner = options?.runner ?? createOpenClawProcessRunner();
+    this.runnerOptions = options?.runnerOptions;
+    const executable = selectOpenClawExecutable({
+      explicitExecutable: options?.executable,
+    });
+    this.agentAdapter = createAgentCliProviderAdapter({
+      defaults: createOpenClawInvocationDefaults(executable),
+    });
+  }
+
+  getConfig(): ModelProviderConfig {
+    return this.config;
+  }
+
+  async invoke(request: ModelRequest): Promise<ModelResponse> {
+    const input = this.validateInput(request.input);
+    const start = Date.now();
+
+    const result = await this.agentAdapter.invoke(
+      {
+        args: this.invocationArgs(),
+        input: renderTextModelInput(input),
+        metadata: {
+          provider: 'openclaw',
+          providerId: this.config.id,
+          modelId: this.config.modelId,
+          traceId: request.traceId,
+        },
+        runnerOptions: this.mergeRunnerOptions(request),
+      },
+      this.runner,
+    );
+
+    if (!result.ok) {
+      throw toProviderError(result.failure, result.stderr, result.stdout);
+    }
+
+    return {
+      output: result.stdout.trimEnd(),
+      providerId: this.config.id as ProviderId,
+      usage: {
+        computeMs: result.durationMs ?? Date.now() - start,
+      },
+      traceId: request.traceId,
+    };
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    const input = this.validateInput(request.input);
+    let emittedContent = false;
+    let finalResult: AgentCliRunResult | undefined;
+
+    try {
+      const events = this.agentAdapter.stream(
+        {
+          args: this.invocationArgs(),
+          input: renderTextModelInput(input),
+          metadata: {
+            provider: 'openclaw',
+            providerId: this.config.id,
+            modelId: this.config.modelId,
+            traceId: request.traceId,
+          },
+          runnerOptions: this.mergeRunnerOptions(request),
+        },
+        this.runner,
+      );
+
+      for await (const event of events) {
+        if (event.stream === 'system') {
+          finalResult = event.result;
+          continue;
+        }
+
+        if (event.stream !== 'stdout' || event.text.length === 0) continue;
+
+        emittedContent = true;
+        yield { content: event.text, done: false };
+      }
+
+      if (finalResult === undefined) {
+        throw new NousError(
+          'OpenClaw streaming ended without a process result.',
+          'PROVIDER_UNAVAILABLE',
+          { provider: 'openclaw', failureKind: 'unknown' },
+        );
+      }
+
+      if (!finalResult.ok) {
+        throw toProviderError(finalResult.failure, finalResult.stderr, finalResult.stdout);
+      }
+
+      if (!emittedContent && finalResult.stdout.trimEnd().length > 0) {
+        yield { content: finalResult.stdout.trimEnd(), done: false };
+      }
+
+      yield { content: '', done: true };
+    } catch (error) {
+      if (error instanceof NousError) throw error;
+      throw new NousError(
+        `OpenClaw streaming failed: ${error instanceof Error ? error.message : String(error)}`,
+        'PROVIDER_UNAVAILABLE',
+        { provider: 'openclaw', failureKind: 'unknown' },
+      );
+    }
+  }
+
+  private validateInput(input: unknown): TextModelInput {
+    const result = TextModelInputSchema.safeParse(input);
+    if (!result.success) {
+      throw new ValidationError(
+        'Invalid OpenClaw provider input',
+        result.error.errors.map((error) => ({
+          path: error.path.join('.'),
+          message: error.message,
+        })),
+      );
+    }
+    return result.data;
+  }
+
+  private invocationArgs(): readonly string[] {
+    if (
+      this.config.modelId.length === 0 ||
+      this.config.modelId === OPENCLAW_DEFAULT_MODEL_ID
+    ) {
+      return [];
+    }
+    return ['--model', this.config.modelId];
+  }
+
+  private mergeRunnerOptions(request: ModelRequest): AgentCliRunnerOptions | undefined {
+    const signal = request.abortSignal
+      ? { aborted: request.abortSignal.aborted }
+      : this.runnerOptions?.signal;
+
+    if (!signal && !this.runnerOptions) {
+      return undefined;
+    }
+
+    return {
+      ...this.runnerOptions,
+      ...(signal ? { signal } : {}),
+    };
+  }
+}
+
+export function selectOpenClawExecutable(
+  options: {
+    readonly explicitExecutable?: string;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+  } = {},
+): string {
+  const env = options.env ?? process.env;
+  return options.explicitExecutable
+    ?? env[OPENCLAW_NOUS_BIN_ENV]
+    ?? env[OPENCLAW_BIN_ENV]
+    ?? OPENCLAW_PROVIDER_DEFINITION.agentCli.command.executable;
+}
+
+export function createOpenClawProcessRunner(
+  options: OpenClawProcessRunnerOptions = {},
+): AgentCliRunner {
+  return {
+    async run(invocation, runnerOptions) {
+      return normalizeAgentCliRunResult(
+        await runOpenClawProcessRaw(invocation, runnerOptions, options),
+      );
+    },
+    async *stream(invocation, runnerOptions) {
+      const queue: AgentCliStreamEvent[] = [];
+      let wake: (() => void) | undefined;
+      let completed = false;
+
+      const push = (event: AgentCliStreamEvent): void => {
+        queue.push(event);
+        wake?.();
+        wake = undefined;
+      };
+
+      const waitForEvent = (): Promise<void> => {
+        if (queue.length > 0 || completed) return Promise.resolve();
+        return new Promise((resolve) => {
+          wake = resolve;
+        });
+      };
+
+      void runOpenClawProcessRaw(invocation, runnerOptions, options, (event) => {
+        push(event);
+      }).then((rawResult) => {
+        push({ stream: 'system', result: normalizeAgentCliRunResult(rawResult) });
+      }).finally(() => {
+        completed = true;
+        wake?.();
+        wake = undefined;
+      });
+
+      while (!completed || queue.length > 0) {
+        await waitForEvent();
+        while (queue.length > 0) {
+          yield queue.shift()!;
+        }
+      }
+    },
+  };
+}
+
+function runOpenClawProcessRaw(
+  invocation: AgentCliInvocation,
+  runnerOptions: AgentCliRunnerOptions | undefined,
+  options: OpenClawProcessRunnerOptions,
+  onTranscriptEvent?: (event: AgentCliStreamEvent) => void,
+): Promise<AgentCliRawResult> {
+  const startedAt = Date.now();
+  if (runnerOptions?.signal?.aborted) {
+    return Promise.resolve({
+      startedAt,
+      endedAt: Date.now(),
+      error: new Error('Agent CLI invocation aborted before start.'),
+    });
+  }
+
+  const platform = options.platform ?? process.platform;
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      const env = buildProcessEnv(invocation.command.env, runnerOptions, options);
+      child = spawn(invocation.command.executable, [...(invocation.command.args ?? [])], {
+        cwd: invocation.command.cwd,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        shell: platform === 'win32',
+      });
+    } catch (error) {
+      resolve({ error, startedAt, endedAt: Date.now() });
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    const timeout = invocation.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+      }, invocation.timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      onTranscriptEvent?.({ stream: 'stdout', text: chunk, timestamp: new Date().toISOString() });
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+      onTranscriptEvent?.({ stream: 'stderr', text: chunk, timestamp: new Date().toISOString() });
+    });
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve({ stdout, stderr, error, timedOut, startedAt, endedAt: Date.now() });
+    });
+    child.on('close', (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve({ exitCode, signal, stdout, stderr, timedOut, startedAt, endedAt: Date.now() });
+    });
+
+    child.stdin.end(invocation.input ?? '');
+  });
+}
+
+function buildProcessEnv(
+  invocationEnv: Readonly<Record<string, string>> | undefined,
+  runnerOptions: AgentCliRunnerOptions | undefined,
+  options: OpenClawProcessRunnerOptions,
+): NodeJS.ProcessEnv {
+  const baseEnv = options.baseEnv ?? process.env;
+  const policy = runnerOptions?.environmentPolicy;
+  const env: NodeJS.ProcessEnv = {};
+
+  if (!policy || policy.mergeStrategy === 'explicit') {
+    assignDefinedEnv(env, baseEnv);
+  } else if (policy.mergeStrategy === 'allowlist') {
+    for (const key of policy.allowlist ?? []) {
+      const value = baseEnv[key];
+      if (value !== undefined && isValidEnvKey(key)) env[key] = value;
+    }
+  }
+
+  assignDefinedEnv(env, policy?.env);
+  assignDefinedEnv(env, invocationEnv);
+  return env;
+}
+
+function assignDefinedEnv(
+  target: NodeJS.ProcessEnv,
+  source: Readonly<Record<string, string | undefined>> | undefined,
+): void {
+  if (!source) return;
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined && isValidEnvKey(key)) {
+      target[key] = value;
+    }
+  }
+}
+
+function isValidEnvKey(key: string): boolean {
+  return key.length > 0 && !key.includes('=');
+}
+
+function renderTextModelInput(input: TextModelInput): string {
+  if ('prompt' in input) {
+    return input.prompt;
+  }
+
+  const sections: string[] = [];
+  if (typeof input.system === 'string' && input.system.trim().length > 0) {
+    sections.push(input.system.trim());
+  } else if (Array.isArray(input.system) && input.system.length > 0) {
+    sections.push(JSON.stringify(input.system, null, 2));
+  }
+
+  for (const message of input.messages) {
+    sections.push(`${message.role}: ${renderMessageContent(message.content)}`);
+  }
+
+  if (input.tools && input.tools.length > 0) {
+    sections.push(`Available tools:\n${JSON.stringify(input.tools, null, 2)}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+function renderMessageContent(content: string | readonly unknown[]): string {
+  return typeof content === 'string'
+    ? content
+    : JSON.stringify(content, null, 2);
+}
+
+function toProviderError(
+  failure: AgentCliFailure | undefined,
+  stderr?: string,
+  stdout?: string,
+): NousError {
+  if (!failure) {
+    return new NousError(
+      'OpenClaw invocation failed.',
+      'PROVIDER_UNAVAILABLE',
+      { provider: 'openclaw', stderr, stdout },
+    );
+  }
+
+  return new NousError(
+    stderr && stderr.trim().length > 0
+      ? `${failure.message} ${stderr.trim().slice(0, 500)}`
+      : failure.message,
+    failure.kind === 'auth' ? 'PROVIDER_ERROR' : 'PROVIDER_UNAVAILABLE',
+    {
+      provider: 'openclaw',
+      failureKind: failure.kind,
+      exitCode: failure.exitCode,
+      signal: failure.signal,
+      timedOut: failure.timedOut,
+      stderr,
+      stdout,
+    },
+  );
+}

--- a/self/subcortex/providers/src/providers/openclaw/index.ts
+++ b/self/subcortex/providers/src/providers/openclaw/index.ts
@@ -18,10 +18,14 @@ export {
   OpenClawProvider,
   createOpenClawInvocationDefaults,
   createOpenClawProcessRunner,
+  planOpenClawSpawn,
   selectOpenClawExecutable,
 } from './implementation.js';
 export type {
+  OpenClawCommandResolver,
   OpenClawProcessRunnerOptions,
   OpenClawProviderOptions,
+  OpenClawRunnerOptions,
+  OpenClawSpawnPlan,
 } from './implementation.js';
 export { providerFactory } from './provider.js';

--- a/self/subcortex/providers/src/providers/openclaw/index.ts
+++ b/self/subcortex/providers/src/providers/openclaw/index.ts
@@ -1,0 +1,27 @@
+export {
+  OPENCLAW_EXECUTION_CAPABILITY_PROFILE,
+  createOpenClawAdapter,
+  providerAdapter,
+  renderOpenClawPrompt,
+} from './adapter.js';
+export {
+  OPENCLAW_DEFAULT_ENDPOINT,
+  OPENCLAW_DEFAULT_MODEL_ID,
+  OPENCLAW_DEFAULT_TIMEOUT_MS,
+  OPENCLAW_MAX_TIMEOUT_MS,
+  OPENCLAW_PROVIDER_DEFINITION,
+  providerDefinition,
+} from './definition.js';
+export {
+  OPENCLAW_AGENT_ADAPTER,
+  OPENCLAW_INVOCATION_DEFAULTS,
+  OpenClawProvider,
+  createOpenClawInvocationDefaults,
+  createOpenClawProcessRunner,
+  selectOpenClawExecutable,
+} from './implementation.js';
+export type {
+  OpenClawProcessRunnerOptions,
+  OpenClawProviderOptions,
+} from './implementation.js';
+export { providerFactory } from './provider.js';

--- a/self/subcortex/providers/src/providers/openclaw/provider.ts
+++ b/self/subcortex/providers/src/providers/openclaw/provider.ts
@@ -1,0 +1,12 @@
+import { OpenClawProvider } from './implementation.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'openclaw',
+  create(config, options) {
+    return new OpenClawProvider(config, {
+      runner: options?.agentCliRunner,
+      runnerOptions: options?.agentCliRunnerOptions,
+    });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
Implement OpenClaw as a certified CLI provider leaf under self/subcortex/providers/src/providers/openclaw/, modeled on the reference codex-cli leaf and built against the agent-cli protocol.

The leaf declares its metadata via ProviderDefinitionLeaf (provider id derived from vendorKey, executionCapabilityProfile session_bound_command), runs a one-shot `openclaw run --headless --no-color` invocation with the prompt over stdin and the response read from stdout, and supports both invoke() and streaming, executable overrides, abort signals, and typed NousError failure mapping.

- Regenerate the provider catalog so the leaf is auto-discovered
- Add OpenClaw helpers to the codegen extra-exports map and src/index.ts
- Add unit suite (injected fake runner) and extend roster assertions

Refs #299

## Summary
Adds an OpenClaw CLI provider leaf so nous-core can run OpenClaw as a model
provider, alongside the existing anthropic / openai / ollama / codex-cli leaves.
OpenClaw is a command-line agent, so it's implemented on the `agent-cli`
protocol and modeled on the reference `codex-cli` leaf.

Note: per the 2026-06-18 maintainer update on #299, this targets the current
CLI-provider-leaf contract (not the deprecated `AgentAdapter` path), and is
based on `feat/contributor-friendly-inference-provider-surface`.

## Linked Issue
Closes #299

## Changes
- New leaf `self/subcortex/providers/src/providers/openclaw/` (`definition`,
  `adapter`, `implementation`, `provider`, `index`)
- `agent-cli` invocation: one-shot `openclaw run --headless --no-color`, prompt
  over stdin, response read from stdout; supports `invoke()` and streaming
- `ProviderDefinitionLeaf` metadata: provider id derived from `vendorKey`,
  `executionCapabilityProfile: 'session_bound_command'`, env-var executable
  overrides, abort-signal handling, typed `NousError` failure mapping
- Regenerated the provider catalog (`provider-definitions/adapters/factories`)
  and added OpenClaw helpers to the codegen extras map + package `index.ts`
- New unit suite (injected fake runner) + extended the certified-provider
  roster assertions to include `openclaw`

## Verification
- [x] Tests pass — `@nous/subcortex-providers` suite: 314 passed, 2 skipped
      (the 2 skipped are pre-existing `codex-cli.live.test.ts` cases needing a
      real CLI binary); new `openclaw.test.ts`: 9/9
- [ ] Lint passes (`pnpm lint`) — not run locally
- [x] Typecheck passes — `tsc --build --force` clean (via `pnpm build`)
- [x] Build passes — `pnpm build` clean
- [x] Manually ran the change end-to-end (see below)

### Manual behavior check
Exercised the leaf through an injected fake runner (input → expected → actual all matched):
- `invoke()` returns trimmed stdout as output, with derived `usage.computeMs`
- default model omits `--model`; a concrete model appends `--model <id>`
- `messages[]` render to the stdin prompt
- non-zero CLI exit maps to a thrown `NousError` carrying the stderr tail
- `stream()` yields stdout transcript chunks then a terminal `{content:'', done:true}`
- `generate:providers --check` stays green after adding the leaf

## Checklist
- [x] Commits follow Conventional Commits
- [x] Docs updated if behavior changed (or N/A) — N/A (definition `caveats` document the CLI contract)
- [ ] Branch flow — see note below