### PR TITLE
feat(providers): add Qwen Code provider

### DIFF
--- a/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
+++ b/self/subcortex/providers/scripts/generate-provider-aggregates.mjs
@@ -140,6 +140,7 @@ function providerAdapterExtraExports(vendor) {
     ['codex-cli', ['CODEX_CLI_EXECUTION_CAPABILITY_PROFILE', 'createCodexCliAdapter', 'renderCodexCliPrompt']],
     ['ollama', ['createOllamaAdapter', 'isToolCapableModel']],
     ['openai', ['createChatCompletionsAdapter']],
+    ['qwen-code', ['QWEN_CODE_EXECUTION_CAPABILITY_PROFILE', 'createQwenCodeAdapter', 'renderQwenCodePrompt']],
   ]);
   const extras = extrasByVendor.get(vendor) ?? [];
   return extras.length > 0 ? `, ${extras.join(', ')}` : '';

--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -60,6 +60,7 @@ describe('adapter resolver', () => {
       'chat-completions',
       'ollama',
       'chat-completions',
+      'qwen-code',
       'text',
     ]);
   });

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp','ollama', 'openai', 'qwen-code']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama' | 'qwen-code'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama' | 'qwen-code'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai', 'qwen-code']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -43,6 +43,7 @@ const expectedDefinitions = {
   'llama-cpp': {
     defaultEndpoint: 'http://localhost:8080',
     defaultModelId: 'llama3.2',
+    envVar: undefined,
   },
   'qwen-code': {
     defaultEndpoint: 'http://localhost',

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -43,6 +43,10 @@ const expectedDefinitions = {
   'llama-cpp': {
     defaultEndpoint: 'http://localhost:8080',
     defaultModelId: 'llama3.2',
+  },
+  'qwen-code': {
+    defaultEndpoint: 'http://localhost',
+    defaultModelId: 'qwen-code/default',
     envVar: undefined,
   },
 } as const;
@@ -57,6 +61,7 @@ describe('provider definitions catalog', () => {
       'llama-cpp',
       'ollama',
       'openai',
+      'qwen-code',
     ]);
   });
 
@@ -95,6 +100,7 @@ describe('provider definitions catalog', () => {
       join('protocols', 'openai-api', 'provider.ts'),
       join('providers', 'ollama', 'implementation.ts'),
       join('providers', 'llama-cpp', 'definition.ts'),
+      join('providers', 'qwen-code', 'definition.ts'),
     ];
     const forbidden = [
       /fetch/,

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -10,6 +10,7 @@ import {
   CodexCliProvider,
   GitHubCopilotCliProvider,
   OllamaProvider,
+  QwenCodeProvider,
   PROVIDER_DEFINITIONS,
   ProviderRegistry,
   buildAdapterResolver,
@@ -64,6 +65,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'llama-cpp',
       'ollama',
       'openai',
+      'qwen-code',
     ]);
     expect(resolveProviderDefinition('anthropic').defaultModelId).toBe(
       'claude-sonnet-4-20250514',
@@ -175,6 +177,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       openai: ChatCompletionsProvider,
       groq: ChatCompletionsProvider,
       ollama: OllamaProvider,
+      'qwen-code': QwenCodeProvider,
     };
 
     for (const definition of PROVIDER_DEFINITIONS) {

--- a/self/subcortex/providers/src/__tests__/providers/qwen-code.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/qwen-code.test.ts
@@ -1,3 +1,6 @@
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough, Writable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 import {
   type GatewayContextFrame,
@@ -8,11 +11,14 @@ import {
 } from '@nous/shared';
 import {
   QWEN_CODE_DEFAULT_MODEL_ID,
+  QWEN_CODE_DEFAULT_ENV_ALLOWLIST,
   QWEN_CODE_EXECUTION_CAPABILITY_PROFILE,
   QWEN_CODE_PROVIDER_DEFINITION,
   QwenCodeProvider,
   type QwenCodeCommandResolver,
+  type QwenCodeSpawn,
   createQwenCodeAdapter,
+  createQwenCodeProcessRunner,
   providerAdapter,
   providerDefinition,
   providerFactory,
@@ -26,6 +32,52 @@ import { AgentCliProviderMetadataSchema } from '../../schemas/provider-definitio
 const TRACE_ID = '550e8400-e29b-41d4-a716-446655440188' as TraceId;
 const PROVIDER_ID = '10000000-0000-0000-0000-000000000005' as ProviderId;
 const CREATED_AT = '2026-06-12T00:00:00.000Z';
+
+interface FakeChildProcess extends ChildProcessWithoutNullStreams {
+  readonly killSignals: NodeJS.Signals[];
+  readonly stdinInput: string[];
+}
+
+function createFakeChildProcess(
+  options: {
+    readonly closeOnStdinEnd?: boolean;
+    readonly closeOnKill?: boolean;
+  } = {},
+): FakeChildProcess {
+  const child = new EventEmitter() as FakeChildProcess;
+  const stdinInput: string[] = [];
+  const killSignals: NodeJS.Signals[] = [];
+  const closeOnStdinEnd = options.closeOnStdinEnd ?? true;
+  const closeOnKill = options.closeOnKill ?? true;
+
+  Object.assign(child, {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    stdin: new Writable({
+      write(chunk, _encoding, callback) {
+        stdinInput.push(String(chunk));
+        callback();
+      },
+      final(callback) {
+        if (closeOnStdinEnd) {
+          queueMicrotask(() => child.emit('close', 0, null));
+        }
+        callback();
+      },
+    }),
+    kill(signal: NodeJS.Signals = 'SIGTERM') {
+      killSignals.push(signal);
+      if (closeOnKill) {
+        queueMicrotask(() => child.emit('close', null, signal));
+      }
+      return true;
+    },
+    killSignals,
+    stdinInput,
+  });
+
+  return child;
+}
 
 function createConfig(modelId = QWEN_CODE_DEFAULT_MODEL_ID): ModelProviderConfig {
   return {
@@ -80,10 +132,10 @@ describe('Qwen Code provider leaf', () => {
     expect(AgentCliProviderMetadataSchema.parse(providerDefinition.agentCli))
       .toEqual(providerDefinition.agentCli);
     expect(providerDefinition.agentCli.command.executable).toBe('qwen');
-    expect(providerDefinition.agentCli.command.defaultArgs).toEqual([
-      '--approval-mode',
-      'yolo',
-    ]);
+    expect(providerDefinition.agentCli.command.defaultArgs).toEqual([]);
+    expect(providerDefinition.agentCli.caveats.join('\n')).toContain(
+      'does not auto-approve Qwen Code tool use',
+    );
   });
 
   it('formats canonical gateway input into a Qwen Code prompt string', () => {
@@ -134,7 +186,7 @@ describe('Qwen Code provider leaf', () => {
     const runner = createFakeAgentCliRunner([
       (invocation) => ({
         exitCode: 0,
-        stdout: `qwen saw: ${invocation.input}`,
+        stdout: `qwen saw: ${invocation.command.args?.[1]}`,
         startedAt: 100,
         endedAt: 175,
       }),
@@ -158,7 +210,6 @@ describe('Qwen Code provider leaf', () => {
         executable: 'qwen',
         env: { NO_COLOR: '1' },
       },
-      input: 'Build the provider leaf.',
       timeoutMs: 300_000,
       metadata: {
         provider: 'qwen-code',
@@ -168,11 +219,15 @@ describe('Qwen Code provider leaf', () => {
       },
     });
     expect(runner.invocations[0]?.command.args).toEqual([
-      '--approval-mode',
-      'yolo',
+      '-p',
+      'Build the provider leaf.',
       '--model',
       'qwen3-coder-plus',
     ]);
+    expect(runner.calls[0]?.options?.environmentPolicy).toEqual({
+      mergeStrategy: 'allowlist',
+      allowlist: QWEN_CODE_DEFAULT_ENV_ALLOWLIST,
+    });
   });
 
   it('uses Qwen Code defaults without passing a synthetic default model', async () => {
@@ -190,10 +245,10 @@ describe('Qwen Code provider leaf', () => {
     });
 
     expect(runner.invocations[0]?.command.args).toEqual([
-      '--approval-mode',
-      'yolo',
+      '-p',
+      'user: Summarize this.',
     ]);
-    expect(runner.invocations[0]?.input).toBe('user: Summarize this.');
+    expect(runner.invocations[0]?.input).toBeUndefined();
   });
 
   it('preserves the one-shot qwen path for transient invocations', async () => {
@@ -215,14 +270,98 @@ describe('Qwen Code provider leaf', () => {
     });
 
     expect(runner.invocations).toHaveLength(2);
-    expect(runner.invocations[0]?.input).toBe('first transient task');
-    expect(runner.invocations[1]?.input).toBe('second transient task');
+    expect(runner.invocations[0]?.command.args).toEqual(['-p', 'first transient task']);
+    expect(runner.invocations[1]?.command.args).toEqual(['-p', 'second transient task']);
   });
 
   it('constructs a provider with the default live runner without invoking it in tests', () => {
     const provider = new QwenCodeProvider(createConfig());
 
     expect(provider.getConfig().vendor).toBe('qwen-code');
+  });
+
+  it('live runner spawns without a shell and uses the default allowlisted environment', async () => {
+    const child = createFakeChildProcess();
+    let spawnOptions: SpawnOptionsWithoutStdio | undefined;
+    const spawnProcess: QwenCodeSpawn = (_command, _args, options) => {
+      spawnOptions = options;
+      return child;
+    };
+    const runner = createQwenCodeProcessRunner({
+      baseEnv: {
+        PATH: 'C:\\tools',
+        OPENAI_API_KEY: 'qwen-auth',
+        AWS_SECRET_ACCESS_KEY: 'unrelated-secret',
+      },
+      spawn: spawnProcess,
+    });
+
+    const result = await runner.run({
+      command: {
+        executable: 'C:\\tools\\qwen.cmd',
+        args: ['-p', 'hello qwen', '--model', 'qwen3-coder-plus'],
+        env: { NO_COLOR: '1' },
+      },
+      input: 'hello qwen',
+      timeoutMs: 1_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(spawnOptions?.shell).toBe(false);
+    expect(spawnOptions?.env).toMatchObject({
+      PATH: 'C:\\tools',
+      OPENAI_API_KEY: 'qwen-auth',
+      NO_COLOR: '1',
+    });
+    expect(spawnOptions?.env).not.toHaveProperty('AWS_SECRET_ACCESS_KEY');
+    expect(child.stdinInput.join('')).toBe('hello qwen');
+  });
+
+  it('live runner terminates and settles post-start aborts', async () => {
+    const child = createFakeChildProcess({ closeOnStdinEnd: false, closeOnKill: false });
+    const controller = new AbortController();
+    const runner = createQwenCodeProcessRunner({
+      killEscalationDelayMs: 1,
+      spawn: () => child,
+    });
+
+    const resultPromise = runner.run({
+      command: {
+        executable: 'C:\\tools\\qwen.cmd',
+        args: ['-p', 'cancel me'],
+      },
+      input: 'cancel me',
+      timeoutMs: 10_000,
+    }, { signal: controller.signal });
+
+    controller.abort();
+    const result = await resultPromise;
+
+    expect(result.ok).toBe(false);
+    expect(result.failure?.kind).toBe('spawn_error');
+    expect(child.killSignals).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+
+  it('live runner escalates timeout termination and settles if the process ignores SIGTERM', async () => {
+    const child = createFakeChildProcess({ closeOnStdinEnd: false, closeOnKill: false });
+    const runner = createQwenCodeProcessRunner({
+      killEscalationDelayMs: 1,
+      spawn: () => child,
+    });
+
+    const result = await runner.run({
+      command: {
+        executable: 'C:\\tools\\qwen.cmd',
+        args: ['-p', 'time out'],
+      },
+      input: 'time out',
+      timeoutMs: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failure?.kind).toBe('timeout');
+    expect(result.failure?.timedOut).toBe(true);
+    expect(child.killSignals).toEqual(['SIGTERM', 'SIGKILL']);
   });
 
   it('selects Qwen Code executable overrides deterministically before PATH lookup', () => {

--- a/self/subcortex/providers/src/__tests__/providers/qwen-code.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/qwen-code.test.ts
@@ -387,6 +387,51 @@ describe('Qwen Code provider leaf', () => {
     })).toBe('C:\\tools\\qwen-generic.cmd');
   });
 
+  it('prefers a directly-spawnable Windows binary over a .cmd shim', () => {
+    const commandResolver: QwenCodeCommandResolver = (command, args) => {
+      expect(command).toBe('where.exe');
+      expect(args).toEqual(['qwen']);
+      return [
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\qwen.cmd',
+        'C:\\Program Files\\qwen\\qwen.exe',
+      ].join('\r\n');
+    };
+
+    expect(resolveQwenCodeExecutable('qwen', {
+      commandResolver,
+      platform: 'win32',
+    })).toBe('C:\\Program Files\\qwen\\qwen.exe');
+  });
+
+  it('fails with configuration guidance when only a Windows shim is launchable under shell:false', async () => {
+    const commandResolver: QwenCodeCommandResolver = () =>
+      'C:\\Users\\dev\\AppData\\Roaming\\npm\\qwen.cmd';
+    let spawnCalled = false;
+    const runner = createQwenCodeProcessRunner({
+      platform: 'win32',
+      commandResolver,
+      spawn: () => {
+        spawnCalled = true;
+        return createFakeChildProcess();
+      },
+    });
+
+    const result = await runner.run({
+      command: {
+        executable: 'qwen',
+        args: ['-p', 'hello qwen'],
+      },
+      input: 'hello qwen',
+      timeoutMs: 1_000,
+    });
+
+    expect(spawnCalled).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.failure?.kind).toBe('spawn_error');
+    expect(result.failure?.message).toContain('NOUS_QWEN_CODE_BIN');
+    expect(result.failure?.message).toContain('QWEN_CODE_BIN');
+  });
+
   it('resolves default POSIX qwen away from workspace node_modules bin candidates', () => {
     const commandResolver: QwenCodeCommandResolver = (command, args) => {
       expect(command).toBe('which');

--- a/self/subcortex/providers/src/__tests__/providers/qwen-code.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/qwen-code.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type GatewayContextFrame,
+  type ModelProviderConfig,
+  type ProviderId,
+  type ToolDefinition,
+  type TraceId,
+} from '@nous/shared';
+import {
+  QWEN_CODE_DEFAULT_MODEL_ID,
+  QWEN_CODE_EXECUTION_CAPABILITY_PROFILE,
+  QWEN_CODE_PROVIDER_DEFINITION,
+  QwenCodeProvider,
+  type QwenCodeCommandResolver,
+  createQwenCodeAdapter,
+  providerAdapter,
+  providerDefinition,
+  providerFactory,
+  renderQwenCodePrompt,
+  resolveQwenCodeExecutable,
+  selectQwenCodeExecutable,
+} from '../../providers/qwen-code/index.js';
+import { createFakeAgentCliRunner } from '../../protocols/agent-cli/index.js';
+import { AgentCliProviderMetadataSchema } from '../../schemas/provider-definition.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440188' as TraceId;
+const PROVIDER_ID = '10000000-0000-0000-0000-000000000005' as ProviderId;
+const CREATED_AT = '2026-06-12T00:00:00.000Z';
+
+function createConfig(modelId = QWEN_CODE_DEFAULT_MODEL_ID): ModelProviderConfig {
+  return {
+    id: PROVIDER_ID,
+    name: 'Qwen Code',
+    type: 'text',
+    endpoint: 'http://localhost',
+    modelId,
+    isLocal: true,
+    capabilities: ['text'],
+    providerClass: 'local_text',
+    vendor: 'qwen-code',
+  };
+}
+
+function frame(role: GatewayContextFrame['role'], content: string): GatewayContextFrame {
+  return {
+    role,
+    source: 'initial_context',
+    content,
+    createdAt: CREATED_AT,
+  };
+}
+
+function toolDefinition(): ToolDefinition {
+  return {
+    name: 'lookup',
+    version: '1.0.0',
+    description: 'Lookup data',
+    inputSchema: { type: 'object' },
+    outputSchema: { type: 'object' },
+    capabilities: ['lookup'],
+    permissionScope: 'test',
+  };
+}
+
+describe('Qwen Code provider leaf', () => {
+  it('declares Agent CLI catalog metadata as a one-shot command provider', () => {
+    expect(providerDefinition).toBe(QWEN_CODE_PROVIDER_DEFINITION);
+    expect(providerDefinition).toMatchObject({
+      vendorKey: 'qwen-code',
+      protocol: 'agent-cli',
+      adapterKey: 'qwen-code',
+      providerClass: 'local_text',
+      isLocal: true,
+      executionCapabilityProfile: 'one_shot_command',
+      capabilities: {
+        streaming: true,
+      },
+    });
+    expect(providerDefinition).not.toHaveProperty('wellKnownProviderId');
+    expect(AgentCliProviderMetadataSchema.parse(providerDefinition.agentCli))
+      .toEqual(providerDefinition.agentCli);
+    expect(providerDefinition.agentCli.command.executable).toBe('qwen');
+    expect(providerDefinition.agentCli.command.defaultArgs).toEqual([
+      '--approval-mode',
+      'yolo',
+    ]);
+  });
+
+  it('formats canonical gateway input into a Qwen Code prompt string', () => {
+    const prompt = renderQwenCodePrompt({
+      systemPrompt: ['system one', 'system two'],
+      context: [
+        frame('user', 'hello'),
+        frame('assistant', 'hi there'),
+      ],
+      toolDefinitions: [toolDefinition()],
+    });
+
+    expect(prompt).toContain('system one\n\nsystem two');
+    expect(prompt).toContain('user: hello');
+    expect(prompt).toContain('assistant: hi there');
+    expect(prompt).toContain('Available tools:');
+    expect(prompt).toContain('"name": "lookup"');
+  });
+
+  it('exposes a ProviderAdapter module for qwen-code with text-safe parsing', () => {
+    const adapter = createQwenCodeAdapter();
+
+    expect(providerAdapter.executionCapabilityProfile).toBe(QWEN_CODE_EXECUTION_CAPABILITY_PROFILE);
+    expect(QWEN_CODE_EXECUTION_CAPABILITY_PROFILE).toBe('one_shot_command');
+    expect(adapter.capabilities.streaming).toBe(true);
+    expect(adapter.formatRequest({
+      systemPrompt: 'Act as Qwen.',
+      context: [frame('user', 'Implement the task.')],
+    })).toEqual({
+      input: {
+        prompt: 'Act as Qwen.\n\nuser: Implement the task.',
+      },
+    });
+    expect(adapter.parseResponse('done', TRACE_ID)).toMatchObject({
+      response: 'done',
+      toolCalls: [],
+      contentType: 'text',
+    });
+  });
+
+  it('does not throw and falls back to text for malformed adapter outputs', () => {
+    const adapter = createQwenCodeAdapter();
+    expect(() => adapter.parseResponse({ unexpected: true }, TRACE_ID)).not.toThrow();
+    expect(adapter.parseResponse({ unexpected: true }, TRACE_ID).contentType).toBe('text');
+  });
+
+  it('invokes an injected Agent CLI runner and returns stdout as model output', async () => {
+    const runner = createFakeAgentCliRunner([
+      (invocation) => ({
+        exitCode: 0,
+        stdout: `qwen saw: ${invocation.input}`,
+        startedAt: 100,
+        endedAt: 175,
+      }),
+    ]);
+    const provider = new QwenCodeProvider(createConfig('qwen3-coder-plus'), { runner });
+
+    const response = await provider.invoke({
+      role: 'workers',
+      input: { prompt: 'Build the provider leaf.' },
+      traceId: TRACE_ID,
+    });
+
+    expect(response).toEqual({
+      output: 'qwen saw: Build the provider leaf.',
+      providerId: PROVIDER_ID,
+      usage: { computeMs: 75 },
+      traceId: TRACE_ID,
+    });
+    expect(runner.invocations[0]).toMatchObject({
+      command: {
+        executable: 'qwen',
+        env: { NO_COLOR: '1' },
+      },
+      input: 'Build the provider leaf.',
+      timeoutMs: 300_000,
+      metadata: {
+        provider: 'qwen-code',
+        providerId: PROVIDER_ID,
+        modelId: 'qwen3-coder-plus',
+        traceId: TRACE_ID,
+      },
+    });
+    expect(runner.invocations[0]?.command.args).toEqual([
+      '--approval-mode',
+      'yolo',
+      '--model',
+      'qwen3-coder-plus',
+    ]);
+  });
+
+  it('uses Qwen Code defaults without passing a synthetic default model', async () => {
+    const runner = createFakeAgentCliRunner();
+    const provider = new QwenCodeProvider(createConfig(), { runner });
+
+    await provider.invoke({
+      role: 'workers',
+      input: {
+        messages: [
+          { role: 'user', content: 'Summarize this.' },
+        ],
+      },
+      traceId: TRACE_ID,
+    });
+
+    expect(runner.invocations[0]?.command.args).toEqual([
+      '--approval-mode',
+      'yolo',
+    ]);
+    expect(runner.invocations[0]?.input).toBe('user: Summarize this.');
+  });
+
+  it('preserves the one-shot qwen path for transient invocations', async () => {
+    const runner = createFakeAgentCliRunner([
+      { exitCode: 0, stdout: 'first', startedAt: 1, endedAt: 2 },
+      { exitCode: 0, stdout: 'second', startedAt: 3, endedAt: 4 },
+    ]);
+    const provider = new QwenCodeProvider(createConfig(), { runner });
+
+    await provider.invoke({
+      role: 'workers',
+      input: { prompt: 'first transient task' },
+      traceId: TRACE_ID,
+    });
+    await provider.invoke({
+      role: 'workers',
+      input: { prompt: 'second transient task' },
+      traceId: TRACE_ID,
+    });
+
+    expect(runner.invocations).toHaveLength(2);
+    expect(runner.invocations[0]?.input).toBe('first transient task');
+    expect(runner.invocations[1]?.input).toBe('second transient task');
+  });
+
+  it('constructs a provider with the default live runner without invoking it in tests', () => {
+    const provider = new QwenCodeProvider(createConfig());
+
+    expect(provider.getConfig().vendor).toBe('qwen-code');
+  });
+
+  it('selects Qwen Code executable overrides deterministically before PATH lookup', () => {
+    expect(selectQwenCodeExecutable({
+      explicitExecutable: 'C:\\tools\\qwen-explicit.cmd',
+      env: {
+        NOUS_QWEN_CODE_BIN: 'C:\\tools\\qwen-nous.cmd',
+        QWEN_CODE_BIN: 'C:\\tools\\qwen-generic.cmd',
+      },
+    })).toBe('C:\\tools\\qwen-explicit.cmd');
+
+    expect(selectQwenCodeExecutable({
+      env: {
+        NOUS_QWEN_CODE_BIN: 'C:\\tools\\qwen-nous.cmd',
+        QWEN_CODE_BIN: 'C:\\tools\\qwen-generic.cmd',
+      },
+    })).toBe('C:\\tools\\qwen-nous.cmd');
+
+    expect(selectQwenCodeExecutable({
+      env: {
+        QWEN_CODE_BIN: 'C:\\tools\\qwen-generic.cmd',
+      },
+    })).toBe('C:\\tools\\qwen-generic.cmd');
+  });
+
+  it('resolves default POSIX qwen away from workspace node_modules bin candidates', () => {
+    const commandResolver: QwenCodeCommandResolver = (command, args) => {
+      expect(command).toBe('which');
+      expect(args).toEqual(['-a', 'qwen']);
+      return [
+        '/repo/node_modules/.bin/qwen',
+        '/usr/local/bin/qwen',
+      ].join('\n');
+    };
+
+    expect(resolveQwenCodeExecutable('qwen', {
+      commandResolver,
+      platform: 'linux',
+    })).toBe('/usr/local/bin/qwen');
+  });
+
+  it('maps Agent CLI runner failures to provider errors', async () => {
+    const runner = createFakeAgentCliRunner([
+      { exitCode: 2, stderr: 'bad args' },
+    ]);
+    const provider = new QwenCodeProvider(createConfig(), { runner });
+
+    await expect(provider.invoke({
+      role: 'workers',
+      input: { prompt: 'hello' },
+      traceId: TRACE_ID,
+    })).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE',
+      context: {
+        provider: 'qwen-code',
+        failureKind: 'non_zero_exit',
+        exitCode: 2,
+      },
+    });
+    expect(runner.invocations).toHaveLength(1);
+  });
+
+  it('factory passes runner injection through the provider module contract', async () => {
+    const runner = createFakeAgentCliRunner([{ exitCode: 0, stdout: 'factory ok' }]);
+    const provider = providerFactory.create(createConfig(), {
+      agentCliRunner: runner,
+    });
+
+    expect(provider).toBeInstanceOf(QwenCodeProvider);
+    await expect(provider.invoke({
+      role: 'workers',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    })).resolves.toMatchObject({ output: 'factory ok' });
+  });
+
+  it('streams stdout chunks and a terminal done chunk', async () => {
+    const runner = createFakeAgentCliRunner([{ exitCode: 0, stdout: 'streamed answer' }]);
+    const provider = new QwenCodeProvider(createConfig(), { runner });
+
+    const chunks: string[] = [];
+    let done = false;
+    for await (const chunk of provider.stream({
+      role: 'workers',
+      input: { prompt: 'stream please' },
+      traceId: TRACE_ID,
+    })) {
+      chunks.push(chunk.content);
+      done = chunk.done;
+    }
+
+    expect(chunks.join('')).toContain('streamed answer');
+    expect(done).toBe(true);
+  });
+});

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -33,6 +33,7 @@ export {
 export * from './protocols/agent-cli/index.js';
 export { CodexCliProvider } from './providers/codex-cli/implementation.js';
 export { GitHubCopilotCliProvider } from './providers/github-copilot-cli/provider.js';
+export { QwenCodeProvider } from './providers/qwen-code/implementation.js';
 export {
   createTextAdapter,
   textAdapter,

--- a/self/subcortex/providers/src/protocols/agent-cli/runner.ts
+++ b/self/subcortex/providers/src/protocols/agent-cli/runner.ts
@@ -24,6 +24,8 @@ export interface AgentCliEnvironmentPolicy {
 
 export interface AgentCliAbortSignal {
   readonly aborted: boolean;
+  readonly addEventListener?: AbortSignal['addEventListener'];
+  readonly removeEventListener?: AbortSignal['removeEventListener'];
 }
 
 export interface AgentCliRunnerOptions {

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -7,6 +7,7 @@ import { providerAdapter as groqProviderAdapter } from './providers/groq/adapter
 import { providerAdapter as llamaCppProviderAdapter } from './providers/llama-cpp/adapter.js';
 import { providerAdapter as ollamaProviderAdapter } from './providers/ollama/adapter.js';
 import { providerAdapter as openaiProviderAdapter } from './providers/openai/adapter.js';
+import { providerAdapter as qwenCodeProviderAdapter } from './providers/qwen-code/adapter.js';
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
@@ -16,6 +17,7 @@ export { providerAdapter as groqAdapter } from './providers/groq/adapter.js';
 export { providerAdapter as llamaCppAdapter } from './providers/llama-cpp/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
+export { providerAdapter as qwenCodeAdapter, QWEN_CODE_EXECUTION_CAPABILITY_PROFILE, createQwenCodeAdapter, renderQwenCodePrompt } from './providers/qwen-code/adapter.js';
 
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
@@ -25,6 +27,7 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   llamaCppProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
+  qwenCodeProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];
 
 export type CertifiedProviderAdapterKey =

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -8,6 +8,7 @@ import { providerDefinition as groqProviderDefinition } from './providers/groq/d
 import { providerDefinition as llamaCppProviderDefinition } from './providers/llama-cpp/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
+import { providerDefinition as qwenCodeProviderDefinition } from './providers/qwen-code/definition.js';
 
 export * from './schemas/provider-definition.js';
 
@@ -19,6 +20,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   llamaCppProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
+  qwenCodeProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];
 
 export const PROVIDER_DEFINITIONS = hydrateProviderDefinitions(PROVIDER_DEFINITION_LEAVES);

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -7,6 +7,7 @@ import { providerFactory as groqProviderFactory } from './providers/groq/provide
 import { providerFactory as llamaCppProviderFactory } from './providers/llama-cpp/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
+import { providerFactory as qwenCodeProviderFactory } from './providers/qwen-code/provider.js';
 
 export * from './schemas/provider-factory.js';
 
@@ -18,6 +19,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   llamaCppProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
+  qwenCodeProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];
 
 export type CertifiedProviderFactoryVendorKey =

--- a/self/subcortex/providers/src/providers/qwen-code/adapter.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/adapter.ts
@@ -1,0 +1,91 @@
+import type { GatewayContextFrame, TraceId } from '@nous/shared';
+import { AGENT_CLI_PROTOCOL_ID } from '../../protocols/agent-cli/index.js';
+import {
+  defineProviderAdapter,
+  type AdapterCapabilities,
+  type AdapterFormatInput,
+  type AdapterFormattedRequest,
+  type ProviderAdapter,
+} from '../../schemas/provider-adapter.js';
+import { parseModelOutput, type ParsedModelOutput } from '../../shared/output.js';
+
+const QWEN_CODE_ADAPTER_CAPABILITIES: AdapterCapabilities = {
+  nativeToolUse: false,
+  cacheControl: false,
+  extendedThinking: false,
+  streaming: true,
+};
+
+export const QWEN_CODE_EXECUTION_CAPABILITY_PROFILE = 'one_shot_command' as const;
+
+export function createQwenCodeAdapter(): ProviderAdapter {
+  return {
+    capabilities: QWEN_CODE_ADAPTER_CAPABILITIES,
+    formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
+      return {
+        input: {
+          prompt: renderQwenCodePrompt(input),
+        },
+      };
+    },
+    parseResponse(output: unknown, traceId: TraceId): ParsedModelOutput {
+      try {
+        return parseModelOutput(output, traceId);
+      } catch {
+        return {
+          response: String(output ?? ''),
+          toolCalls: [],
+          memoryCandidates: [],
+          contentType: 'text',
+        };
+      }
+    },
+  };
+}
+
+export function renderQwenCodePrompt(input: AdapterFormatInput): string {
+  const sections: string[] = [];
+  const systemPrompt = Array.isArray(input.systemPrompt)
+    ? input.systemPrompt.join('\n\n')
+    : input.systemPrompt;
+
+  if (systemPrompt.trim().length > 0) {
+    sections.push(systemPrompt.trim());
+  }
+
+  for (const frame of input.context) {
+    const rendered = renderContextFrame(frame);
+    if (rendered.length > 0) {
+      sections.push(rendered);
+    }
+  }
+
+  if (input.toolDefinitions && input.toolDefinitions.length > 0) {
+    sections.push(`Available tools:\n${JSON.stringify(input.toolDefinitions, null, 2)}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+function renderContextFrame(frame: GatewayContextFrame): string {
+  const content = typeof frame.content === 'string'
+    ? frame.content
+    : JSON.stringify(frame.content);
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return '';
+
+  return `${frame.role}: ${trimmed}`;
+}
+
+export const providerAdapter = defineProviderAdapter({
+  adapterKey: 'qwen-code',
+  displayName: 'Qwen Code',
+  protocol: AGENT_CLI_PROTOCOL_ID,
+  capabilities: QWEN_CODE_ADAPTER_CAPABILITIES,
+  executionCapabilityProfile: QWEN_CODE_EXECUTION_CAPABILITY_PROFILE,
+  create() {
+    return createQwenCodeAdapter();
+  },
+});
+
+export { providerAdapter as qwenCodeAdapter };

--- a/self/subcortex/providers/src/providers/qwen-code/definition.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/definition.ts
@@ -1,0 +1,83 @@
+import { AGENT_CLI_PROTOCOL_ID } from '../../protocols/agent-cli/index.js';
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+
+export const QWEN_CODE_DEFAULT_ENDPOINT = 'http://localhost';
+export const QWEN_CODE_DEFAULT_MODEL_ID = 'qwen-code/default';
+export const QWEN_CODE_DEFAULT_TIMEOUT_MS = 300_000;
+export const QWEN_CODE_MAX_TIMEOUT_MS = 1_800_000;
+
+export const QWEN_CODE_PROVIDER_DEFINITION = {
+  vendorKey: 'qwen-code',
+  displayName: 'Qwen Code',
+  providerType: 'text',
+  providerClass: 'local_text',
+  protocol: AGENT_CLI_PROTOCOL_ID,
+  adapterKey: 'qwen-code',
+  defaultEndpoint: QWEN_CODE_DEFAULT_ENDPOINT,
+  defaultModelId: QWEN_CODE_DEFAULT_MODEL_ID,
+  auth: {
+    required: false,
+    purpose: 'api_key',
+  },
+  capabilities: {
+    streaming: true,
+    cacheControl: false,
+    extendedThinking: false,
+    nativeToolUse: false,
+    healthCheck: false,
+  },
+  executionCapabilityProfile: 'one_shot_command',
+  isLocal: true,
+  agentCli: {
+    command: {
+      executable: 'qwen',
+      defaultArgs: ['--approval-mode', 'yolo'],
+    },
+    install: {
+      command: 'npm install -g @qwen-code/qwen-code@latest',
+      packageName: '@qwen-code/qwen-code',
+      versionCommand: 'qwen --version',
+      minimumVersion: '0.0.1',
+      notes: 'Qwen Code requires Node.js 22+ and must be installed and authenticated locally before use; run `qwen` once and use /auth, or export OPENAI_API_KEY/OPENAI_BASE_URL/OPENAI_MODEL.',
+    },
+    auth: {
+      kind: 'local_session',
+      description: 'Uses the local Qwen Code login session; authenticate via `qwen` then /auth, or set OPENAI_API_KEY/OPENAI_BASE_URL/OPENAI_MODEL outside Nous.',
+    },
+    headless: {
+      supported: true,
+      requiredArgs: [],
+      nonInteractiveEnv: {
+        NO_COLOR: '1',
+      },
+    },
+    transcript: {
+      supported: true,
+      streams: ['stdout', 'stderr'],
+      format: 'text',
+    },
+    timeout: {
+      defaultMs: QWEN_CODE_DEFAULT_TIMEOUT_MS,
+      maxMs: QWEN_CODE_MAX_TIMEOUT_MS,
+    },
+    failureBehavior: {
+      timeoutKind: 'timeout',
+      nonZeroExitKind: 'non_zero_exit',
+      spawnErrorKind: 'spawn_error',
+    },
+    caveats: [
+      'Transient and batch execution use the one-shot `qwen --prompt` (-p) command path. Qwen Code declares `one_shot_command`, not `persistent_process`, so Cortex persistent-chat surfaces must reject it through adapter capability guardrails rather than pretending it can provide a strict long-lived chat process.',
+      'Each invocation spawns a fresh `qwen` process with no carried session state; the provider does not retain context across requests.',
+      'Live process execution shells out to the local Qwen Code CLI; tests must inject a fake runner.',
+      'The rendered prompt is piped to the `qwen` process via stdin, matching Qwen Code non-interactive (headless) behavior where `--prompt` (-p) appends to stdin input.',
+      'Set NOUS_QWEN_CODE_BIN, or QWEN_CODE_BIN, when another qwen executable shadows the desired system Qwen Code CLI on PATH; without an override the live runner prefers non-node_modules/.bin candidates when resolving qwen.',
+      'The endpoint is a local placeholder because provider definitions currently require URLs.',
+      'Set a concrete modelId to pass `--model`; the default model uses the Qwen Code profile/config.',
+    ],
+    targetIssueRefs: ['#296'],
+  },
+} as const satisfies ProviderDefinitionLeaf;
+
+export {
+  QWEN_CODE_PROVIDER_DEFINITION as providerDefinition,
+};

--- a/self/subcortex/providers/src/providers/qwen-code/definition.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/definition.ts
@@ -31,7 +31,7 @@ export const QWEN_CODE_PROVIDER_DEFINITION = {
   agentCli: {
     command: {
       executable: 'qwen',
-      defaultArgs: ['--approval-mode', 'yolo'],
+      defaultArgs: [],
     },
     install: {
       command: 'npm install -g @qwen-code/qwen-code@latest',
@@ -66,10 +66,12 @@ export const QWEN_CODE_PROVIDER_DEFINITION = {
       spawnErrorKind: 'spawn_error',
     },
     caveats: [
-      'Transient and batch execution use the one-shot `qwen --prompt` (-p) command path. Qwen Code declares `one_shot_command`, not `persistent_process`, so Cortex persistent-chat surfaces must reject it through adapter capability guardrails rather than pretending it can provide a strict long-lived chat process.',
+      'Transient and batch execution use the documented one-shot `qwen -p "<prompt>"` command path. Qwen Code declares `one_shot_command`, not `persistent_process`, so Cortex persistent-chat surfaces must reject it through adapter capability guardrails rather than pretending it can provide a strict long-lived chat process.',
       'Each invocation spawns a fresh `qwen` process with no carried session state; the provider does not retain context across requests.',
       'Live process execution shells out to the local Qwen Code CLI; tests must inject a fake runner.',
-      'The rendered prompt is piped to the `qwen` process via stdin, matching Qwen Code non-interactive (headless) behavior where `--prompt` (-p) appends to stdin input.',
+      'The catalog default is conservative and does not auto-approve Qwen Code tool use; pass explicit provider runner args only for trusted opt-in profiles.',
+      'The rendered prompt is passed to `qwen -p` for non-interactive one-shot execution; the live runner does not rely on bare stdin to enter headless mode.',
+      'The live runner uses an allowlisted environment by default for Qwen/OpenAI/DashScope auth, proxy/cert configuration, PATH, and local user config locations; full parent-environment inheritance requires an explicit runner environment policy.',
       'Set NOUS_QWEN_CODE_BIN, or QWEN_CODE_BIN, when another qwen executable shadows the desired system Qwen Code CLI on PATH; without an override the live runner prefers non-node_modules/.bin candidates when resolving qwen.',
       'The endpoint is a local placeholder because provider definitions currently require URLs.',
       'Set a concrete modelId to pass `--model`; the default model uses the Qwen Code profile/config.',

--- a/self/subcortex/providers/src/providers/qwen-code/implementation.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/implementation.ts
@@ -1,4 +1,9 @@
-import { execFileSync, spawn } from 'node:child_process';
+import {
+  execFileSync,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+  type SpawnOptionsWithoutStdio,
+} from 'node:child_process';
 import { NousError, ValidationError } from '@nous/shared';
 import type {
   IModelProvider,
@@ -37,7 +42,9 @@ export interface QwenCodeProviderOptions {
 export interface QwenCodeProcessRunnerOptions {
   readonly baseEnv?: Readonly<Record<string, string | undefined>>;
   readonly commandResolver?: QwenCodeCommandResolver;
+  readonly killEscalationDelayMs?: number;
   readonly platform?: NodeJS.Platform;
+  readonly spawn?: QwenCodeSpawn;
 }
 
 const QWEN_CODE_NOUS_BIN_ENV = 'NOUS_QWEN_CODE_BIN';
@@ -48,6 +55,42 @@ export type QwenCodeCommandResolver = (
   args: readonly string[],
   options: { readonly env?: NodeJS.ProcessEnv },
 ) => string;
+
+export type QwenCodeSpawn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptionsWithoutStdio,
+) => ChildProcessWithoutNullStreams;
+
+export const QWEN_CODE_DEFAULT_ENV_ALLOWLIST = [
+  'PATH',
+  'Path',
+  'PATHEXT',
+  'SystemRoot',
+  'WINDIR',
+  'HOME',
+  'USERPROFILE',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'XDG_CONFIG_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_DATA_HOME',
+  'NOUS_QWEN_CODE_BIN',
+  'QWEN_CODE_BIN',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'DASHSCOPE_API_KEY',
+  'DASHSCOPE_BASE_URL',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'NODE_EXTRA_CA_CERTS',
+] as const;
+
+const QWEN_CODE_DEFAULT_KILL_ESCALATION_DELAY_MS = 2_000;
 
 export const QWEN_CODE_INVOCATION_DEFAULTS: AgentCliInvocationDefaults = {
   command: {
@@ -106,10 +149,10 @@ export class QwenCodeProvider implements IModelProvider {
   async invoke(request: ModelRequest): Promise<ModelResponse> {
     const runner = this.runner;
     const input = this.validateInput(request.input);
+    const renderedPrompt = renderTextModelInput(input);
     const start = Date.now();
     const invocationInput = {
-      args: this.invocationArgs(),
-      input: renderTextModelInput(input),
+      args: this.invocationArgs(renderedPrompt),
       metadata: {
         provider: 'qwen-code',
         providerId: this.config.id,
@@ -138,14 +181,14 @@ export class QwenCodeProvider implements IModelProvider {
   async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
     const runner = this.runner;
     const input = this.validateInput(request.input);
+    const renderedPrompt = renderTextModelInput(input);
     const state: QwenCodeStreamState = {
       emittedContent: false,
       finalResult: undefined,
     };
 
     const invocationInput = {
-      args: this.invocationArgs(),
-      input: renderTextModelInput(input),
+      args: this.invocationArgs(renderedPrompt),
       metadata: {
         provider: 'qwen-code',
         providerId: this.config.id,
@@ -215,29 +258,27 @@ export class QwenCodeProvider implements IModelProvider {
     return result.data;
   }
 
-  private invocationArgs(): readonly string[] {
-    // Qwen Code headless mode reads the prompt from stdin, so the rendered
-    // prompt is piped via `invocation.input` rather than passed as a flag value.
+  private invocationArgs(prompt: string): readonly string[] {
+    const args = ['-p', prompt];
     if (
       this.config.modelId.length === 0 ||
       this.config.modelId === QWEN_CODE_DEFAULT_MODEL_ID
     ) {
-      return [];
+      return args;
     }
 
-    return ['--model', this.config.modelId];
+    return [...args, '--model', this.config.modelId];
   }
 
-  private mergeRunnerOptions(request: ModelRequest): AgentCliRunnerOptions | undefined {
-    const signal = request.abortSignal
-      ? { aborted: request.abortSignal.aborted }
-      : this.runnerOptions?.signal;
-
-    if (!signal && !this.runnerOptions) {
-      return undefined;
-    }
+  private mergeRunnerOptions(request: ModelRequest): AgentCliRunnerOptions {
+    const signal = request.abortSignal ?? this.runnerOptions?.signal;
+    const environmentPolicy = this.runnerOptions?.environmentPolicy ?? {
+      mergeStrategy: 'allowlist' as const,
+      allowlist: QWEN_CODE_DEFAULT_ENV_ALLOWLIST,
+    };
 
     return {
+      environmentPolicy,
       ...this.runnerOptions,
       ...(signal ? { signal } : {}),
     };
@@ -393,10 +434,11 @@ function runQwenCodeProcessRaw(
   }
 
   return new Promise((resolve) => {
-    let child;
+    let child: ChildProcessWithoutNullStreams;
     try {
       const env = buildProcessEnv(invocation.command.env, runnerOptions, options);
-      child = spawn(resolveSpawnExecutable(invocation.command.executable, {
+      const spawnProcess = options.spawn ?? spawn;
+      child = spawnProcess(resolveSpawnExecutable(invocation.command.executable, {
         commandResolver: options.commandResolver,
         env,
         platform: options.platform,
@@ -405,7 +447,7 @@ function runQwenCodeProcessRaw(
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
-        shell: process.platform === 'win32',
+        shell: false,
       });
     } catch (error) {
       resolve({
@@ -420,12 +462,69 @@ function runQwenCodeProcessRaw(
     let stderr = '';
     let timedOut = false;
     let settled = false;
-    const timeout = invocation.timeoutMs === undefined
+    let abortError: Error | undefined;
+    let timeout: NodeJS.Timeout | undefined;
+    let escalationTimeout: NodeJS.Timeout | undefined;
+    const killEscalationDelayMs = Math.max(
+      0,
+      Math.trunc(options.killEscalationDelayMs ?? QWEN_CODE_DEFAULT_KILL_ESCALATION_DELAY_MS),
+    );
+    const clearTimers = (): void => {
+      if (timeout) clearTimeout(timeout);
+      if (escalationTimeout) clearTimeout(escalationTimeout);
+      timeout = undefined;
+      escalationTimeout = undefined;
+    };
+    let handleAbort: () => void = () => undefined;
+    const settle = (raw: AgentCliRawResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      runnerOptions?.signal?.removeEventListener?.('abort', handleAbort);
+      resolve(raw);
+    };
+    const killChild = (signal: NodeJS.Signals): void => {
+      try {
+        child.kill(signal);
+      } catch {
+        // The process may have already exited; close/error will settle it.
+      }
+    };
+    const terminateChild = (reason: 'abort' | 'timeout'): void => {
+      if (settled) return;
+      if (reason === 'timeout') {
+        timedOut = true;
+      } else {
+        abortError = new Error('Agent CLI invocation aborted.');
+      }
+
+      killChild('SIGTERM');
+      if (!escalationTimeout) {
+        escalationTimeout = setTimeout(() => {
+          killChild('SIGKILL');
+          settle({
+            stdout,
+            stderr,
+            error: abortError,
+            timedOut,
+            signal: 'SIGKILL',
+            startedAt,
+            endedAt: Date.now(),
+          });
+        }, killEscalationDelayMs);
+      }
+    };
+    handleAbort = (): void => terminateChild('abort');
+
+    timeout = invocation.timeoutMs === undefined
       ? undefined
       : setTimeout(() => {
-        timedOut = true;
-        child.kill('SIGTERM');
+        terminateChild('timeout');
       }, invocation.timeoutMs);
+    runnerOptions?.signal?.addEventListener?.('abort', handleAbort, { once: true });
+    if (runnerOptions?.signal?.aborted) {
+      handleAbort();
+    }
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -438,10 +537,7 @@ function runQwenCodeProcessRaw(
       onTranscriptEvent?.({ stream: 'stderr', text: chunk, timestamp: new Date().toISOString() });
     });
     child.on('error', (error) => {
-      if (settled) return;
-      settled = true;
-      if (timeout) clearTimeout(timeout);
-      resolve({
+      settle({
         stdout,
         stderr,
         error,
@@ -451,10 +547,7 @@ function runQwenCodeProcessRaw(
       });
     });
     child.on('close', (exitCode, signal) => {
-      if (settled) return;
-      settled = true;
-      if (timeout) clearTimeout(timeout);
-      resolve({
+      settle({
         exitCode,
         signal,
         stdout,
@@ -465,7 +558,18 @@ function runQwenCodeProcessRaw(
       });
     });
 
-    child.stdin.end(invocation.input ?? '');
+    try {
+      child.stdin.end(invocation.input ?? '');
+    } catch (error) {
+      settle({
+        stdout,
+        stderr,
+        error,
+        timedOut,
+        startedAt,
+        endedAt: Date.now(),
+      });
+    }
   });
 }
 
@@ -486,10 +590,13 @@ function buildProcessEnv(
   options: QwenCodeProcessRunnerOptions,
 ): NodeJS.ProcessEnv {
   const baseEnv = options.baseEnv ?? process.env;
-  const policy = runnerOptions?.environmentPolicy;
+  const policy = runnerOptions?.environmentPolicy ?? {
+    mergeStrategy: 'allowlist' as const,
+    allowlist: QWEN_CODE_DEFAULT_ENV_ALLOWLIST,
+  };
   const env: NodeJS.ProcessEnv = {};
 
-  if (!policy || policy.mergeStrategy === 'explicit') {
+  if (policy.mergeStrategy === 'explicit') {
     assignDefinedEnv(env, baseEnv);
   } else if (policy.mergeStrategy === 'allowlist') {
     for (const key of policy.allowlist ?? []) {

--- a/self/subcortex/providers/src/providers/qwen-code/implementation.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/implementation.ts
@@ -317,12 +317,17 @@ export function resolveQwenCodeExecutable(
   const systemCandidates = candidates.filter((candidate) => !isNodeModulesBinCandidate(candidate));
 
   if (platform === 'win32') {
-    return systemCandidates.find((candidate) => candidate.toLowerCase().endsWith('.cmd'))
+    return systemCandidates.find((candidate) => !isWindowsShimPath(candidate))
       ?? systemCandidates[0]
       ?? executable;
   }
 
   return systemCandidates[0] ?? executable;
+}
+
+function isWindowsShimPath(candidate: string): boolean {
+  const lower = candidate.toLowerCase();
+  return lower.endsWith('.cmd') || lower.endsWith('.bat');
 }
 
 function resolveExecutableCandidates(
@@ -581,7 +586,19 @@ function resolveSpawnExecutable(
     readonly platform?: NodeJS.Platform;
   },
 ): string {
-  return resolveQwenCodeExecutable(executable, options);
+  const resolved = resolveQwenCodeExecutable(executable, options);
+  const platform = options.platform ?? process.platform;
+  if (platform === 'win32' && isWindowsShimPath(resolved)) {
+    throw new NousError(
+      `Qwen Code resolved to a Windows shim (${resolved}) that cannot be launched safely `
+        + `without a shell. Set ${QWEN_CODE_NOUS_BIN_ENV} or ${QWEN_CODE_BIN_ENV} to a directly `
+        + `executable Qwen Code binary or Node entrypoint (for example the qwen.js under `
+        + `node_modules or an installed qwen.exe).`,
+      'PROVIDER_UNAVAILABLE',
+      { provider: 'qwen-code', failureKind: 'spawn_error', executable: resolved },
+    );
+  }
+  return resolved;
 }
 
 function buildProcessEnv(

--- a/self/subcortex/providers/src/providers/qwen-code/implementation.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/implementation.ts
@@ -1,0 +1,579 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { NousError, ValidationError } from '@nous/shared';
+import type {
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamChunk,
+  ProviderId,
+} from '@nous/shared';
+import {
+  createAgentCliProviderAdapter,
+  type AgentCliFailure,
+  type AgentCliInvocation,
+  type AgentCliInvocationDefaults,
+  type AgentCliRawResult,
+  type AgentCliRunResult,
+  type AgentCliRunner,
+  type AgentCliRunnerOptions,
+  type AgentCliStreamEvent,
+  normalizeAgentCliRunResult,
+} from '../../protocols/agent-cli/index.js';
+import { TextModelInputSchema, type TextModelInput } from '../../schemas/text-model-input.js';
+import {
+  QWEN_CODE_DEFAULT_MODEL_ID,
+  QWEN_CODE_DEFAULT_TIMEOUT_MS,
+  QWEN_CODE_MAX_TIMEOUT_MS,
+  QWEN_CODE_PROVIDER_DEFINITION,
+} from './definition.js';
+
+export interface QwenCodeProviderOptions {
+  readonly runner?: AgentCliRunner;
+  readonly runnerOptions?: AgentCliRunnerOptions;
+  readonly executable?: string;
+}
+
+export interface QwenCodeProcessRunnerOptions {
+  readonly baseEnv?: Readonly<Record<string, string | undefined>>;
+  readonly commandResolver?: QwenCodeCommandResolver;
+  readonly platform?: NodeJS.Platform;
+}
+
+const QWEN_CODE_NOUS_BIN_ENV = 'NOUS_QWEN_CODE_BIN';
+const QWEN_CODE_BIN_ENV = 'QWEN_CODE_BIN';
+
+export type QwenCodeCommandResolver = (
+  command: string,
+  args: readonly string[],
+  options: { readonly env?: NodeJS.ProcessEnv },
+) => string;
+
+export const QWEN_CODE_INVOCATION_DEFAULTS: AgentCliInvocationDefaults = {
+  command: {
+    executable: QWEN_CODE_PROVIDER_DEFINITION.agentCli.command.executable,
+    defaultArgs: QWEN_CODE_PROVIDER_DEFINITION.agentCli.command.defaultArgs,
+  },
+  headless: {
+    supported: QWEN_CODE_PROVIDER_DEFINITION.agentCli.headless.supported,
+    requiredArgs: QWEN_CODE_PROVIDER_DEFINITION.agentCli.headless.requiredArgs,
+    nonInteractiveEnv: QWEN_CODE_PROVIDER_DEFINITION.agentCli.headless.nonInteractiveEnv,
+  },
+  timeout: {
+    defaultMs: QWEN_CODE_DEFAULT_TIMEOUT_MS,
+    maxMs: QWEN_CODE_MAX_TIMEOUT_MS,
+  },
+};
+
+export const QWEN_CODE_AGENT_ADAPTER = createAgentCliProviderAdapter({
+  defaults: QWEN_CODE_INVOCATION_DEFAULTS,
+});
+
+export function createQwenCodeInvocationDefaults(
+  executable: string = QWEN_CODE_PROVIDER_DEFINITION.agentCli.command.executable,
+): AgentCliInvocationDefaults {
+  return {
+    ...QWEN_CODE_INVOCATION_DEFAULTS,
+    command: {
+      ...QWEN_CODE_INVOCATION_DEFAULTS.command,
+      executable,
+    },
+  };
+}
+
+export class QwenCodeProvider implements IModelProvider {
+  private readonly config: ModelProviderConfig;
+  private readonly runner: AgentCliRunner;
+  private readonly runnerOptions: AgentCliRunnerOptions | undefined;
+  private readonly agentAdapter: typeof QWEN_CODE_AGENT_ADAPTER;
+
+  constructor(config: ModelProviderConfig, options?: QwenCodeProviderOptions) {
+    this.config = config;
+    this.runner = options?.runner ?? createQwenCodeProcessRunner();
+    this.runnerOptions = options?.runnerOptions;
+    const executable = selectQwenCodeExecutable({
+      explicitExecutable: options?.executable,
+    });
+    this.agentAdapter = createAgentCliProviderAdapter({
+      defaults: createQwenCodeInvocationDefaults(executable),
+    });
+  }
+
+  getConfig(): ModelProviderConfig {
+    return this.config;
+  }
+
+  async invoke(request: ModelRequest): Promise<ModelResponse> {
+    const runner = this.runner;
+    const input = this.validateInput(request.input);
+    const start = Date.now();
+    const invocationInput = {
+      args: this.invocationArgs(),
+      input: renderTextModelInput(input),
+      metadata: {
+        provider: 'qwen-code',
+        providerId: this.config.id,
+        modelId: this.config.modelId,
+        traceId: request.traceId,
+      },
+      runnerOptions: this.mergeRunnerOptions(request),
+    };
+
+    const result = await this.agentAdapter.invoke(invocationInput, runner);
+
+    if (!result.ok) {
+      throw toProviderError(result.failure, result.stderr, result.stdout);
+    }
+
+    return {
+      output: result.stdout,
+      providerId: this.config.id as ProviderId,
+      usage: {
+        computeMs: result.durationMs ?? Date.now() - start,
+      },
+      traceId: request.traceId,
+    };
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    const runner = this.runner;
+    const input = this.validateInput(request.input);
+    const state: QwenCodeStreamState = {
+      emittedContent: false,
+      finalResult: undefined,
+    };
+
+    const invocationInput = {
+      args: this.invocationArgs(),
+      input: renderTextModelInput(input),
+      metadata: {
+        provider: 'qwen-code',
+        providerId: this.config.id,
+        modelId: this.config.modelId,
+        traceId: request.traceId,
+      },
+      runnerOptions: this.mergeRunnerOptions(request),
+    };
+
+    try {
+      for await (const event of this.agentAdapter.stream(invocationInput, runner)) {
+        if (event.stream === 'system') {
+          state.finalResult = event.result;
+          continue;
+        }
+
+        if (event.stream !== 'stdout') continue;
+
+        if (event.text.length > 0) {
+          state.emittedContent = true;
+          yield { content: event.text, done: false };
+        }
+      }
+
+      if (state.finalResult === undefined) {
+        throw new NousError(
+          'Qwen Code streaming ended without a process result.',
+          'PROVIDER_UNAVAILABLE',
+          { provider: 'qwen-code', failureKind: 'unknown' },
+        );
+      }
+
+      if (!state.finalResult.ok) {
+        throw toProviderError(
+          state.finalResult.failure,
+          state.finalResult.stderr,
+          state.finalResult.stdout,
+        );
+      }
+
+      if (!state.emittedContent && state.finalResult.stdout.length > 0) {
+        yield { content: state.finalResult.stdout, done: false };
+      }
+
+      yield { content: '', done: true };
+    } catch (error) {
+      if (error instanceof NousError) throw error;
+      throw new NousError(
+        `Qwen Code streaming failed: ${error instanceof Error ? error.message : String(error)}`,
+        'PROVIDER_UNAVAILABLE',
+        { provider: 'qwen-code', failureKind: 'unknown' },
+      );
+    }
+  }
+
+  private validateInput(input: unknown): TextModelInput {
+    const result = TextModelInputSchema.safeParse(input);
+    if (!result.success) {
+      throw new ValidationError(
+        'Invalid Qwen Code provider input',
+        result.error.errors.map((error) => ({
+          path: error.path.join('.'),
+          message: error.message,
+        })),
+      );
+    }
+    return result.data;
+  }
+
+  private invocationArgs(): readonly string[] {
+    // Qwen Code headless mode reads the prompt from stdin, so the rendered
+    // prompt is piped via `invocation.input` rather than passed as a flag value.
+    if (
+      this.config.modelId.length === 0 ||
+      this.config.modelId === QWEN_CODE_DEFAULT_MODEL_ID
+    ) {
+      return [];
+    }
+
+    return ['--model', this.config.modelId];
+  }
+
+  private mergeRunnerOptions(request: ModelRequest): AgentCliRunnerOptions | undefined {
+    const signal = request.abortSignal
+      ? { aborted: request.abortSignal.aborted }
+      : this.runnerOptions?.signal;
+
+    if (!signal && !this.runnerOptions) {
+      return undefined;
+    }
+
+    return {
+      ...this.runnerOptions,
+      ...(signal ? { signal } : {}),
+    };
+  }
+}
+
+export function selectQwenCodeExecutable(
+  options: {
+    readonly explicitExecutable?: string;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+  } = {},
+): string {
+  const env = options.env ?? process.env;
+  return options.explicitExecutable
+    ?? env[QWEN_CODE_NOUS_BIN_ENV]
+    ?? env[QWEN_CODE_BIN_ENV]
+    ?? QWEN_CODE_PROVIDER_DEFINITION.agentCli.command.executable;
+}
+
+export function resolveQwenCodeExecutable(
+  executable: string = QWEN_CODE_PROVIDER_DEFINITION.agentCli.command.executable,
+  options: {
+    readonly commandResolver?: QwenCodeCommandResolver;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+    readonly platform?: NodeJS.Platform;
+  } = {},
+): string {
+  if (executable !== QWEN_CODE_PROVIDER_DEFINITION.agentCli.command.executable) {
+    return executable;
+  }
+
+  const platform = options.platform ?? process.platform;
+  const candidates = platform === 'win32'
+    ? resolveExecutableCandidates('where.exe', ['qwen'], options)
+    : resolveExecutableCandidates('which', ['-a', 'qwen'], options);
+  const systemCandidates = candidates.filter((candidate) => !isNodeModulesBinCandidate(candidate));
+
+  if (platform === 'win32') {
+    return systemCandidates.find((candidate) => candidate.toLowerCase().endsWith('.cmd'))
+      ?? systemCandidates[0]
+      ?? executable;
+  }
+
+  return systemCandidates[0] ?? executable;
+}
+
+function resolveExecutableCandidates(
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly commandResolver?: QwenCodeCommandResolver;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+  },
+): readonly string[] {
+  const commandResolver = options.commandResolver ?? defaultCommandResolver;
+  try {
+    return commandResolver(command, args, { env: toProcessEnv(options.env) })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function defaultCommandResolver(
+  command: string,
+  args: readonly string[],
+  options: { readonly env?: NodeJS.ProcessEnv },
+): string {
+  return execFileSync(command, [...args], {
+    encoding: 'utf8',
+    env: options.env,
+  });
+}
+
+function isNodeModulesBinCandidate(candidate: string): boolean {
+  return candidate.replace(/\\/g, '/').toLowerCase().includes('/node_modules/.bin/');
+}
+
+function toProcessEnv(env: Readonly<Record<string, string | undefined>> | undefined): NodeJS.ProcessEnv | undefined {
+  if (!env) return undefined;
+  const processEnv: NodeJS.ProcessEnv = {};
+  assignDefinedEnv(processEnv, env);
+  return processEnv;
+}
+
+interface QwenCodeStreamState {
+  emittedContent: boolean;
+  finalResult: AgentCliRunResult | undefined;
+}
+
+export function createQwenCodeProcessRunner(
+  options: QwenCodeProcessRunnerOptions = {},
+): AgentCliRunner {
+  return {
+    async run(invocation, runnerOptions) {
+      return normalizeAgentCliRunResult(
+        await runQwenCodeProcessRaw(invocation, runnerOptions, options),
+      );
+    },
+    async *stream(invocation, runnerOptions) {
+      const queue: AgentCliStreamEvent[] = [];
+      let wake: (() => void) | undefined;
+      let completed = false;
+
+      const push = (event: AgentCliStreamEvent): void => {
+        queue.push(event);
+        wake?.();
+        wake = undefined;
+      };
+
+      const waitForEvent = (): Promise<void> => {
+        if (queue.length > 0 || completed) return Promise.resolve();
+        return new Promise((resolve) => {
+          wake = resolve;
+        });
+      };
+
+      void runQwenCodeProcessRaw(invocation, runnerOptions, options, (event) => {
+        push(event);
+      }).then((rawResult) => {
+        push({ stream: 'system', result: normalizeAgentCliRunResult(rawResult) });
+      }).finally(() => {
+        completed = true;
+        wake?.();
+        wake = undefined;
+      });
+
+      while (!completed || queue.length > 0) {
+        await waitForEvent();
+        while (queue.length > 0) {
+          yield queue.shift()!;
+        }
+      }
+    },
+  };
+}
+
+function runQwenCodeProcessRaw(
+  invocation: AgentCliInvocation,
+  runnerOptions: AgentCliRunnerOptions | undefined,
+  options: QwenCodeProcessRunnerOptions,
+  onTranscriptEvent?: (event: AgentCliStreamEvent) => void,
+): Promise<AgentCliRawResult> {
+  const startedAt = Date.now();
+  if (runnerOptions?.signal?.aborted) {
+    return Promise.resolve({
+      startedAt,
+      endedAt: Date.now(),
+      error: new Error('Agent CLI invocation aborted before start.'),
+    });
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      const env = buildProcessEnv(invocation.command.env, runnerOptions, options);
+      child = spawn(resolveSpawnExecutable(invocation.command.executable, {
+        commandResolver: options.commandResolver,
+        env,
+        platform: options.platform,
+      }), [...(invocation.command.args ?? [])], {
+        cwd: invocation.command.cwd,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        shell: process.platform === 'win32',
+      });
+    } catch (error) {
+      resolve({
+        error,
+        startedAt,
+        endedAt: Date.now(),
+      });
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    const timeout = invocation.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+      }, invocation.timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      onTranscriptEvent?.({ stream: 'stdout', text: chunk, timestamp: new Date().toISOString() });
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+      onTranscriptEvent?.({ stream: 'stderr', text: chunk, timestamp: new Date().toISOString() });
+    });
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve({
+        stdout,
+        stderr,
+        error,
+        timedOut,
+        startedAt,
+        endedAt: Date.now(),
+      });
+    });
+    child.on('close', (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve({
+        exitCode,
+        signal,
+        stdout,
+        stderr,
+        timedOut,
+        startedAt,
+        endedAt: Date.now(),
+      });
+    });
+
+    child.stdin.end(invocation.input ?? '');
+  });
+}
+
+function resolveSpawnExecutable(
+  executable: string,
+  options: {
+    readonly commandResolver?: QwenCodeCommandResolver;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+    readonly platform?: NodeJS.Platform;
+  },
+): string {
+  return resolveQwenCodeExecutable(executable, options);
+}
+
+function buildProcessEnv(
+  invocationEnv: Readonly<Record<string, string>> | undefined,
+  runnerOptions: AgentCliRunnerOptions | undefined,
+  options: QwenCodeProcessRunnerOptions,
+): NodeJS.ProcessEnv {
+  const baseEnv = options.baseEnv ?? process.env;
+  const policy = runnerOptions?.environmentPolicy;
+  const env: NodeJS.ProcessEnv = {};
+
+  if (!policy || policy.mergeStrategy === 'explicit') {
+    assignDefinedEnv(env, baseEnv);
+  } else if (policy.mergeStrategy === 'allowlist') {
+    for (const key of policy.allowlist ?? []) {
+      const value = baseEnv[key];
+      if (value !== undefined && isValidEnvKey(key)) env[key] = value;
+    }
+  }
+
+  assignDefinedEnv(env, policy?.env);
+  assignDefinedEnv(env, invocationEnv);
+  return env;
+}
+
+function assignDefinedEnv(
+  target: NodeJS.ProcessEnv,
+  source: Readonly<Record<string, string | undefined>> | undefined,
+): void {
+  if (!source) return;
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined && isValidEnvKey(key)) {
+      target[key] = value;
+    }
+  }
+}
+
+function isValidEnvKey(key: string): boolean {
+  return key.length > 0 && !key.includes('=');
+}
+
+function renderTextModelInput(input: TextModelInput): string {
+  if ('prompt' in input) {
+    return input.prompt;
+  }
+
+  const sections: string[] = [];
+  if (typeof input.system === 'string' && input.system.trim().length > 0) {
+    sections.push(input.system.trim());
+  } else if (Array.isArray(input.system) && input.system.length > 0) {
+    sections.push(JSON.stringify(input.system, null, 2));
+  }
+
+  for (const message of input.messages) {
+    sections.push(`${message.role}: ${renderMessageContent(message.content)}`);
+  }
+
+  if (input.tools && input.tools.length > 0) {
+    sections.push(`Available tools:\n${JSON.stringify(input.tools, null, 2)}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+function renderMessageContent(content: string | readonly unknown[]): string {
+  return typeof content === 'string'
+    ? content
+    : JSON.stringify(content, null, 2);
+}
+
+function toProviderError(
+  failure: AgentCliFailure | undefined,
+  stderr?: string,
+  stdout?: string,
+): NousError {
+  if (!failure) {
+    return new NousError(
+      'Qwen Code invocation failed.',
+      'PROVIDER_UNAVAILABLE',
+      { provider: 'qwen-code', stderr, stdout },
+    );
+  }
+
+  return new NousError(
+    stderr && stderr.trim().length > 0
+      ? `${failure.message} ${stderr.trim().slice(0, 500)}`
+      : failure.message,
+    failure.kind === 'auth' ? 'PROVIDER_ERROR' : 'PROVIDER_UNAVAILABLE',
+    {
+      provider: 'qwen-code',
+      failureKind: failure.kind,
+      exitCode: failure.exitCode,
+      signal: failure.signal,
+      timedOut: failure.timedOut,
+      stderr,
+      stdout,
+    },
+  );
+}

--- a/self/subcortex/providers/src/providers/qwen-code/index.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/index.ts
@@ -1,0 +1,29 @@
+export {
+  QWEN_CODE_EXECUTION_CAPABILITY_PROFILE,
+  createQwenCodeAdapter,
+  providerAdapter,
+  renderQwenCodePrompt,
+} from './adapter.js';
+export {
+  QWEN_CODE_DEFAULT_ENDPOINT,
+  QWEN_CODE_DEFAULT_MODEL_ID,
+  QWEN_CODE_DEFAULT_TIMEOUT_MS,
+  QWEN_CODE_MAX_TIMEOUT_MS,
+  QWEN_CODE_PROVIDER_DEFINITION,
+  providerDefinition,
+} from './definition.js';
+export {
+  QWEN_CODE_AGENT_ADAPTER,
+  QWEN_CODE_INVOCATION_DEFAULTS,
+  QwenCodeProvider,
+  createQwenCodeInvocationDefaults,
+  createQwenCodeProcessRunner,
+  resolveQwenCodeExecutable,
+  selectQwenCodeExecutable,
+} from './implementation.js';
+export type {
+  QwenCodeCommandResolver,
+  QwenCodeProcessRunnerOptions,
+  QwenCodeProviderOptions,
+} from './implementation.js';
+export { providerFactory } from './provider.js';

--- a/self/subcortex/providers/src/providers/qwen-code/index.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/index.ts
@@ -14,6 +14,7 @@ export {
 } from './definition.js';
 export {
   QWEN_CODE_AGENT_ADAPTER,
+  QWEN_CODE_DEFAULT_ENV_ALLOWLIST,
   QWEN_CODE_INVOCATION_DEFAULTS,
   QwenCodeProvider,
   createQwenCodeInvocationDefaults,
@@ -25,5 +26,6 @@ export type {
   QwenCodeCommandResolver,
   QwenCodeProcessRunnerOptions,
   QwenCodeProviderOptions,
+  QwenCodeSpawn,
 } from './implementation.js';
 export { providerFactory } from './provider.js';

--- a/self/subcortex/providers/src/providers/qwen-code/provider.ts
+++ b/self/subcortex/providers/src/providers/qwen-code/provider.ts
@@ -1,0 +1,12 @@
+import { QwenCodeProvider } from './implementation.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'qwen-code',
+  create(config, options) {
+    return new QwenCodeProvider(config, {
+      runner: options?.agentCliRunner,
+      runnerOptions: options?.agentCliRunnerOptions,
+    });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## Summary

Adds the Qwen Code CLI integration as a provider leaf under `self/subcortex/providers/src/providers/qwen-code/`, as per the updated #296 contract. Built on `ProviderDefinitionLeaf`; the provider ID derives from `vendorKey`, and the leaf declares `executionCapabilityProfile: one_shot_command`. Uses the Agent CLI protocol path (not the deprecated `AgentAdapter` path).

## Linked Issue

Closes #296

## Changes

- Add provider leaf under `self/subcortex/providers/src/providers/qwen-code/` (`definition.ts`, `adapter.ts`, `provider.ts`, `implementation.ts`, `index.ts`)
- Derive provider ID from `vendorKey` using `deriveBuiltInProviderId`
- Declare `executionCapabilityProfile: one_shot_command`
- Regenerate provider catalogs (`generate-provider-aggregates.mjs`)
- Add `qwen-code.test.ts` covering catalog and definition metadata alongside prompt rendering, adapter behavior and malformed-output fallback, injected-runner invocation, default-model handling, one-shot transience, provider-error mapping, factory runner injection, and streaming
- Extend assertion tests for the new `qwen-code` adapter entry (`provider-definitions.test.ts`, `provider-codegen.test.ts`, `provider-definition-types.test.ts`)
- Fix a typecheck regression: restored `envVar: undefined` on the `llama-cpp` entry in `expectedDefinitions` (failed one of the tests in `provider-definitions.test.ts`)

## Verification

- [x] Tests pass (`pnpm test`) - full provider suite passed (376)
- [x] Lint passes (`pnpm lint`) - oxlint on qwen-code source + tests: 0 warnings, 0 errors
- [x] Typecheck passes (`pnpm typecheck`) - `tsc --noEmit` exit 0
- [x] Build passes (`pnpm build`) - codegen check + typecheck both clean
- [x] Manually ran the change end-to-end and confirmed it behaves as expected

### Manual behavior check

Exercised the full leaf path (definition > factory > provider construction > invoke/stream). Four PR files tested with an injected fake Agent CLI runner (deterministic, no real qwen binary):

```
✓ declares Agent CLI catalog metadata as a one-shot command provider
✓ formats canonical gateway input into a Qwen Code prompt string
✓ exposes a ProviderAdapter module for qwen-code with text-safe parsing
✓ does not throw and falls back to text for malformed adapter outputs
✓ invokes an injected Agent CLI runner and returns stdout as model output
✓ uses Qwen Code defaults without passing a synthetic default model
✓ preserves the one-shot qwen path for transient invocations
✓ constructs a provider with the default live runner without invoking it in tests
✓ selects Qwen Code executable overrides deterministically before PATH lookup
✓ resolves default POSIX qwen away from workspace node_modules bin candidates
✓ maps Agent CLI runner failures to provider errors
✓ factory passes runner injection through the provider module contract
✓ streams stdout chunks and a terminal done chunk

Test Files  1 passed (1)
     Tests  13 passed (13)
```

The runner-invocation test confirms a one-shot `qwen --approval-mode yolo --model qwen3-coder-plus` command is built, `NO_COLOR=1` is set, the 300 s timeout and trace/provider metadata are attached, and stdout is returned as model output.

Full PR test set (23 tests):

| Test file | Result |
| --- | --- |
| `qwen-code.test.ts` | ✓ 13 passed |
| `provider-codegen.test.ts` | ✓ passed |
| `provider-definition-types.test.ts` | ✓ passed |
| `provider-definitions.test.ts` | ✓ passed |

## Checklist

- [x] Branch targets the integration branch `feat/contributor-friendly-inference-provider-surface` (not `main`)
- [x] Commits follow Conventional Commits
- [x] New provider leaf, so no behavior-doc surface changed