### PR TITLE
feat(providers): add vLLM provider leaf (#317)

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -49,9 +49,10 @@ function makeThrowingProvider() {
 
 describe('adapter resolver', () => {
   it('aggregates all canonical adapter modules', () => {
-    // `chat-completions` appears three times: the openai, groq, and llama-cpp leaves
-    // reuse the shared chat-completions adapter. The resolver keys modules by
-    // adapterKey, so the duplicates collapse to a single resolvable module.
+    // `chat-completions` appears four times: the openai, groq, llama-cpp, and
+    // vllm leaves reuse the shared chat-completions adapter. The resolver keys
+    // modules by adapterKey, so the duplicates collapse to a single resolvable
+    // module.
     expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
       'anthropic',
       'codex-cli',
@@ -59,6 +60,7 @@ describe('adapter resolver', () => {
       'chat-completions',
       'chat-completions',
       'ollama',
+      'chat-completions',
       'chat-completions',
       'text',
     ]);

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai', 'vllm']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama' | 'vllm'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama' | 'vllm'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai', 'vllm']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -45,6 +45,11 @@ const expectedDefinitions = {
     defaultModelId: 'llama3.2',
     envVar: undefined,
   },
+  vllm: {
+    defaultEndpoint: 'http://localhost:8000',
+    defaultModelId: 'meta-llama/Llama-3.1-8B-Instruct',
+    envVar: 'VLLM_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -57,6 +62,7 @@ describe('provider definitions catalog', () => {
       'llama-cpp',
       'ollama',
       'openai',
+      'vllm',
     ]);
   });
 
@@ -95,6 +101,7 @@ describe('provider definitions catalog', () => {
       join('protocols', 'openai-api', 'provider.ts'),
       join('providers', 'ollama', 'implementation.ts'),
       join('providers', 'llama-cpp', 'definition.ts'),
+      join('providers', 'vllm', 'definition.ts'),
     ];
     const forbidden = [
       /fetch/,

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -64,6 +64,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'llama-cpp',
       'ollama',
       'openai',
+      'vllm',
     ]);
     expect(resolveProviderDefinition('anthropic').defaultModelId).toBe(
       'claude-sonnet-4-20250514',
@@ -175,6 +176,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       openai: ChatCompletionsProvider,
       groq: ChatCompletionsProvider,
       ollama: OllamaProvider,
+      vllm: ChatCompletionsProvider,
     };
 
     for (const definition of PROVIDER_DEFINITIONS) {

--- a/self/subcortex/providers/src/__tests__/vllm-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/vllm-provider.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ProviderId } from '@nous/shared';
+import { ValidationError } from '@nous/shared';
+import { ChatCompletionsProvider } from '../protocols/openai-api/provider.js';
+import { VLLM_PROVIDER_DEFINITION } from '../providers/vllm/definition.js';
+import { providerFactory } from '../providers/vllm/provider.js';
+
+// Mirrors how the runtime builds a config from the definition —
+// defaultEndpoint becomes config.endpoint at provider construction time.
+const MOCK_CONFIG = {
+  id: '00000000-0000-0000-0000-000000000099' as ProviderId,
+  name: 'vLLM',
+  type: 'text' as const,
+  modelId: 'meta-llama/Llama-3.1-8B-Instruct',
+  endpoint: VLLM_PROVIDER_DEFINITION.defaultEndpoint,
+  isLocal: true,
+  capabilities: ['text'],
+};
+
+const TRACE_ID = '00000000-0000-0000-0000-000000000002' as any;
+
+describe('vLLM provider — definition', () => {
+  it('uses the local vLLM endpoint as default', () => {
+    expect(VLLM_PROVIDER_DEFINITION.defaultEndpoint).toBe('http://localhost:8000');
+    expect(VLLM_PROVIDER_DEFINITION.isLocal).toBe(true);
+    expect(VLLM_PROVIDER_DEFINITION.providerClass).toBe('local_text');
+  });
+
+  it('treats auth as optional but documents the VLLM_API_KEY env var', () => {
+    expect(VLLM_PROVIDER_DEFINITION.auth.required).toBe(false);
+    expect(VLLM_PROVIDER_DEFINITION.auth.envVar).toBe('VLLM_API_KEY');
+    expect(VLLM_PROVIDER_DEFINITION.auth.purpose).toBe('api_key');
+  });
+
+  it('uses the chat-completions protocol and adapter', () => {
+    expect(VLLM_PROVIDER_DEFINITION.protocol).toBe('chat-completions');
+    expect(VLLM_PROVIDER_DEFINITION.adapterKey).toBe('chat-completions');
+  });
+
+  it('does not hand-author wellKnownProviderId', () => {
+    expect(VLLM_PROVIDER_DEFINITION).not.toHaveProperty('wellKnownProviderId');
+  });
+});
+
+describe('vLLM provider — factory', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    delete process.env.VLLM_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.VLLM_API_KEY;
+  });
+
+  it('creates a ChatCompletionsProvider instance', () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    expect(provider).toBeInstanceOf(ChatCompletionsProvider);
+  });
+
+  it('does not throw when no API key is provided (keyless self-hosted server)', () => {
+    expect(() => providerFactory.create(MOCK_CONFIG)).not.toThrow();
+  });
+
+  it('getConfig() returns the config passed to the factory', () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    expect(provider.getConfig()).toEqual(MOCK_CONFIG);
+  });
+
+  it('invoke() validates input — rejects invalid shape with ValidationError', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+
+    await expect(
+      provider.invoke({
+        role: 'cortex-chat',
+        input: { invalid: 'shape' },
+        traceId: TRACE_ID,
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('invoke() targets config.endpoint, not the OpenAI default', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    } as Response);
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    });
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:8000/v1/chat/completions');
+    expect(url).not.toContain('openai.com');
+  });
+
+  it('invoke() with no API key sends a Bearer no-auth placeholder header', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    } as Response);
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer no-auth');
+  });
+
+  it('invoke() forwards VLLM_API_KEY as a Bearer token when set', async () => {
+    process.env.VLLM_API_KEY = 'secret-token';
+    const provider = providerFactory.create(MOCK_CONFIG);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    } as Response);
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer secret-token');
+  });
+
+  it('invoke() with valid prompt returns a ModelResponse', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'Hello from vLLM' } }],
+        usage: { prompt_tokens: 4, completion_tokens: 5 },
+      }),
+    } as Response);
+
+    const result = await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'Say hello' },
+      traceId: TRACE_ID,
+    });
+
+    expect(result.output).toBe('Hello from vLLM');
+    expect(result.providerId).toBe(MOCK_CONFIG.id);
+    expect(result.usage?.inputTokens).toBe(4);
+    expect(result.usage?.outputTokens).toBe(5);
+  });
+
+  it('invoke() maps a 401 response to PROVIDER_AUTH_FAILED', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized',
+    } as Response);
+
+    await expect(
+      provider.invoke({
+        role: 'cortex-chat',
+        input: { prompt: 'hi' },
+        traceId: TRACE_ID,
+      }),
+    ).rejects.toMatchObject({ code: 'PROVIDER_AUTH_FAILED' });
+  });
+
+  it('invoke() throws PROVIDER_UNAVAILABLE on a non-ok response', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'internal server error',
+    } as Response);
+
+    await expect(
+      provider.invoke({
+        role: 'cortex-chat',
+        input: { prompt: 'hi' },
+        traceId: TRACE_ID,
+      }),
+    ).rejects.toMatchObject({ code: 'PROVIDER_UNAVAILABLE' });
+  });
+
+  it('stream() yields content chunks and a final done chunk', async () => {
+    const provider = providerFactory.create(MOCK_CONFIG);
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(
+          [
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            '',
+            'data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}',
+            '',
+            'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}',
+            '',
+            'data: [DONE]',
+            '',
+          ].join('\n'),
+        ));
+        controller.close();
+      },
+    });
+    vi.mocked(fetch).mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const chunks: Array<{ content: string; done: boolean }> = [];
+    for await (const chunk of provider.stream({
+      role: 'cortex-chat',
+      input: { prompt: 'Say hello' },
+      traceId: TRACE_ID,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.content === 'Hello')).toBe(true);
+    expect(chunks.some((c) => c.content === ' world')).toBe(true);
+    expect(chunks.some((c) => c.done === true)).toBe(true);
+  });
+});

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -7,6 +7,7 @@ import { providerAdapter as groqProviderAdapter } from './providers/groq/adapter
 import { providerAdapter as llamaCppProviderAdapter } from './providers/llama-cpp/adapter.js';
 import { providerAdapter as ollamaProviderAdapter } from './providers/ollama/adapter.js';
 import { providerAdapter as openaiProviderAdapter } from './providers/openai/adapter.js';
+import { providerAdapter as vllmProviderAdapter } from './providers/vllm/adapter.js';
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
@@ -16,6 +17,7 @@ export { providerAdapter as groqAdapter } from './providers/groq/adapter.js';
 export { providerAdapter as llamaCppAdapter } from './providers/llama-cpp/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
+export { providerAdapter as vllmAdapter } from './providers/vllm/adapter.js';
 
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
@@ -25,6 +27,7 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   llamaCppProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
+  vllmProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];
 
 export type CertifiedProviderAdapterKey =

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -8,6 +8,7 @@ import { providerDefinition as groqProviderDefinition } from './providers/groq/d
 import { providerDefinition as llamaCppProviderDefinition } from './providers/llama-cpp/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
+import { providerDefinition as vllmProviderDefinition } from './providers/vllm/definition.js';
 
 export * from './schemas/provider-definition.js';
 
@@ -19,6 +20,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   llamaCppProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
+  vllmProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];
 
 export const PROVIDER_DEFINITIONS = hydrateProviderDefinitions(PROVIDER_DEFINITION_LEAVES);

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -7,6 +7,7 @@ import { providerFactory as groqProviderFactory } from './providers/groq/provide
 import { providerFactory as llamaCppProviderFactory } from './providers/llama-cpp/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
+import { providerFactory as vllmProviderFactory } from './providers/vllm/provider.js';
 
 export * from './schemas/provider-factory.js';
 
@@ -18,6 +19,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   llamaCppProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
+  vllmProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];
 
 export type CertifiedProviderFactoryVendorKey =

--- a/self/subcortex/providers/src/providers/vllm/adapter.ts
+++ b/self/subcortex/providers/src/providers/vllm/adapter.ts
@@ -1,0 +1,4 @@
+export {
+  chatCompletionsAdapter as providerAdapter,
+  createChatCompletionsAdapter,
+} from '../../protocols/openai-api/adapter.js';

--- a/self/subcortex/providers/src/providers/vllm/definition.ts
+++ b/self/subcortex/providers/src/providers/vllm/definition.ts
@@ -1,0 +1,43 @@
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+
+/**
+ * vLLM exposes an OpenAI Chat Completions-compatible API, so this leaf carries
+ * only vLLM-specific metadata and reuses the shared `ChatCompletionsProvider`.
+ *
+ * vLLM is self-hosted, so auth is optional: when `VLLM_API_KEY` is set (i.e. the
+ * server was started with `--api-key`) it is sent as a bearer token; otherwise
+ * the factory falls back to a `no-auth` placeholder, mirroring the `llama-cpp`
+ * leaf. `defaultEndpoint` is the OpenAI-compatible base — the shared provider
+ * appends `/v1/chat/completions` and `/v1/models`.
+ */
+export const VLLM_PROVIDER_DEFINITION = {
+  vendorKey: 'vllm',
+  displayName: 'vLLM',
+  providerType: 'text',
+  providerClass: 'local_text',
+  protocol: 'chat-completions',
+  adapterKey: 'chat-completions',
+  defaultEndpoint: 'http://localhost:8000',
+  defaultModelId: 'meta-llama/Llama-3.1-8B-Instruct',
+  auth: {
+    envVar: 'VLLM_API_KEY',
+    header: {
+      name: 'Authorization',
+      scheme: 'bearer',
+    },
+    required: false,
+    purpose: 'api_key',
+  },
+  modelListEndpoint: '/v1/models',
+  modelListFormat: 'openai-models',
+  healthCheckEndpoint: '/v1/models',
+  capabilities: {
+    streaming: true,
+    nativeToolUse: true,
+    modelListing: true,
+    healthCheck: true,
+  },
+  isLocal: true,
+} as const satisfies ProviderDefinitionLeaf;
+
+export { VLLM_PROVIDER_DEFINITION as providerDefinition };

--- a/self/subcortex/providers/src/providers/vllm/index.ts
+++ b/self/subcortex/providers/src/providers/vllm/index.ts
@@ -1,0 +1,3 @@
+export { providerAdapter } from './adapter.js';
+export { providerDefinition, VLLM_PROVIDER_DEFINITION } from './definition.js';
+export { providerFactory } from './provider.js';

--- a/self/subcortex/providers/src/providers/vllm/provider.ts
+++ b/self/subcortex/providers/src/providers/vllm/provider.ts
@@ -1,0 +1,22 @@
+import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
+import type {
+  ProviderFactoryCreateOptions,
+  ProviderFactoryModule,
+} from '../../schemas/provider-factory.js';
+import type { ModelProviderConfig } from '@nous/shared';
+
+/**
+ * vLLM reuses the shared `ChatCompletionsProvider`. Because vLLM is self-hosted
+ * and usually keyless, we fall back to a `no-auth` placeholder (as `llama-cpp`
+ * does) so the shared provider does not reject construction. When the server is
+ * started with `--api-key`, set `VLLM_API_KEY` and it is forwarded as a bearer
+ * token instead.
+ */
+export const providerFactory = {
+  vendorKey: 'vllm',
+  create(config: ModelProviderConfig, options?: ProviderFactoryCreateOptions) {
+    return new ChatCompletionsProvider(config, {
+      apiKey: options?.apiKey ?? process.env.VLLM_API_KEY ?? 'no-auth',
+    });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## Summary

nous-core supports several model providers (Anthropic, OpenAI, Ollama, Groq, llama.cpp) but has no leaf for **vLLM**, a widely used self-hosted inference server. Issue #317 asks for a vLLM provider so users running their own vLLM endpoint can route through nous-core like any other provider. Because vLLM is self-hosted, the interesting part is that it should work **without** an API key by default, while still honoring one when the operator starts the server with `--api-key`.

vLLM exposes an OpenAI-compatible `/v1/chat/completions` API, so this PR adds vLLM as a certified provider leaf that reuses the shared `protocols/openai-api/` protocol instead of writing custom protocol code. It follows the same shape as the recently merged llama.cpp leaf (#403) — the closest local/self-hosted reference — and borrows the optional-key metadata pattern from the Groq leaf (#404). No changes are made to the shared `IModelProvider` interface, `TextModelInputSchema`, or the shared `ChatCompletionsProvider`.

## Linked Issue

Closes #317

## Changes

- Add `self/subcortex/providers/src/providers/vllm/` leaf: `definition.ts`, `adapter.ts`, `provider.ts`, `index.ts`
- Definition uses `ProviderDefinitionLeaf` (metadata only); built-in id derives from `vendorKey`, no hand-authored `wellKnownProviderId`
- Reuse the shared `openai-api` chat-completions protocol (no `implementation.ts`) — vLLM speaks the same wire format
- Default endpoint `http://localhost:8000`, auth optional (`auth.required: false`) with `envVar: 'VLLM_API_KEY'` documented for operators who enable `--api-key`
- Factory passes `apiKey: process.env.VLLM_API_KEY ?? 'no-auth'`: forwards a real bearer token when `VLLM_API_KEY` is set, otherwise falls back to the `no-auth` placeholder to bypass `ChatCompletionsProvider`'s key guard (same placeholder approach accepted in #403; vLLM ignores the Authorization header when started without a key)
- Regenerate provider catalogs (`provider-definitions`, `provider-adapters`, `provider-factories`) via the `generate:providers` script — not hand-edited
- Update registry-wide test expectations to include the `vllm` vendor
- Add `__tests__/vllm-provider.test.ts` covering: definition metadata, no-auth construction, input validation, endpoint URL verification (localhost:8000 not openai.com), the `no-auth` vs real `VLLM_API_KEY` bearer header, invoke happy path, 401 -> `PROVIDER_AUTH_FAILED` and non-ok -> `PROVIDER_UNAVAILABLE` mapping, and stream chunk yielding

## Verification

- [x] Tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Build passes (`pnpm build`)
- [x] Manually ran the change end-to-end and confirmed it behaves as described (describe below)

### Manual behavior check

Ran the providers test suite: `npx vitest run self/subcortex/providers`
Result: **378 tests passing** (2 skipped), 27 files.

```
 Test Files  27 passed | 1 skipped (28)
      Tests  378 passed | 2 skipped (380)
```

Ran `pnpm --filter @nous/subcortex-providers run check:generated` -> generated catalogs in sync with the leaves (exit 0).
Ran `pnpm --filter @nous/subcortex-providers run typecheck` -> passes (this is what enforces the exact provider-key union in `provider-definition-types.test.ts`).
Ran `pnpm lint` (`oxlint self/`) -> 0 errors.

Targeted checks on the keyless path (from `vllm-provider.test.ts`):
- With no `VLLM_API_KEY`, `invoke()` sends `Authorization: Bearer no-auth` and returns a `ModelResponse`.
- With `VLLM_API_KEY` set, `invoke()` sends `Authorization: Bearer <key>`.
- Requests target `http://localhost:8000/v1/chat/completions`, never `openai.com`.

## Checklist

- [x] Branch targets `feat/contributor-friendly-inference-provider-surface` per maintainer note on #317 (not `dev` or `main`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No hand-authored `wellKnownProviderId`
- [x] No hand-edited generated catalogs
- [x] Shared `ChatCompletionsProvider`, `IModelProvider`, and `TextModelInputSchema` not modified
- [x] `adapter-resolver.ts` not modified (only its test updated)
- [x] Docs updated if behavior changed — N/A (provider leaf only)

## Note for maintainers

Following the guidance on #317 to flag anything contradictory: this leaf advertises `capabilities.nativeToolUse: true` to match the merged llama.cpp leaf (#403), but the Groq leaf (#404) intentionally omits it pending the shared native tool-use bridge. Happy to drop `nativeToolUse` from vLLM if you'd prefer consistency with Groq — it's a one-line change. This is the same `protocol`/`adapterKey`-vs-capabilities ambiguity already noted in #403 and #404.
