### PR TITLE
Add Google Gemini provider leaf

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -56,6 +56,7 @@ describe('adapter resolver', () => {
       'anthropic',
       'codex-cli',
       'chat-completions',
+      'gemini',
       'github-copilot-cli',
       'chat-completions',
       'chat-completions',
@@ -70,6 +71,7 @@ describe('adapter resolver', () => {
     expect(resolveAdapter('anthropic').capabilities.cacheControl).toBe(true);
     expect(resolveAdapter('chat-completions').capabilities.nativeToolUse).toBe(true);
     expect(resolveAdapter('codex-cli').capabilities.streaming).toBe(true);
+    expect(resolveAdapter('gemini').capabilities.streaming).toBe(true);
     expect(resolveAdapter('github-copilot-cli').capabilities.nativeToolUse).toBe(false);
     expect(resolveAdapter('ollama').capabilities.extendedThinking).toBe(true);
     expect(resolveAdapter('text').capabilities.nativeToolUse).toBe(false);
@@ -98,6 +100,7 @@ describe('adapter resolver', () => {
   it('resolves current provider definition vendors', () => {
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'anthropic' }))).toBe('anthropic');
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'codex-cli' }))).toBe('codex-cli');
+    expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'gemini' }))).toBe('gemini');
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'ollama' }))).toBe('ollama');
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'moonshot' }))).toBe('chat-completions');
   });

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'deepinfra', 'github-copilot-cli', 'groq', 'llama-cpp', 'moonshot', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'deepinfra', 'gemini', 'github-copilot-cli', 'groq', 'llama-cpp', 'moonshot', 'ollama', 'openai']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'deepinfra' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'moonshot' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'moonshot' | 'openai' | 'ollama'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'deepinfra' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'moonshot' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'llama-cpp' | 'moonshot' | 'openai' | 'ollama'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 
@@ -29,7 +29,7 @@ describe('provider definition type derivation', () => {
       (definition) => definition.vendorKey,
     );
 
-    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'deepinfra', 'github-copilot-cli', 'groq', 'llama-cpp', 'moonshot', 'ollama', 'openai']);
+    expect(keys.sort()).toEqual(['anthropic', 'codex-cli', 'deepinfra', 'gemini', 'github-copilot-cli', 'groq', 'llama-cpp', 'moonshot', 'ollama', 'openai']);
   });
 
   it('supports local leaf-addition fixtures without production branch logic', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -55,6 +55,11 @@ const expectedDefinitions = {
     defaultModelId: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
     envVar: 'DEEPINFRA_API_KEY',
   },
+  gemini: {
+    defaultEndpoint: 'https://generativelanguage.googleapis.com',
+    defaultModelId: 'gemini-2.5-flash',
+    envVar: 'GEMINI_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -63,6 +68,7 @@ describe('provider definitions catalog', () => {
       'anthropic',
       'codex-cli',
       'deepinfra',
+      'gemini',
       'github-copilot-cli',
       'groq',
       'llama-cpp',
@@ -108,12 +114,9 @@ describe('provider definitions catalog', () => {
       join('providers', 'ollama', 'implementation.ts'),
       join('providers', 'llama-cpp', 'definition.ts'),
       join('providers', 'deepinfra', 'definition.ts'),
+      join('providers', 'gemini', 'implementation.ts'),
     ];
-    const forbidden = [
-      /fetch/,
-      /process\.env/,
-      /new (AnthropicProvider|ChatCompletionsProvider|OllamaProvider)/,
-    ];
+    const forbidden = [/fetch/, /process\.env/, /new \w+Provider/];
 
     for (const file of providerFiles) {
       const source = readFileSync(join(providersSrcDir, file), 'utf8');

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -8,6 +8,7 @@ import {
   ChatCompletionsProvider,
   CERTIFIED_PROVIDER_FACTORIES,
   CodexCliProvider,
+  GeminiProvider,
   GitHubCopilotCliProvider,
   OllamaProvider,
   PROVIDER_DEFINITIONS,
@@ -54,6 +55,7 @@ afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.MOONSHOT_API_KEY;
   delete process.env.GROQ_API_KEY;
+  delete process.env.GEMINI_API_KEY;
 });
 
 describe('provider definition to adapter to registry pipeline', () => {
@@ -62,6 +64,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'anthropic',
       'codex-cli',
       'deepinfra',
+      'gemini',
       'github-copilot-cli',
       'groq',
       'llama-cpp',
@@ -176,6 +179,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     process.env.OPENAI_API_KEY = 'test-openai-key';
     process.env.MOONSHOT_API_KEY = 'test-moonshot-key';
     process.env.GROQ_API_KEY = 'test-groq-key';
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
 
     const registry = new ProviderRegistry(createEmptyConfig());
     const expectedClassByVendor = {
@@ -185,6 +189,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       moonshot: ChatCompletionsProvider,
       'llama-cpp': ChatCompletionsProvider,
       'deepinfra': ChatCompletionsProvider,
+      gemini: GeminiProvider,
       openai: ChatCompletionsProvider,
       groq: ChatCompletionsProvider,
       ollama: OllamaProvider,

--- a/self/subcortex/providers/src/__tests__/providers/gemini.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/gemini.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ProviderId } from '@nous/shared';
+import { NousError, ValidationError } from '@nous/shared';
+import {
+  GEMINI_DEFAULT_ENDPOINT,
+  GEMINI_DEFAULT_MODEL_ID,
+  providerDefinition,
+  providerFactory,
+  createGeminiAdapter,
+  GeminiProvider,
+} from '../../providers/gemini/index.js';
+import { ProviderDefinitionSchema } from '../../schemas/provider-definition.js';
+import { deriveBuiltInProviderId } from '../../provider-identity.js';
+import type { AdapterFormatInput } from '../../schemas/provider-adapter.js';
+
+const MOCK_CONFIG = {
+  id: deriveBuiltInProviderId('gemini') as ProviderId,
+  name: 'Google Gemini',
+  type: 'text' as const,
+  modelId: GEMINI_DEFAULT_MODEL_ID,
+  endpoint: GEMINI_DEFAULT_ENDPOINT,
+  isLocal: false,
+  capabilities: ['chat', 'streaming'],
+};
+
+const TRACE_ID = '00000000-0000-0000-0000-000000000071' as never;
+
+describe('Gemini provider leaf', () => {
+  it('exposes native Gemini metadata without hand-authored wellKnownProviderId', () => {
+    expect(providerDefinition.vendorKey).toBe('gemini');
+    expect(providerDefinition.displayName).toBe('Google Gemini');
+    expect(providerDefinition.protocol).toBe('gemini-generate-content');
+    expect(providerDefinition.adapterKey).toBe('gemini');
+    expect(providerDefinition.defaultEndpoint).toBe('https://generativelanguage.googleapis.com');
+    expect(providerDefinition.defaultModelId).toBe('gemini-2.5-flash');
+    expect(providerDefinition.auth).toEqual({
+      envVar: 'GEMINI_API_KEY',
+      vaultKeyNamespace: 'gemini',
+      header: {
+        name: 'x-goog-api-key',
+        scheme: 'raw',
+      },
+      required: true,
+      purpose: 'api_key',
+    });
+    expect(providerDefinition.capabilities?.streaming).toBe(true);
+    expect(providerDefinition.capabilities?.nativeToolUse).toBe(false);
+    expect('wellKnownProviderId' in providerDefinition).toBe(false);
+  });
+
+  it('satisfies the shared ProviderDefinitionSchema once hydrated with a derived id', () => {
+    const hydrated = {
+      ...providerDefinition,
+      wellKnownProviderId: deriveBuiltInProviderId('gemini') as ProviderId,
+    };
+    expect(() => ProviderDefinitionSchema.parse(hydrated)).not.toThrow();
+  });
+
+  it('factory builds a GeminiProvider for the gemini vendor', () => {
+    const provider = providerFactory.create(MOCK_CONFIG, { apiKey: 'test-gemini-key' });
+    expect(providerFactory.vendorKey).toBe('gemini');
+    expect(provider).toBeInstanceOf(GeminiProvider);
+    expect(provider.getConfig()).toEqual(MOCK_CONFIG);
+  });
+});
+
+describe('createGeminiAdapter', () => {
+  const adapter = createGeminiAdapter();
+
+  it('declares text streaming capabilities without native tool use', () => {
+    expect(adapter.capabilities).toEqual({
+      nativeToolUse: false,
+      cacheControl: false,
+      extendedThinking: false,
+      streaming: true,
+    });
+  });
+
+  it('formats system prompts and context into TextModelInput messages', () => {
+    const input: AdapterFormatInput = {
+      systemPrompt: ['Identity', 'Guardrails'],
+      context: [
+        { role: 'user', content: 'Hello', source: 'initial_context', createdAt: '2026-01-01T00:00:00Z' },
+        { role: 'assistant', content: 'Hi', source: 'model_output', createdAt: '2026-01-01T00:00:01Z' },
+        { role: 'tool', content: 'tool result', source: 'tool_result', createdAt: '2026-01-01T00:00:02Z' },
+      ],
+      modelRequirements: { profile: 'fast', fallbackPolicy: 'block_if_unmet' },
+    };
+
+    expect(adapter.formatRequest(input).input).toEqual({
+      messages: [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi' },
+        { role: 'user', content: 'tool result' },
+      ],
+      systemSegments: ['Identity', 'Guardrails'],
+      model_profile: 'fast',
+    });
+  });
+
+  it('parses Gemini candidate text into canonical output', () => {
+    const result = adapter.parseResponse({
+      candidates: [
+        {
+          content: {
+            parts: [{ text: 'Hello, ' }, { text: 'world!' }],
+          },
+        },
+      ],
+    }, TRACE_ID);
+
+    expect(result).toEqual({
+      response: 'Hello, world!',
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: 'text',
+    });
+  });
+});
+
+describe('GeminiProvider', () => {
+  const originalApiKey = process.env.GEMINI_API_KEY;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalApiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalApiKey;
+    }
+  });
+
+  it('constructor throws PROVIDER_AUTH_FAILED when no API key is available', () => {
+    delete process.env.GEMINI_API_KEY;
+
+    expect(() => new GeminiProvider(MOCK_CONFIG)).toThrow(NousError);
+  });
+
+  it('invoke() validates input and rejects invalid payloads', async () => {
+    const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'test-gemini-key' });
+
+    await expect(
+      provider.invoke({
+        role: 'cortex-chat',
+        input: {},
+        traceId: TRACE_ID,
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('invoke() sends native generateContent request and parses response', async () => {
+    const provider = new GeminiProvider(
+      { ...MOCK_CONFIG, maxTokens: 1024 },
+      { apiKey: 'test-gemini-key' },
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'Hello from Gemini' }],
+              },
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 6,
+            candidatesTokenCount: 4,
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const result = await provider.invoke({
+      role: 'cortex-chat',
+      input: {
+        messages: [
+          { role: 'system', content: 'Be concise.' },
+          { role: 'user', content: 'Say hello.' },
+          { role: 'assistant', content: 'Previous reply.' },
+        ],
+      },
+      traceId: TRACE_ID,
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+
+    expect(url).toBe('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent');
+    expect(headers['x-goog-api-key']).toBe('test-gemini-key');
+    expect(headers.Authorization).toBeUndefined();
+    expect(body).toEqual({
+      contents: [
+        { role: 'user', parts: [{ text: 'Say hello.' }] },
+        { role: 'model', parts: [{ text: 'Previous reply.' }] },
+      ],
+      systemInstruction: {
+        parts: [{ text: 'Be concise.' }],
+      },
+      generationConfig: {
+        maxOutputTokens: 1024,
+      },
+    });
+    expect(result).toEqual({
+      output: 'Hello from Gemini',
+      providerId: MOCK_CONFIG.id,
+      usage: {
+        inputTokens: 6,
+        outputTokens: 4,
+        computeMs: undefined,
+      },
+      traceId: TRACE_ID,
+    });
+  });
+
+  it('invoke() converts prompt input to a single Gemini user content', async () => {
+    const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'test-gemini-key' });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [{ content: { parts: [{ text: 'Prompt response' }] } }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await provider.invoke({
+      role: 'cortex-chat',
+      input: { prompt: 'Write a haiku.' },
+      traceId: TRACE_ID,
+    });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+
+    expect(body).toEqual({
+      contents: [
+        { role: 'user', parts: [{ text: 'Write a haiku.' }] },
+      ],
+      generationConfig: {
+        maxOutputTokens: 4096,
+      },
+    });
+  });
+
+  it('stream() parses Gemini SSE chunks and emits usage on the terminal chunk', async () => {
+    const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'test-gemini-key' });
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n\n'));
+        controller.enqueue(encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}\n\n'));
+        controller.close();
+      },
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    );
+
+    const chunks = [];
+    for await (const chunk of provider.stream({
+      role: 'cortex-chat',
+      input: { prompt: 'Say hello.' },
+      traceId: TRACE_ID,
+    })) {
+      chunks.push(chunk);
+    }
+
+    const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse');
+    expect(chunks).toEqual([
+      { content: 'Hel', done: false, usage: undefined },
+      {
+        content: 'lo',
+        done: true,
+        usage: {
+          inputTokens: 3,
+          outputTokens: 2,
+        },
+      },
+    ]);
+  });
+
+  it('invoke() throws PROVIDER_AUTH_FAILED with PRV-AUTH-FAILURE on 403', async () => {
+    const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'bad-key' });
+    vi.mocked(fetch).mockResolvedValue(new Response('forbidden', { status: 403 }));
+
+    await expect(
+      provider.invoke({
+        role: 'cortex-chat',
+        input: { prompt: 'hi' },
+        traceId: TRACE_ID,
+      }),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_AUTH_FAILED',
+      context: { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+    });
+  });
+
+  it('invoke() throws PROVIDER_UNAVAILABLE with PRV-RATE-LIMIT on 429', async () => {
+    const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'test-gemini-key' });
+    vi.mocked(fetch).mockResolvedValue(new Response('rate limited', { status: 429 }));
+
+    await expect(
+      provider.invoke({
+        role: 'cortex-chat',
+        input: { prompt: 'hi' },
+        traceId: TRACE_ID,
+      }),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE',
+      context: { failoverReasonCode: 'PRV-RATE-LIMIT' },
+    });
+  });
+});

--- a/self/subcortex/providers/src/__tests__/providers/gemini.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/gemini.test.ts
@@ -288,6 +288,66 @@ describe('GeminiProvider', () => {
     ]);
   });
 
+  it('stream() times out stalled body reads after response headers arrive', async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    const provider = new GeminiProvider(
+      MOCK_CONFIG,
+      { apiKey: 'test-gemini-key', timeoutMs: 50 },
+    );
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    );
+
+    const iterator = provider.stream({
+      role: 'cortex-chat',
+      input: { prompt: 'Stall after headers.' },
+      traceId: TRACE_ID,
+    })[Symbol.asyncIterator]();
+
+    const read = iterator.next();
+    const expectation = expect(read).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE',
+      context: { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expectation;
+    expect(cancel).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('stream() cancels the reader when caller aborts during body consumption', async () => {
+    const cancel = vi.fn();
+    const abortController = new AbortController();
+    const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'test-gemini-key' });
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    );
+
+    const iterator = provider.stream({
+      role: 'cortex-chat',
+      input: { prompt: 'Abort after headers.' },
+      traceId: TRACE_ID,
+      abortSignal: abortController.signal,
+    })[Symbol.asyncIterator]();
+
+    const read = iterator.next();
+    await Promise.resolve();
+    abortController.abort();
+
+    await expect(read).rejects.toMatchObject({
+      code: 'ABORTED',
+    });
+    expect(cancel).toHaveBeenCalled();
+  });
+
   it('invoke() throws PROVIDER_AUTH_FAILED with PRV-AUTH-FAILURE on 403', async () => {
     const provider = new GeminiProvider(MOCK_CONFIG, { apiKey: 'bad-key' });
     vi.mocked(fetch).mockResolvedValue(new Response('forbidden', { status: 403 }));

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -2,6 +2,7 @@
  * @nous/subcortex-providers — Model provider adapters for Nous-OSS.
  */
 export { AnthropicProvider } from './providers/anthropic/implementation.js';
+export { GeminiProvider } from './providers/gemini/implementation.js';
 export * from './adapter-resolver.js';
 export * from './provider-adapters.js';
 export * from './provider-definitions.js';

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -3,6 +3,7 @@ import type { ProviderAdapterModule } from './schemas/provider-adapter.js';
 import { providerAdapter as anthropicProviderAdapter } from './providers/anthropic/adapter.js';
 import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cli/adapter.js';
 import { providerAdapter as deepinfraProviderAdapter } from './providers/deepinfra/adapter.js';
+import { providerAdapter as geminiProviderAdapter } from './providers/gemini/adapter.js';
 import { providerAdapter as githubCopilotCliProviderAdapter } from './providers/github-copilot-cli/adapter.js';
 import { providerAdapter as groqProviderAdapter } from './providers/groq/adapter.js';
 import { providerAdapter as llamaCppProviderAdapter } from './providers/llama-cpp/adapter.js';
@@ -14,6 +15,7 @@ export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
 export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
 export { providerAdapter as deepinfraAdapter } from './providers/deepinfra/adapter.js';
+export { providerAdapter as geminiAdapter } from './providers/gemini/adapter.js';
 export { providerAdapter as githubCopilotCliAdapter } from './providers/github-copilot-cli/adapter.js';
 export { providerAdapter as groqAdapter } from './providers/groq/adapter.js';
 export { providerAdapter as llamaCppAdapter } from './providers/llama-cpp/adapter.js';
@@ -25,6 +27,7 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
   codexCliProviderAdapter,
   deepinfraProviderAdapter,
+  geminiProviderAdapter,
   githubCopilotCliProviderAdapter,
   groqProviderAdapter,
   llamaCppProviderAdapter,

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -4,6 +4,7 @@ import { hydrateProviderDefinitions } from './provider-identity.js';
 import { providerDefinition as anthropicProviderDefinition } from './providers/anthropic/definition.js';
 import { providerDefinition as codexCliProviderDefinition } from './providers/codex-cli/definition.js';
 import { providerDefinition as deepinfraProviderDefinition } from './providers/deepinfra/definition.js';
+import { providerDefinition as geminiProviderDefinition } from './providers/gemini/definition.js';
 import { providerDefinition as githubCopilotCliProviderDefinition } from './providers/github-copilot-cli/definition.js';
 import { providerDefinition as groqProviderDefinition } from './providers/groq/definition.js';
 import { providerDefinition as llamaCppProviderDefinition } from './providers/llama-cpp/definition.js';
@@ -17,6 +18,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   anthropicProviderDefinition,
   codexCliProviderDefinition,
   deepinfraProviderDefinition,
+  geminiProviderDefinition,
   githubCopilotCliProviderDefinition,
   groqProviderDefinition,
   llamaCppProviderDefinition,

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -3,6 +3,7 @@ import type { ProviderFactoryModule } from './schemas/provider-factory.js';
 import { providerFactory as anthropicProviderFactory } from './providers/anthropic/provider.js';
 import { providerFactory as codexCliProviderFactory } from './providers/codex-cli/provider.js';
 import { providerFactory as deepinfraProviderFactory } from './providers/deepinfra/provider.js';
+import { providerFactory as geminiProviderFactory } from './providers/gemini/provider.js';
 import { providerFactory as githubCopilotCliProviderFactory } from './providers/github-copilot-cli/provider.js';
 import { providerFactory as groqProviderFactory } from './providers/groq/provider.js';
 import { providerFactory as llamaCppProviderFactory } from './providers/llama-cpp/provider.js';
@@ -16,6 +17,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   anthropicProviderFactory,
   codexCliProviderFactory,
   deepinfraProviderFactory,
+  geminiProviderFactory,
   githubCopilotCliProviderFactory,
   groqProviderFactory,
   llamaCppProviderFactory,

--- a/self/subcortex/providers/src/providers/gemini/adapter.ts
+++ b/self/subcortex/providers/src/providers/gemini/adapter.ts
@@ -1,0 +1,121 @@
+import type { TraceId } from '@nous/shared';
+import type { ParsedModelOutput } from '../../shared/output.js';
+import {
+  defineProviderAdapter,
+  type AdapterCapabilities,
+  type AdapterFormatInput,
+  type AdapterFormattedRequest,
+  type ProviderAdapter,
+} from '../../schemas/provider-adapter.js';
+
+const GEMINI_ADAPTER_CAPABILITIES: AdapterCapabilities = {
+  nativeToolUse: false,
+  cacheControl: false,
+  extendedThinking: false,
+  streaming: true,
+};
+
+export function createGeminiAdapter(): ProviderAdapter {
+  return {
+    capabilities: GEMINI_ADAPTER_CAPABILITIES,
+    formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
+      const systemSegments = Array.isArray(input.systemPrompt)
+        ? input.systemPrompt
+        : [input.systemPrompt];
+
+      const messages = input.context.map((frame) => ({
+        role: frame.role === 'tool' ? ('user' as const) : frame.role,
+        content: frame.content,
+      }));
+
+      return {
+        input: {
+          messages,
+          systemSegments,
+          ...(input.modelRequirements ? { model_profile: input.modelRequirements.profile } : {}),
+        },
+      };
+    },
+    parseResponse(output: unknown, _traceId: TraceId): ParsedModelOutput {
+      try {
+        return parseGeminiResponse(output);
+      } catch {
+        return {
+          response: String(output ?? ''),
+          toolCalls: [],
+          memoryCandidates: [],
+          contentType: 'text',
+        };
+      }
+    },
+  };
+}
+
+function parseGeminiResponse(output: unknown): ParsedModelOutput {
+  if (typeof output === 'string') {
+    return {
+      response: output,
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: 'text',
+    };
+  }
+
+  if (!output || typeof output !== 'object') {
+    return {
+      response: String(output ?? ''),
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: 'text',
+    };
+  }
+
+  const obj = output as Record<string, unknown>;
+  if (typeof obj.response === 'string') {
+    return {
+      response: obj.response,
+      toolCalls: [],
+      memoryCandidates: [],
+      contentType: 'text',
+    };
+  }
+
+  const choices = obj.candidates;
+  if (Array.isArray(choices)) {
+    const content = (choices[0] as Record<string, unknown> | undefined)?.content;
+    const parts = content && typeof content === 'object'
+      ? (content as Record<string, unknown>).parts
+      : undefined;
+    if (Array.isArray(parts)) {
+      return {
+        response: parts
+          .map((part) => {
+            if (!part || typeof part !== 'object') return '';
+            const text = (part as Record<string, unknown>).text;
+            return typeof text === 'string' ? text : '';
+          })
+          .join(''),
+        toolCalls: [],
+        memoryCandidates: [],
+        contentType: 'text',
+      };
+    }
+  }
+
+  return {
+    response: String(output),
+    toolCalls: [],
+    memoryCandidates: [],
+    contentType: 'text',
+  };
+}
+
+export const providerAdapter = defineProviderAdapter({
+  adapterKey: 'gemini',
+  displayName: 'Google Gemini',
+  protocol: 'gemini-generate-content',
+  capabilities: GEMINI_ADAPTER_CAPABILITIES,
+  create() {
+    return createGeminiAdapter();
+  },
+});

--- a/self/subcortex/providers/src/providers/gemini/definition.ts
+++ b/self/subcortex/providers/src/providers/gemini/definition.ts
@@ -1,0 +1,5 @@
+export {
+  GEMINI_DEFAULT_ENDPOINT,
+  GEMINI_DEFAULT_MODEL_ID,
+  GEMINI_PROVIDER_DEFINITION as providerDefinition,
+} from './implementation.js';

--- a/self/subcortex/providers/src/providers/gemini/implementation.ts
+++ b/self/subcortex/providers/src/providers/gemini/implementation.ts
@@ -1,0 +1,395 @@
+import { NousError, ValidationError } from '@nous/shared';
+import type {
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamChunk,
+} from '@nous/shared';
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+import { TextModelInputSchema, type TextModelInput } from '../../schemas/text-model-input.js';
+
+export const GEMINI_DEFAULT_ENDPOINT = 'https://generativelanguage.googleapis.com';
+export const GEMINI_DEFAULT_MODEL_ID = 'gemini-2.5-flash';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+const GEMINI_API_VERSION = 'v1beta';
+
+export const GEMINI_PROVIDER_DEFINITION = {
+  vendorKey: 'gemini',
+  displayName: 'Google Gemini',
+  providerType: 'text',
+  providerClass: 'remote_text',
+  protocol: 'gemini-generate-content',
+  adapterKey: 'gemini',
+  defaultEndpoint: GEMINI_DEFAULT_ENDPOINT,
+  defaultModelId: GEMINI_DEFAULT_MODEL_ID,
+  auth: {
+    envVar: 'GEMINI_API_KEY',
+    vaultKeyNamespace: 'gemini',
+    header: {
+      name: 'x-goog-api-key',
+      scheme: 'raw',
+    },
+    required: true,
+    purpose: 'api_key',
+  },
+  capabilities: {
+    streaming: true,
+    nativeToolUse: false,
+    modelListing: false,
+  },
+  isLocal: false,
+} as const satisfies ProviderDefinitionLeaf;
+
+interface GeminiPart {
+  text?: string;
+}
+
+interface GeminiContent {
+  role?: 'user' | 'model';
+  parts?: GeminiPart[];
+}
+
+interface GeminiGenerateResponse {
+  candidates?: Array<{
+    content?: GeminiContent;
+    finishReason?: string;
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
+}
+
+interface GeminiFormattedInput {
+  contents: GeminiContent[];
+  systemInstruction?: { parts: GeminiPart[] };
+}
+
+export class GeminiProvider implements IModelProvider {
+  private readonly config: ModelProviderConfig;
+  private readonly endpoint: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+
+  constructor(
+    config: ModelProviderConfig,
+    options?: { apiKey?: string; timeoutMs?: number },
+  ) {
+    this.config = config;
+    this.endpoint = config.endpoint ?? GEMINI_DEFAULT_ENDPOINT;
+    this.apiKey = options?.apiKey ?? process.env.GEMINI_API_KEY ?? '';
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    if (!this.apiKey) {
+      throw new NousError(
+        'Gemini API key required — set GEMINI_API_KEY or pass apiKey option',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+  }
+
+  getConfig(): ModelProviderConfig {
+    return this.config;
+  }
+
+  async invoke(request: ModelRequest): Promise<ModelResponse> {
+    const input = this.validateInput(request.input);
+    const formatted = this.toGeminiFormat(input);
+    const response = await this.fetchWithTimeout(this.getUrl('generateContent'), {
+      method: 'POST',
+      headers: this.getHeaders(),
+      signal: request.abortSignal,
+      body: JSON.stringify(this.buildRequestBody(formatted)),
+    });
+
+    await this.throwForResponseError(response);
+
+    const data = (await response.json()) as GeminiGenerateResponse;
+
+    return {
+      output: this.extractText(data),
+      providerId: this.config.id,
+      usage: {
+        inputTokens: data.usageMetadata?.promptTokenCount,
+        outputTokens: data.usageMetadata?.candidatesTokenCount,
+        computeMs: undefined,
+      },
+      traceId: request.traceId,
+    };
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    const input = this.validateInput(request.input);
+    const formatted = this.toGeminiFormat(input);
+    const response = await this.fetchWithTimeout(`${this.getUrl('streamGenerateContent')}?alt=sse`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      signal: request.abortSignal,
+      body: JSON.stringify(this.buildRequestBody(formatted)),
+    });
+
+    await this.throwForResponseError(response);
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new NousError('No response body', 'PROVIDER_UNAVAILABLE');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+    let yieldedDone = false;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() ?? '';
+
+        for (const eventChunk of events) {
+          const event = this.parseStreamEvent(eventChunk);
+          if (!event) continue;
+
+          inputTokens = event.usageMetadata?.promptTokenCount ?? inputTokens;
+          outputTokens = event.usageMetadata?.candidatesTokenCount ?? outputTokens;
+
+          const content = this.extractText(event);
+          const doneFlag = event.candidates?.some((candidate) => candidate.finishReason) ?? false;
+          yieldedDone = yieldedDone || doneFlag;
+
+          if (content || doneFlag) {
+            yield {
+              content,
+              done: doneFlag,
+              usage: doneFlag ? { inputTokens, outputTokens } : undefined,
+            };
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        const event = this.parseStreamEvent(buffer);
+        if (event) {
+          inputTokens = event.usageMetadata?.promptTokenCount ?? inputTokens;
+          outputTokens = event.usageMetadata?.candidatesTokenCount ?? outputTokens;
+          const content = this.extractText(event);
+          const doneFlag = event.candidates?.some((candidate) => candidate.finishReason) ?? false;
+          yieldedDone = yieldedDone || doneFlag;
+
+          if (content || doneFlag) {
+            yield {
+              content,
+              done: doneFlag,
+              usage: doneFlag ? { inputTokens, outputTokens } : undefined,
+            };
+          }
+        }
+      }
+
+      if (!yieldedDone) {
+        yield {
+          content: '',
+          done: true,
+          usage: { inputTokens, outputTokens },
+        };
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private validateInput(input: unknown): TextModelInput {
+    const result = TextModelInputSchema.safeParse(input);
+    if (!result.success) {
+      const errors = result.error.errors.map((error) => ({
+        path: error.path.join('.'),
+        message: error.message,
+      }));
+      throw new ValidationError('Invalid model input', errors);
+    }
+    return result.data;
+  }
+
+  private toGeminiFormat(input: TextModelInput): GeminiFormattedInput {
+    const contents: GeminiContent[] = [];
+    const systemParts: GeminiPart[] = [];
+
+    if ('messages' in input && Array.isArray(input.messages)) {
+      for (const message of input.messages) {
+        const text = this.messageContentToText(message.content);
+        if (message.role === 'system') {
+          if (text) systemParts.push({ text });
+          continue;
+        }
+
+        contents.push({
+          role: message.role === 'assistant' ? 'model' : 'user',
+          parts: [{ text }],
+        });
+      }
+    } else {
+      contents.push({
+        role: 'user',
+        parts: [{ text: 'prompt' in input ? input.prompt : '' }],
+      });
+    }
+
+    if (input.systemSegments && input.systemSegments.length > 0) {
+      systemParts.splice(
+        0,
+        systemParts.length,
+        ...input.systemSegments.map((text) => ({ text })),
+      );
+    }
+
+    return {
+      contents,
+      ...(systemParts.length > 0 ? { systemInstruction: { parts: systemParts } } : {}),
+    };
+  }
+
+  private messageContentToText(content: unknown): string {
+    return typeof content === 'string' ? content : JSON.stringify(content);
+  }
+
+  private buildRequestBody(formatted: GeminiFormattedInput): Record<string, unknown> {
+    return {
+      contents: formatted.contents,
+      ...(formatted.systemInstruction ? { systemInstruction: formatted.systemInstruction } : {}),
+      generationConfig: {
+        maxOutputTokens: this.config.maxTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+      },
+    };
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': this.apiKey,
+    };
+  }
+
+  private getUrl(method: 'generateContent' | 'streamGenerateContent'): string {
+    const apiRoot = this.getApiRoot();
+    return `${apiRoot}/models/${this.normalizeModelId(this.config.modelId)}:${method}`;
+  }
+
+  private getApiRoot(): string {
+    const root = this.endpoint.replace(/\/$/, '');
+    return root.endsWith(`/${GEMINI_API_VERSION}`) ? root : `${root}/${GEMINI_API_VERSION}`;
+  }
+
+  private normalizeModelId(modelId: string): string {
+    return modelId.replace(/^models\//, '');
+  }
+
+  private extractText(response: GeminiGenerateResponse): string {
+    return response.candidates?.[0]?.content?.parts
+      ?.map((part) => part.text ?? '')
+      .join('') ?? '';
+  }
+
+  private async throwForResponseError(response: Response): Promise<void> {
+    if (response.status === 401 || response.status === 403) {
+      throw new NousError(
+        'Gemini API key invalid or missing',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+
+    if (response.status === 404) {
+      throw new NousError(
+        `Gemini model not found: ${this.config.modelId}`,
+        'MODEL_NOT_FOUND',
+        { failoverReasonCode: 'PRV-MODEL-NOT-FOUND' },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new NousError(
+        `Gemini rate limit: ${response.status}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-RATE-LIMIT' },
+      );
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new NousError(
+        `Gemini API error ${response.status}: ${text.slice(0, 200)}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+      );
+    }
+  }
+
+  private parseStreamEvent(eventChunk: string): GeminiGenerateResponse | null {
+    const dataLines = eventChunk
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart());
+
+    if (dataLines.length === 0) {
+      return null;
+    }
+
+    const payload = dataLines.join('\n');
+    if (!payload || payload === '[DONE]') {
+      return null;
+    }
+
+    return JSON.parse(payload) as GeminiGenerateResponse;
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(
+      () => timeoutController.abort(new DOMException('provider_timeout', 'AbortError')),
+      this.timeoutMs,
+    );
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, timeoutController.signal])
+      : timeoutController.signal;
+
+    try {
+      return await fetch(url, {
+        ...init,
+        signal,
+      });
+    } catch (error) {
+      if (timeoutController.signal.aborted) {
+        throw new NousError(
+          `Gemini request timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        );
+      }
+
+      if ((error as Error).name === 'AbortError') {
+        throw new NousError('Gemini request aborted.', 'ABORTED');
+      }
+
+      throw new NousError(
+        `Gemini endpoint unreachable: ${(error as Error).message}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/self/subcortex/providers/src/providers/gemini/implementation.ts
+++ b/self/subcortex/providers/src/providers/gemini/implementation.ts
@@ -148,7 +148,7 @@ export class GeminiProvider implements IModelProvider {
 
     try {
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await this.readStreamChunk(reader, request.abortSignal);
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
@@ -350,6 +350,51 @@ export class GeminiProvider implements IModelProvider {
     }
 
     return JSON.parse(payload) as GeminiGenerateResponse;
+  }
+
+  private async readStreamChunk(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    abortSignal?: AbortSignal,
+  ): ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']> {
+    if (abortSignal?.aborted) {
+      await reader.cancel().catch(() => undefined);
+      throw new NousError('Gemini request aborted.', 'ABORTED');
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let abortHandler: (() => void) | undefined;
+
+    const boundedRead = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        reject(new NousError(
+          `Gemini stream read timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        ));
+        void reader.cancel(new DOMException('provider_timeout', 'AbortError'))
+          .catch(() => undefined);
+      }, this.timeoutMs);
+
+      if (abortSignal) {
+        abortHandler = () => {
+          reject(new NousError('Gemini request aborted.', 'ABORTED'));
+          void reader.cancel().catch(() => undefined);
+        };
+        abortSignal.addEventListener('abort', abortHandler, { once: true });
+      }
+    });
+
+    try {
+      return await Promise.race([
+        reader.read(),
+        boundedRead,
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      if (abortSignal && abortHandler) {
+        abortSignal.removeEventListener('abort', abortHandler);
+      }
+    }
   }
 
   private async fetchWithTimeout(

--- a/self/subcortex/providers/src/providers/gemini/index.ts
+++ b/self/subcortex/providers/src/providers/gemini/index.ts
@@ -1,0 +1,8 @@
+export { providerAdapter, createGeminiAdapter } from './adapter.js';
+export {
+  GEMINI_DEFAULT_ENDPOINT,
+  GEMINI_DEFAULT_MODEL_ID,
+  providerDefinition,
+} from './definition.js';
+export { providerFactory } from './provider.js';
+export { GeminiProvider } from './implementation.js';

--- a/self/subcortex/providers/src/providers/gemini/provider.ts
+++ b/self/subcortex/providers/src/providers/gemini/provider.ts
@@ -1,0 +1,9 @@
+import { GeminiProvider } from './implementation.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'gemini',
+  create(config, options) {
+    return new GeminiProvider(config, { apiKey: options?.apiKey });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## Summary
- Add a certified Google Gemini provider leaf under self/subcortex/providers/src/providers/gemini
- Implement native Gemini generateContent and streamGenerateContent request handling with x-goog-api-key auth
- Add Gemini adapter formatting/parsing, factory wiring, generated catalogs, public export, and provider roster tests

## Validation
- node self/subcortex/providers/scripts/generate-provider-aggregates.mjs --check
- node_modules/.bin/vitest run self/subcortex/providers/src/__tests__/providers/gemini.test.ts --config self/subcortex/providers/vitest.config.ts
- /Users/kushalramaiya/Documents/Nous-core/node_modules/.bin/vitest run src/__tests__/provider-codegen.test.ts src/__tests__/public-exports.test.ts src/__tests__/provider-definitions src/__tests__/adapter-resolver.test.ts src/__tests__/provider-pipeline-integration.test.ts --config vitest.config.ts
- node_modules/.bin/vitest run self/subcortex/providers/src/__tests__ --config self/subcortex/providers/vitest.config.ts
- node_modules/.bin/oxlint self/subcortex/providers/src/providers/gemini self/subcortex/providers/src/__tests__/providers/gemini.test.ts self/subcortex/providers/src/index.ts

## Notes
- Typecheck currently fails on the base branch due to existing missing @nous/shared CLI-session exports; the Gemini-specific roster/type errors from this branch are resolved.

Closes #71