### PR TITLE
feat(subcortex-providers): add Zhipu GLM provider leaf

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -51,8 +51,8 @@ describe('adapter resolver', () => {
   it('aggregates all canonical adapter modules', () => {
     // `chat-completions` appears multiple times: azure-openai, dashscope, deepinfra, groq,
     // huggingface-tgi, llama-cpp, moonshot, openai, openrouter, perplexity,
-    // vllm, and xai all reuse the shared chat-completions adapter. mistral uses
-    // its own adapterKey for resolver isolation.
+    // vllm, xai, and zhipu all reuse the shared chat-completions adapter.
+    // mistral uses its own adapterKey for resolver isolation.
     // The resolver keys modules by adapterKey, so the duplicates collapse to a single
     // resolvable module. Order follows the generated CERTIFIED_PROVIDER_ADAPTER_MODULES
     // (alphabetical by vendor) with the text fallback appended last.
@@ -75,6 +75,7 @@ describe('adapter resolver', () => {
       'chat-completions',       
       'chat-completions',        
       'qwen-code',
+      'chat-completions',
       'chat-completions',
       'chat-completions',
       'text',

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -39,6 +39,7 @@ describe('provider aggregate codegen', () => {
       'qwen-code',
       'vllm',
       'xai',
+      'zhipu',
     ]);
   });
 

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai'>
+  Equal<ProviderVendorKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai' | 'zhipu'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai' | 'zhipu'>
 >;
 
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
@@ -50,6 +50,7 @@ describe('provider definition type derivation', () => {
       'qwen-code',
       'vllm',
       'xai',
+      'zhipu',
     ]);
   });
 

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -110,6 +110,11 @@ const expectedDefinitions = {
     defaultModelId: 'mistral-large-latest',
     envVar: 'MISTRAL_API_KEY',
   },
+  zhipu: {
+    defaultEndpoint: 'https://api.z.ai/api/paas/v4',
+    defaultModelId: 'glm-4.6',
+    envVar: 'ZHIPU_API_KEY',
+  },
 } as const;
 
 describe('provider definitions catalog', () => {
@@ -134,7 +139,8 @@ describe('provider definitions catalog', () => {
       'perplexity',
       'qwen-code',
       'vllm',
-      'xai'
+      'xai',
+      'zhipu'
     ]);
   });
 

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -68,6 +68,7 @@ afterEach(() => {
   delete process.env.VLLM_API_KEY;
   delete process.env.MISTRAL_API_KEY;
   delete process.env.XAI_API_KEY;
+  delete process.env.ZHIPU_API_KEY;
 });
 
 describe('provider definition to adapter to registry pipeline', () => {
@@ -92,7 +93,8 @@ describe('provider definition to adapter to registry pipeline', () => {
       'perplexity',
       'qwen-code',
       'vllm',
-      'xai'
+      'xai',
+      'zhipu'
     ]);
     expect(resolveProviderDefinition('anthropic').defaultModelId).toBe(
       'claude-sonnet-4-20250514',
@@ -211,6 +213,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     process.env.PERPLEXITY_API_KEY = 'test-perplexity-key';
     process.env.MISTRAL_API_KEY = 'test-mistral-key';
     process.env.XAI_API_KEY = 'test-xai-key';
+    process.env.ZHIPU_API_KEY = 'test-zhipu-key';
 
     const registry = new ProviderRegistry(createEmptyConfig());
     const expectedClassByVendor = {
@@ -234,6 +237,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       perplexity: ChatCompletionsProvider,
       vllm: ChatCompletionsProvider,
       xai: ChatCompletionsProvider,
+      zhipu: ChatCompletionsProvider,
     };
 
     for (const definition of PROVIDER_DEFINITIONS) {

--- a/self/subcortex/providers/src/__tests__/providers/zhipu.live.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/zhipu.live.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelProviderConfig, ProviderId, TraceId } from '@nous/shared';
+import {
+  ChatCompletionsProvider,
+  resolveProviderDefinition,
+  resolveProviderFactory,
+} from '../../index.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440188' as TraceId;
+const PROVIDER_ID = '00000000-0000-0000-0000-0000000000bb' as ProviderId;
+
+// Gated live blackbox test. Skipped unless NOUS_ZHIPU_LIVE_BT=1 is set, so it
+// never runs in normal CI and does not require a credential to be present. Run with:
+//   NOUS_ZHIPU_LIVE_BT=1 ZHIPU_API_KEY=... \
+//     pnpm --filter @nous/subcortex-providers exec vitest run src/__tests__/providers/zhipu.live.test.ts
+const liveIt = process.env.NOUS_ZHIPU_LIVE_BT === '1' ? it : it.skip;
+
+function liveConfig(): ModelProviderConfig {
+  const definition = resolveProviderDefinition('zhipu');
+  return {
+    id: PROVIDER_ID,
+    name: 'Zhipu GLM',
+    type: 'text',
+    endpoint: definition.defaultEndpoint,
+    modelId: definition.defaultModelId,
+    isLocal: false,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'remote_text',
+    vendor: 'zhipu',
+  };
+}
+
+function createLiveProvider(): ChatCompletionsProvider {
+  const factory = resolveProviderFactory('zhipu');
+  if (!factory) {
+    throw new Error('zhipu provider factory is not registered');
+  }
+  const provider = factory.create(liveConfig(), {
+    apiKey: process.env.ZHIPU_API_KEY,
+  });
+  if (!(provider instanceof ChatCompletionsProvider)) {
+    throw new Error('expected zhipu factory to construct a ChatCompletionsProvider');
+  }
+  return provider;
+}
+
+describe('zhipu provider live BT', () => {
+  liveIt('invokes the real Zhipu GLM chat completions API', async () => {
+    const provider = createLiveProvider();
+
+    const response = await provider.invoke({
+      role: 'workers',
+      input: {
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a live provider smoke test. Reply with exactly the requested token and nothing else.',
+          },
+          {
+            role: 'user',
+            content: 'Reply with exactly: ZHIPU_PROVIDER_CHAT_OK',
+          },
+        ],
+      },
+      traceId: TRACE_ID,
+    });
+
+    expect(response.providerId).toBe(PROVIDER_ID);
+    expect(String(response.output)).toContain('ZHIPU_PROVIDER_CHAT_OK');
+  }, 180_000);
+
+  liveIt('streams a response from the real Zhipu GLM API', async () => {
+    const provider = createLiveProvider();
+
+    let streamed = '';
+    for await (const chunk of provider.stream({
+      role: 'workers',
+      input: {
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a live provider streaming smoke test. Reply with exactly the requested token and nothing else.',
+          },
+          {
+            role: 'user',
+            content: 'Reply with exactly: ZHIPU_PROVIDER_STREAM_OK',
+          },
+        ],
+      },
+      traceId: TRACE_ID,
+    })) {
+      streamed += chunk.content;
+    }
+
+    expect(streamed).toContain('ZHIPU_PROVIDER_STREAM_OK');
+  }, 180_000);
+});

--- a/self/subcortex/providers/src/__tests__/providers/zhipu.test.ts
+++ b/self/subcortex/providers/src/__tests__/providers/zhipu.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelProviderConfig, ProviderId, TraceId } from '@nous/shared';
+import {
+  ADAPTER_RESOLVER,
+  ChatCompletionsProvider,
+  PROVIDER_DEFINITIONS,
+  ProviderDefinitionSchema,
+  deriveBuiltInProviderId,
+  resolveProviderDefinition,
+  resolveProviderFactory,
+} from '../../index.js';
+import {
+  providerAdapter,
+  providerDefinition,
+  providerFactory,
+} from '../../providers/zhipu/index.js';
+import { ZHIPU_PROVIDER_DEFINITION } from '../../providers/zhipu/definition.js';
+
+const TRACE_ID = '550e8400-e29b-41d4-a716-446655440177' as TraceId;
+const PROVIDER_ID = '00000000-0000-0000-0000-0000000000bb' as ProviderId;
+
+function zhipuConfig(): ModelProviderConfig {
+  const definition = resolveProviderDefinition('zhipu');
+  return {
+    id: PROVIDER_ID,
+    name: 'Zhipu GLM',
+    type: 'text',
+    endpoint: definition.defaultEndpoint,
+    modelId: definition.defaultModelId,
+    isLocal: false,
+    capabilities: ['chat', 'streaming'],
+    providerClass: 'remote_text',
+    vendor: 'zhipu',
+  };
+}
+
+describe('zhipu provider leaf — definition', () => {
+  it('exposes the leaf definition under the canonical alias', () => {
+    expect(providerDefinition).toBe(ZHIPU_PROVIDER_DEFINITION);
+  });
+
+  it('does not hand-author a built-in provider id', () => {
+    expect('wellKnownProviderId' in ZHIPU_PROVIDER_DEFINITION).toBe(false);
+  });
+
+  it('declares Zhipu GLM identity, protocol, and credential metadata', () => {
+    expect(ZHIPU_PROVIDER_DEFINITION.vendorKey).toBe('zhipu');
+    expect(ZHIPU_PROVIDER_DEFINITION.protocol).toBe('chat-completions');
+    expect(ZHIPU_PROVIDER_DEFINITION.adapterKey).toBe('chat-completions');
+    expect(ZHIPU_PROVIDER_DEFINITION.defaultEndpoint).toBe('https://api.z.ai/api/paas/v4');
+    expect(ZHIPU_PROVIDER_DEFINITION.defaultModelId).toBe('glm-4.6');
+    expect(ZHIPU_PROVIDER_DEFINITION.isLocal).toBe(false);
+    expect(ZHIPU_PROVIDER_DEFINITION.auth).toEqual({
+      envVar: 'ZHIPU_API_KEY',
+      vaultKeyNamespace: 'zhipu',
+      header: {
+        name: 'Authorization',
+        scheme: 'bearer',
+      },
+      required: true,
+      purpose: 'api_key',
+    });
+  });
+
+  it('does not declare a model-list endpoint (falls back to the default model)', () => {
+    expect('modelListEndpoint' in ZHIPU_PROVIDER_DEFINITION).toBe(false);
+    expect('modelListFormat' in ZHIPU_PROVIDER_DEFINITION).toBe(false);
+  });
+
+  it('is hydrated into PROVIDER_DEFINITIONS with a derived built-in id', () => {
+    const hydrated = resolveProviderDefinition('zhipu');
+    expect(PROVIDER_DEFINITIONS).toContainEqual(hydrated);
+    expect(hydrated.wellKnownProviderId).toBe(deriveBuiltInProviderId('zhipu'));
+  });
+
+  it('validates through ProviderDefinitionSchema after hydration', () => {
+    const hydrated = resolveProviderDefinition('zhipu');
+    expect(ProviderDefinitionSchema.parse(hydrated)).toEqual(hydrated);
+  });
+});
+
+describe('zhipu provider leaf — adapter (GLM chat completions shape)', () => {
+  it('reuses the shared chat-completions adapter', () => {
+    expect(providerAdapter).toBe(ADAPTER_RESOLVER.resolveModule('chat-completions'));
+  });
+
+  it('parses a GLM text response', () => {
+    const adapter = ADAPTER_RESOLVER.resolveAdapter(ZHIPU_PROVIDER_DEFINITION.adapterKey);
+    const parsed = adapter.parseResponse(
+      {
+        id: 'chatcmpl-glm',
+        model: 'glm-4.6',
+        choices: [{ message: { role: 'assistant', content: 'Hello from GLM' } }],
+        usage: { prompt_tokens: 12, completion_tokens: 4 },
+      },
+      TRACE_ID,
+    );
+
+    expect(parsed.response).toBe('Hello from GLM');
+    expect(parsed.toolCalls).toEqual([]);
+    expect(parsed.contentType).toBe('text');
+  });
+
+  it('parses GLM native tool calls', () => {
+    const adapter = ADAPTER_RESOLVER.resolveAdapter(ZHIPU_PROVIDER_DEFINITION.adapterKey);
+    const parsed = adapter.parseResponse(
+      {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '',
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'search', arguments: '{"query":"weather"}' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      TRACE_ID,
+    );
+
+    expect(parsed.toolCalls).toEqual([
+      { name: 'search', params: { query: 'weather' }, id: 'call_1' },
+    ]);
+  });
+
+  it('returns a text fallback instead of throwing on malformed output', () => {
+    const adapter = ADAPTER_RESOLVER.resolveAdapter(ZHIPU_PROVIDER_DEFINITION.adapterKey);
+    expect(() => adapter.parseResponse({ unexpected: true }, TRACE_ID)).not.toThrow();
+    expect(adapter.parseResponse({ unexpected: true }, TRACE_ID).contentType).toBe('text');
+  });
+});
+
+describe('zhipu provider leaf — factory', () => {
+  it('is registered under the zhipu vendor key', () => {
+    expect(resolveProviderFactory('zhipu')).toBe(providerFactory);
+    expect(providerFactory.vendorKey).toBe('zhipu');
+  });
+
+  it('constructs a ChatCompletionsProvider with the supplied credential', () => {
+    const provider = providerFactory.create(zhipuConfig(), { apiKey: 'zhipu-key' });
+    expect(provider).toBeInstanceOf(ChatCompletionsProvider);
+    expect(provider.getConfig().vendor).toBe('zhipu');
+  });
+
+  it('fails closed instead of falling back to OPENAI_API_KEY when no Zhipu key is present', () => {
+    const previousZhipu = process.env.ZHIPU_API_KEY;
+    const previousOpenai = process.env.OPENAI_API_KEY;
+    delete process.env.ZHIPU_API_KEY;
+    process.env.OPENAI_API_KEY = 'openai-key-should-not-be-used';
+    try {
+      expect(() => providerFactory.create(zhipuConfig(), {})).toThrow(/ZHIPU_API_KEY/);
+      expect(() => providerFactory.create(zhipuConfig())).toThrow(/ZHIPU_API_KEY/);
+    } finally {
+      if (previousZhipu === undefined) delete process.env.ZHIPU_API_KEY;
+      else process.env.ZHIPU_API_KEY = previousZhipu;
+      if (previousOpenai === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = previousOpenai;
+    }
+  });
+
+  it('resolves the credential from ZHIPU_API_KEY when no apiKey option is supplied', () => {
+    const previousZhipu = process.env.ZHIPU_API_KEY;
+    process.env.ZHIPU_API_KEY = 'zhipu-env-key';
+    try {
+      const provider = providerFactory.create(zhipuConfig());
+      expect(provider).toBeInstanceOf(ChatCompletionsProvider);
+    } finally {
+      if (previousZhipu === undefined) delete process.env.ZHIPU_API_KEY;
+      else process.env.ZHIPU_API_KEY = previousZhipu;
+    }
+  });
+});

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -20,6 +20,7 @@ import { providerAdapter as perplexityProviderAdapter } from './providers/perple
 import { providerAdapter as qwenCodeProviderAdapter } from './providers/qwen-code/adapter.js';
 import { providerAdapter as vllmProviderAdapter } from './providers/vllm/adapter.js';
 import { providerAdapter as xaiProviderAdapter } from './providers/xai/adapter.js';
+import { providerAdapter as zhipuProviderAdapter } from './providers/zhipu/adapter.js';
 
 export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
@@ -42,6 +43,7 @@ export { providerAdapter as perplexityAdapter } from './providers/perplexity/ada
 export { providerAdapter as qwenCodeAdapter, QWEN_CODE_EXECUTION_CAPABILITY_PROFILE, createQwenCodeAdapter, renderQwenCodePrompt } from './providers/qwen-code/adapter.js';
 export { providerAdapter as vllmAdapter } from './providers/vllm/adapter.js';
 export { providerAdapter as xaiAdapter } from './providers/xai/adapter.js';
+export { providerAdapter as zhipuAdapter } from './providers/zhipu/adapter.js';
 
 export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
@@ -64,6 +66,7 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   qwenCodeProviderAdapter,
   vllmProviderAdapter,
   xaiProviderAdapter,
+  zhipuProviderAdapter,
 ] as const satisfies readonly ProviderAdapterModule[];
 
 export type CertifiedProviderAdapterKey =

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -21,6 +21,7 @@ import { providerDefinition as perplexityProviderDefinition } from './providers/
 import { providerDefinition as qwenCodeProviderDefinition } from './providers/qwen-code/definition.js';
 import { providerDefinition as vllmProviderDefinition } from './providers/vllm/definition.js';
 import { providerDefinition as xaiProviderDefinition } from './providers/xai/definition.js';
+import { providerDefinition as zhipuProviderDefinition } from './providers/zhipu/definition.js';
 
 export * from './schemas/provider-definition.js';
 
@@ -45,6 +46,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   qwenCodeProviderDefinition,
   vllmProviderDefinition,
   xaiProviderDefinition,
+  zhipuProviderDefinition,
 ] as const satisfies readonly ProviderDefinitionLeaf[];
 
 export const PROVIDER_DEFINITIONS = hydrateProviderDefinitions(PROVIDER_DEFINITION_LEAVES);

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -20,6 +20,7 @@ import { providerFactory as perplexityProviderFactory } from './providers/perple
 import { providerFactory as qwenCodeProviderFactory } from './providers/qwen-code/provider.js';
 import { providerFactory as vllmProviderFactory } from './providers/vllm/provider.js';
 import { providerFactory as xaiProviderFactory } from './providers/xai/provider.js';
+import { providerFactory as zhipuProviderFactory } from './providers/zhipu/provider.js';
 
 export * from './schemas/provider-factory.js';
 
@@ -44,6 +45,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   qwenCodeProviderFactory,
   vllmProviderFactory,
   xaiProviderFactory,
+  zhipuProviderFactory,
 ] as const satisfies readonly ProviderFactoryModule[];
 
 export type CertifiedProviderFactoryVendorKey =

--- a/self/subcortex/providers/src/providers/zhipu/adapter.ts
+++ b/self/subcortex/providers/src/providers/zhipu/adapter.ts
@@ -1,0 +1,3 @@
+export {
+  chatCompletionsAdapter as providerAdapter,
+} from '../../protocols/openai-api/adapter.js';

--- a/self/subcortex/providers/src/providers/zhipu/definition.ts
+++ b/self/subcortex/providers/src/providers/zhipu/definition.ts
@@ -1,0 +1,37 @@
+// Zhipu GLM — OpenAI Chat Completions-compatible leaf (z.ai `paas/v4` surface).
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+
+// The z.ai base already carries the `/api/paas/v4` version segment, so the
+// factory overrides the shared `/v1/chat/completions` default (see provider.ts).
+const DEFAULT_ENDPOINT = 'https://api.z.ai/api/paas/v4';
+const DEFAULT_MODEL_ID = 'glm-4.6';
+
+export const ZHIPU_PROVIDER_DEFINITION = {
+  vendorKey: 'zhipu',
+  displayName: 'Zhipu GLM',
+  providerType: 'text',
+  providerClass: 'remote_text',
+  protocol: 'chat-completions',
+  adapterKey: 'chat-completions',
+  defaultEndpoint: DEFAULT_ENDPOINT,
+  defaultModelId: DEFAULT_MODEL_ID,
+  auth: {
+    envVar: 'ZHIPU_API_KEY',
+    vaultKeyNamespace: 'zhipu',
+    header: {
+      name: 'Authorization',
+      scheme: 'bearer',
+    },
+    required: true,
+    purpose: 'api_key',
+  },
+  // Zhipu exposes no public model-list endpoint, so discovery is omitted and
+  // the runtime falls back to defaultModelId. GLM supports tools + streaming.
+  capabilities: {
+    streaming: true,
+    nativeToolUse: true,
+  },
+  isLocal: false,
+} as const satisfies ProviderDefinitionLeaf;
+
+export { ZHIPU_PROVIDER_DEFINITION as providerDefinition };

--- a/self/subcortex/providers/src/providers/zhipu/definition.ts
+++ b/self/subcortex/providers/src/providers/zhipu/definition.ts
@@ -25,11 +25,12 @@ export const ZHIPU_PROVIDER_DEFINITION = {
     required: true,
     purpose: 'api_key',
   },
-  // Zhipu exposes no public model-list endpoint, so discovery is omitted and
-  // the runtime falls back to defaultModelId. GLM supports tools + streaming.
+  // Zhipu exposes no public model-list endpoint, so discovery is omitted and the
+  // runtime falls back to defaultModelId. GLM supports streaming. Z.AI supports
+  // native function calling upstream, but Nous's shared Chat Completions path can't
+  // complete that tool-call round trip yet (#390), so nativeToolUse is omitted.
   capabilities: {
     streaming: true,
-    nativeToolUse: true,
   },
   isLocal: false,
 } as const satisfies ProviderDefinitionLeaf;

--- a/self/subcortex/providers/src/providers/zhipu/index.ts
+++ b/self/subcortex/providers/src/providers/zhipu/index.ts
@@ -1,0 +1,4 @@
+export { providerAdapter } from './adapter.js';
+export { providerDefinition } from './definition.js';
+export { providerFactory } from './provider.js';
+export { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';

--- a/self/subcortex/providers/src/providers/zhipu/provider.ts
+++ b/self/subcortex/providers/src/providers/zhipu/provider.ts
@@ -1,0 +1,26 @@
+import { NousError } from '@nous/shared';
+import { ChatCompletionsProvider } from '../../protocols/openai-api/provider.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'zhipu',
+  create(config, options?) {
+    // Fail closed: ChatCompletionsProvider falls back to OPENAI_API_KEY when no
+    // key is passed, which could leak an OpenAI credential to Zhipu. Resolve the
+    // Zhipu key explicitly and refuse to construct without it.
+    const apiKey = options?.apiKey ?? process.env.ZHIPU_API_KEY;
+    if (!apiKey) {
+      throw new NousError(
+        'Zhipu API key required — set ZHIPU_API_KEY or pass the apiKey option',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+    // Zhipu's paas/v4 base already includes the version, so its completions
+    // route is `/chat/completions` (no `/v1`), unlike OpenAI's default.
+    return new ChatCompletionsProvider(config, {
+      apiKey,
+      completionsPath: '/chat/completions',
+    });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## Summary
Add the Zhipu GLM model provider as a certified provider leaf, implemented against the current provider-leaf contract (issue #320).

## Linked Issue
Closes #320

## Changes
- Add `self/subcortex/providers/src/providers/zhipu/` leaf: `definition.ts`, `adapter.ts`, `provider.ts`, `index.ts`
- Definition uses `ProviderDefinitionLeaf` (metadata only); built-in id derives from `vendorKey`, no hand-authored `wellKnownProviderId`
- Reuse the shared `openai-api` chat-completions protocol (no `implementation.ts`)
- Endpoint targets the z.ai `paas/v4` surface (`https://api.z.ai/api/paas/v4`); because that base already carries the `/api/paas/v4` version segment, the factory overrides the shared default and uses `/chat/completions` (no `/v1`)
- Factory fails closed on missing credentials: it resolves `ZHIPU_API_KEY` explicitly and refuses to construct rather than falling back to `OPENAI_API_KEY` (which would leak an OpenAI credential to Zhipu)
- Discovery is omitted (Zhipu exposes no public model-list endpoint); the runtime falls back to `defaultModelId`
- Regenerate provider catalogs (`provider-definitions`, `provider-adapters`, `provider-factories`)
- Update registry-wide test expectations to include the zhipu vendor
- Add `__tests__/providers/zhipu.test.ts` covering definition hydration (canonical alias, derived built-in id, schema validation, no model-list endpoint), adapter parsing (text / native tool calls / malformed fallback), and factory construction (fail-closed auth + `ZHIPU_API_KEY` resolution)
- Add gated `__tests__/providers/zhipu.live.test.ts` (live invoke + stream smoke test), following the `codex-cli.live.test.ts` pattern
- Set the default model to `glm-4.6`

## Verification
- [x] Tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Build passes (`pnpm build`)
- [x] Manually ran the change end-to-end and confirmed it behaves as described (describe below)

### Test run (`pnpm test`)
![pnpm test results](https://ix7l8rtzlf.ufs.sh/f/fsfgZfmadWBrCviJggsYyWGqkzhK04c6wj2ZnPfgl18MEvFX)

### Manual behavior check
Ran the gated live test against the real Zhipu GLM API and both invoke + stream passed:
```
  NOUS_ZHIPU_LIVE_BT=1 ZHIPU_API_KEY=... \
    pnpm --filter @nous/subcortex-providers exec vitest run src/__tests__/providers/zhipu.live.test.ts
```
Result: 2 passed.

![live test results](https://ix7l8rtzlf.ufs.sh/f/fsfgZfmadWBrCouEeXsYyWGqkzhK04c6wj2ZnPfgl18MEvFX)

## Checklist
- [x] Branch follows flow: targets integration branch `feat/contributor-friendly-inference-provider-surface` per the provider-leaf work (not `main`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Docs updated if behavior changed (or N/A)
