### PR TITLE
feat(subcortex-providers): add Groq model provider leaf

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -49,9 +49,13 @@ function makeThrowingProvider() {
 
 describe('adapter resolver', () => {
   it('aggregates all canonical adapter modules', () => {
+    // `chat-completions` appears twice: both the openai and groq leaves reuse the
+    // shared chat-completions adapter. The resolver keys modules by adapterKey, so
+    // the duplicate collapses to a single resolvable module.
     expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
       'anthropic',
       'codex-cli',
+      'chat-completions',
       'ollama',
       'chat-completions',
       'text',
@@ -95,12 +99,12 @@ describe('adapter resolver', () => {
   it('falls back to name heuristic for non-catalog provider configs', () => {
     expect(resolveAdapterKeyFromConfig(makeProvider({ name: 'claude-3-opus' }))).toBe('anthropic');
     expect(resolveAdapterKeyFromConfig(makeProvider({ name: 'gpt-4-turbo' }))).toBe('chat-completions');
-    expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'groq', name: 'my-gpt-model' }))).toBe('chat-completions');
+    expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'unknown-vendor', name: 'my-gpt-model' }))).toBe('chat-completions');
     expect(resolveAdapterKeyFromConfig(makeProvider({ name: 'ollama-llama3' }))).toBe('ollama');
   });
 
   it('falls back to text when provider config cannot resolve', () => {
-    expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'groq', name: 'custom-model' }))).toBe('text');
+    expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'unknown-vendor', name: 'custom-model' }))).toBe('text');
     expect(resolveAdapterKeyFromConfig(makeProvider({}))).toBe('text');
     expect(resolveAdapterKeyFromConfig(makeThrowingProvider())).toBe('text');
   });

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'groq', 'ollama', 'openai']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'groq' | 'openai' | 'ollama'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'groq' | 'openai' | 'ollama'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'groq', 'ollama', 'openai']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -30,6 +30,11 @@ const expectedDefinitions = {
     defaultModelId: 'llama3.2',
     envVar: undefined,
   },
+  groq: {
+    defaultEndpoint: 'https://api.groq.com/openai',
+    defaultModelId: 'llama-3.3-70b-versatile',
+    envVar: 'GROQ_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -37,6 +42,7 @@ describe('provider definitions catalog', () => {
     expect(PROVIDER_DEFINITIONS.map((definition) => definition.vendorKey).sort()).toEqual([
       'anthropic',
       'codex-cli',
+      'groq',
       'ollama',
       'openai',
     ]);

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -53,6 +53,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     expect(PROVIDER_DEFINITIONS.map((definition) => definition.vendorKey)).toEqual([
       'anthropic',
       'codex-cli',
+      'groq',
       'ollama',
       'openai',
     ]);
@@ -155,12 +156,14 @@ describe('provider definition to adapter to registry pipeline', () => {
   it('constructs providers from registry-derived definitions with env-var credentials', () => {
     process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
     process.env.OPENAI_API_KEY = 'test-openai-key';
+    process.env.GROQ_API_KEY = 'test-groq-key';
 
     const registry = new ProviderRegistry(createEmptyConfig());
     const expectedClassByVendor = {
       anthropic: AnthropicProvider,
       'codex-cli': CodexCliProvider,
       openai: ChatCompletionsProvider,
+      groq: ChatCompletionsProvider,
       ollama: OllamaProvider,
     };
 

--- a/self/subcortex/providers/src/__tests__/providers/groq.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/groq.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import type { ProviderId } from '@nous/shared';
+import {
+  GROQ_DEFAULT_ENDPOINT,
+  GROQ_DEFAULT_MODEL_ID,
+  GROQ_PROVIDER_DEFINITION,
+  providerDefinition,
+  providerFactory,
+} from '../../providers/groq/index.js';
+import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
+import { ProviderDefinitionSchema } from '../../schemas/provider-definition.js';
+import { deriveBuiltInProviderId } from '../../provider-identity.js';
+
+const MOCK_CONFIG = {
+  id: deriveBuiltInProviderId('groq'),
+  name: 'Groq',
+  type: 'text' as const,
+  modelId: GROQ_DEFAULT_MODEL_ID,
+  isLocal: false,
+  capabilities: ['text'],
+};
+
+describe('Groq provider leaf', () => {
+  it('exposes Groq-specific OpenAI-compatible metadata', () => {
+    expect(providerDefinition).toBe(GROQ_PROVIDER_DEFINITION);
+    expect(GROQ_PROVIDER_DEFINITION.vendorKey).toBe('groq');
+    expect(GROQ_PROVIDER_DEFINITION.protocol).toBe('chat-completions');
+    expect(GROQ_PROVIDER_DEFINITION.adapterKey).toBe('chat-completions');
+    expect(GROQ_PROVIDER_DEFINITION.defaultEndpoint).toBe(GROQ_DEFAULT_ENDPOINT);
+    expect(GROQ_DEFAULT_ENDPOINT).toBe('https://api.groq.com/openai');
+    expect(GROQ_PROVIDER_DEFINITION.defaultModelId).toBe('llama-3.3-70b-versatile');
+    expect(GROQ_PROVIDER_DEFINITION.auth.envVar).toBe('GROQ_API_KEY');
+    expect(GROQ_PROVIDER_DEFINITION.auth.header).toEqual({
+      name: 'Authorization',
+      scheme: 'bearer',
+    });
+    expect(GROQ_PROVIDER_DEFINITION.modelListEndpoint).toBe('/v1/models');
+    expect(GROQ_PROVIDER_DEFINITION.modelListFormat).toBe('openai-models');
+  });
+
+  it('advertises streaming and model listing but not nativeToolUse (pending the #390 tool-use bridge)', () => {
+    expect(GROQ_PROVIDER_DEFINITION.capabilities?.streaming).toBe(true);
+    expect(GROQ_PROVIDER_DEFINITION.capabilities?.modelListing).toBe(true);
+    expect('nativeToolUse' in (GROQ_PROVIDER_DEFINITION.capabilities ?? {})).toBe(false);
+  });
+
+  it('does not hand-author wellKnownProviderId (derived centrally from vendorKey)', () => {
+    expect('wellKnownProviderId' in GROQ_PROVIDER_DEFINITION).toBe(false);
+  });
+
+  it('satisfies the shared ProviderDefinitionSchema once hydrated with a derived id', () => {
+    const hydrated = {
+      ...GROQ_PROVIDER_DEFINITION,
+      wellKnownProviderId: deriveBuiltInProviderId('groq') as ProviderId,
+    };
+    expect(() => ProviderDefinitionSchema.parse(hydrated)).not.toThrow();
+  });
+
+  it('factory builds a ChatCompletionsProvider for the groq vendor', () => {
+    const provider = providerFactory.create(MOCK_CONFIG, { apiKey: 'test-groq-key' });
+    expect(providerFactory.vendorKey).toBe('groq');
+    expect(provider).toBeInstanceOf(ChatCompletionsProvider);
+    expect(provider.getConfig()).toEqual(MOCK_CONFIG);
+  });
+});

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -2,18 +2,21 @@
 import type { ProviderAdapterModule } from './schemas/provider-adapter.js';
 import { providerAdapter as anthropicProviderAdapter } from './providers/anthropic/adapter.js';
 import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cli/adapter.js';
+import { providerAdapter as groqProviderAdapter } from './providers/groq/adapter.js';
 import { providerAdapter as ollamaProviderAdapter } from './providers/ollama/adapter.js';
 import { providerAdapter as openaiProviderAdapter } from './providers/openai/adapter.js';
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
 export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
+export { providerAdapter as groqAdapter } from './providers/groq/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
 
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
   codexCliProviderAdapter,
+  groqProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -3,6 +3,7 @@ import type { ProviderDefinition, ProviderDefinitionLeaf } from './schemas/provi
 import { hydrateProviderDefinitions } from './provider-identity.js';
 import { providerDefinition as anthropicProviderDefinition } from './providers/anthropic/definition.js';
 import { providerDefinition as codexCliProviderDefinition } from './providers/codex-cli/definition.js';
+import { providerDefinition as groqProviderDefinition } from './providers/groq/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
 
@@ -11,6 +12,7 @@ export * from './schemas/provider-definition.js';
 const PROVIDER_DEFINITION_LEAVES = [
   anthropicProviderDefinition,
   codexCliProviderDefinition,
+  groqProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -2,6 +2,7 @@
 import type { ProviderFactoryModule } from './schemas/provider-factory.js';
 import { providerFactory as anthropicProviderFactory } from './providers/anthropic/provider.js';
 import { providerFactory as codexCliProviderFactory } from './providers/codex-cli/provider.js';
+import { providerFactory as groqProviderFactory } from './providers/groq/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
 
@@ -10,6 +11,7 @@ export * from './schemas/provider-factory.js';
 export const CERTIFIED_PROVIDER_FACTORIES = [
   anthropicProviderFactory,
   codexCliProviderFactory,
+  groqProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];

--- a/self/subcortex/providers/src/providers/groq/adapter.ts
+++ b/self/subcortex/providers/src/providers/groq/adapter.ts
@@ -1,0 +1,4 @@
+export {
+  chatCompletionsAdapter as providerAdapter,
+  createChatCompletionsAdapter,
+} from '../../protocols/openai-api/adapter.js';

--- a/self/subcortex/providers/src/providers/groq/definition.ts
+++ b/self/subcortex/providers/src/providers/groq/definition.ts
@@ -1,0 +1,47 @@
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+
+export const GROQ_DEFAULT_ENDPOINT = 'https://api.groq.com/openai';
+export const GROQ_DEFAULT_MODEL_ID = 'llama-3.3-70b-versatile';
+
+/**
+ * Groq exposes an OpenAI Chat Completions-compatible API, so this leaf carries
+ * only Groq-specific metadata and reuses the shared `ChatCompletionsProvider`.
+ * `defaultEndpoint` is the OpenAI-compatible base. 
+ * The shared provider appends `/v1/chat/completions` and `/v1/models`.
+ */
+export const GROQ_PROVIDER_DEFINITION = {
+  vendorKey: 'groq',
+  displayName: 'Groq',
+  providerType: 'text',
+  providerClass: 'remote_text',
+  protocol: 'chat-completions',
+  adapterKey: 'chat-completions',
+  defaultEndpoint: GROQ_DEFAULT_ENDPOINT,
+  defaultModelId: GROQ_DEFAULT_MODEL_ID,
+  auth: {
+    envVar: 'GROQ_API_KEY',
+    vaultKeyNamespace: 'groq',
+    header: {
+      name: 'Authorization',
+      scheme: 'bearer',
+    },
+    required: true,
+    purpose: 'api_key',
+  },
+  modelListEndpoint: '/v1/models',
+  modelListFormat: 'openai-models',
+  capabilities: {
+    streaming: true,
+    modelListing: true,
+    // `nativeToolUse` is intentionally omitted: per #390 a provider must not
+    // advertise it until the shared native tool-use bridge supports the full
+    // request/tool-call/tool-result loop.
+  },
+  isLocal: false,
+  // No `wellKnownProviderId`: built-in provider ids are derived centrally from
+  // `vendorKey` by `provider-identity.ts` and hydrated into the catalog.
+} as const satisfies ProviderDefinitionLeaf;
+
+export {
+  GROQ_PROVIDER_DEFINITION as providerDefinition,
+};

--- a/self/subcortex/providers/src/providers/groq/index.ts
+++ b/self/subcortex/providers/src/providers/groq/index.ts
@@ -1,0 +1,9 @@
+export { providerAdapter } from './adapter.js';
+export {
+  GROQ_DEFAULT_ENDPOINT,
+  GROQ_DEFAULT_MODEL_ID,
+  GROQ_PROVIDER_DEFINITION,
+  providerDefinition,
+} from './definition.js';
+export { providerFactory } from './provider.js';
+export { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';

--- a/self/subcortex/providers/src/providers/groq/provider.ts
+++ b/self/subcortex/providers/src/providers/groq/provider.ts
@@ -1,0 +1,9 @@
+import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'groq',
+  create(config, options) {
+    return new ChatCompletionsProvider(config, { apiKey: options?.apiKey });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## Summary

This PR adds a certified provider leaf for **Groq**. Groq exposes an OpenAI Chat Completions-compatible API, so this ships as a thin config-entry leaf that carries Groq-specific metadata and reuses the shared `ChatCompletionsProvider` (no custom adapter class and no `implementation.ts`).

Closes #309. Refs #390 (native tool use - see notes below).

## What changed

**New leaf - `self/subcortex/providers/src/providers/groq/`:**
- `definition.ts` - Groq metadata: `vendorKey: 'groq'`, `defaultEndpoint: 'https://api.groq.com/openai'`,
  `GROQ_API_KEY` bearer auth, `defaultModelId: 'llama-3.3-70b-versatile'`, `/v1/models`
  discovery via `modelListFormat: 'openai-models'`, and `capabilities: { streaming, modelListing }`.
- `provider.ts` - factory (`vendorKey: 'groq'`) wrapping `ChatCompletionsProvider`.
- `adapter.ts` + `index.ts` - reuse the shared chat-completions adapter / leaf public surface.

**Generated catalogs** - regenerated via `generate:providers` (not hand-edited):
`provider-definitions.ts`, `provider-adapters.ts`, `provider-factories.ts` (+3 lines total).

**Tests:**
- New `__tests__/providers/groq.test.ts` (definition metadata, capability omissions,
  derived-id behavior, factory construction).
- Extended the existing provider-roster assertions in `adapter-resolver`,
  `provider-codegen`, `provider-definition-types`, `provider-definitions`, and
  `provider-pipeline-integration` to include `groq`.

## Design decisions (per the updated docs + maintainer guidance)

- **No hand-authored `wellKnownProviderId`** - derived centrally from `vendorKey`
  via `provider-identity.ts`.
- **`nativeToolUse` intentionally omitted** - per #390, a provider should not advertise it until the shared native tool-use bridge supports the full request/tool-call/result
  loop. Groq's API does support tool use, so this can be enabled once #390 lands.
- **`defaultModelId: 'llama-3.3-70b-versatile'`** - chosen as a stable, production,
  general-purpose default (Groq lists it as a current recommended model; the larger
  Llama 4 *Maverick* is already deprecated on Groq). Model discovery via `/v1/models`
  lets users select any other available model at runtime. Happy to change the default
  if you'd prefer another.

## Items I want to flag 
1. **Duplicate `chat-completions` adapter module.** Because the openai and groq leaves
   both reuse the shared chat-completions adapter, `CERTIFIED_PROVIDER_ADAPTER_MODULES`
   now lists `chat-completions` twice. It's harmless (the resolver keys modules by
   `adapterKey`, so it collapses to one), but the generator could dedupe by `adapterKey`
   if you'd prefer. I documented this in the adapter-resolver test.
2. **Repurposed placeholder tests.** Two `adapter-resolver` cases used `vendor: 'groq'`
   as a stand-in for an *unknown* vendor. Since `groq` is now a real catalog vendor, I
   switched those to `'unknown-vendor'` to preserve the tests' original intent.

## Verification

- `pnpm --filter @nous/subcortex-providers run typecheck` - passes
- `pnpm lint` - 0 errors
- Full providers test suite - 310 passed

## Acceptance criteria (#309)

- [x] Implements the provider contract (invoke / stream / getConfig) - via the shared `ChatCompletionsProvider`.
- [x] Validates input against `TextModelInputSchema` - inherited from the shared provider.
- [x] Handles streaming - inherited; capability advertised.
- [x] Exported through the leaf + regenerated catalogs.
- [x] Tests under `src/__tests__/`.
- [x] Scope boundary respected - did not modify the provider interface or `TextModelInputSchema`.