### PR TITLE
docs: add managed inference relay architecture

### DIFF
--- a/docs/content/docs/architecture/managed-inference-relay/architecture.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/architecture.mdx
@@ -1,0 +1,95 @@
+---
+title: Architecture Overview
+description: Problem statement, product goal, and core concepts for managed inference relay
+---
+
+# Architecture Overview
+
+NueOS Cloud needs a managed inference architecture for cloud-backed model supply providers that do not fit the thin static API-key provider leaf model.
+
+## Problem statement
+
+The current provider adapter shape assumes:
+
+- a static API key
+- a relatively static endpoint
+- one provider leaf per vendor
+- client/runtime-owned provider configuration
+- simple request forwarding
+
+That works for direct provider APIs such as OpenAI, Anthropic, Groq, Mistral, Together AI, and Gemini API.
+
+Cloud supply platforms such as Vertex AI, AWS Bedrock, and Azure AI Foundry involve additional server-side concerns:
+
+- cloud project, account, or subscription identity
+- region-aware endpoints
+- IAM, OAuth, SigV4, managed identity, or other non-static auth flows
+- tenant-level quota and billing concerns
+- provider-side quota and capacity
+- model availability by region
+- routing and fallback policy
+- server-side credential control
+
+These concerns should not be forced into ordinary client-side provider leaves.
+
+## Product goal
+
+For a NueOS Cloud subscription, a tenant should call Nue-managed inference without caring which backend provider serves the request.
+
+Clients request stable Nue aliases such as:
+
+```text
+nue:auto
+nue:cheap
+nue:balanced
+nue:premium
+nue:code
+nue:reasoning
+```
+
+Nue selects the backend route based on subscription tier, requested capability, model quality, cost efficiency, latency, regional availability, provider health, quota, and fallback policy.
+
+## Goals
+
+- Provide a first-party Nue Cloud provider leaf for NueOS clients.
+- Keep tenant authentication separate from provider authentication.
+- Keep provider credentials server-side.
+- Support regional low-overhead streaming relay.
+- Support provider routing, fallback, metering, and billing.
+- Support cloud supply providers as server-side connectors.
+- Avoid exposing backend provider selection as a required client concern.
+
+## Non-goals
+
+- Do not redesign every provider adapter as part of this architecture.
+- Do not require contributor provider leaves to implement cloud supply routing.
+- Do not expose provider credentials to clients.
+- Do not require tenants to understand Vertex, Bedrock, or Azure auth.
+- Do not make any single cloud provider define the entire abstraction.
+- Do not require full multi-provider routing in the first implementation phase.
+
+## Key concepts
+
+### Tenant auth
+
+Tenant auth is authentication from the customer/client to NueOS Cloud.
+
+```http
+Authorization: Bearer <nue-tenant-token>
+```
+
+Tenant auth answers who the user is, which org/workspace owns the request, which subscription tier applies, which quota applies, and which billing/data policies apply.
+
+### Provider auth
+
+Provider auth is authentication from NueOS Cloud to the backend model provider. Examples include Vertex service account OAuth, Bedrock IAM/SigV4, Azure managed identity or deployment credentials, OpenAI/Anthropic API keys, and private auth for internal runtimes.
+
+Provider auth remains server-side.
+
+### Inference session
+
+An inference session is a short-lived server-side routing decision binding a tenant, workspace, requested model alias, selected backend provider/model/region, budget, timeout, fallback policy, and trace context.
+
+### Regional relay
+
+The regional relay is a lightweight data-plane component that streams between the client and selected provider connector. It is not a raw tunnel: it preserves auth, quota enforcement, metering, observability, provider credential secrecy, and fallback support.

--- a/docs/content/docs/architecture/managed-inference-relay/control-plane.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/control-plane.mdx
@@ -1,0 +1,122 @@
+---
+title: Control Plane and Routing
+description: Tenant authentication, model aliases, route decisions, sessions, and relay tokens
+---
+
+# Control Plane and Routing
+
+The control plane makes business-sensitive routing decisions before inference begins.
+
+## Responsibilities
+
+The control plane owns:
+
+- tenant authentication
+- org/workspace/subscription resolution
+- quota checks
+- budget estimation
+- provider/model/region selection
+- inference session creation
+- relay token issuance
+- intended route recording
+- fallback policy preparation
+- preflight audit events
+
+## Model aliases
+
+Nue-managed models should be addressable by stable aliases:
+
+```text
+nue:auto
+nue:cheap
+nue:balanced
+nue:premium
+nue:code
+nue:reasoning
+```
+
+An alias does not need to map one-to-one to a provider model. It may resolve differently depending on tenant tier, region, latency, provider health, current pricing, context window requirements, tool-use requirements, safety/compliance policy, and fallback availability.
+
+Example resolution:
+
+```json
+{
+  "requested_model": "nue:balanced",
+  "resolved_provider": "vertex-ai",
+  "resolved_model": "gemini-2.5-flash",
+  "region": "us-central1"
+}
+```
+
+## Route decision
+
+A route decision should be explicit and auditable.
+
+```json
+{
+  "tenant_id": "tenant_123",
+  "workspace_id": "workspace_456",
+  "session_id": "inf_abc",
+  "requested_model": "nue:auto",
+  "selected_provider": "vertex-ai",
+  "selected_model": "gemini-2.5-flash",
+  "region": "us-central1",
+  "fallbacks": [
+    {
+      "provider": "bedrock",
+      "model": "claude-haiku",
+      "region": "us-east-1"
+    }
+  ],
+  "max_input_tokens": 64000,
+  "max_output_tokens": 4096,
+  "budget_cents": 12,
+  "expires_at": "2026-07-07T12:00:00Z"
+}
+```
+
+## Relay token
+
+The control plane issues a short-lived signed relay token for the selected route.
+
+The token should include:
+
+- tenant ID
+- workspace ID
+- session ID
+- route ID
+- selected provider/model/region
+- expiration
+- budget limits
+- allowed operation
+- streaming permission
+- trace ID
+
+The token must not include provider credentials.
+
+Recommended properties:
+
+- short TTL
+- single-session or narrow route scope
+- signed by Nue
+- validated by the relay
+- optionally bound to tenant token/session metadata
+
+## Routing policy inputs
+
+Routing policy may consider:
+
+- requested model alias
+- tenant subscription tier
+- max latency target
+- required context length
+- tool-use support
+- multimodal support
+- region/compliance constraints
+- provider health
+- provider quota
+- estimated cost
+- recent latency
+- fallback availability
+
+Fallback should be selected before the stream starts when possible. Once streaming begins, transparent fallback is harder and may require explicit restart semantics.

--- a/docs/content/docs/architecture/managed-inference-relay/implementation-plan.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/implementation-plan.mdx
@@ -1,0 +1,65 @@
+---
+title: Implementation Plan
+description: Phased rollout for the NueOS Cloud managed inference relay
+---
+
+# Implementation Plan
+
+The managed inference relay should be implemented incrementally. The first version should prove the client-facing Nue Cloud provider path and a single backend route before adding full multi-provider optimization.
+
+## Phase 1: Nue Cloud provider leaf and static backend
+
+- add `nue-ai-api` / `nue-cloud` provider leaf
+- implement Nue Cloud OpenAI-compatible endpoint
+- route to one static backend provider
+- support non-streaming invocation
+- support streaming invocation
+- emit basic usage events
+
+## Phase 2: Session and relay MVP
+
+- add managed inference session API
+- add relay token format
+- implement regional relay MVP
+- support one provider connector
+- add basic fallback before stream start
+- record trace and usage events
+
+## Phase 3: Cloud supply connectors
+
+- implement Vertex AI connector
+- implement Bedrock connector
+- implement Azure connector
+- add provider auth lifecycle handling
+- add provider-specific error classification
+
+## Phase 4: Routing and catalog
+
+- add capability catalog
+- add pricing catalog
+- support model aliases
+- support tenant-tier routing
+- support provider health-aware routing
+- support region-aware routing
+
+## Phase 5: Billing and optimization
+
+- add billing ledger integration
+- add provider cost reconciliation
+- add unit-economics dashboards
+- add route optimization
+- add tenant policy controls
+- add advanced fallback policies
+
+## Open questions
+
+- Should the public provider name be `nue-ai-api`, `nue-cloud`, or `nue-managed`?
+- Should the first external API be session-first or OpenAI-compatible?
+- Which relay runtime should be used first?
+- Should relay regions map directly to provider regions?
+- Should Vertex support begin with OpenAI-compatible routes or native routes?
+- Should Bedrock use Converse first or provider-specific InvokeModel calls?
+- Should managed provider routing be configurable per tenant?
+- Should tenants be able to opt out of specific backend providers?
+- Should BYOC Vertex/Bedrock/Azure be separate provider leaves or later enterprise features?
+- What prompt/response logging defaults should apply for NueOS Cloud subscriptions?

--- a/docs/content/docs/architecture/managed-inference-relay/index.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Managed Inference Relay
+description: Overview of NueOS Cloud managed model routing and regional inference relay architecture
+---
+
+# Managed Inference Relay
+
+The managed inference relay is the NueOS Cloud path for tenant-authenticated model inference where Nue chooses and operates the backend model supply provider.
+
+Instead of asking clients to configure Vertex AI, AWS Bedrock, Azure AI Foundry, direct frontier APIs, or hosted open-weight pools, clients call a first-party Nue endpoint. Nue authenticates the tenant, selects the backend route, forwards the request through a low-overhead regional relay, and records usage for quota, billing, and operations.
+
+```text
+NueOS client
+  ↓
+nue-ai-api / nue-cloud provider leaf
+  ↓
+Nue Cloud control plane
+  ↓
+regional inference relay
+  ↓
+server-side provider connector
+  ↓
+Vertex / Bedrock / Azure / OpenAI / Anthropic / vLLM / etc.
+```
+
+## Why this exists
+
+The current provider leaf model works well for direct or BYOK providers with static API keys and stable endpoints. Cloud supply platforms have a different shape: project/account identity, regional endpoints, OAuth/IAM/SigV4 authentication, quotas, capacity, tenant policy, and billing all matter.
+
+The managed relay keeps those concerns server-side while presenting a stable Nue-facing API to clients.
+
+## Reading order
+
+1. [Architecture Overview](/docs/architecture/managed-inference-relay/architecture) — problem statement, goals, non-goals, and core concepts.
+2. [Control Plane and Routing](/docs/architecture/managed-inference-relay/control-plane) — tenant auth, model aliases, route decisions, sessions, and relay tokens.
+3. [Regional Relay Data Plane](/docs/architecture/managed-inference-relay/relay-data-plane) — low-overhead streaming relay behavior and runtime responsibilities.
+4. [Server-side Provider Connectors](/docs/architecture/managed-inference-relay/provider-connectors) — Vertex, Bedrock, Azure, direct API, and open-weight connector responsibilities.
+5. [Metering, Billing, and Observability](/docs/architecture/managed-inference-relay/metering-billing) — usage ledger, cost tracking, quota, traces, and privacy constraints.
+6. [Implementation Plan](/docs/architecture/managed-inference-relay/implementation-plan) — phased rollout from a static backend to managed routing and billing optimization.
+
+## Relation to provider adapters
+
+Provider adapters remain the right path for direct provider integrations such as OpenAI, Anthropic, Groq, Mistral, Together AI, Gemini API, and local runtimes.
+
+The managed inference relay is a different path for NueOS Cloud subscriptions where Nue owns provider credentials, routing, quota, billing, fallback, and supply optimization.

--- a/docs/content/docs/architecture/managed-inference-relay/meta.json
+++ b/docs/content/docs/architecture/managed-inference-relay/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Managed Inference Relay",
+  "pages": [
+    "index",
+    "architecture",
+    "control-plane",
+    "relay-data-plane",
+    "provider-connectors",
+    "metering-billing",
+    "implementation-plan"
+  ]
+}

--- a/docs/content/docs/architecture/managed-inference-relay/metering-billing.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/metering-billing.mdx
@@ -1,0 +1,93 @@
+---
+title: Metering, Billing, and Observability
+description: Usage events, billing ledger, quota, tracing, security, and privacy requirements
+---
+
+# Metering, Billing, and Observability
+
+The managed inference relay must emit reliable usage and trace data for tenant billing, quota enforcement, provider reconciliation, operations, and routing optimization.
+
+## Usage events
+
+Each request should emit usage events.
+
+```json
+{
+  "tenant_id": "tenant_123",
+  "workspace_id": "workspace_456",
+  "session_id": "inf_abc",
+  "provider": "vertex-ai",
+  "model": "gemini-2.5-flash",
+  "region": "us-central1",
+  "input_tokens": 1200,
+  "output_tokens": 800,
+  "estimated_provider_cost": 0.0021,
+  "billable_amount": 0.006,
+  "latency_ms": 1840,
+  "status": "success"
+}
+```
+
+The usage ledger should support:
+
+- tenant billing
+- quota enforcement
+- cost tracking
+- provider reconciliation
+- abuse detection
+- routing optimization
+- operational dashboards
+
+## Capability and pricing catalog
+
+Routing should use a model/provider catalog that tracks capabilities, regions, pricing, health, and quota state.
+
+Example catalog record:
+
+```json
+{
+  "provider": "vertex-ai",
+  "model": "gemini-2.5-flash",
+  "aliases": ["nue:auto", "nue:cheap", "nue:balanced"],
+  "regions": ["us-central1", "us-east4"],
+  "capabilities": {
+    "streaming": true,
+    "tool_use": true,
+    "vision": true,
+    "context_window": 1048576
+  },
+  "pricing": {
+    "input_per_million_tokens": 0.30,
+    "output_per_million_tokens": 2.50
+  },
+  "latency_class": "low",
+  "quality_tier": "balanced"
+}
+```
+
+## Observability
+
+The system should expose:
+
+- session ID
+- trace ID
+- selected provider/model/region
+- fallback attempts
+- latency
+- token usage
+- provider error classification
+- tenant quota consumption
+- estimated cost
+- relay runtime metrics
+
+Observability should not expose provider secrets or unnecessary sensitive prompt content.
+
+## Security requirements
+
+The system must keep provider credentials server-side, scope relay tokens narrowly, enforce tenant authorization before relay access, enforce request/session budget, avoid leaking provider credentials in logs, prevent cross-tenant session access, and record audit events for provider route decisions.
+
+## Privacy and data policy
+
+NueOS Cloud should enforce tenant data policy at routing time. Policy dimensions may include allowed regions, allowed providers, retention mode, logging mode, training opt-out requirements, regulated-data restrictions, and enterprise isolation requirements.
+
+The router should only select providers compatible with tenant policy.

--- a/docs/content/docs/architecture/managed-inference-relay/provider-connectors.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/provider-connectors.mdx
@@ -1,0 +1,72 @@
+---
+title: Server-side Provider Connectors
+description: Responsibilities for Vertex, Bedrock, Azure, direct API, and open-weight connectors
+---
+
+# Server-side Provider Connectors
+
+Provider connectors live server-side and are selected by the control plane route decision.
+
+Examples:
+
+```text
+vertex-ai-connector
+bedrock-connector
+azure-openai-connector
+openai-connector
+anthropic-connector
+vllm-connector
+```
+
+## Connector responsibilities
+
+A provider connector should:
+
+- build provider-specific endpoints
+- authenticate or sign provider requests
+- transform request shape where needed
+- stream provider responses
+- normalize response chunks where needed
+- classify provider errors
+- expose usage metadata when available
+
+## Vertex AI connector
+
+The Vertex connector should handle Google Cloud-specific supply concerns:
+
+- service account / ADC / workload identity auth
+- OAuth bearer token minting and refresh
+- project/location-aware endpoint construction
+- Vertex OpenAI-compatible or native route selection
+- Google auth, quota, rate-limit, and model availability error classification
+
+Vertex is not just a static API-key provider. It should primarily be modeled as a managed supply connector for NueOS Cloud. A separate BYOC/BYOK provider leaf may be considered later for advanced users.
+
+## Bedrock connector
+
+The Bedrock connector should handle AWS-specific supply concerns:
+
+- AWS IAM / STS credentials
+- SigV4 request signing
+- Bedrock Converse / InvokeModel APIs
+- Bedrock streaming event mapping
+- throttling, auth, quota, and model availability error classification
+
+## Azure connector
+
+The Azure connector should handle Azure AI Foundry / Azure OpenAI concerns:
+
+- deployment/resource-aware endpoint construction
+- Azure region and deployment routing
+- API key, managed identity, or Entra auth where appropriate
+- quota, region, deployment, and auth error classification
+
+## Direct API connectors
+
+Direct API connectors may support providers such as OpenAI, Anthropic, Mistral, Groq, and Together AI. These connectors may be simpler than cloud substrate connectors, but they still run server-side for Nue-managed subscriptions.
+
+## Open-weight runtime connectors
+
+Open-weight connectors may support vLLM, TGI, Ollama-like internal runtimes, dedicated GPU pools, or third-party hosted open-weight endpoints.
+
+They should expose capacity, model capabilities, health, and usage data to the routing layer.

--- a/docs/content/docs/architecture/managed-inference-relay/relay-data-plane.mdx
+++ b/docs/content/docs/architecture/managed-inference-relay/relay-data-plane.mdx
@@ -1,0 +1,83 @@
+---
+title: Regional Relay Data Plane
+description: Low-overhead streaming relay responsibilities and runtime constraints
+---
+
+# Regional Relay Data Plane
+
+The regional relay is the Nue-controlled data-plane component that forwards inference requests to backend providers.
+
+It should be deployed as close as practical to the selected backend provider and should stream response data with minimal buffering.
+
+## Runtime shape
+
+The relay may be implemented as:
+
+- edge function
+- regional serverless function
+- lightweight regional service
+- Cloud Run-style service
+- Fly.io-style regional service
+- Lambda-style regional service
+- Cloudflare Worker-style service where runtime constraints allow
+
+Pure edge runtimes should be evaluated carefully for long streaming responses, outbound fetch limits, Node crypto compatibility, AWS SigV4 support, Google auth compatibility, and regional placement.
+
+## Responsibilities
+
+The relay owns:
+
+- relay token verification
+- session state validation
+- timeout and budget enforcement
+- provider connector loading
+- provider auth attachment
+- provider request forwarding
+- response streaming
+- usage event emission
+- trace event emission
+- provider error classification
+- fallback before stream start where possible
+
+## Not a raw tunnel
+
+The relay should be low-overhead, but it is not a raw tunnel. It must preserve:
+
+- Nue tenant authorization
+- quota and budget enforcement
+- provider credential secrecy
+- usage metering
+- observability
+- route auditability
+- provider error classification
+
+The relay should not expose provider credentials, reveal unnecessary provider internals, buffer entire streaming responses, perform broad model selection itself, or bypass tenant quota/billing enforcement.
+
+## Streaming behavior
+
+Preferred behavior:
+
+- stream provider output without buffering the full response
+- use SSE where compatible
+- support OpenAI-compatible chunks where helpful
+- include final usage metadata where available
+- emit internal trace and usage events asynchronously where possible
+
+Example final usage event shape:
+
+```json
+{
+  "type": "usage",
+  "session_id": "inf_abc",
+  "input_tokens": 1200,
+  "output_tokens": 800,
+  "provider": "vertex-ai",
+  "model": "gemini-2.5-flash"
+}
+```
+
+## Failure handling
+
+The relay should classify failures into categories such as auth failure, quota exhausted, provider unavailable, timeout, rate limit, invalid request, model unavailable, region unavailable, and tenant budget exceeded.
+
+Fallback policy should define which failures are retryable. In general, fallback is safest before the first response chunk is streamed.

--- a/docs/content/docs/architecture/meta.json
+++ b/docs/content/docs/architecture/meta.json
@@ -1,1 +1,1 @@
-{"title":"Architecture","pages":["repo-folder-structure","tech-stack","entity-model","pfc-mode-capability-matrix","project-model","interaction-surfaces","security-baseline","agent-trust-model","workmode-and-authority-boundaries","workflow-spec-comparison"]}
+{"title":"Architecture","pages":["repo-folder-structure","tech-stack","entity-model","pfc-mode-capability-matrix","project-model","interaction-surfaces","managed-inference-relay","security-baseline","agent-trust-model","workmode-and-authority-boundaries","workflow-spec-comparison"]}


### PR DESCRIPTION
## Summary
- Adds managed inference relay architecture docs under the Architecture section.
- Splits the spec across overview, control plane, relay data plane, provider connectors, metering/billing, and implementation plan pages.
- Updates architecture navigation metadata to include the new section.

## Validation
- `pnpm --filter docs build` passed in the authoring worktree.

## Scope
Docs only.