### PR TITLE
Feat/mistral adapter

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -52,11 +52,10 @@ describe('adapter resolver', () => {
 // `chat-completions` appears four times: groq, llama-cpp, mistral, and openai leaves
     // all reuse the shared chat-completions adapter. The resolver keys modules by adapterKey,
     // so duplicates collapse to a single resolvable module.
-    expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
+   expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
       'anthropic',
       'codex-cli',
       'github-copilot-cli',
-      'chat-completions',
       'chat-completions',
       'chat-completions',
       'chat-completions',

--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -49,13 +49,15 @@ function makeThrowingProvider() {
 
 describe('adapter resolver', () => {
   it('aggregates all canonical adapter modules', () => {
-    // `chat-completions` appears three times: the openai, groq, and llama-cpp leaves
-    // reuse the shared chat-completions adapter. The resolver keys modules by
-    // adapterKey, so the duplicates collapse to a single resolvable module.
+// `chat-completions` appears four times: groq, llama-cpp, mistral, and openai leaves
+    // all reuse the shared chat-completions adapter. The resolver keys modules by adapterKey,
+    // so duplicates collapse to a single resolvable module.
     expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
       'anthropic',
       'codex-cli',
       'github-copilot-cli',
+      'chat-completions',
+      'chat-completions',
       'chat-completions',
       'chat-completions',
       'ollama',

--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -49,16 +49,16 @@ function makeThrowingProvider() {
 
 describe('adapter resolver', () => {
   it('aggregates all canonical adapter modules', () => {
-// `chat-completions` appears four times: groq, llama-cpp, mistral, and openai leaves
-    // all reuse the shared chat-completions adapter. The resolver keys modules by adapterKey,
-    // so duplicates collapse to a single resolvable module.
+// `chat-completions` appears three times: groq, llama-cpp, and openai leaves
+    // all reuse the shared chat-completions adapter. mistral uses its own 'mistral' adapterKey.
+    // The resolver keys modules by adapterKey, so duplicates collapse to a single resolvable module.
    expect(ADAPTER_MODULES.map((module) => module.adapterKey)).toEqual([
       'anthropic',
       'codex-cli',
       'github-copilot-cli',
       'chat-completions',
       'chat-completions',
-      'chat-completions',
+      'mistral',
       'ollama',
       'chat-completions',
       'text',
@@ -70,6 +70,7 @@ describe('adapter resolver', () => {
     expect(resolveAdapter('chat-completions').capabilities.nativeToolUse).toBe(true);
     expect(resolveAdapter('codex-cli').capabilities.streaming).toBe(true);
     expect(resolveAdapter('github-copilot-cli').capabilities.nativeToolUse).toBe(false);
+    expect(resolveAdapter('mistral').capabilities.nativeToolUse).toBe(true);
     expect(resolveAdapter('ollama').capabilities.extendedThinking).toBe(true);
     expect(resolveAdapter('text').capabilities.nativeToolUse).toBe(false);
   });

--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -70,7 +70,7 @@ describe('adapter resolver', () => {
     expect(resolveAdapter('chat-completions').capabilities.nativeToolUse).toBe(true);
     expect(resolveAdapter('codex-cli').capabilities.streaming).toBe(true);
     expect(resolveAdapter('github-copilot-cli').capabilities.nativeToolUse).toBe(false);
-    expect(resolveAdapter('mistral').capabilities.nativeToolUse).toBe(true);
+    expect(resolveAdapter('mistral').capabilities.nativeToolUse).toBe(false);
     expect(resolveAdapter('ollama').capabilities.extendedThinking).toBe(true);
     expect(resolveAdapter('text').capabilities.nativeToolUse).toBe(false);
   });

--- a/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Mistral provider leaf tests.
+ *
+ * Covers the testing checklist requirements:
+ * - Definition: schema validation, vendorKey, adapterKey, protocol, auth metadata.
+ * - Adapter: formatRequest (system prompt, context, tools), parseResponse (text,
+ *   tool_calls, malformed, no-throw contract).
+ * - Provider implementation: input validation, request shape, auth header, error
+ *   classification (401/403, 429, unavailable), streaming, timeout, abort.
+ *
+ * Uses Mistral-shaped fixtures — not copied from Anthropic tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ProviderId } from '@nous/shared';
+import { NousError, ValidationError } from '@nous/shared';
+import { MistralProvider, MISTRAL_PROVIDER_DEFINITION } from '../providers/mistral/implementation.js';
+import { createMistralAdapter } from '../providers/mistral/adapter.js';
+import type { AdapterFormatInput } from '../schemas/provider-adapter.js';
+import { ProviderDefinitionSchema } from '../schemas/provider-definition.js';
+
+const MOCK_CONFIG = {
+  id: '00000000-0000-0000-0000-000000000201' as ProviderId,
+  name: 'Mistral',
+  type: 'text' as const,
+  modelId: 'mistral-medium-latest',
+  endpoint: 'https://api.mistral.ai',
+  isLocal: false,
+  capabilities: ['chat', 'streaming'],
+};
+
+const TRACE_ID = '00000000-0000-0000-0000-000000000202' as any;
+
+describe('MISTRAL_PROVIDER_DEFINITION', () => {
+  it('satisfies ProviderDefinitionSchema', () => {
+    expect(() =>
+      ProviderDefinitionSchema.parse({
+        ...MISTRAL_PROVIDER_DEFINITION,
+        wellKnownProviderId: '00000000-0000-0000-0000-000000000000',
+      }),
+    ).not.toThrow();
+  });
+
+  it('has correct vendorKey, adapterKey, and protocol', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.vendorKey).toBe('mistral');
+    expect(MISTRAL_PROVIDER_DEFINITION.adapterKey).toBe('chat-completions');
+    expect(MISTRAL_PROVIDER_DEFINITION.protocol).toBe('chat-completions');
+  });
+
+  it('declares api_key auth with correct env var and vault namespace', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.auth.purpose).toBe('api_key');
+    expect(MISTRAL_PROVIDER_DEFINITION.auth.required).toBe(true);
+    expect(MISTRAL_PROVIDER_DEFINITION.auth.envVar).toBe('MISTRAL_API_KEY');
+    expect(MISTRAL_PROVIDER_DEFINITION.auth.vaultKeyNamespace).toBe('mistral');
+  });
+
+  it('declares bearer auth header for model discovery', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.auth.header).toEqual({
+      name: 'Authorization',
+      scheme: 'bearer',
+    });
+  });
+
+  it('opts into model listing with correct endpoint and format', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.modelListEndpoint).toBe('/v1/models');
+    expect(MISTRAL_PROVIDER_DEFINITION.modelListFormat).toBe('openai-models');
+    expect(MISTRAL_PROVIDER_DEFINITION.capabilities?.modelListing).toBe(true);
+  });
+
+  it('is not a local provider', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.isLocal).toBe(false);
+  });
+
+  it('does not declare wellKnownProviderId — derived from vendorKey by catalog', () => {
+    expect((MISTRAL_PROVIDER_DEFINITION as Record<string, unknown>).wellKnownProviderId).toBeUndefined();
+  });
+
+  it('does not declare cacheControl or extendedThinking capabilities', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.capabilities?.cacheControl).toBe(false);
+    expect(MISTRAL_PROVIDER_DEFINITION.capabilities?.extendedThinking).toBe(false);
+  });
+});
+
+describe('createMistralAdapter', () => {
+  const adapter = createMistralAdapter();
+
+  describe('capabilities', () => {
+    it('declares nativeToolUse and streaming; no cacheControl or extendedThinking', () => {
+      expect(adapter.capabilities).toEqual({
+        nativeToolUse: true,
+        cacheControl: false,
+        extendedThinking: false,
+        streaming: true,
+      });
+    });
+  });
+
+  describe('formatRequest', () => {
+    it('places string system prompt as first system message', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: 'You are a helpful assistant.',
+        context: [],
+      };
+      const result = adapter.formatRequest(input);
+      const messages = result.input.messages as Array<{ role: string; content: string }>;
+      expect(messages[0]).toEqual({ role: 'system', content: 'You are a helpful assistant.' });
+    });
+
+    it('flattens string[] system prompt to a joined string', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: ['Identity block', 'Task frame', 'Guardrails'],
+        context: [],
+      };
+      const result = adapter.formatRequest(input);
+      const messages = result.input.messages as Array<{ role: string; content: string }>;
+      expect(messages[0]).toEqual({
+        role: 'system',
+        content: 'Identity block\nTask frame\nGuardrails',
+      });
+    });
+
+    it('appends context messages after the system message', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: 'Be concise.',
+        context: [
+          { role: 'user', content: 'Hello', source: 'initial_context', createdAt: '2026-01-01T00:00:00Z' },
+          { role: 'assistant', content: 'Hi!', source: 'model_output', createdAt: '2026-01-01T00:00:01Z' },
+        ],
+      };
+      const result = adapter.formatRequest(input);
+      const messages = result.input.messages as Array<{ role: string; content: string }>;
+      expect(messages).toHaveLength(3);
+      expect(messages[0].role).toBe('system');
+      expect(messages[1]).toEqual({ role: 'user', content: 'Hello' });
+      expect(messages[2]).toEqual({ role: 'assistant', content: 'Hi!' });
+    });
+
+    it('formats tool definitions to OpenAI function-call shape', () => {
+      const input: AdapterFormatInput = {
+        systemPrompt: 'test',
+        context: [],
+        toolDefinitions: [
+          {
+            name: 'search',
+            version: '1.0.0',
+            description: 'Search for files',
+            inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+            outputSchema: {},
+            capabilities: ['read'],
+            permissionScope: 'project',
+          },
+        ],
+      };
+      const result = adapter.formatRequest(input);
+      expect(result.input.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'search',
+            description: 'Search for files',
+            parameters: { type: 'object', properties: { query: { type: 'string' } } },
+          },
+        },
+      ]);
+    });
+
+    it('omits tools key when no tool definitions are provided', () => {
+      const input: AdapterFormatInput = { systemPrompt: 'test', context: [] };
+      const result = adapter.formatRequest(input);
+      expect(result.input.tools).toBeUndefined();
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('parses chat completions text response', () => {
+      const output = {
+        choices: [{ message: { content: 'Hello from Mistral' }, finish_reason: 'stop' }],
+      };
+      const result = adapter.parseResponse(output, TRACE_ID);
+      expect(result.response).toBe('Hello from Mistral');
+      expect(result.toolCalls).toEqual([]);
+      expect(result.contentType).toBe('text');
+    });
+
+    it('parses tool_calls from chat completions response', () => {
+      const output = {
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_abc123',
+                  type: 'function',
+                  function: { name: 'search', arguments: '{"query":"test"}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      };
+      const result = adapter.parseResponse(output, TRACE_ID);
+      expect(result.toolCalls).toEqual([
+        { name: 'search', params: { query: 'test' }, id: 'call_abc123' },
+      ]);
+    });
+
+    it('returns empty response string when message content is null', () => {
+      const output = {
+        choices: [{ message: { content: null }, finish_reason: 'stop' }],
+      };
+      const result = adapter.parseResponse(output, TRACE_ID);
+      expect(result.response).toBe('');
+      expect(result.toolCalls).toEqual([]);
+    });
+
+    it('parses plain string output', () => {
+      const result = adapter.parseResponse('plain string response', TRACE_ID);
+      expect(result.response).toBe('plain string response');
+      expect(result.contentType).toBe('text');
+    });
+
+    it('never throws on malformed output', () => {
+      expect(() => adapter.parseResponse(null, TRACE_ID)).not.toThrow();
+      expect(() => adapter.parseResponse(undefined, TRACE_ID)).not.toThrow();
+      expect(() => adapter.parseResponse(42, TRACE_ID)).not.toThrow();
+      expect(() => adapter.parseResponse({ choices: 'not-an-array' }, TRACE_ID)).not.toThrow();
+      expect(() => adapter.parseResponse({ choices: [null] }, TRACE_ID)).not.toThrow();
+    });
+
+    it('returns fallback string for completely unexpected output', () => {
+      const result = adapter.parseResponse({ unexpected: true }, TRACE_ID);
+      expect(typeof result.response).toBe('string');
+      expect(result.toolCalls).toEqual([]);
+    });
+  });
+});
+
+describe('MistralProvider', () => {
+  const originalApiKey = process.env.MISTRAL_API_KEY;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.MISTRAL_API_KEY = 'test-mistral-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalApiKey === undefined) {
+      delete process.env.MISTRAL_API_KEY;
+    } else {
+      process.env.MISTRAL_API_KEY = originalApiKey;
+    }
+  });
+
+  it('implements IModelProvider — getConfig returns config', () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    expect(provider.getConfig()).toEqual(MOCK_CONFIG);
+  });
+
+  it('constructor throws PROVIDER_AUTH_FAILED when no API key is available', () => {
+    delete process.env.MISTRAL_API_KEY;
+    expect(() => new MistralProvider(MOCK_CONFIG)).toThrow(NousError);
+  });
+
+  it('invoke() validates input — rejects invalid shape with ValidationError', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    await expect(
+      provider.invoke({ role: 'cortex-chat', input: {}, traceId: TRACE_ID }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('invoke() sends Chat Completions body with Bearer auth header', async () => {
+    const provider = new MistralProvider(
+      { ...MOCK_CONFIG, maxTokens: 1024 },
+      { apiKey: 'test-mistral-key' },
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'Hello from Mistral' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 10, completion_tokens: 5 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const result = await provider.invoke({
+      role: 'cortex-chat',
+      input: {
+        messages: [
+          { role: 'system', content: 'Be concise.' },
+          { role: 'user', content: 'Say hello.' },
+          { role: 'assistant', content: 'Previous reply.' },
+        ],
+      },
+      traceId: TRACE_ID,
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+
+    expect(url).toBe('https://api.mistral.ai/v1/chat/completions');
+    expect(headers['Authorization']).toBe('Bearer test-mistral-key');
+    expect(headers['x-api-key']).toBeUndefined();
+    expect(body).toEqual({
+      model: 'mistral-medium-latest',
+      max_tokens: 1024,
+      messages: [
+        { role: 'system', content: 'Be concise.' },
+        { role: 'user', content: 'Say hello.' },
+        { role: 'assistant', content: 'Previous reply.' },
+      ],
+      stream: false,
+    });
+    expect(result).toEqual({
+      output: 'Hello from Mistral',
+      providerId: MOCK_CONFIG.id,
+      usage: { inputTokens: 10, outputTokens: 5, computeMs: undefined },
+      traceId: TRACE_ID,
+    });
+  });
+
+  it('invoke() converts { prompt } input to a single user message', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'Prompt response' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 3, completion_tokens: 2 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'Write a haiku.' },
+      traceId: TRACE_ID,
+    });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body).toEqual({
+      model: 'mistral-medium-latest',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'Write a haiku.' }],
+      stream: false,
+    });
+  });
+
+  it('invoke() throws PROVIDER_AUTH_FAILED with PRV-AUTH-FAILURE on 401', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'bad-key' });
+    vi.mocked(fetch).mockResolvedValue(new Response('unauthorized', { status: 401 }));
+    await expect(
+      provider.invoke({ role: 'cortex-chat', input: { prompt: 'hi' }, traceId: TRACE_ID }),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_AUTH_FAILED',
+      context: { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+    });
+  });
+
+  it('invoke() throws PROVIDER_AUTH_FAILED with PRV-AUTH-FAILURE on 403', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'bad-key' });
+    vi.mocked(fetch).mockResolvedValue(new Response('forbidden', { status: 403 }));
+    await expect(
+      provider.invoke({ role: 'cortex-chat', input: { prompt: 'hi' }, traceId: TRACE_ID }),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_AUTH_FAILED',
+      context: { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+    });
+  });
+
+  it('invoke() throws PROVIDER_UNAVAILABLE with PRV-RATE-LIMIT on 429', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    vi.mocked(fetch).mockResolvedValue(new Response('rate limited', { status: 429 }));
+    await expect(
+      provider.invoke({ role: 'cortex-chat', input: { prompt: 'hi' }, traceId: TRACE_ID }),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE',
+      context: { failoverReasonCode: 'PRV-RATE-LIMIT' },
+    });
+  });
+
+  it('invoke() throws PROVIDER_UNAVAILABLE with PRV-PROVIDER-UNAVAILABLE on 500', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    vi.mocked(fetch).mockResolvedValue(new Response('internal error', { status: 500 }));
+    await expect(
+      provider.invoke({ role: 'cortex-chat', input: { prompt: 'hi' }, traceId: TRACE_ID }),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE',
+      context: { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+    });
+  });
+
+  it('stream() parses Chat Completions SSE deltas and emits done chunk with usage', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+              '',
+              'data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}',
+              '',
+              'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":3}}',
+              '',
+              'data: [DONE]',
+              '',
+            ].join('\n'),
+          ),
+        );
+        controller.close();
+      },
+    });
+    vi.mocked(fetch).mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const chunks: Array<{ content: string; done: boolean; usage?: unknown }> = [];
+    for await (const chunk of provider.stream({
+      role: 'cortex-chat',
+      input: { prompt: 'Stream this.' },
+      traceId: TRACE_ID,
+    })) {
+      chunks.push(chunk);
+    }
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+
+    expect(body.stream).toBe(true);
+    expect(chunks).toEqual([
+      { content: 'Hello', done: false },
+      { content: ' world', done: false },
+      { content: '', done: true, usage: { inputTokens: 8, outputTokens: 3 } },
+    ]);
+  });
+});
+
+describe('MistralProvider — fetchWithTimeout classification', () => {
+  const originalApiKey = process.env.MISTRAL_API_KEY;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.MISTRAL_API_KEY = 'test-mistral-key';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalApiKey === undefined) delete process.env.MISTRAL_API_KEY;
+    else process.env.MISTRAL_API_KEY = originalApiKey;
+  });
+
+  it('timeout abort is classified as request timed out, not endpoint unreachable', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { timeoutMs: 50 });
+    let capturedReason: unknown;
+
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const sig = (init as RequestInit).signal;
+        sig?.addEventListener('abort', () => {
+          capturedReason = (sig as AbortSignal).reason;
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const promise = provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    });
+    let caught: NousError | undefined;
+    const settled = promise.catch((e) => { caught = e as NousError; });
+
+    await vi.advanceTimersByTimeAsync(60);
+    await settled;
+
+    expect(caught).toBeInstanceOf(NousError);
+    expect(caught?.message).toContain('Mistral request timed out after');
+    expect(caught?.message).not.toContain('Mistral endpoint unreachable');
+    expect(capturedReason).toBeInstanceOf(DOMException);
+  });
+});

--- a/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
@@ -134,7 +134,7 @@ describe('createMistralAdapter', () => {
       expect(messages[2]).toEqual({ role: 'assistant', content: 'Hi!' });
     });
 
-    it('formats tool definitions to OpenAI function-call shape', () => {
+    it('does not emit tools in request body when nativeToolUse is false', () => {
       const input: AdapterFormatInput = {
         systemPrompt: 'test',
         context: [],
@@ -150,17 +150,8 @@ describe('createMistralAdapter', () => {
           },
         ],
       };
-      const result = adapter.formatRequest(input);
-      expect(result.input.tools).toEqual([
-        {
-          type: 'function',
-          function: {
-            name: 'search',
-            description: 'Search for files',
-            parameters: { type: 'object', properties: { query: { type: 'string' } } },
-          },
-        },
-      ]);
+       const result = adapter.formatRequest(input);
+      expect(result.input.tools).toBeUndefined();
     });
 
     it('omits tools key when no tool definitions are provided', () => {

--- a/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
@@ -22,7 +22,7 @@ const MOCK_CONFIG = {
   id: '00000000-0000-0000-0000-000000000201' as ProviderId,
   name: 'Mistral',
   type: 'text' as const,
-  modelId: 'mistral-medium-latest',
+  modelId: 'mistral-large-latest',
   endpoint: 'https://api.mistral.ai',
   isLocal: false,
   capabilities: ['chat', 'streaming'],
@@ -42,7 +42,7 @@ describe('MISTRAL_PROVIDER_DEFINITION', () => {
 
   it('has correct vendorKey, adapterKey, and protocol', () => {
     expect(MISTRAL_PROVIDER_DEFINITION.vendorKey).toBe('mistral');
-    expect(MISTRAL_PROVIDER_DEFINITION.adapterKey).toBe('chat-completions');
+    expect(MISTRAL_PROVIDER_DEFINITION.adapterKey).toBe('mistral');
     expect(MISTRAL_PROVIDER_DEFINITION.protocol).toBe('chat-completions');
   });
 
@@ -305,7 +305,7 @@ describe('MistralProvider', () => {
     expect(headers['Authorization']).toBe('Bearer test-mistral-key');
     expect(headers['x-api-key']).toBeUndefined();
     expect(body).toEqual({
-      model: 'mistral-medium-latest',
+      model: 'mistral-large-latest',
       max_tokens: 1024,
       messages: [
         { role: 'system', content: 'Be concise.' },
@@ -343,7 +343,7 @@ describe('MistralProvider', () => {
     const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(String(init.body)) as Record<string, unknown>;
     expect(body).toEqual({
-      model: 'mistral-medium-latest',
+      model: 'mistral-large-latest',
       max_tokens: 4096,
       messages: [{ role: 'user', content: 'Write a haiku.' }],
       stream: false,
@@ -436,6 +436,222 @@ describe('MistralProvider', () => {
       { content: ' world', done: false },
       { content: '', done: true, usage: { inputTokens: 8, outputTokens: 3 } },
     ]);
+  });
+});
+
+describe('MistralProvider — invoke() tool_calls passthrough (Issue 2)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.MISTRAL_API_KEY = 'test-mistral-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.MISTRAL_API_KEY;
+  });
+
+  it('returns structured {choices} output when response contains tool_calls', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    const toolCallResponse = {
+      choices: [
+        {
+          message: {
+            content: null,
+            tool_calls: [
+              { id: 'call_abc', type: 'function', function: { name: 'search', arguments: '{"q":"test"}' } },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(toolCallResponse), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const result = await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'Call a tool.' },
+      traceId: TRACE_ID,
+    });
+
+    expect(result.output).toEqual({ choices: toolCallResponse.choices });
+  });
+
+  it('returns string output when response has no tool_calls', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: 'text reply' }, finish_reason: 'stop' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const result = await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'hi' },
+      traceId: TRACE_ID,
+    });
+
+    expect(result.output).toBe('text reply');
+  });
+});
+
+describe('MistralProvider — stream() finish_reason tool_calls (Issue 3)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.MISTRAL_API_KEY = 'test-mistral-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.MISTRAL_API_KEY;
+  });
+
+  it('emits done chunk when finish_reason is tool_calls', async () => {
+    const provider = new MistralProvider(MOCK_CONFIG, { apiKey: 'test-mistral-key' });
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}',
+              '',
+              'data: [DONE]',
+              '',
+            ].join('\n'),
+          ),
+        );
+        controller.close();
+      },
+    });
+    vi.mocked(fetch).mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const chunks: Array<{ content: string; done: boolean }> = [];
+    for await (const chunk of provider.stream({
+      role: 'cortex-chat',
+      input: { prompt: 'call a tool' },
+      traceId: TRACE_ID,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toContainEqual(expect.objectContaining({ done: true }));
+  });
+});
+
+describe('MistralProvider — getChatUrl endpoint normalization (Issue 5)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.MISTRAL_API_KEY = 'test-mistral-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.MISTRAL_API_KEY;
+  });
+
+  it('does not double-append /v1 when endpoint already ends with /v1', async () => {
+    const provider = new MistralProvider(
+      { ...MOCK_CONFIG, endpoint: 'https://api.mistral.ai/v1' },
+      { apiKey: 'test-mistral-key' },
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await provider.invoke({ role: 'cortex-chat', input: { prompt: 'hi' }, traceId: TRACE_ID });
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.mistral.ai/v1/chat/completions');
+  });
+
+  it('does not double-append /v1 when endpoint ends with /v1/', async () => {
+    const provider = new MistralProvider(
+      { ...MOCK_CONFIG, endpoint: 'https://api.mistral.ai/v1/' },
+      { apiKey: 'test-mistral-key' },
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await provider.invoke({ role: 'cortex-chat', input: { prompt: 'hi' }, traceId: TRACE_ID });
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.mistral.ai/v1/chat/completions');
+  });
+});
+
+describe('createMistralAdapter — formatRequest tool frame handling (Issue 4)', () => {
+  const adapter = createMistralAdapter();
+
+  it('emits tool role with tool_call_id when frame has metadata.tool_call_id', () => {
+    const input: AdapterFormatInput = {
+      systemPrompt: 'test',
+      context: [
+        {
+          role: 'tool',
+          content: '{"result":"ok"}',
+          source: 'tool_result',
+          createdAt: '2026-01-01T00:00:00Z',
+          metadata: { tool_call_id: 'call_abc123' },
+        },
+      ],
+    };
+    const result = adapter.formatRequest(input);
+    const messages = result.input.messages as Array<{ role: string; content: string; tool_call_id?: string }>;
+    const toolMsg = messages.find((m) => m.role === 'tool');
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg?.tool_call_id).toBe('call_abc123');
+    expect(toolMsg?.content).toBe('{"result":"ok"}');
+  });
+
+  it('falls back to user role when tool frame has no metadata.tool_call_id', () => {
+    const input: AdapterFormatInput = {
+      systemPrompt: 'test',
+      context: [
+        { role: 'tool', content: 'result text', source: 'tool_result', createdAt: '2026-01-01T00:00:00Z' },
+      ],
+    };
+    const result = adapter.formatRequest(input);
+    const messages = result.input.messages as Array<{ role: string; content: string }>;
+    const toolMsg = messages.find((m) => m.content === 'result text');
+    expect(toolMsg?.role).toBe('user');
+  });
+});
+
+describe('createMistralAdapter — parseResponse missing message (Issue 7)', () => {
+  const adapter = createMistralAdapter();
+
+  it('returns empty string when choices[0].message is absent', () => {
+    const result = adapter.parseResponse({ choices: [{ finish_reason: 'stop' }] }, TRACE_ID);
+    expect(result.response).toBe('');
+    expect(result.toolCalls).toEqual([]);
+  });
+
+  it('returns empty string when choices array is empty', () => {
+    const result = adapter.parseResponse({ choices: [] }, TRACE_ID);
+    expect(result.response).toBe('');
+  });
+});
+
+describe('MISTRAL_PROVIDER_DEFINITION — adapterKey isolation (Issue 1)', () => {
+  it('adapterKey is mistral, not chat-completions', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.adapterKey).toBe('mistral');
+  });
+});
+
+describe('MISTRAL_PROVIDER_DEFINITION — defaultModelId is mistral-large-latest (Issue 6)', () => {
+  it('defaultModelId is mistral-large-latest', () => {
+    expect(MISTRAL_PROVIDER_DEFINITION.defaultModelId).toBe('mistral-large-latest');
   });
 });
 

--- a/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
+++ b/self/subcortex/providers/src/__tests__/mistral-provider.test.ts
@@ -84,9 +84,9 @@ describe('createMistralAdapter', () => {
   const adapter = createMistralAdapter();
 
   describe('capabilities', () => {
-    it('declares nativeToolUse and streaming; no cacheControl or extendedThinking', () => {
+    it('declares streaming; no nativeToolUse, cacheControl, or extendedThinking', () => {
       expect(adapter.capabilities).toEqual({
-        nativeToolUse: true,
+        nativeToolUse: false,
         cacheControl: false,
         extendedThinking: false,
         streaming: true,

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+expect(output).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'mistral', 'ollama', 'openai']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'mistral' | 'openai' | 'ollama'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'mistral' | 'openai' | 'ollama'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'github-copilot-cli', 'groq', 'llama-cpp', 'mistral', 'ollama', 'openai']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -45,6 +45,11 @@ const expectedDefinitions = {
     defaultModelId: 'llama3.2',
     envVar: undefined,
   },
+  mistral: {
+    defaultEndpoint: 'https://api.mistral.ai',
+    defaultModelId: 'mistral-medium-latest',
+    envVar: 'MISTRAL_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -55,6 +60,7 @@ describe('provider definitions catalog', () => {
       'github-copilot-cli',
       'groq',
       'llama-cpp',
+      'mistral',
       'ollama',
       'openai',
     ]);

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -47,7 +47,7 @@ const expectedDefinitions = {
   },
   mistral: {
     defaultEndpoint: 'https://api.mistral.ai',
-    defaultModelId: 'mistral-medium-latest',
+    defaultModelId: 'mistral-large-latest',
     envVar: 'MISTRAL_API_KEY',
   },
 } as const;

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -9,6 +9,7 @@ import {
   CERTIFIED_PROVIDER_FACTORIES,
   CodexCliProvider,
   GitHubCopilotCliProvider,
+  MistralProvider,
   OllamaProvider,
   PROVIDER_DEFINITIONS,
   ProviderRegistry,
@@ -62,9 +63,9 @@ describe('provider definition to adapter to registry pipeline', () => {
       'github-copilot-cli',
       'groq',
       'llama-cpp',
+      'mistral',
       'ollama',
-      'openai',
-    ]);
+      'openai',    ]);
     expect(resolveProviderDefinition('anthropic').defaultModelId).toBe(
       'claude-sonnet-4-20250514',
     );
@@ -165,6 +166,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
     process.env.OPENAI_API_KEY = 'test-openai-key';
     process.env.GROQ_API_KEY = 'test-groq-key';
+    process.env.MISTRAL_API_KEY = 'test-mistral-key';
 
     const registry = new ProviderRegistry(createEmptyConfig());
     const expectedClassByVendor = {
@@ -174,6 +176,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'llama-cpp': ChatCompletionsProvider,
       openai: ChatCompletionsProvider,
       groq: ChatCompletionsProvider,
+      mistral: MistralProvider,
       ollama: OllamaProvider,
     };
 
@@ -251,6 +254,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     expect(resolver.resolveAdapter('missing').capabilities).toEqual(textAdapter.capabilities);
   });
 });
+
 
 describe('github-copilot-cli — role compatibility', () => {
   it('declares session_bound_command profile', () => {

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -2,8 +2,10 @@
  * @nous/subcortex-providers — Model provider adapters for Nous-OSS.
  */
 export { AnthropicProvider } from './providers/anthropic/implementation.js';
+export { MistralProvider } from './providers/mistral/implementation.js';
 export * from './adapter-resolver.js';
 export * from './provider-adapters.js';
+export { CODEX_CLI_EXECUTION_CAPABILITY_PROFILE } from './providers/codex-cli/adapter.js';
 export * from './provider-definitions.js';
 export * from './provider-identity.js';
 export * from './provider-factories.js';
@@ -69,3 +71,5 @@ export type {
 } from '@nous/subcortex-inference-runtime';
 export { TextModelInputSchema } from './schemas/text-model-input.js';
 export type { TextModelInput } from './schemas/text-model-input.js';
+
+

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -5,6 +5,7 @@ import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cl
 import { providerAdapter as githubCopilotCliProviderAdapter } from './providers/github-copilot-cli/adapter.js';
 import { providerAdapter as groqProviderAdapter } from './providers/groq/adapter.js';
 import { providerAdapter as llamaCppProviderAdapter } from './providers/llama-cpp/adapter.js';
+import { providerAdapter as mistralProviderAdapter } from './providers/mistral/adapter.js';
 import { providerAdapter as ollamaProviderAdapter } from './providers/ollama/adapter.js';
 import { providerAdapter as openaiProviderAdapter } from './providers/openai/adapter.js';
 
@@ -14,6 +15,7 @@ export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROF
 export { providerAdapter as githubCopilotCliAdapter } from './providers/github-copilot-cli/adapter.js';
 export { providerAdapter as groqAdapter } from './providers/groq/adapter.js';
 export { providerAdapter as llamaCppAdapter } from './providers/llama-cpp/adapter.js';
+export { providerAdapter as mistralAdapter } from './providers/mistral/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
 
@@ -23,6 +25,7 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   githubCopilotCliProviderAdapter,
   groqProviderAdapter,
   llamaCppProviderAdapter,
+  mistralProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -6,6 +6,7 @@ import { providerDefinition as codexCliProviderDefinition } from './providers/co
 import { providerDefinition as githubCopilotCliProviderDefinition } from './providers/github-copilot-cli/definition.js';
 import { providerDefinition as groqProviderDefinition } from './providers/groq/definition.js';
 import { providerDefinition as llamaCppProviderDefinition } from './providers/llama-cpp/definition.js';
+import { providerDefinition as mistralProviderDefinition } from './providers/mistral/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
 
@@ -17,6 +18,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   githubCopilotCliProviderDefinition,
   groqProviderDefinition,
   llamaCppProviderDefinition,
+  mistralProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -5,6 +5,7 @@ import { providerFactory as codexCliProviderFactory } from './providers/codex-cl
 import { providerFactory as githubCopilotCliProviderFactory } from './providers/github-copilot-cli/provider.js';
 import { providerFactory as groqProviderFactory } from './providers/groq/provider.js';
 import { providerFactory as llamaCppProviderFactory } from './providers/llama-cpp/provider.js';
+import { providerFactory as mistralProviderFactory } from './providers/mistral/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
 
@@ -16,6 +17,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   githubCopilotCliProviderFactory,
   groqProviderFactory,
   llamaCppProviderFactory,
+  mistralProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];

--- a/self/subcortex/providers/src/providers/mistral/adapter.ts
+++ b/self/subcortex/providers/src/providers/mistral/adapter.ts
@@ -24,7 +24,7 @@ import {
 } from '../../schemas/provider-adapter.js';
 
 const MISTRAL_CAPABILITIES: AdapterCapabilities = {
-  nativeToolUse: true,
+  nativeToolUse: false,
   cacheControl: false,
   extendedThinking: false,
   streaming: true,
@@ -69,7 +69,7 @@ function formatContextMessages(
     if (frame.role === 'user' || frame.role === 'assistant') {
       messages.push({ role: frame.role, content: frame.content });
     } else if (frame.role === 'system') {
-      messages.push({ role: 'user', content: frame.content });
+      messages.push({ role: 'system', content: frame.content });
     } else if (frame.role === 'tool') {
       if (frame.metadata?.tool_call_id) {
         messages.push({ role: 'tool', content: frame.content, tool_call_id: frame.metadata.tool_call_id as string });

--- a/self/subcortex/providers/src/providers/mistral/adapter.ts
+++ b/self/subcortex/providers/src/providers/mistral/adapter.ts
@@ -54,7 +54,7 @@ function detectContentType(text: string): { response: string; contentType: 'text
   return { response: text, contentType: 'text' };
 }
 
-type ChatMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+type ChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content: string; tool_call_id?: string };
 
 function flattenSystemPrompt(systemPrompt: string | string[]): string {
   return Array.isArray(systemPrompt) ? systemPrompt.join('\n') : systemPrompt;
@@ -71,7 +71,11 @@ function formatContextMessages(
     } else if (frame.role === 'system') {
       messages.push({ role: 'user', content: frame.content });
     } else if (frame.role === 'tool') {
-      messages.push({ role: 'user', content: frame.content });
+      if (frame.metadata?.tool_call_id) {
+        messages.push({ role: 'tool', content: frame.content, tool_call_id: frame.metadata.tool_call_id as string });
+      } else {
+        messages.push({ role: 'user', content: frame.content });
+      }
     }
   }
 
@@ -135,7 +139,7 @@ function parseMistralResponse(output: unknown, log?: ILogChannel): ParsedModelOu
 
   if (!message) {
     return {
-      response: String(output),
+      response: '',
       toolCalls: [],
       memoryCandidates: [],
       contentType: 'text',
@@ -216,7 +220,7 @@ export function createMistralAdapter(log?: ILogChannel): ProviderAdapter {
 }
 
 export const providerAdapter = defineProviderAdapter({
-  adapterKey: 'chat-completions',
+  adapterKey: 'mistral',
   displayName: 'Mistral',
   protocol: 'chat-completions',
   capabilities: MISTRAL_CAPABILITIES,

--- a/self/subcortex/providers/src/providers/mistral/adapter.ts
+++ b/self/subcortex/providers/src/providers/mistral/adapter.ts
@@ -4,8 +4,7 @@
  * Mistral's API is Chat Completions-compatible. This adapter handles:
  * - System prompt flattening (array segments joined, no cache_control).
  * - Context frame mapping to Chat Completions message roles.
- * - Tool definition formatting to OpenAI function-call shape.
- * - Response parsing for text content and tool_calls.
+ * - Response parsing for text content and tool_calls (defensive only).
  *
  * Do not copy Anthropic-specific constructs: no cache_control segments,
  * no thinking blocks, no top-level combinator flattening, no x-api-key header.
@@ -82,20 +81,7 @@ function formatContextMessages(
   return messages;
 }
 
-function formatToolDefinitions(
-  toolDefinitions?: readonly import('@nous/shared').ToolDefinition[],
-): Array<{ type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }> | undefined {
-  if (!toolDefinitions || toolDefinitions.length === 0) return undefined;
 
-  return toolDefinitions.map((tool) => ({
-    type: 'function' as const,
-    function: {
-      name: tool.name,
-      description: tool.description ?? '',
-      parameters: (tool.inputSchema as Record<string, unknown>) ?? { type: 'object', properties: {} },
-    },
-  }));
-}
 
 interface ChatCompletionsChoice {
   message?: {
@@ -179,7 +165,7 @@ export function createMistralAdapter(log?: ILogChannel): ProviderAdapter {
     formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
       const systemText = flattenSystemPrompt(input.systemPrompt);
       const contextMessages = formatContextMessages(input.context);
-      const tools = formatToolDefinitions(input.toolDefinitions);
+     
 
       const messages: ChatMessage[] = [
         { role: 'system', content: systemText },
@@ -188,9 +174,7 @@ export function createMistralAdapter(log?: ILogChannel): ProviderAdapter {
 
       const body: Record<string, unknown> = { messages };
 
-      if (tools) {
-        body.tools = tools;
-      }
+   
 
       if (input.modelRequirements) {
         body.model_profile = input.modelRequirements.profile;

--- a/self/subcortex/providers/src/providers/mistral/adapter.ts
+++ b/self/subcortex/providers/src/providers/mistral/adapter.ts
@@ -1,0 +1,228 @@
+/**
+ * Mistral provider adapter — OpenAI Chat Completions wire protocol.
+ *
+ * Mistral's API is Chat Completions-compatible. This adapter handles:
+ * - System prompt flattening (array segments joined, no cache_control).
+ * - Context frame mapping to Chat Completions message roles.
+ * - Tool definition formatting to OpenAI function-call shape.
+ * - Response parsing for text content and tool_calls.
+ *
+ * Do not copy Anthropic-specific constructs: no cache_control segments,
+ * no thinking blocks, no top-level combinator flattening, no x-api-key header.
+ *
+ * parseResponse(...) must not throw. Malformed or unexpected output is caught
+ * and returned as a plain text fallback.
+ */
+import type { ILogChannel, TraceId } from '@nous/shared';
+import type { ParsedModelOutput } from '../../shared/output.js';
+import {
+  defineProviderAdapter,
+  type AdapterCapabilities,
+  type AdapterFormatInput,
+  type AdapterFormattedRequest,
+  type ProviderAdapter,
+} from '../../schemas/provider-adapter.js';
+
+const MISTRAL_CAPABILITIES: AdapterCapabilities = {
+  nativeToolUse: true,
+  cacheControl: false,
+  extendedThinking: false,
+  streaming: true,
+};
+
+const OPENUI_PREFIX = '%%openui\n';
+
+const CARD_TAG_PATTERNS = [
+  '<StatusCard',
+  '<ActionCard',
+  '<ApprovalCard',
+  '<WorkflowCard',
+  '<FollowUpBlock',
+];
+
+function detectContentType(text: string): { response: string; contentType: 'text' | 'openui' } {
+  let stripped = text;
+  let hadPrefix = false;
+  if (text.startsWith(OPENUI_PREFIX)) {
+    stripped = text.slice(OPENUI_PREFIX.length);
+    hadPrefix = true;
+  }
+  const hasCardTag = CARD_TAG_PATTERNS.some((p) => stripped.includes(p));
+  if (hadPrefix || hasCardTag) {
+    return { response: stripped, contentType: 'openui' };
+  }
+  return { response: text, contentType: 'text' };
+}
+
+type ChatMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+
+function flattenSystemPrompt(systemPrompt: string | string[]): string {
+  return Array.isArray(systemPrompt) ? systemPrompt.join('\n') : systemPrompt;
+}
+
+function formatContextMessages(
+  context: readonly import('@nous/shared').GatewayContextFrame[],
+): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  for (const frame of context) {
+    if (frame.role === 'user' || frame.role === 'assistant') {
+      messages.push({ role: frame.role, content: frame.content });
+    } else if (frame.role === 'system') {
+      messages.push({ role: 'user', content: frame.content });
+    } else if (frame.role === 'tool') {
+      messages.push({ role: 'user', content: frame.content });
+    }
+  }
+
+  return messages;
+}
+
+function formatToolDefinitions(
+  toolDefinitions?: readonly import('@nous/shared').ToolDefinition[],
+): Array<{ type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }> | undefined {
+  if (!toolDefinitions || toolDefinitions.length === 0) return undefined;
+
+  return toolDefinitions.map((tool) => ({
+    type: 'function' as const,
+    function: {
+      name: tool.name,
+      description: tool.description ?? '',
+      parameters: (tool.inputSchema as Record<string, unknown>) ?? { type: 'object', properties: {} },
+    },
+  }));
+}
+
+interface ChatCompletionsChoice {
+  message?: {
+    content?: string | null;
+    tool_calls?: Array<{
+      id?: string;
+      type?: string;
+      function?: { name?: string; arguments?: string };
+    }>;
+  };
+  finish_reason?: string;
+}
+
+interface ChatCompletionsResponse {
+  choices?: ChatCompletionsChoice[];
+}
+
+function parseMistralResponse(output: unknown, log?: ILogChannel): ParsedModelOutput {
+  if (typeof output === 'string') {
+    const detected = detectContentType(output);
+    return {
+      response: detected.response,
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: detected.contentType,
+    };
+  }
+
+  if (!output || typeof output !== 'object') {
+    return {
+      response: String(output ?? ''),
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: 'text',
+    };
+  }
+
+  const obj = output as ChatCompletionsResponse;
+  const choice = obj.choices?.[0];
+  const message = choice?.message;
+
+  if (!message) {
+    return {
+      response: String(output),
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: 'text',
+    };
+  }
+
+  const toolCalls: Array<{ name: string; params: unknown; id?: string }> = [];
+
+  if (Array.isArray(message.tool_calls)) {
+    for (const tc of message.tool_calls) {
+      if (!tc.function?.name) continue;
+      let params: unknown = {};
+      try {
+        params = tc.function.arguments ? JSON.parse(tc.function.arguments) : {};
+      } catch {
+        log?.error(`Mistral: failed to parse tool_call arguments for "${tc.function.name}"`);
+      }
+      toolCalls.push({ name: tc.function.name, params, id: tc.id });
+    }
+  }
+
+  const text = message.content ?? '';
+  const detected = detectContentType(text);
+
+  return {
+    response: detected.response,
+    toolCalls,
+    memoryCandidates: [],
+    contentType: detected.contentType,
+  };
+}
+
+export function createMistralAdapter(log?: ILogChannel): ProviderAdapter {
+  return {
+    capabilities: MISTRAL_CAPABILITIES,
+
+    formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
+      const systemText = flattenSystemPrompt(input.systemPrompt);
+      const contextMessages = formatContextMessages(input.context);
+      const tools = formatToolDefinitions(input.toolDefinitions);
+
+      const messages: ChatMessage[] = [
+        { role: 'system', content: systemText },
+        ...contextMessages,
+      ];
+
+      const body: Record<string, unknown> = { messages };
+
+      if (tools) {
+        body.tools = tools;
+      }
+
+      if (input.modelRequirements) {
+        body.model_profile = input.modelRequirements.profile;
+      }
+
+      return { input: body };
+    },
+
+    parseResponse(output: unknown, _traceId: TraceId): ParsedModelOutput {
+      try {
+        return parseMistralResponse(output, log);
+      } catch (error) {
+        log?.error('Mistral parseResponse error — falling back to String(output)', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          outputType: typeof output,
+          outputKeys: output && typeof output === 'object' ? Object.keys(output) : [],
+        });
+        return {
+          response: String(output ?? ''),
+          toolCalls: [],
+          memoryCandidates: [],
+          contentType: 'text',
+        };
+      }
+    },
+  };
+}
+
+export const providerAdapter = defineProviderAdapter({
+  adapterKey: 'chat-completions',
+  displayName: 'Mistral',
+  protocol: 'chat-completions',
+  capabilities: MISTRAL_CAPABILITIES,
+  create(options) {
+    return createMistralAdapter(options?.log);
+  },
+});
+
+export { providerAdapter as mistralAdapter };

--- a/self/subcortex/providers/src/providers/mistral/definition.ts
+++ b/self/subcortex/providers/src/providers/mistral/definition.ts
@@ -1,0 +1,3 @@
+export {
+  MISTRAL_PROVIDER_DEFINITION as providerDefinition,
+} from './implementation.js';

--- a/self/subcortex/providers/src/providers/mistral/implementation.ts
+++ b/self/subcortex/providers/src/providers/mistral/implementation.ts
@@ -20,7 +20,7 @@ import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.j
 import { TextModelInputSchema, type TextModelInput } from '../../schemas/text-model-input.js';
 
 const DEFAULT_ENDPOINT = 'https://api.mistral.ai';
-const DEFAULT_MODEL_ID = 'mistral-medium-latest';
+const DEFAULT_MODEL_ID = 'mistral-large-latest';
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_TOKENS = 4096;
 
@@ -30,7 +30,7 @@ export const MISTRAL_PROVIDER_DEFINITION = {
   providerType: 'text',
   providerClass: 'remote_text',
   protocol: 'chat-completions',
-  adapterKey: 'chat-completions',
+  adapterKey: 'mistral',
   defaultEndpoint: DEFAULT_ENDPOINT,
   defaultModelId: DEFAULT_MODEL_ID,
   auth: {
@@ -130,7 +130,9 @@ export class MistralProvider implements IModelProvider {
     await this.throwForResponseError(response);
 
     const data = (await response.json()) as MistralChatResponse;
-    const output = data.choices?.[0]?.message?.content ?? '';
+    const message = data.choices?.[0]?.message;
+    const hasToolCalls = Array.isArray(message?.tool_calls) && message.tool_calls.length > 0;
+    const output = hasToolCalls ? { choices: data.choices } : (message?.content ?? '');
 
     return {
       output,
@@ -197,7 +199,7 @@ export class MistralProvider implements IModelProvider {
             yield { content, done: false };
           }
 
-          if (finishReason === 'stop' || finishReason === 'length') {
+          if (finishReason === 'stop' || finishReason === 'length' || finishReason === 'tool_calls') {
             yield {
               content: '',
               done: true,
@@ -262,7 +264,7 @@ export class MistralProvider implements IModelProvider {
   }
 
   private getChatUrl(): string {
-    return `${this.endpoint.replace(/\/$/, '')}/v1/chat/completions`;
+    return `${this.endpoint.replace(/\/v1\/?$/, '').replace(/\/$/, '')}/v1/chat/completions`;
   }
 
   private async throwForResponseError(response: Response): Promise<void> {

--- a/self/subcortex/providers/src/providers/mistral/implementation.ts
+++ b/self/subcortex/providers/src/providers/mistral/implementation.ts
@@ -49,7 +49,6 @@ export const MISTRAL_PROVIDER_DEFINITION = {
     streaming: true,
     cacheControl: false,
     extendedThinking: false,
-    nativeToolUse: true,
     modelListing: true,
   },
   isLocal: false,

--- a/self/subcortex/providers/src/providers/mistral/implementation.ts
+++ b/self/subcortex/providers/src/providers/mistral/implementation.ts
@@ -1,0 +1,328 @@
+/**
+ * Mistral AI provider — Chat Completions wire protocol.
+ *
+ * Mistral's API is OpenAI Chat Completions-compatible. This leaf owns its own
+ * request execution rather than delegating to src/protocols/openai-api because
+ * it uses Mistral-specific auth, endpoint, default model, and capabilities.
+ *
+ * Do not copy Anthropic-specific semantics (cache_control, extended thinking,
+ * Anthropic version headers) — they do not apply here.
+ */
+import { NousError, ValidationError } from '@nous/shared';
+import type {
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamChunk,
+} from '@nous/shared';
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+import { TextModelInputSchema, type TextModelInput } from '../../schemas/text-model-input.js';
+
+const DEFAULT_ENDPOINT = 'https://api.mistral.ai';
+const DEFAULT_MODEL_ID = 'mistral-medium-latest';
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_TOKENS = 4096;
+
+export const MISTRAL_PROVIDER_DEFINITION = {
+  vendorKey: 'mistral',
+  displayName: 'Mistral',
+  providerType: 'text',
+  providerClass: 'remote_text',
+  protocol: 'chat-completions',
+  adapterKey: 'chat-completions',
+  defaultEndpoint: DEFAULT_ENDPOINT,
+  defaultModelId: DEFAULT_MODEL_ID,
+  auth: {
+    envVar: 'MISTRAL_API_KEY',
+    vaultKeyNamespace: 'mistral',
+    header: {
+      name: 'Authorization',
+      scheme: 'bearer',
+    },
+    required: true,
+    purpose: 'api_key',
+  },
+  modelListEndpoint: '/v1/models',
+  modelListFormat: 'openai-models',
+  capabilities: {
+    streaming: true,
+    cacheControl: false,
+    extendedThinking: false,
+    nativeToolUse: true,
+    modelListing: true,
+  },
+  isLocal: false,
+} as const satisfies ProviderDefinitionLeaf;
+
+interface MistralChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface MistralToolCall {
+  id?: string;
+  type?: string;
+  function?: { name?: string; arguments?: string };
+}
+
+interface MistralChatResponse {
+  choices?: Array<{
+    message?: {
+      content?: string | null;
+      tool_calls?: MistralToolCall[];
+    };
+    finish_reason?: string;
+  }>;
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+}
+
+interface MistralStreamDelta {
+  choices?: Array<{
+    delta?: { content?: string | null };
+    finish_reason?: string | null;
+  }>;
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+}
+
+interface MistralFormattedMessages {
+  messages: MistralChatMessage[];
+}
+
+export class MistralProvider implements IModelProvider {
+  private readonly config: ModelProviderConfig;
+  private readonly endpoint: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+
+  constructor(
+    config: ModelProviderConfig,
+    options?: { apiKey?: string; timeoutMs?: number },
+  ) {
+    this.config = config;
+    this.endpoint = config.endpoint ?? DEFAULT_ENDPOINT;
+    this.apiKey = options?.apiKey ?? process.env.MISTRAL_API_KEY ?? '';
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    if (!this.apiKey) {
+      throw new NousError(
+        'Mistral API key required — set MISTRAL_API_KEY or pass apiKey option',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+  }
+
+  getConfig(): ModelProviderConfig {
+    return this.config;
+  }
+
+  async invoke(request: ModelRequest): Promise<ModelResponse> {
+    const input = this.validateInput(request.input);
+    const formatted = this.toMistralMessages(input);
+    const response = await this.fetchWithTimeout(this.getChatUrl(), {
+      method: 'POST',
+      headers: this.getHeaders(),
+      signal: request.abortSignal,
+      body: JSON.stringify(this.buildRequestBody(formatted, false)),
+    });
+
+    await this.throwForResponseError(response);
+
+    const data = (await response.json()) as MistralChatResponse;
+    const output = data.choices?.[0]?.message?.content ?? '';
+
+    return {
+      output,
+      providerId: this.config.id,
+      usage: {
+        inputTokens: data.usage?.prompt_tokens,
+        outputTokens: data.usage?.completion_tokens,
+        computeMs: undefined,
+      },
+      traceId: request.traceId,
+    };
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    const input = this.validateInput(request.input);
+    const formatted = this.toMistralMessages(input);
+    const response = await this.fetchWithTimeout(this.getChatUrl(), {
+      method: 'POST',
+      headers: this.getHeaders(),
+      signal: request.abortSignal,
+      body: JSON.stringify(this.buildRequestBody(formatted, true)),
+    });
+
+    await this.throwForResponseError(response);
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new NousError('No response body', 'PROVIDER_UNAVAILABLE');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('data:')) continue;
+
+          const payload = trimmed.slice(5).trimStart();
+          if (!payload || payload === '[DONE]') continue;
+
+          const chunk = JSON.parse(payload) as MistralStreamDelta;
+
+          if (chunk.usage) {
+            inputTokens = chunk.usage.prompt_tokens ?? inputTokens;
+            outputTokens = chunk.usage.completion_tokens ?? outputTokens;
+          }
+
+          const choice = chunk.choices?.[0];
+          const content = choice?.delta?.content;
+          const finishReason = choice?.finish_reason;
+
+          if (content) {
+            yield { content, done: false };
+          }
+
+          if (finishReason === 'stop' || finishReason === 'length') {
+            yield {
+              content: '',
+              done: true,
+              usage: { inputTokens, outputTokens },
+            };
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private validateInput(input: unknown): TextModelInput {
+    const result = TextModelInputSchema.safeParse(input);
+    if (!result.success) {
+      const errors = result.error.errors.map((e) => ({
+        path: e.path.join('.'),
+        message: e.message,
+      }));
+      throw new ValidationError('Invalid model input', errors);
+    }
+    return result.data;
+  }
+
+  private toMistralMessages(input: TextModelInput): MistralFormattedMessages {
+    const messages: MistralChatMessage[] = [];
+
+    if ('messages' in input && Array.isArray(input.messages)) {
+      for (const msg of input.messages) {
+        if (msg.role === 'system' || msg.role === 'user' || msg.role === 'assistant') {
+          messages.push({ role: msg.role, content: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content) });
+        }
+      }
+      return { messages };
+    }
+
+    if ('prompt' in input) {
+      messages.push({ role: 'user', content: input.prompt });
+    }
+
+    return { messages };
+  }
+
+  private buildRequestBody(
+    formatted: MistralFormattedMessages,
+    stream: boolean,
+  ): Record<string, unknown> {
+    return {
+      model: this.config.modelId,
+      max_tokens: this.config.maxTokens ?? DEFAULT_MAX_TOKENS,
+      messages: formatted.messages,
+      stream,
+    };
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+  }
+
+  private getChatUrl(): string {
+    return `${this.endpoint.replace(/\/$/, '')}/v1/chat/completions`;
+  }
+
+  private async throwForResponseError(response: Response): Promise<void> {
+    if (response.status === 401 || response.status === 403) {
+      throw new NousError(
+        'Mistral API key invalid or missing',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new NousError(
+        `Mistral rate limit exceeded: ${response.status}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-RATE-LIMIT' },
+      );
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new NousError(
+        `Mistral API error ${response.status}: ${text.slice(0, 200)}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+      );
+    }
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(
+      () => timeoutController.abort(new DOMException('provider_timeout', 'AbortError')),
+      this.timeoutMs,
+    );
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, timeoutController.signal])
+      : timeoutController.signal;
+
+    try {
+      return await fetch(url, { ...init, signal });
+    } catch (error) {
+      if (timeoutController.signal.aborted) {
+        throw new NousError(
+          `Mistral request timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        );
+      }
+      if ((error as Error).name === 'AbortError') {
+        throw new NousError('Mistral request aborted.', 'ABORTED');
+      }
+      throw new NousError(
+        `Mistral endpoint unreachable: ${(error as Error).message}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+

--- a/self/subcortex/providers/src/providers/mistral/index.ts
+++ b/self/subcortex/providers/src/providers/mistral/index.ts
@@ -1,0 +1,4 @@
+export { providerAdapter, mistralAdapter } from './adapter.js';
+export { providerDefinition } from './definition.js';
+export { providerFactory } from './provider.js';
+export { MistralProvider, MISTRAL_PROVIDER_DEFINITION } from './implementation.js';

--- a/self/subcortex/providers/src/providers/mistral/provider.ts
+++ b/self/subcortex/providers/src/providers/mistral/provider.ts
@@ -1,0 +1,9 @@
+import { MistralProvider } from './implementation.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'mistral',
+  create(config, options) {
+    return new MistralProvider(config, { apiKey: options?.apiKey });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## What does this PR do?

Adds a Mistral AI model provider under self/subcortex/providers/src/providers/mistral/, 
following the certified provider leaf structure documented in the provider-adapters docs. 
Mistral uses the OpenAI-compatible Chat Completions protocol, so I reused that protocol 
while keeping Mistral's own auth, endpoint defaults, and adapter behavior in its own files.

## Why was this PR needed?

There wasn't a Mistral implementation of IModelProvider yet, so Mistral models couldn't 
be used through nous-core. This adds invoke, stream, and getConfig with Bearer token auth 
and dynamic model discovery.

Before opening this PR I went back and did a critical pass on my own code instead of just 
trusting that the tests passed. Glad I did, because I found a few real bugs: tool_calls 
were getting silently dropped in both invoke() and stream(), my adapterKey collided with 
the shared chat-completions key (which meant my custom adapter was actually dead code at 
runtime, the resolver was always picking openai's adapter instead), tool_call_id was 
getting lost on multi-turn tool conversations, and a malformed response could end up 
showing the literal string "[object Object]" instead of failing gracefully. All of these 
are fixed here with regression tests so they don't come back.

## What are the relevant issue numbers?

Closes #308

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior (42 tests, including 7 regression tests for the bugs above)
- [x] All tests passing (42/42 own suite, 56/56 focused provider suite)
- [x] Follows project style guide (typecheck and generated-catalog checks pass)
- [x] No breaking changes introduced
- [x] Documentation updated (n/a, no docs changes needed for this addition)

## Notes for reviewers

- adapterKey is 'mistral', not 'chat-completions', so the adapter is actually reachable 
  through ADAPTER_RESOLVER. protocol stays 'chat-completions' since the wire format 
  itself didn't change.
- defaultModelId is mistral-large-latest, matching the example in Mistral's own API docs.
- While rebasing onto the latest version of this branch I noticed 
  CODEX_CLI_EXECUTION_CAPABILITY_PROFILE was exported from the generated 
  provider-adapters.ts but never re-exported from src/index.ts, which broke cortex-core's 
  typecheck. Added the explicit re-export here since it was blocking a clean build.