### PR TITLE
Fix issue 313

### DIFF
--- a/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
+++ b/self/subcortex/providers/src/__tests__/adapter-resolver.test.ts
@@ -60,6 +60,7 @@ describe('adapter resolver', () => {
       'anthropic',
       'chat-completions',
       'codex-cli',
+      'cohere',
       'chat-completions',
       'chat-completions',
       'gemini',

--- a/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-codegen.test.ts
@@ -22,6 +22,7 @@ describe('provider aggregate codegen', () => {
       'anthropic',
       'azure-openai',
       'codex-cli',
+      'cohere',
       'dashscope',
       'deepinfra',
       'gemini',

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definition-types.test.ts
@@ -16,10 +16,10 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type _ProviderVendorKeyIsExact = Expect<
-  Equal<ProviderVendorKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai'>
+  Equal<ProviderVendorKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'cohere' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai'>
 >;
 type _BootstrapProviderKeyIsExact = Expect<
-  Equal<BootstrapProviderKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai'>
+  Equal<BootstrapProviderKey, 'anthropic' | 'azure-openai' | 'codex-cli' | 'cohere' | 'dashscope' | 'deepinfra' | 'gemini' | 'github-copilot-cli' | 'groq' | 'huggingface-tgi' | 'llama-cpp' | 'mistral' | 'moonshot' | 'openai' | 'ollama' | 'openclaw' | 'openrouter' | 'perplexity' | 'qwen-code' | 'vllm' | 'xai'>
 >;
 
 type _ProviderVendorKeyDoesNotWiden = Expect<Equal<string extends ProviderVendorKey ? true : false, false>>;
@@ -33,6 +33,7 @@ describe('provider definition type derivation', () => {
       'anthropic',
       'azure-openai',
       'codex-cli',
+      'cohere',
       'dashscope',
       'deepinfra',
       'gemini',

--- a/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-definitions/provider-definitions.test.ts
@@ -20,6 +20,11 @@ const expectedDefinitions = {
     defaultModelId: 'gpt-4o',
     envVar: 'AZURE_OPENAI_API_KEY',
   },
+  cohere: {
+    defaultEndpoint: 'https://api.cohere.com',
+    defaultModelId: 'command-a-03-2025',
+    envVar: 'COHERE_API_KEY',
+  },
   openai: {
     defaultEndpoint: 'https://api.openai.com',
     defaultModelId: 'gpt-4o',
@@ -118,6 +123,7 @@ describe('provider definitions catalog', () => {
       'anthropic',
       'azure-openai',
       'codex-cli',
+      'cohere',
       'dashscope',
       'deepinfra',
       'gemini',
@@ -171,6 +177,7 @@ describe('provider definitions catalog', () => {
       join('providers', 'anthropic', 'implementation.ts'),
       join('providers', 'azure-openai', 'definition.ts'),
       join('providers', 'codex-cli', 'definition.ts'),
+      join('providers', 'cohere', 'implementation.ts'),
       join('providers', 'dashscope', 'definition.ts'),
       join('providers', 'openclaw', 'definition.ts'),
       join('protocols', 'openai-api', 'provider.ts'),

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -77,6 +77,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       'anthropic',
       'azure-openai',
       'codex-cli',
+      'cohere',
       'dashscope',
       'deepinfra',
       'gemini',

--- a/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
+++ b/self/subcortex/providers/src/__tests__/provider-pipeline-integration.test.ts
@@ -6,6 +6,7 @@ import {
   ADAPTER_RESOLVER,
   AnthropicProvider,
   ChatCompletionsProvider,
+  CohereProvider,
   CERTIFIED_PROVIDER_FACTORIES,
   CodexCliProvider,
   GeminiProvider,
@@ -203,6 +204,7 @@ describe('provider definition to adapter to registry pipeline', () => {
     process.env.OPENAI_API_KEY = 'test-openai-key';
     process.env.DEEPINFRA_API_KEY = 'test-deepinfra-key';
     process.env.HUGGINGFACE_API_KEY = 'test-huggingface-key';
+    process.env.COHERE_API_KEY = 'test-cohere-key';
     process.env.MOONSHOT_API_KEY = 'test-moonshot-key';
     process.env.GROQ_API_KEY = 'test-groq-key';
     process.env.GEMINI_API_KEY = 'test-gemini-key';
@@ -217,6 +219,7 @@ describe('provider definition to adapter to registry pipeline', () => {
       anthropic: AnthropicProvider,
       'azure-openai': ChatCompletionsProvider,
       'codex-cli': CodexCliProvider,
+      cohere: CohereProvider,
       dashscope: ChatCompletionsProvider,
       'github-copilot-cli': GitHubCopilotCliProvider,
       moonshot: ChatCompletionsProvider,

--- a/self/subcortex/providers/src/index.ts
+++ b/self/subcortex/providers/src/index.ts
@@ -4,6 +4,7 @@
 export { AnthropicProvider } from './providers/anthropic/implementation.js';
 export { GeminiProvider } from './providers/gemini/implementation.js';
 export { MistralProvider } from './providers/mistral/implementation.js';
+export { CohereProvider } from './providers/cohere/implementation.js';
 export * from './adapter-resolver.js';
 export * from './provider-adapters.js';
 export { CODEX_CLI_EXECUTION_CAPABILITY_PROFILE } from './providers/codex-cli/adapter.js';

--- a/self/subcortex/providers/src/provider-adapters.ts
+++ b/self/subcortex/providers/src/provider-adapters.ts
@@ -3,6 +3,7 @@ import type { ProviderAdapterModule } from './schemas/provider-adapter.js';
 import { providerAdapter as anthropicProviderAdapter } from './providers/anthropic/adapter.js';
 import { providerAdapter as azureOpenaiProviderAdapter } from './providers/azure-openai/adapter.js';
 import { providerAdapter as codexCliProviderAdapter } from './providers/codex-cli/adapter.js';
+import { providerAdapter as cohereProviderAdapter } from './providers/cohere/adapter.js';
 import { providerAdapter as dashscopeProviderAdapter } from './providers/dashscope/adapter.js';
 import { providerAdapter as deepinfraProviderAdapter } from './providers/deepinfra/adapter.js';
 import { providerAdapter as geminiProviderAdapter } from './providers/gemini/adapter.js';
@@ -25,6 +26,7 @@ export * from './schemas/provider-adapter.js';
 export { providerAdapter as anthropicAdapter, createAnthropicAdapter } from './providers/anthropic/adapter.js';
 export { providerAdapter as azureOpenaiAdapter } from './providers/azure-openai/adapter.js';
 export { providerAdapter as codexCliAdapter, CODEX_CLI_EXECUTION_CAPABILITY_PROFILE, createCodexCliAdapter, renderCodexCliPrompt } from './providers/codex-cli/adapter.js';
+export { providerAdapter as cohereAdapter } from './providers/cohere/adapter.js';
 export { providerAdapter as dashscopeAdapter } from './providers/dashscope/adapter.js';
 export { providerAdapter as deepinfraAdapter } from './providers/deepinfra/adapter.js';
 export { providerAdapter as geminiAdapter } from './providers/gemini/adapter.js';
@@ -47,6 +49,7 @@ export const CERTIFIED_PROVIDER_ADAPTER_MODULES = [
   anthropicProviderAdapter,
   azureOpenaiProviderAdapter,
   codexCliProviderAdapter,
+  cohereProviderAdapter,
   dashscopeProviderAdapter,
   deepinfraProviderAdapter,
   geminiProviderAdapter,

--- a/self/subcortex/providers/src/provider-definitions.ts
+++ b/self/subcortex/providers/src/provider-definitions.ts
@@ -4,6 +4,7 @@ import { hydrateProviderDefinitions } from './provider-identity.js';
 import { providerDefinition as anthropicProviderDefinition } from './providers/anthropic/definition.js';
 import { providerDefinition as azureOpenaiProviderDefinition } from './providers/azure-openai/definition.js';
 import { providerDefinition as codexCliProviderDefinition } from './providers/codex-cli/definition.js';
+import { providerDefinition as cohereProviderDefinition } from './providers/cohere/definition.js';
 import { providerDefinition as dashscopeProviderDefinition } from './providers/dashscope/definition.js';
 import { providerDefinition as deepinfraProviderDefinition } from './providers/deepinfra/definition.js';
 import { providerDefinition as geminiProviderDefinition } from './providers/gemini/definition.js';
@@ -28,6 +29,7 @@ const PROVIDER_DEFINITION_LEAVES = [
   anthropicProviderDefinition,
   azureOpenaiProviderDefinition,
   codexCliProviderDefinition,
+  cohereProviderDefinition,
   dashscopeProviderDefinition,
   deepinfraProviderDefinition,
   geminiProviderDefinition,

--- a/self/subcortex/providers/src/provider-factories.ts
+++ b/self/subcortex/providers/src/provider-factories.ts
@@ -3,6 +3,7 @@ import type { ProviderFactoryModule } from './schemas/provider-factory.js';
 import { providerFactory as anthropicProviderFactory } from './providers/anthropic/provider.js';
 import { providerFactory as azureOpenaiProviderFactory } from './providers/azure-openai/provider.js';
 import { providerFactory as codexCliProviderFactory } from './providers/codex-cli/provider.js';
+import { providerFactory as cohereProviderFactory } from './providers/cohere/provider.js';
 import { providerFactory as dashscopeProviderFactory } from './providers/dashscope/provider.js';
 import { providerFactory as deepinfraProviderFactory } from './providers/deepinfra/provider.js';
 import { providerFactory as geminiProviderFactory } from './providers/gemini/provider.js';
@@ -27,6 +28,7 @@ export const CERTIFIED_PROVIDER_FACTORIES = [
   anthropicProviderFactory,
   azureOpenaiProviderFactory,
   codexCliProviderFactory,
+  cohereProviderFactory,
   dashscopeProviderFactory,
   deepinfraProviderFactory,
   geminiProviderFactory,

--- a/self/subcortex/providers/src/providers/cohere/adapter.ts
+++ b/self/subcortex/providers/src/providers/cohere/adapter.ts
@@ -1,0 +1,185 @@
+/**
+ * Cohere provider adapter — native tool-use via Chat API v2.
+ *
+ * ProviderAdapter for Cohere's Chat API.
+ */
+import type { TraceId } from '@nous/shared';
+import type { ParsedModelOutput } from '../../shared/output.js';
+import {
+  defineProviderAdapter,
+  type AdapterCapabilities,
+  type AdapterFormatInput,
+  type AdapterFormattedRequest,
+  type ProviderAdapter,
+} from '../../schemas/provider-adapter.js';
+
+const COHERE_CAPABILITIES: AdapterCapabilities = {
+  nativeToolUse: true,
+  cacheControl: false,
+  extendedThinking: false,
+  streaming: true,
+};
+
+type CohereRole = 'user' | 'assistant' | 'system' | 'tool';
+
+interface CohereMessage {
+  role: CohereRole;
+  content?: string;
+  tool_calls?: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }>;
+  tool_call_id?: string;
+}
+
+function formatMessages(
+  systemPrompt: string | string[],
+  context: readonly import('@nous/shared').GatewayContextFrame[],
+): CohereMessage[] {
+  const systemText = Array.isArray(systemPrompt) ? systemPrompt.join('\n') : systemPrompt;
+  const messages: CohereMessage[] = systemText ? [{ role: 'system', content: systemText }] : [];
+
+  for (const frame of context) {
+    if (frame.role === 'tool' && frame.metadata?.tool_call_id) {
+      messages.push({
+        role: 'tool',
+        tool_call_id: frame.metadata.tool_call_id as string,
+        content: frame.content,
+      });
+      continue;
+    }
+
+    if (frame.role === 'assistant' && Array.isArray(frame.metadata?.tool_calls)) {
+      const toolCalls = (
+        frame.metadata!.tool_calls as Array<{ id?: string; name: string; input: unknown }>
+      )
+        .filter((tc) => tc.id)
+        .map((tc) => ({
+          id: tc.id as string,
+          type: 'function' as const,
+          function: { name: tc.name, arguments: JSON.stringify(tc.input ?? {}) },
+        }));
+
+      messages.push({
+        role: 'assistant',
+        content: frame.content.trim() || undefined,
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      });
+      continue;
+    }
+
+    const role: CohereRole = frame.role === 'system' ? 'system' : frame.role === 'tool' ? 'tool' : frame.role;
+    messages.push({ role, content: frame.content });
+  }
+
+  return messages;
+}
+
+function formatTools(
+  toolDefinitions?: readonly import('@nous/shared').ToolDefinition[],
+): Array<Record<string, unknown>> | undefined {
+  if (!toolDefinitions || toolDefinitions.length === 0) return undefined;
+
+  return toolDefinitions.map((tool) => ({
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description ?? '',
+      parameters: tool.inputSchema ?? { type: 'object', properties: {} },
+    },
+  }));
+}
+
+interface CohereContentBlock {
+  type?: string;
+  text?: string;
+}
+
+interface CohereToolCall {
+  id?: string;
+  function?: { name?: string; arguments?: string };
+}
+
+interface CohereResponse {
+  message?: {
+    content?: CohereContentBlock[];
+    tool_calls?: CohereToolCall[];
+  };
+}
+
+function parseCohereResponse(output: unknown): ParsedModelOutput {
+  if (typeof output === 'string') {
+    return { response: output, toolCalls: [], memoryCandidates: [], contentType: 'text' };
+  }
+
+  if (!output || typeof output !== 'object') {
+    return { response: String(output ?? ''), toolCalls: [], memoryCandidates: [], contentType: 'text' };
+  }
+
+  const obj = output as CohereResponse;
+  const contentBlocks = obj.message?.content;
+  const textParts = Array.isArray(contentBlocks)
+    ? contentBlocks.filter((b) => b.type === 'text' && typeof b.text === 'string').map((b) => b.text as string)
+    : [];
+
+  const toolCalls: Array<{ name: string; params: unknown; id?: string }> = [];
+  if (Array.isArray(obj.message?.tool_calls)) {
+    for (const tc of obj.message!.tool_calls!) {
+      if (!tc.function?.name) continue;
+      let params: unknown = {};
+      try {
+        params = tc.function.arguments ? JSON.parse(tc.function.arguments) : {};
+      } catch {
+        params = {};
+      }
+      toolCalls.push({ name: tc.function.name, params, id: tc.id });
+    }
+  }
+
+  return {
+    response: textParts.join(''),
+    toolCalls,
+    memoryCandidates: [],
+    contentType: 'text',
+  };
+}
+
+export function createCohereAdapter(): ProviderAdapter {
+  return {
+    capabilities: COHERE_CAPABILITIES,
+
+    formatRequest(input: AdapterFormatInput): AdapterFormattedRequest {
+      const messages = formatMessages(input.systemPrompt, input.context);
+      const tools = formatTools(input.toolDefinitions);
+
+      const result: Record<string, unknown> = { messages };
+      if (tools) {
+        result.tools = tools;
+      }
+
+      return { input: result };
+    },
+
+    parseResponse(output: unknown, _traceId: TraceId): ParsedModelOutput {
+      try {
+        return parseCohereResponse(output);
+      } catch {
+        return {
+          response: String(output ?? ''),
+          toolCalls: [],
+          memoryCandidates: [],
+          contentType: 'text',
+        };
+      }
+    },
+  };
+}
+
+export const providerAdapter = defineProviderAdapter({
+  adapterKey: 'cohere',
+  displayName: 'Cohere',
+  protocol: 'cohere-chat',
+  capabilities: COHERE_CAPABILITIES,
+  create() {
+    return createCohereAdapter();
+  },
+});
+
+export { providerAdapter as cohereAdapter };

--- a/self/subcortex/providers/src/providers/cohere/definition.ts
+++ b/self/subcortex/providers/src/providers/cohere/definition.ts
@@ -1,0 +1,3 @@
+export {
+  COHERE_PROVIDER_DEFINITION as providerDefinition,
+} from './implementation.js';

--- a/self/subcortex/providers/src/providers/cohere/implementation.ts
+++ b/self/subcortex/providers/src/providers/cohere/implementation.ts
@@ -1,0 +1,377 @@
+import { NousError, ValidationError } from '@nous/shared';
+import type {
+  IModelProvider,
+  ModelProviderConfig,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamChunk,
+} from '@nous/shared';
+import type { ProviderDefinitionLeaf } from '../../schemas/provider-definition.js';
+import { TextModelInputSchema, type TextModelInput } from '../../schemas/text-model-input.js';
+
+const DEFAULT_ENDPOINT = 'https://api.cohere.com';
+const DEFAULT_MODEL_ID = 'command-a-03-2025';
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export const COHERE_PROVIDER_DEFINITION = {
+  vendorKey: 'cohere',
+  displayName: 'Cohere',
+  providerType: 'text',
+  providerClass: 'remote_text',
+  protocol: 'cohere-chat',
+  adapterKey: 'cohere',
+  defaultEndpoint: DEFAULT_ENDPOINT,
+  defaultModelId: DEFAULT_MODEL_ID,
+  auth: {
+    envVar: 'COHERE_API_KEY',
+    vaultKeyNamespace: 'cohere',
+    header: {
+      name: 'Authorization',
+      scheme: 'bearer',
+    },
+    required: true,
+    purpose: 'api_key',
+  },
+  capabilities: {
+    streaming: true,
+    cacheControl: false,
+    extendedThinking: false,
+    nativeToolUse: true,
+    modelListing: false,
+  },
+  isLocal: false,
+} as const satisfies ProviderDefinitionLeaf;
+
+interface CohereContentBlock {
+  type?: string;
+  text?: string;
+}
+
+interface CohereToolCall {
+  id?: string;
+  type?: string;
+  function?: { name?: string; arguments?: string };
+}
+
+interface CohereChatResponse {
+  message?: {
+    role?: string;
+    content?: CohereContentBlock[];
+    tool_calls?: CohereToolCall[];
+  };
+  finish_reason?: string;
+  usage?: {
+    billed_units?: { input_tokens?: number; output_tokens?: number };
+  };
+}
+
+interface CohereStreamEvent {
+  type?: string;
+  delta?: {
+    message?: {
+      content?: { text?: string };
+      tool_calls?: { function?: { name?: string; arguments?: string } };
+    };
+    finish_reason?: string;
+    usage?: { billed_units?: { input_tokens?: number; output_tokens?: number } };
+  };
+}
+
+interface CohereFormattedInput {
+  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+  tools?: Array<Record<string, unknown>>;
+}
+
+export class CohereProvider implements IModelProvider {
+  private readonly config: ModelProviderConfig;
+  private readonly endpoint: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+
+  constructor(
+    config: ModelProviderConfig,
+    options?: { apiKey?: string; timeoutMs?: number },
+  ) {
+    this.config = config;
+    this.endpoint = config.endpoint ?? DEFAULT_ENDPOINT;
+    this.apiKey = options?.apiKey ?? process.env.COHERE_API_KEY ?? '';
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    if (!this.apiKey) {
+      throw new NousError(
+        'Cohere API key required — set COHERE_API_KEY or pass apiKey option',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+  }
+
+  getConfig(): ModelProviderConfig {
+    return this.config;
+  }
+
+  async invoke(request: ModelRequest): Promise<ModelResponse> {
+    const input = this.validateInput(request.input);
+    const formatted = this.toCohereFormat(input);
+    const response = await this.fetchWithTimeout(this.getUrl(), {
+      method: 'POST',
+      headers: this.getHeaders(),
+      signal: request.abortSignal,
+      body: JSON.stringify(this.buildRequestBody(formatted, false)),
+    });
+
+    await this.throwForResponseError(response);
+
+    const data = (await response.json()) as CohereChatResponse;
+
+    const hasToolCalls = (data.message?.tool_calls?.length ?? 0) > 0;
+    const output = hasToolCalls
+      ? { message: data.message, finish_reason: data.finish_reason }
+      : (data.message?.content?.find((part) => part.type === 'text')?.text ?? '');
+
+    return {
+      output,
+      providerId: this.config.id,
+      usage: {
+        inputTokens: data.usage?.billed_units?.input_tokens,
+        outputTokens: data.usage?.billed_units?.output_tokens,
+        computeMs: undefined,
+      },
+      traceId: request.traceId,
+    };
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+    const input = this.validateInput(request.input);
+    const formatted = this.toCohereFormat(input);
+    const response = await this.fetchWithTimeout(this.getUrl(), {
+      method: 'POST',
+      headers: this.getHeaders(),
+      signal: request.abortSignal,
+      body: JSON.stringify(this.buildRequestBody(formatted, true)),
+    });
+
+    await this.throwForResponseError(response);
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new NousError('No response body', 'PROVIDER_UNAVAILABLE');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() ?? '';
+
+        for (const eventChunk of events) {
+          const event = this.parseStreamEvent(eventChunk);
+          if (!event) continue;
+
+          if (event.type === 'content-delta') {
+            const content = event.delta?.message?.content?.text ?? '';
+            if (content) {
+              yield { content, done: false };
+            }
+            continue;
+          }
+
+          if (event.type === 'message-end') {
+            outputTokens = event.delta?.usage?.billed_units?.output_tokens ?? outputTokens;
+            inputTokens = event.delta?.usage?.billed_units?.input_tokens ?? inputTokens;
+
+            yield {
+              content: '',
+              done: true,
+              usage: { inputTokens, outputTokens },
+            };
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        const event = this.parseStreamEvent(buffer);
+        if (event?.type === 'message-end') {
+          outputTokens = event.delta?.usage?.billed_units?.output_tokens ?? outputTokens;
+          inputTokens = event.delta?.usage?.billed_units?.input_tokens ?? inputTokens;
+
+          yield {
+            content: '',
+            done: true,
+            usage: { inputTokens, outputTokens },
+          };
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private validateInput(input: unknown): TextModelInput {
+    const result = TextModelInputSchema.safeParse(input);
+    if (!result.success) {
+      const errors = result.error.errors.map((error) => ({
+        path: error.path.join('.'),
+        message: error.message,
+      }));
+      throw new ValidationError('Invalid model input', errors);
+    }
+    return result.data;
+  }
+
+  private toCohereFormat(input: TextModelInput): CohereFormattedInput {
+    const result: CohereFormattedInput = { messages: [] };
+
+    if (input.tools && input.tools.length > 0) {
+      result.tools = input.tools;
+    }
+
+    if ('messages' in input && Array.isArray(input.messages)) {
+      result.messages = input.messages
+        .filter(
+          (message): message is { role: 'user' | 'assistant' | 'system'; content: string } =>
+            message.role === 'user' || message.role === 'assistant' || message.role === 'system',
+        )
+        .map((message) => ({ role: message.role, content: message.content }));
+
+      if (input.systemSegments && input.systemSegments.length > 0) {
+        result.messages = [
+          { role: 'system', content: input.systemSegments.join('\n') },
+          ...result.messages,
+        ];
+      }
+
+      return result;
+    }
+
+    if (input.systemSegments && input.systemSegments.length > 0) {
+      result.messages.push({ role: 'system', content: input.systemSegments.join('\n') });
+    }
+
+    result.messages.push({
+      role: 'user',
+      content: 'prompt' in input ? input.prompt : '',
+    });
+
+    return result;
+  }
+
+  private buildRequestBody(
+    formatted: CohereFormattedInput,
+    stream: boolean,
+  ): Record<string, unknown> {
+    return {
+      model: this.config.modelId,
+      messages: formatted.messages,
+      ...(formatted.tools && formatted.tools.length > 0 ? { tools: formatted.tools } : {}),
+      stream,
+    };
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+  }
+
+  private getUrl(): string {
+    return `${this.endpoint.replace(/\/$/, '')}/v2/chat`;
+  }
+
+  private async throwForResponseError(response: Response): Promise<void> {
+    if (response.status === 401 || response.status === 403) {
+      throw new NousError(
+        'API key invalid or missing',
+        'PROVIDER_AUTH_FAILED',
+        { failoverReasonCode: 'PRV-AUTH-FAILURE' },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new NousError(
+        `Cohere rate limit: ${response.status}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-RATE-LIMIT' },
+      );
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new NousError(
+        `Cohere API error ${response.status}: ${text.slice(0, 200)}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+      );
+    }
+  }
+
+  private parseStreamEvent(eventChunk: string): CohereStreamEvent | null {
+    const lines = eventChunk.split(/\r?\n/);
+    const dataLines: string[] = [];
+
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).trimStart());
+      }
+    }
+
+    if (dataLines.length === 0) {
+      return null;
+    }
+
+    const payload = dataLines.join('\n');
+    if (!payload || payload === '[DONE]') {
+      return null;
+    }
+
+    return JSON.parse(payload) as CohereStreamEvent;
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(
+      () => timeoutController.abort(new DOMException('provider_timeout', 'AbortError')),
+      this.timeoutMs,
+    );
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, timeoutController.signal])
+      : timeoutController.signal;
+
+    try {
+      return await fetch(url, { ...init, signal });
+    } catch (error) {
+      if (timeoutController.signal.aborted) {
+        throw new NousError(
+          `Cohere request timed out after ${this.timeoutMs}ms`,
+          'PROVIDER_UNAVAILABLE',
+          { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+        );
+      }
+      if ((error as Error).name === 'AbortError') {
+        throw new NousError('Cohere request aborted.', 'ABORTED');
+      }
+
+      throw new NousError(
+        `Cohere endpoint unreachable: ${(error as Error).message}`,
+        'PROVIDER_UNAVAILABLE',
+        { failoverReasonCode: 'PRV-PROVIDER-UNAVAILABLE' },
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/self/subcortex/providers/src/providers/cohere/index.ts
+++ b/self/subcortex/providers/src/providers/cohere/index.ts
@@ -1,0 +1,4 @@
+export { providerAdapter } from './adapter.js';
+export { providerDefinition } from './definition.js';
+export { providerFactory } from './provider.js';
+export { CohereProvider } from './implementation.js';

--- a/self/subcortex/providers/src/providers/cohere/provider.ts
+++ b/self/subcortex/providers/src/providers/cohere/provider.ts
@@ -1,0 +1,9 @@
+import { CohereProvider } from './implementation.js';
+import type { ProviderFactoryModule } from '../../schemas/provider-factory.js';
+
+export const providerFactory = {
+  vendorKey: 'cohere',
+  create(config, options) {
+    return new CohereProvider(config, { apiKey: options?.apiKey });
+  },
+} as const satisfies ProviderFactoryModule;


### PR DESCRIPTION
## What does this PR do?

Adds a certified Cohere provider leaf at `self/subcortex/providers/src/providers/cohere/`
(definition.ts, adapter.ts, provider.ts, implementation.ts, index.ts), modeled structurally
on the Anthropic leaf but implemented against Cohere's v2 Chat API (`POST /v2/chat`,
Bearer auth, native tool-calling via `tool_calls`, SSE streaming with
`content-delta`/`message-end` events). Regenerates the provider catalogs
(`provider-definitions.ts`, `provider-adapters.ts`, `provider-factories.ts`) via
`generate:providers` so Cohere is selectable as a model provider.

## Why was this PR needed?

Cohere was one of the vendors with no provider leaf, so requests couldn't be routed to
Cohere-hosted models. Per the issue's 2026-06-18 scope update, this targets the new
provider-leaf system (definition/adapter/factory contracts) on
`feat/contributor-friendly-inference-provider-surface`, not the superseded
hand-written `IModelProvider` approach.

## What are the relevant issue numbers?

Closes #313

## Screenshots / Recordings (if applicable)

Full test suite: **569 passed, 0 failed, 4 skipped** (573 total), after rebasing onto
the latest integration branch (which also picked up the new `azure-openai` and
`dashscope` leaves alongside this one). `typecheck` and `check:generated` both pass clean.

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior (adapter parsing exercised via shared
      `provider-pipeline-integration.test.ts` fixtures; no dedicated
      `cohere-provider.test.ts`/`cohere-adapter.test.ts` unit tests yet — noted below)
- [x] All tests passing
- [x] Follows project style guide (leaf shape matches Anthropic reference; catalogs
      regenerated, not hand-edited)
- [x] No breaking changes introduced
- [ ] Documentation updated (n/a — no user-facing docs changes needed for this leaf)

**Known gaps / follow-ups (flagging proactively for reviewers):**
- No dedicated `cohere-provider.test.ts` / `cohere-adapter.test.ts` yet — happy to add
  before merge if preferred over relying on shared fixture coverage.
- `modelListing: false` — Cohere exposes a models endpoint, but I didn't confirm its
  response shape matches either supported `ProviderModelListFormatSchema` format
  (`anthropic-models` / `openai-models`), so I left it unimplemented rather than guess.
- Not yet verified against a live `COHERE_API_KEY` — only exercised against mocked
  fixtures so far.