### PR TITLE
feat(providers): add xAI model provider leaf

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -70,6 +70,7 @@ describe('adapter resolver', () => {
       'chat-completions',
       'chat-completions',
       'chat-completions',
+      'chat-completions',
       'text',
     ]);
   });
@@ -115,6 +116,7 @@ describe('adapter resolver', () => {
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'openclaw' }))).toBe('openclaw');
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'openrouter' }))).toBe('chat-completions');
     expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'perplexity' }))).toBe('chat-completions');
+    expect(resolveAdapterKeyFromConfig(makeProvider({ vendor: 'xai' }))).toBe('chat-completions');
   });
 
   it('falls back to name heuristic for non-catalog provider configs', () => {

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -19,7 +19,7 @@ describe('provider aggregate codegen', () => {
       .trim()
       .split(/\r?\n/);
 
-    expect(output).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai']);
+    expect(output).toEqual(['anthropic', 'codex-cli', 'ollama', 'openai', 'xai']);
   });
 
   it('keeps checked-in generated files in sync with provider leaves', () => {

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama'>
+  Equal<ProviderVendorKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama' | 'xai'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'codex-cli' | 'openai' | 'ollama' | 'xai'>
 >;
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
 

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -86,7 +86,7 @@ const expectedDefinitions = {
     envVar: 'VLLM_API_KEY',
   },
   xai: {
-    defaultEndpoint: 'https://api.x.ai/v1',
+    defaultEndpoint: 'https://api.x.ai',
     defaultModelId: 'grok-4.3',
     envVar: 'XAI_API_KEY',
   },

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -80,6 +80,11 @@ const expectedDefinitions = {
     defaultModelId: 'meta-llama/Llama-3.1-8B-Instruct',
     envVar: 'VLLM_API_KEY',
   },
+  xai: {
+    defaultEndpoint: 'https://api.x.ai/v1',
+    defaultModelId: 'grok-2-1212',
+    envVar: 'XAI_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -99,6 +104,7 @@ describe('provider definitions catalog', () => {
       'openrouter',
       'perplexity',
       'vllm',
+      'xai'
     ]);
   });
 
@@ -143,6 +149,7 @@ describe('provider definitions catalog', () => {
       join('providers', 'openrouter', 'definition.ts'),
       join('providers', 'perplexity', 'definition.ts'),
       join('providers', 'vllm', 'definition.ts'),
+      join('providers', 'xai', 'definition.ts'),
     ];
     const forbidden = [
       /fetch/,

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -87,7 +87,7 @@ const expectedDefinitions = {
   },
   xai: {
     defaultEndpoint: 'https://api.x.ai/v1',
-    defaultModelId: 'grok-2-1212',
+    defaultModelId: 'grok-4.3',
     envVar: 'XAI_API_KEY',
   },
 } as const;

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -60,6 +60,7 @@ afterEach(() => {
   delete process.env.OPENROUTER_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.VLLM_API_KEY;
+  delete process.env.XAI_API_KEY;
 });
 
 describe('provider definition to adapter to registry pipeline', () => {
@@ -79,6 +80,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'openrouter',
       'perplexity',
       'vllm',
+      'xai'
     ]);
     expect(resolveProviderDefinition('anthropic').defaultModelId).toBe(
       'claude-sonnet-4-20250514',
@@ -192,6 +194,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     process.env.GROQ_API_KEY = 'test-groq-key';
     process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
     process.env.PERPLEXITY_API_KEY = 'test-perplexity-key';
+    process.env.XAI_API_KEY = 'test-xai-key';
 
     const registry = new ProviderRegistry(createEmptyConfig());
     const expectedClassByVendor = {
@@ -209,6 +212,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       openrouter: ChatCompletionsProvider,
       perplexity: ChatCompletionsProvider,
       vllm: ChatCompletionsProvider,
+      xai: ChatCompletionsProvider,
     };
 
     for (const definition of PROVIDER_DEFINITIONS) {

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -83,10 +83,10 @@ describe('provider definition to adapter to registry pipeline', () => {
       'moonshot',
       'ollama',
       'openai',
-      'qwen-code',
       'openclaw',
       'openrouter',
       'perplexity',
+      'qwen-code',
       'vllm',
       'xai'
     ]);

--- a/self/subcortex/providers/src/__tests__/providers/xai.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/xai.test.ts
@@ -12,6 +12,10 @@ import {
   providerDefinition,
   providerFactory,
 } from '../../providers/xai/index.js';
+import type { TraceId } from '@nous/shared';
+import { ADAPTER_RESOLVER } from '../../index.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440199' as TraceId;
 
 describe('xAI Grok Provider Leaf Package Integration', () => {
   beforeEach(() => {
@@ -57,7 +61,6 @@ describe('xAI Grok Provider Leaf Package Integration', () => {
       const registeredDef = PROVIDER_DEFINITIONS.find(d => d.vendorKey === 'xai');
       const expectedId = deriveBuiltInProviderId('xai');
       
-      // Look at the hydrated registry entry where wellKnownProviderId / id are resolved
       expect(registeredDef?.wellKnownProviderId).toBe(expectedId);
       expect(registeredDef?.vendorKey).toBe('xai');
     });
@@ -103,6 +106,23 @@ describe('xAI Grok Provider Leaf Package Integration', () => {
       expect(() => {
         providerFactory.create(mockFactoryConfig);
       }).toThrow(/xAI API key required/i);
+    });
+  });
+
+  describe('Adapter Parsing', () => {
+    it('parses a Grok text response', () => {
+      const adapter = ADAPTER_RESOLVER.resolveAdapter(providerDefinition.adapterKey);
+      const parsed = adapter.parseResponse({
+        choices: [{ message: { role: 'assistant', content: 'Hello from Grok' } }],
+      }, TRACE_ID);
+      expect(parsed.response).toBe('Hello from Grok');
+      expect(parsed.contentType).toBe('text');
+    });
+
+    it('returns text fallback on malformed output without throwing', () => {
+      const adapter = ADAPTER_RESOLVER.resolveAdapter(providerDefinition.adapterKey);
+      expect(() => adapter.parseResponse({ unexpected: true }, TRACE_ID)).not.toThrow();
+      expect(adapter.parseResponse({ unexpected: true }, TRACE_ID).contentType).toBe('text');
     });
   });
 });

--- a/self/subcortex/providers/src/__tests__/providers/xai.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/xai.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ChatCompletionsProvider,
+  PROVIDER_DEFINITIONS,
+  ProviderDefinitionSchema,
+  deriveBuiltInProviderId,
+  resolveProviderDefinition,
+  resolveProviderFactory,
+} from '../../index.js';
+import {
+  providerAdapter,
+  providerDefinition,
+  providerFactory,
+} from '../../providers/xai/index.js';
+
+describe('xAI Grok Provider Leaf Package Integration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  describe('Registry Registration', () => {
+    it('should be registered correctly in the global PROVIDER_DEFINITIONS catalog', () => {
+      const registeredDef = PROVIDER_DEFINITIONS.find(d => d.vendorKey === 'xai');
+      expect(registeredDef).toBeDefined();
+      expect(registeredDef).toMatchObject({
+        vendorKey: 'xai',
+        adapterKey: 'chat-completions',
+      });
+    });
+
+    it('should be retrievable via core package resolution methods', () => {
+      const resolvedDef = resolveProviderDefinition('xai' as any);
+      expect(resolvedDef).toBeDefined();
+      expect(resolvedDef?.vendorKey).toBe('xai');
+
+      const resolvedFactory = resolveProviderFactory('xai' as any);
+      expect(resolvedFactory).toBe(providerFactory);
+    });
+
+    it('should declare the correct target protocol adapter metadata', () => {
+      expect(providerAdapter).toBeDefined();
+      expect(providerAdapter.adapterKey).toBe('chat-completions');
+    });
+  });
+
+  describe('Provider Leaf Definition', () => {
+    it('should strictly comply with the global ProviderDefinitionSchema parsing rules when hydrated', () => {
+      const registeredDef = PROVIDER_DEFINITIONS.find(d => d.vendorKey === 'xai');
+      expect(registeredDef).toBeDefined();
+      
+      const parsed = ProviderDefinitionSchema.safeParse(registeredDef);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('should compute the correct runtime built-in provider ID using core utility logic', () => {
+      const registeredDef = PROVIDER_DEFINITIONS.find(d => d.vendorKey === 'xai');
+      const expectedId = deriveBuiltInProviderId('xai');
+      
+      // Look at the hydrated registry entry where wellKnownProviderId / id are resolved
+      expect(registeredDef?.wellKnownProviderId).toBe(expectedId);
+      expect(registeredDef?.vendorKey).toBe('xai');
+    });
+
+    it('should strictly satisfy the auth contract for settings configuration testing', () => {
+      const { auth } = providerDefinition;
+      expect(auth).toBeDefined();
+      expect(auth.envVar).toBe('XAI_API_KEY');
+      expect(auth.vaultKeyNamespace).toBe('xai');
+      expect(auth.required).toBe(true);
+      expect(auth.header).toEqual({
+        name: 'Authorization',
+        scheme: 'bearer',
+      });
+    });
+  });
+
+  describe('Provider Factory Security Boundaries', () => {
+    const mockFactoryConfig = {
+      vendorKey: 'xai',
+      model: 'grok-2-1212',
+      defaultEndpoint: 'https://api.x.ai/v1',
+    } as any;
+
+    it('should successfully instantiate ChatCompletionsProvider when an explicit key option is passed', () => {
+      const provider = providerFactory.create(mockFactoryConfig, {
+        apiKey: 'xai-direct-token-12345',
+      });
+      expect(provider).toBeInstanceOf(ChatCompletionsProvider);
+    });
+
+    it('should successfully instantiate via the XAI_API_KEY environment variable when config options are missing', () => {
+      vi.stubEnv('XAI_API_KEY', 'xai-env-token-67890');
+      
+      const provider = providerFactory.create(mockFactoryConfig);
+      expect(provider).toBeInstanceOf(ChatCompletionsProvider);
+    });
+
+    it('should fail closed, throwing an explicit validation error instead of fallback creeping into OPENAI_API_KEY', () => {
+      vi.stubEnv('XAI_API_KEY', '');
+      vi.stubEnv('OPENAI_API_KEY', 'sk-accidental-leaked-openai-key-boundary');
+
+      expect(() => {
+        providerFactory.create(mockFactoryConfig);
+      }).toThrow(/xAI API key required/i);
+    });
+  });
+});

--- a/self/subcortex/providers/src/__tests__/providers/xai.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/xai.test.ts
@@ -81,8 +81,8 @@ describe('xAI Grok Provider Leaf Package Integration', () => {
   describe('Provider Factory Security Boundaries', () => {
     const mockFactoryConfig = {
       vendorKey: 'xai',
-      model: 'grok-2-1212',
-      defaultEndpoint: 'https://api.x.ai/v1',
+      model: 'grok-4.3',
+      defaultEndpoint: 'https://api.x.ai',
     } as any;
 
     it('should successfully instantiate ChatCompletionsProvider when an explicit key option is passed', () => {

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -15,8 +15,8 @@ import { providerAdapter as openaiProviderAdapter } from './providers/openai/ada
 import { providerAdapter as openclawProviderAdapter } from './providers/openclaw/adapter.js';
 import { providerAdapter as openrouterProviderAdapter } from './providers/openrouter/adapter.js';
 import { providerAdapter as perplexityProviderAdapter } from './providers/perplexity/adapter.js';
-import { providerAdapter as vllmProviderAdapter } from './providers/vllm/adapter.js';
 import { providerAdapter as qwenCodeProviderAdapter } from './providers/qwen-code/adapter.js';
+import { providerAdapter as vllmProviderAdapter } from './providers/vllm/adapter.js';
 import { providerAdapter as xaiProviderAdapter } from './providers/xai/adapter.js';
 
 export * from './schemas/provider-adapter.js';
@@ -32,10 +32,10 @@ export { providerAdapter as mistralAdapter } from './providers/mistral/adapter.j
 export { providerAdapter as moonshotAdapter } from './providers/moonshot/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
-export { providerAdapter as qwenCodeAdapter, QWEN_CODE_EXECUTION_CAPABILITY_PROFILE, createQwenCodeAdapter, renderQwenCodePrompt } from './providers/qwen-code/adapter.js';
 export { providerAdapter as openclawAdapter, OPENCLAW_EXECUTION_CAPABILITY_PROFILE, createOpenClawAdapter, renderOpenClawPrompt } from './providers/openclaw/adapter.js';
 export { providerAdapter as openrouterAdapter } from './providers/openrouter/adapter.js';
 export { providerAdapter as perplexityAdapter } from './providers/perplexity/adapter.js';
+export { providerAdapter as qwenCodeAdapter, QWEN_CODE_EXECUTION_CAPABILITY_PROFILE, createQwenCodeAdapter, renderQwenCodePrompt } from './providers/qwen-code/adapter.js';
 export { providerAdapter as vllmAdapter } from './providers/vllm/adapter.js';
 export { providerAdapter as xaiAdapter } from './providers/xai/adapter.js';
 
@@ -52,10 +52,10 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   moonshotProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
-  qwenCodeProviderAdapter,
   openclawProviderAdapter,
   openrouterProviderAdapter,
   perplexityProviderAdapter,
+  qwenCodeProviderAdapter,
   vllmProviderAdapter,
   xaiProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -4,18 +4,21 @@ import { providerAdapter as anthropicProviderAdapter } from './providers/anthrop
 import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cli/adapter.js';
 import { providerAdapter as ollamaProviderAdapter } from './providers/ollama/adapter.js';
 import { providerAdapter as openaiProviderAdapter } from './providers/openai/adapter.js';
+import { providerAdapter as xaiProviderAdapter } from './providers/xai/adapter.js';
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
 export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
 export { providerAdapter as ollamaAdapter, createOllamaAdapter, isToolCapableModel } from './providers/ollama/adapter.js';
 export { providerAdapter as openaiAdapter, createChatCompletionsAdapter } from './providers/openai/adapter.js';
+export { providerAdapter as xaiAdapter } from './providers/xai/adapter.js';
 
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
   codexCliProviderAdapter,
   ollamaProviderAdapter,
   openaiProviderAdapter,
+  xaiProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];
 
 export type CertifiedProviderAdapterKey =

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -5,6 +5,7 @@ import { providerDefinition as anthropicProviderDefinition } from './providers/a
 import { providerDefinition as codexCliProviderDefinition } from './providers/codex-cli/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
+import { providerDefinition as xaiProviderDefinition } from './providers/xai/definition.js';
 
 export * from './schemas/provider-definition.js';
 
@@ -13,6 +14,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   codexCliProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
+  xaiProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];
 
 export const PROVIDER_DEFINITIONS = hydrateProviderDefinitions(PROVIDER_DEFINITION_LEAVES);

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -13,10 +13,10 @@ import { providerDefinition as mistralProviderDefinition } from './providers/mis
 import { providerDefinition as moonshotProviderDefinition } from './providers/moonshot/definition.js';
 import { providerDefinition as ollamaProviderDefinition } from './providers/ollama/definition.js';
 import { providerDefinition as openaiProviderDefinition } from './providers/openai/definition.js';
-import { providerDefinition as qwenCodeProviderDefinition } from './providers/qwen-code/definition.js';
 import { providerDefinition as openclawProviderDefinition } from './providers/openclaw/definition.js';
 import { providerDefinition as openrouterProviderDefinition } from './providers/openrouter/definition.js';
 import { providerDefinition as perplexityProviderDefinition } from './providers/perplexity/definition.js';
+import { providerDefinition as qwenCodeProviderDefinition } from './providers/qwen-code/definition.js';
 import { providerDefinition as vllmProviderDefinition } from './providers/vllm/definition.js';
 import { providerDefinition as xaiProviderDefinition } from './providers/xai/definition.js';
 
@@ -35,10 +35,10 @@ const PROVIDER_DEFINITION_LEAVES = [
   moonshotProviderDefinition,
   ollamaProviderDefinition,
   openaiProviderDefinition,
-  qwenCodeProviderDefinition,
   openclawProviderDefinition,
   openrouterProviderDefinition,
   perplexityProviderDefinition,
+  qwenCodeProviderDefinition,
   vllmProviderDefinition,
   xaiProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -4,6 +4,7 @@ import { providerFactory as anthropicProviderFactory } from './providers/anthrop
 import { providerFactory as codexCliProviderFactory } from './providers/codex-cli/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
+import { providerFactory as xaiProviderFactory } from './providers/xai/provider.js';
 
 export * from './schemas/provider-factory.js';
 
@@ -12,6 +13,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   codexCliProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
+  xaiProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];
 
 export type CertifiedProviderFactoryVendorKey =

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -12,10 +12,10 @@ import { providerFactory as mistralProviderFactory } from './providers/mistral/p
 import { providerFactory as moonshotProviderFactory } from './providers/moonshot/provider.js';
 import { providerFactory as ollamaProviderFactory } from './providers/ollama/provider.js';
 import { providerFactory as openaiProviderFactory } from './providers/openai/provider.js';
-import { providerFactory as qwenCodeProviderFactory } from './providers/qwen-code/provider.js';
 import { providerFactory as openclawProviderFactory } from './providers/openclaw/provider.js';
 import { providerFactory as openrouterProviderFactory } from './providers/openrouter/provider.js';
 import { providerFactory as perplexityProviderFactory } from './providers/perplexity/provider.js';
+import { providerFactory as qwenCodeProviderFactory } from './providers/qwen-code/provider.js';
 import { providerFactory as vllmProviderFactory } from './providers/vllm/provider.js';
 import { providerFactory as xaiProviderFactory } from './providers/xai/provider.js';
 
@@ -34,10 +34,10 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   moonshotProviderFactory,
   ollamaProviderFactory,
   openaiProviderFactory,
-  qwenCodeProviderFactory,
   openclawProviderFactory,
   openrouterProviderFactory,
   perplexityProviderFactory,
+  qwenCodeProviderFactory,
   vllmProviderFactory,
   xaiProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];

--- a/self/subcortex/providers/src/providers/xai/adapter.ts
+++ b/self/subcortex/providers/src/providers/xai/adapter.ts
@@ -1,0 +1,4 @@
+export {
+  chatCompletionsAdapter as providerAdapter,
+  createChatCompletionsAdapter,
+} from '../../protocols/openai-api/adapter.js';

--- a/self/subcortex/providers/src/providers/xai/definition.ts
+++ b/self/subcortex/providers/src/providers/xai/definition.ts
@@ -2,7 +2,7 @@ import type {
     ProviderDefinitionLeaf 
 } from '../../schemas/provider-definition.js';
 
-const DEFAULT_ENDPOINT = 'https://api.x.ai/v1';
+const DEFAULT_ENDPOINT = 'https://api.x.ai';
 const DEFAULT_MODEL_ID = 'grok-4.3';
 
 export const providerDefinition = {

--- a/self/subcortex/providers/src/providers/xai/definition.ts
+++ b/self/subcortex/providers/src/providers/xai/definition.ts
@@ -3,7 +3,7 @@ import type {
 } from '../../schemas/provider-definition.js';
 
 const DEFAULT_ENDPOINT = 'https://api.x.ai/v1';
-const DEFAULT_MODEL_ID = 'grok-2-1212';
+const DEFAULT_MODEL_ID = 'grok-4.3';
 
 export const providerDefinition = {
     vendorKey: 'xai',

--- a/self/subcortex/providers/src/providers/xai/definition.ts
+++ b/self/subcortex/providers/src/providers/xai/definition.ts
@@ -1,0 +1,36 @@
+import type { 
+    ProviderDefinitionLeaf 
+} from '../../schemas/provider-definition.js';
+import { ProviderDefinition as tProviderDefinition} from '../../provider-definitions.js';
+
+const DEFAULT_ENDPOINT = 'https://api.x.ai/v1';
+const DEFAULT_MODEL_ID = 'grok-2-1212';
+
+export const providerDefinition = {
+    vendorKey: 'xai',
+    displayName: 'xAI Grok',
+    providerType: 'text',
+    providerClass: 'remote_text',
+    protocol: 'chat-completions',
+    adapterKey: 'chat-completions',
+    defaultEndpoint: DEFAULT_ENDPOINT,
+    defaultModelId: DEFAULT_MODEL_ID, 
+    auth: {
+        envVar: 'XAI_API_KEY',
+        vaultKeyNamespace: 'xai',
+        header: {
+        name: 'Authorization',
+        scheme: 'bearer',
+        },
+        required: true,
+        purpose: 'api_key',
+    },
+    modelListEndpoint: '/v1/models',
+    modelListFormat: 'openai-models',
+    capabilities: {
+        streaming: true,
+        nativeToolUse: true,
+        modelListing: true,
+    },
+    isLocal: false,
+} as const satisfies ProviderDefinitionLeaf;

--- a/self/subcortex/providers/src/providers/xai/definition.ts
+++ b/self/subcortex/providers/src/providers/xai/definition.ts
@@ -1,7 +1,6 @@
 import type { 
     ProviderDefinitionLeaf 
 } from '../../schemas/provider-definition.js';
-import { ProviderDefinition as tProviderDefinition} from '../../provider-definitions.js';
 
 const DEFAULT_ENDPOINT = 'https://api.x.ai/v1';
 const DEFAULT_MODEL_ID = 'grok-2-1212';

--- a/self/subcortex/providers/src/providers/xai/index.ts
+++ b/self/subcortex/providers/src/providers/xai/index.ts
@@ -1,0 +1,4 @@
+export { providerAdapter } from './adapter.js';
+export { providerDefinition } from './definition.js';
+export { providerFactory } from './provider.js';
+export { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';

--- a/self/subcortex/providers/src/providers/xai/provider.ts
+++ b/self/subcortex/providers/src/providers/xai/provider.ts
@@ -1,0 +1,9 @@
+import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'xai',
+  create(config, options) {
+    return new ChatCompletionsProvider(config, { apiKey: options?.apiKey });
+  },
+} as const satisfies ProviderFactoryModule;

--- a/self/subcortex/providers/src/providers/xai/provider.ts
+++ b/self/subcortex/providers/src/providers/xai/provider.ts
@@ -1,9 +1,18 @@
+import { NousError } from '@nous/shared';
 import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
 import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
 
 export const providerFactory = {
   vendorKey: 'xai',
-  create(config, options) {
-    return new ChatCompletionsProvider(config, { apiKey: options?.apiKey });
+  create(config, options?) {
+    const apiKey = options?.apiKey ?? process.env.XAI_API_KEY;
+    if (!apiKey) {
+      throw new NousError(
+        'xAI API key required — set XAI_API_KEY or pass apiKey option',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+    return new ChatCompletionsProvider(config, { apiKey });
   },
 } as const satisfies ProviderFactoryModule;

--- a/self/subcortex/providers/src/providers/xai/provider.ts
+++ b/self/subcortex/providers/src/providers/xai/provider.ts
@@ -8,7 +8,7 @@ export const providerFactory = {
     const apiKey = options?.apiKey ?? process.env.XAI_API_KEY;
     if (!apiKey) {
       throw new NousError(
-        'xAI API key required — set XAI_API_KEY or pass apiKey option',
+        'xAI API key required - set XAI_API_KEY or pass apiKey option',
         'PROVIDER_AUTH_FAILED',
         { failoverReasonCode: 'PRV-AUTH-FAILURE' },
       );


### PR DESCRIPTION
## Summary
Add xAI Grok as a provider leaf under the current provider-leaf contract (issue #302). Reuses the shared OpenAI-compatible Chat Completions protocol, thus no custom implementation.ts needed. Includes fail-closed credential handling so the factory never falls back to OPENAI_API_KEY when XAI_API_KEY is absent.

## Linked Issue
Closes #302 

## Changes
- Add `self/subcortex/providers/src/providers/xai/` leaf: `definition.ts`, `adapter.ts`, `provider.ts`, `index.ts`
- Definition uses `ProviderDefinitionLeaf` (metadata only); built-in id derives from `vendorKey`, no hand-authored `wellKnownProviderId``
- Reuse shared `chat-completions` protocol
- Factory resolves `XAI_API_KEY` explicitly and fails closed rather than passing `undefined` downstream
- Regenerate provider catalogs (`provider-definitions`, `provider-adapters`, `provider-factories`)
- Update registry-wide test expectations to include the `xai` vendor
- Add `__tests__/providers/xai.test.ts` covering registry registration, definition hydration, schema validation, auth contract, adapter parsing, and factory security boundaries
- Set default xAI Grok model to grok-4.3

## Verification
- [x] Tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Build passes (`pnpm build`)
- [x] Manually ran the change end-to-end and confirmed it behaves as described

### Manual behavior check

Ran the full provider test suite confirming xAI is correctly discovered, registered, and integrated end-to-end through the real `ProviderRegistry`:

```
pnpm --filter @nous/subcortex-providers exec vitest run src/__tests__/provider-codegen.test.ts src/__tests__/public-exports.test.ts src/__tests__/provider-definitions src/__tests__/adapter-resolver.test.ts src/__tests__/provider-pipeline-integration.test.ts src/__tests__/providers/xai.test.ts --config vitest.config.ts
```
<img width="1402" height="299" alt="image" src="https://github.com/user-attachments/assets/91cd6664-5677-4bca-ba06-efbe84d788ae" />
<img width="1183" height="37" alt="image" src="https://github.com/user-attachments/assets/c8faaede-3423-473b-98cb-8d1e39f08b63" />
<img width="1798" height="256" alt="image" src="https://github.com/user-attachments/assets/d0aaaa9b-2a39-4fb9-990d-efc384fb3db6" />

`Note: Live end-to-end invoke test not included — no xAI API key available, consistent with other provider leaf reviews where the maintainer also noted they could not run live tests without the provider's API key.`

## Checklist
- [x] Branch follows flow: targets feat/contributor-friendly-inference-provider-surface per maintainer note on issue #302)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Docs updated if behavior changed (or N/A)
